### PR TITLE
feat: add common-commands.md for bash commands section

### DIFF
--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -20,6 +20,7 @@ These guidelines define general conventions and practices for working in this re
 - [Question Handling](claude-guidelines/workflow.md)
 - [Problem Solving](claude-guidelines/problem-solving.md)
 - [Language Conventions](claude-guidelines/communication.md)
+- [Common Commands](claude-guidelines/common-commands.md)
 
 </td>
 <td width="50%">
@@ -38,7 +39,7 @@ These guidelines define general conventions and practices for working in this re
 
 | Category | Modules |
 |----------|---------|
-| **Environment & Workflow** | [Environment](claude-guidelines/environment.md), [Workflow](claude-guidelines/workflow.md), [Problem-Solving](claude-guidelines/problem-solving.md), [Communication](claude-guidelines/communication.md), [Git](claude-guidelines/git-commit-format.md) |
+| **Environment & Workflow** | [Environment](claude-guidelines/environment.md), [Workflow](claude-guidelines/workflow.md), [Problem-Solving](claude-guidelines/problem-solving.md), [Communication](claude-guidelines/communication.md), [Git](claude-guidelines/git-commit-format.md), [Commands](claude-guidelines/common-commands.md) |
 | **Code Standards** | [General](claude-guidelines/coding-standards/general.md), [Quality](claude-guidelines/coding-standards/quality.md), [Error Handling](claude-guidelines/coding-standards/error-handling.md), [Cleanup](claude-guidelines/operations/cleanup.md) |
 | **Technical** | [Concurrency](claude-guidelines/coding-standards/concurrency.md), [Memory](claude-guidelines/coding-standards/memory.md), [Performance](claude-guidelines/coding-standards/performance.md) |
 | **Project Management** | [Build](claude-guidelines/project-management/build.md), [Testing](claude-guidelines/project-management/testing.md), [Documentation](claude-guidelines/project-management/documentation.md) |

--- a/project/claude-guidelines/common-commands.md
+++ b/project/claude-guidelines/common-commands.md
@@ -1,0 +1,37 @@
+# Common Commands
+
+> Quick reference for frequently used commands in this project
+
+## Validation Scripts
+
+- `./scripts/verify.sh`: Verify backup integrity and directory structure
+- `./scripts/validate_skills.sh`: Validate SKILL.md files for format compliance
+
+## Installation & Deployment
+
+- `./scripts/install.sh`: Install settings to system (~/.claude/ and project)
+- `./scripts/backup.sh`: Backup current system settings to repository
+- `./scripts/sync.sh`: Synchronize settings between system and backup
+
+## Hook Management
+
+- `./hooks/install-hooks.sh`: Install pre-commit hooks for SKILL.md validation
+
+## Git Operations
+
+- `git status`: Check working tree status
+- `git diff`: View unstaged changes
+- `git add . && git commit -m "message"`: Stage and commit changes
+- `git log --oneline -10`: View recent commit history
+
+## GitHub CLI Commands
+
+- `gh issue list --state open`: List open GitHub issues
+- `gh issue view <number>`: View specific issue details
+- `gh pr create --title "title" --body "body"`: Create pull request
+- `gh pr list`: List pull requests
+
+## Quick Checks
+
+- `wc -l project/CLAUDE.md`: Check CLAUDE.md line count
+- `find . -name "*.md" | wc -l`: Count markdown files in project

--- a/project/claude-guidelines/conditional-loading.md
+++ b/project/claude-guidelines/conditional-loading.md
@@ -99,7 +99,7 @@ Priority 4 (Optional): Load only if explicitly needed
   load: [documentation, communication]
 
 /scripts/, /tools/:
-  load: [general, error-handling]
+  load: [common-commands, general, error-handling]
 
 /src/api/, /routes/, /controllers/:
   load: [security, documentation, error-handling]
@@ -251,6 +251,9 @@ def determine_modules_to_load(context):
 | `issue label` | `github-issue-5w1h` | Labeling guidance |
 | `create PR` | `github-pr-5w1h`, `workflow` | PR creation |
 | `gh issue` | `github-issue-5w1h` | CLI command |
+| `run script` | `common-commands` | Script execution |
+| `install`, `backup`, `sync` | `common-commands` | Setup commands |
+| `validate`, `verify` | `common-commands` | Validation commands |
 
 ## 🔧 Override Mechanisms
 


### PR DESCRIPTION
## Summary

- Create `common-commands.md` with frequently used bash commands as recommended by official documentation
- Add validation scripts, installation commands, git operations, and GitHub CLI commands
- Update `CLAUDE.md` with links to new commands reference
- Update `conditional-loading.md` with command-related loading patterns

## Changes

| File | Change |
|------|--------|
| `common-commands.md` | New file with ~40 lines |
| `CLAUDE.md` | Added link in Quick Reference and Guidelines Index |
| `conditional-loading.md` | Added patterns for scripts and commands |

## Test plan

- [x] Verify all script paths exist in repository
- [x] Check links in CLAUDE.md are correct
- [x] Validate conditional-loading patterns are consistent

Closes #30