### PR TITLE
docs(commands): add Arguments and Options sections to project commands

### DIFF
--- a/project/.claude/commands/code-quality.md
+++ b/project/.claude/commands/code-quality.md
@@ -8,6 +8,19 @@ Analyze code quality and provide improvement suggestions.
 /code-quality [FILE_PATH or DIRECTORY]
 ```
 
+## Arguments
+
+- `FILE_PATH or DIRECTORY`: Target to analyze (required)
+  - If directory, analyze all supported files recursively
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| --depth | unlimited | Max directory depth for recursive analysis |
+| --format | markdown | Output format (markdown, json) |
+| --verbose | false | Include detailed metrics |
+
 ## Instructions
 
 Perform comprehensive code quality analysis:

--- a/project/.claude/commands/git-status.md
+++ b/project/.claude/commands/git-status.md
@@ -8,6 +8,18 @@ Comprehensive git repository status with actionable insights.
 /git-status
 ```
 
+## Arguments
+
+None (operates on current repository)
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| --commits | 5 | Number of recent commits to show |
+| --verbose | false | Include file diff stats |
+| --check-remote | true | Check remote sync status |
+
 ## Instructions
 
 Analyze the current git state and provide:

--- a/project/.claude/commands/pr-review.md
+++ b/project/.claude/commands/pr-review.md
@@ -8,6 +8,18 @@ Review pull requests with comprehensive analysis.
 /pr-review [PR_NUMBER]
 ```
 
+## Arguments
+
+- `PR_NUMBER`: Pull request number to review
+  - If omitted, detect open PR for current branch
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| --depth | standard | Review depth (quick, standard, thorough) |
+| --focus | all | Focus area (security, performance, all) |
+
 ## Instructions
 
 When reviewing a PR, analyze the following:


### PR DESCRIPTION
Closes #41

## Summary
- Add `## Arguments` section to code-quality, git-status, and pr-review commands
- Add `## Options` section with consistent table format to all three commands
- Align project commands structure with global commands for consistency

## Test Plan
- Verify all three files have Arguments and Options sections
- Confirm table format matches specification in issue #41