### PR TITLE
feat: add emphasis expressions to key configuration rules

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -15,6 +15,8 @@ The configuration is organized into focused modules for better token efficiency:
 
 ## Priority Rules
 
+**IMPORTANT:** These rules determine which settings take effect:
+
 1. **Project settings override global settings** - When a project has its own `CLAUDE.md`, those rules take precedence
 2. **Intelligent loading** - Claude Code uses conditional loading rules to automatically select relevant modules (see project's `conditional-loading.md`)
 3. **Explicit conflicts** - If project and global settings conflict, the project setting wins

--- a/global/conversation-language.md
+++ b/global/conversation-language.md
@@ -11,6 +11,7 @@ Claude communicates with users in their preferred language while maintaining tec
 
 ### User Interaction
 - **Default response language**: Korean
+  - **YOU MUST:** Always respond in Korean unless the user explicitly requests English.
 - **Language switching**: Honor explicit user requests to change language
 - **Consistency**: Maintain chosen language throughout session
 

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -9,6 +9,8 @@ These guidelines define general conventions and practices for working in this re
 
 ## Quick Reference
 
+**CRITICAL:** Always consult [environment.md](claude-guidelines/environment.md) first for timezone and locale context.
+
 <table>
 <tr>
 <td width="50%">

--- a/project/claude-guidelines/security.md
+++ b/project/claude-guidelines/security.md
@@ -2,6 +2,8 @@
 
 ## Input Validation
 
+**IMPORTANT:** All user input MUST be validated before processing.
+
 ### Validate All External Input
 
 Never trust data from external sources. Always validate and sanitize:


### PR DESCRIPTION
## Summary
- Add `**IMPORTANT:**` to global/CLAUDE.md Priority Rules section
- Add `**CRITICAL:**` to project/CLAUDE.md Quick Reference section
- Add `**YOU MUST:**` to conversation-language.md Korean response rule
- Add `**IMPORTANT:**` to security.md input validation section

## Why
Per [Anthropic Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices), adding emphasis with "IMPORTANT" or "YOU MUST" improves instruction following reliability. These strategic additions strengthen key rules without overusing emphasis.

## Test plan
- [x] Verify emphasis expressions are properly formatted in markdown
- [x] Confirm no duplicate or conflicting emphasis in the same sections
- [x] Validate that emphasis is used sparingly (4 new instances total)

## Verification Details
| File | Expression | Line | Format |
|------|------------|------|--------|
| global/CLAUDE.md | `**IMPORTANT:**` | 18 | ✅ Valid |
| project/CLAUDE.md | `**CRITICAL:**` | 12 | ✅ Valid |
| conversation-language.md | `**YOU MUST:**` | 14 | ✅ Valid |
| security.md | `**IMPORTANT:**` | 5 | ✅ Valid |

**Total emphasis count**: 6 (2 existing + 4 new) - appropriate level of usage

Closes #29