### PR TITLE
feat(syntax): adopt import syntax for modular file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claude Configuration Backup & Deployment System
 
 <p align="center">
-  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.3.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.4.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-green.svg" alt="License"></a>
   <a href="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml"><img src="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml/badge.svg" alt="CI"></a>
 </p>
@@ -448,11 +448,12 @@ This configuration includes Claude Code Skills for auto-discovery of guidelines 
 
 ### Progressive Disclosure Pattern
 
-Skills use the Progressive Disclosure pattern for token efficiency:
+Skills use the Progressive Disclosure pattern with Import syntax for token efficiency:
 
 1. **SKILL.md**: Contains only essential information (~50 lines)
 2. **reference/**: Symlinks to detailed guideline files
-3. **On-Demand loading**: Claude reads reference files only when necessary
+3. **Import Syntax**: Use `@path/to/file` for on-demand loading (supports up to 5 levels deep)
+4. **On-Demand loading**: Claude reads reference files only when necessary
 
 ```
 skills/coding-guidelines/
@@ -468,6 +469,24 @@ skills/coding-guidelines/
 - Initial load tokens: ~5000 → ~1000 (80% reduction)
 - 1-level deep references for reliable loading
 - Simplified path maintenance
+- Import syntax provides intuitive file references
+
+### Import Syntax
+
+The `@path/to/file` Import syntax (introduced in v1.4.0) provides:
+- More intuitive file references than traditional markdown links
+- Support for up to 5 levels of recursive Import
+- Both relative and absolute path support
+- Automatic ignoring within code blocks
+
+**Example:**
+```markdown
+# CLAUDE.md
+## Core Guidelines
+@claude-guidelines/environment.md
+@claude-guidelines/workflow.md
+@claude-guidelines/coding-standards/general.md
+```
 
 ### Skill Structure
 
@@ -484,8 +503,8 @@ allowed-tools: Read, Grep, Glob  # Optional: restrict tools
 - Use case 1
 - Use case 2
 
-## Quick Reference
-- [Link to guideline](reference/guideline.md)
+## Reference Documents (Import Syntax)
+@reference/guideline.md
 ```
 
 </details>
@@ -825,10 +844,17 @@ curl -sSL -H "Authorization: token YOUR_TOKEN" \
 
 ## Version
 
-- **Version**: 1.3.0
-- **Last Updated**: 2026-01-15
+- **Version**: 1.4.0
+- **Last Updated**: 2026-01-22
 
 ### Changelog
+
+#### v1.4.0 (2026-01-22)
+- Adopted Import syntax (`@path/to/file`) for modular references
+  - Replaced markdown links with Import syntax for better token efficiency
+  - Supports recursive imports up to 5 levels deep
+- Updated all CLAUDE.md files (global and project) to use Import syntax
+- Updated all SKILL.md files to use Import syntax for reference documents
 
 #### v1.3.0 (2026-01-15)
 - Added `/release` command for automated changelog generation

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -2,16 +2,15 @@
 
 This is the global configuration for all Claude Code sessions. These settings apply across all projects unless overridden by project-specific `CLAUDE.md` files.
 
-## Configuration Modules
+## Configuration Modules (Import Syntax)
 
-The configuration is organized into focused modules for better token efficiency:
+The configuration is organized into focused modules using `@path/to/file` Import syntax:
 
 ### Core Settings
-
-- **[Token Management](token-management.md)** - Token usage display, cost tracking, and optimization strategies
-- **[Conversation Language](conversation-language.md)** - Input/output language preferences and translation policies
-- **[Git Identity](git-identity.md)** - User information for git commits
-- **[Commit Settings](commit-settings.md)** - Commit and PR attribution policy (no Claude references)
+@token-management.md
+@conversation-language.md
+@git-identity.md
+@commit-settings.md
 
 ## Priority Rules
 
@@ -51,6 +50,9 @@ To modify these settings:
 
 ## Version History
 
+- **1.3.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
+  - Replaced markdown links with Import syntax
+  - Supports recursive imports up to 5 levels deep
 - **1.2.0** (2026-01-15): CLAUDE.md optimization for official best practices compliance
   - Simplified project/CLAUDE.md (212 → ~85 lines)
   - Added emphasis expressions for key rules
@@ -62,5 +64,5 @@ To modify these settings:
 
 ---
 
-*Last updated: 2026-01-15*
-*Version: 1.2.0*
+*Last updated: 2026-01-22*
+*Version: 1.3.0*

--- a/plugin/skills/api-design/SKILL.md
+++ b/plugin/skills/api-design/SKILL.md
@@ -13,20 +13,17 @@ description: Provides API design guidelines for REST, GraphQL, versioning, loggi
 - Implementing rate limiting or authentication
 - Code review for API endpoints
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### API Design
-
-- [API Design](reference/api-design.md)
+@reference/api-design.md
 
 ### Architecture
-
-- [Architecture and Design](reference/architecture.md)
+@reference/architecture.md
 
 ### Observability
-
-- [Logging Standards](reference/logging.md)
-- [Observability](reference/observability.md)
+@reference/logging.md
+@reference/observability.md
 
 ## Core Principles
 

--- a/plugin/skills/coding-guidelines/SKILL.md
+++ b/plugin/skills/coding-guidelines/SKILL.md
@@ -12,22 +12,19 @@ description: Provides comprehensive coding standards for quality, naming convent
 - Bug fixes requiring code changes
 - Refactoring tasks
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Core Standards
-
-- [General Coding Standards](reference/general.md)
-- [Code Quality](reference/quality.md)
+@reference/general.md
+@reference/quality.md
 
 ### Error & Safety
-
-- [Error Handling](reference/error-handling.md)
-- [Memory Management](reference/memory.md)
+@reference/error-handling.md
+@reference/memory.md
 
 ### Performance
-
-- [Concurrency](reference/concurrency.md)
-- [Performance](reference/performance.md)
+@reference/concurrency.md
+@reference/performance.md
 
 ## Core Principles
 

--- a/plugin/skills/documentation/SKILL.md
+++ b/plugin/skills/documentation/SKILL.md
@@ -14,19 +14,16 @@ description: Provides documentation standards for README, API docs, code comment
 - Cleaning up and organizing project files
 - Setting up linting and formatting tools
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Documentation Standards
-
-- [Documentation Standards](reference/documentation.md)
+@reference/documentation.md
 
 ### Language Conventions
-
-- [Code and Documentation Language](reference/communication.md)
+@reference/communication.md
 
 ### Project Cleanup
-
-- [Cleanup and Finalization](reference/cleanup.md)
+@reference/cleanup.md
 
 ## Core Principles
 

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -45,12 +45,11 @@ Profiling → Identify bottlenecks → Optimize → Verify
 - [ ] Cache invalidation policy
 - [ ] Cache hit rate monitoring
 
-## Reference
-
-- [Performance Guidelines](reference/performance.md)
-- [Memory Management](reference/memory.md)
-- [Concurrency](reference/concurrency.md)
-- [Monitoring](reference/monitoring.md)
+## Reference Documents (Import Syntax)
+@reference/performance.md
+@reference/memory.md
+@reference/concurrency.md
+@reference/monitoring.md
 
 ## Caution
 

--- a/plugin/skills/project-workflow/SKILL.md
+++ b/plugin/skills/project-workflow/SKILL.md
@@ -13,26 +13,23 @@ description: Provides workflow guidelines for problem-solving, git commits, GitH
 - Managing builds and dependencies
 - Setting up testing infrastructure
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Workflow
-
-- [Workflow Guidelines](reference/workflow.md)
-- [Question Handling](reference/question-handling.md)
-- [Problem Solving](reference/workflow-problem-solving.md)
-- [Performance Analysis](reference/performance-analysis.md)
+@reference/workflow.md
+@reference/question-handling.md
+@reference/workflow-problem-solving.md
+@reference/performance-analysis.md
 
 ### GitHub
-
-- [GitHub Issue Guidelines (5W1H)](reference/github-issue-5w1h.md)
-- [GitHub PR Guidelines (5W1H)](reference/github-pr-5w1h.md)
-- [Git Commit Format](reference/git-commit-format.md)
+@reference/github-issue-5w1h.md
+@reference/github-pr-5w1h.md
+@reference/git-commit-format.md
 
 ### Project Management
-
-- [Problem-Solving Principles](reference/problem-solving.md)
-- [Build and Dependency Management](reference/build.md)
-- [Testing Strategy](reference/testing.md)
+@reference/problem-solving.md
+@reference/build.md
+@reference/testing.md
 
 ## Core Principles
 

--- a/plugin/skills/security-audit/SKILL.md
+++ b/plugin/skills/security-audit/SKILL.md
@@ -34,11 +34,10 @@ allowed-tools: Read, Grep, Glob
 - [ ] Permission verification
 - [ ] Resource access control
 
-## Reference
-
-- [Security Guidelines](reference/security.md)
-- [Error Handling (Security)](reference/error-handling.md)
-- [API Security](reference/api-design.md)
+## Reference Documents (Import Syntax)
+@reference/security.md
+@reference/error-handling.md
+@reference/api-design.md
 
 ## OWASP Top 10 Reference
 

--- a/project/.claude/skills/api-design/SKILL.md
+++ b/project/.claude/skills/api-design/SKILL.md
@@ -21,20 +21,17 @@ model: sonnet
 - Implementing rate limiting or authentication
 - Code review for API endpoints
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### API Design
-
-- [API Design](reference/api-design.md)
+@reference/api-design.md
 
 ### Architecture
-
-- [Architecture and Design](reference/architecture.md)
+@reference/architecture.md
 
 ### Observability
-
-- [Logging Standards](reference/logging.md)
-- [Observability](reference/observability.md)
+@reference/logging.md
+@reference/observability.md
 
 ## Core Principles
 

--- a/project/.claude/skills/coding-guidelines/SKILL.md
+++ b/project/.claude/skills/coding-guidelines/SKILL.md
@@ -19,22 +19,19 @@ model: sonnet
 - Bug fixes requiring code changes
 - Refactoring tasks
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Core Standards
-
-- [General Coding Standards](reference/general.md)
-- [Code Quality](reference/quality.md)
+@reference/general.md
+@reference/quality.md
 
 ### Error & Safety
-
-- [Error Handling](reference/error-handling.md)
-- [Memory Management](reference/memory.md)
+@reference/error-handling.md
+@reference/memory.md
 
 ### Performance
-
-- [Concurrency](reference/concurrency.md)
-- [Performance](reference/performance.md)
+@reference/concurrency.md
+@reference/performance.md
 
 ## Core Principles
 

--- a/project/.claude/skills/documentation/SKILL.md
+++ b/project/.claude/skills/documentation/SKILL.md
@@ -20,19 +20,16 @@ model: sonnet
 - Cleaning up and organizing project files
 - Setting up linting and formatting tools
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Documentation Standards
-
-- [Documentation Standards](reference/documentation.md)
+@reference/documentation.md
 
 ### Language Conventions
-
-- [Code and Documentation Language](reference/communication.md)
+@reference/communication.md
 
 ### Project Cleanup
-
-- [Cleanup and Finalization](reference/cleanup.md)
+@reference/cleanup.md
 
 ## Core Principles
 

--- a/project/.claude/skills/performance-review/SKILL.md
+++ b/project/.claude/skills/performance-review/SKILL.md
@@ -52,12 +52,11 @@ Profiling → Identify bottlenecks → Optimize → Verify
 - [ ] Cache invalidation policy
 - [ ] Cache hit rate monitoring
 
-## Reference
-
-- [Performance Guidelines](reference/performance.md)
-- [Memory Management](reference/memory.md)
-- [Concurrency](reference/concurrency.md)
-- [Monitoring](reference/monitoring.md)
+## Reference Documents (Import Syntax)
+@reference/performance.md
+@reference/memory.md
+@reference/concurrency.md
+@reference/monitoring.md
 
 ## Caution
 

--- a/project/.claude/skills/project-workflow/SKILL.md
+++ b/project/.claude/skills/project-workflow/SKILL.md
@@ -21,26 +21,23 @@ model: sonnet
 - Managing builds and dependencies
 - Setting up testing infrastructure
 
-## Quick Reference
+## Reference Documents (Import Syntax)
 
 ### Workflow
-
-- [Workflow Guidelines](reference/workflow.md)
-- [Question Handling](reference/question-handling.md)
-- [Problem Solving](reference/workflow-problem-solving.md)
-- [Performance Analysis](reference/performance-analysis.md)
+@reference/workflow.md
+@reference/question-handling.md
+@reference/workflow-problem-solving.md
+@reference/performance-analysis.md
 
 ### GitHub
-
-- [GitHub Issue Guidelines (5W1H)](reference/github-issue-5w1h.md)
-- [GitHub PR Guidelines (5W1H)](reference/github-pr-5w1h.md)
-- [Git Commit Format](reference/git-commit-format.md)
+@reference/github-issue-5w1h.md
+@reference/github-pr-5w1h.md
+@reference/git-commit-format.md
 
 ### Project Management
-
-- [Problem-Solving Principles](reference/problem-solving.md)
-- [Build and Dependency Management](reference/build.md)
-- [Testing Strategy](reference/testing.md)
+@reference/problem-solving.md
+@reference/build.md
+@reference/testing.md
 
 ## Core Principles
 

--- a/project/.claude/skills/security-audit/SKILL.md
+++ b/project/.claude/skills/security-audit/SKILL.md
@@ -38,11 +38,10 @@ model: sonnet
 - [ ] Permission verification
 - [ ] Resource access control
 
-## Reference
-
-- [Security Guidelines](reference/security.md)
-- [Error Handling (Security)](reference/error-handling.md)
-- [API Security](reference/api-design.md)
+## Reference Documents (Import Syntax)
+@reference/security.md
+@reference/error-handling.md
+@reference/api-design.md
 
 ## OWASP Top 10 Reference
 

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -1,54 +1,54 @@
 # Universal Development Guidelines
 
-Version: 1.3.0
-Last Updated: 2026-01-15
+Version: 1.4.0
+Last Updated: 2026-01-22
 
 These guidelines define general conventions and practices for working in this repository. They emphasize clear procedures, maintainability, and security while allowing language‑specific details to be handled by the appropriate official guidelines.
 
 > **Note**: This project configuration works together with global settings in `~/.claude/CLAUDE.md`. When conflicts occur, project settings take precedence.
 
-## Quick Reference
+## Core Guidelines (Import Syntax)
 
-**CRITICAL:** Always consult [environment.md](claude-guidelines/environment.md) first for timezone and locale context.
+**CRITICAL:** Always consult environment settings first for timezone and locale context.
 
-<table>
-<tr>
-<td width="50%">
+### Environment & Workflow
+@claude-guidelines/environment.md
+@claude-guidelines/workflow.md
+@claude-guidelines/problem-solving.md
+@claude-guidelines/communication.md
+@claude-guidelines/git-commit-format.md
+@claude-guidelines/common-commands.md
 
-**Getting Started**
-- [Environment Settings](claude-guidelines/environment.md)
-- [Question Handling](claude-guidelines/workflow.md)
-- [Problem Solving](claude-guidelines/problem-solving.md)
-- [Language Conventions](claude-guidelines/communication.md)
-- [Common Commands](claude-guidelines/common-commands.md)
+### Code Standards
+@claude-guidelines/coding-standards/general.md
+@claude-guidelines/coding-standards/quality.md
+@claude-guidelines/coding-standards/error-handling.md
+@claude-guidelines/operations/cleanup.md
 
-</td>
-<td width="50%">
+### Technical
+@claude-guidelines/coding-standards/concurrency.md
+@claude-guidelines/coding-standards/memory.md
+@claude-guidelines/coding-standards/performance.md
 
-**Code Development**
-- [Coding Guidelines](claude-guidelines/coding-standards/general.md)
-- [Code Quality](claude-guidelines/coding-standards/quality.md)
-- [Error Handling](claude-guidelines/coding-standards/error-handling.md)
-- [Testing](claude-guidelines/project-management/testing.md)
+### Project Management
+@claude-guidelines/project-management/build.md
+@claude-guidelines/project-management/testing.md
+@claude-guidelines/project-management/documentation.md
 
-</td>
-</tr>
-</table>
+### Security & Operations
+@claude-guidelines/security.md
+@claude-guidelines/operations/monitoring.md
 
-## Guidelines Index
-
-| Category | Modules |
-|----------|---------|
-| **Environment & Workflow** | [Environment](claude-guidelines/environment.md), [Workflow](claude-guidelines/workflow.md), [Problem-Solving](claude-guidelines/problem-solving.md), [Communication](claude-guidelines/communication.md), [Git](claude-guidelines/git-commit-format.md), [Commands](claude-guidelines/common-commands.md) |
-| **Code Standards** | [General](claude-guidelines/coding-standards/general.md), [Quality](claude-guidelines/coding-standards/quality.md), [Error Handling](claude-guidelines/coding-standards/error-handling.md), [Cleanup](claude-guidelines/operations/cleanup.md) |
-| **Technical** | [Concurrency](claude-guidelines/coding-standards/concurrency.md), [Memory](claude-guidelines/coding-standards/memory.md), [Performance](claude-guidelines/coding-standards/performance.md) |
-| **Project Management** | [Build](claude-guidelines/project-management/build.md), [Testing](claude-guidelines/project-management/testing.md), [Documentation](claude-guidelines/project-management/documentation.md) |
-| **Security & Ops** | [Security](claude-guidelines/security.md), [Monitoring](claude-guidelines/operations/monitoring.md) |
-| **API & Architecture** | [API Design](claude-guidelines/api-architecture/api-design.md), [Logging](claude-guidelines/api-architecture/logging.md), [Observability](claude-guidelines/api-architecture/observability.md), [Architecture](claude-guidelines/api-architecture/architecture.md) |
+### API & Architecture
+@claude-guidelines/api-architecture/api-design.md
+@claude-guidelines/api-architecture/logging.md
+@claude-guidelines/api-architecture/observability.md
+@claude-guidelines/api-architecture/architecture.md
 
 ## Module Loading
 
-Modules are auto-loaded via **[Conditional Loading](claude-guidelines/conditional-loading.md)** based on task keywords and file types.
+Modules are auto-loaded via conditional loading based on task keywords and file types.
+@claude-guidelines/conditional-loading.md
 
 **Manual override:** `@load: security, performance` | `@skip: documentation` | `@focus: memory`
 
@@ -83,6 +83,9 @@ When adding new guidelines:
 
 ## Version History
 
+- **1.4.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
+  - Replaced markdown links with Import syntax for better token efficiency
+  - Supports recursive imports up to 5 levels deep
 - **1.3.0** (2026-01-15): Split github-issue-5w1h.md (1,214 → 225 lines) with reference/ directory
 - **1.2.1** (2026-01-15): Optimized conditional-loading.md (309 → 209 lines) for token efficiency
 - **1.2.0** (2026-01-15): Simplified CLAUDE.md (212 → ~85 lines) for token efficiency


### PR DESCRIPTION
Closes #61

## Summary
- Replaced markdown links with `@path/to/file` Import syntax in CLAUDE.md files
- Updated all SKILL.md files to use Import syntax for reference documents
- Updated README.md with Import syntax documentation and version bump to 1.4.0

## Changes Made
- **global/CLAUDE.md**: Converted configuration module links to Import syntax
- **project/CLAUDE.md**: Replaced guideline index with Import syntax references
- **SKILL.md files** (12 files): Updated reference sections to use Import syntax
- **README.md**: Added Import syntax documentation, updated version to 1.4.0

## Import Syntax Benefits
- More intuitive file references
- Support for up to 5 levels of recursive imports
- Both relative and absolute path support
- Automatic ignoring within code blocks

## Test Plan
- [ ] Verify Import syntax is correctly formatted in all files
- [ ] Confirm symbolic links in reference/ directories still work
- [ ] Test Claude Code recognizes the new Import syntax