### PR TITLE
refactor(docs): simplify CLAUDE.md files following best practices

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -1,12 +1,9 @@
 # Claude Code Global Configuration
 
-This is the global configuration for all Claude Code sessions. These settings apply across all projects unless overridden by project-specific `CLAUDE.md` files.
+Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files override these.
 
-## Configuration Modules (Import Syntax)
+## Core Settings (Import Syntax)
 
-The configuration is organized into focused modules using `@path/to/file` Import syntax:
-
-### Core Settings
 @token-management.md
 @conversation-language.md
 @git-identity.md
@@ -14,55 +11,24 @@ The configuration is organized into focused modules using `@path/to/file` Import
 
 ## Priority Rules
 
-**IMPORTANT:** These rules determine which settings take effect:
-
-1. **Project settings override global settings** - When a project has its own `CLAUDE.md`, those rules take precedence
-2. **Intelligent loading** - Claude Code uses conditional loading rules to automatically select relevant modules (see project's `conditional-loading.md`)
-3. **Explicit conflicts** - If project and global settings conflict, the project setting wins
-4. **Token optimization** - Automatic module selection reduces token usage by ~60-70%
+1. **Project overrides global** - Project `CLAUDE.md` takes precedence
+2. **Intelligent loading** - Auto-selects modules via `conditional-loading.md`
+3. **Token optimization** - Reduces usage by ~60-70%
 
 ## Quick Reference
 
-| Aspect | Global Setting | Override Location |
-|--------|---------------|-------------------|
+| Setting | Value | Override |
+|---------|-------|----------|
 | Response language | Korean | Project `communication.md` |
-| Git user info | (See git-identity.md) | Cannot override (personal identity) |
-| Commit message format | (Not specified) | Project `git-commit-format.md` |
-| Claude attribution | Disabled | (Not overridable) |
-| Code documentation language | (Not specified) | Project `documentation.md` |
-| Token display | Always show | (Not overridable) |
+| Git identity | System config | Not overridable |
+| Claude attribution | Disabled | Not overridable |
+| Token display | Always | Not overridable |
 
-## Usage Notes
+## Configuration Updates
 
-- These global settings emphasize **how** Claude Code interacts with you
-- Project-specific settings define **what** standards to follow for code and documentation
-- Both layers work together to provide consistent, personalized assistance
-
-## Updating Configuration
-
-To modify these settings:
-
-1. Edit the relevant module file (e.g., `token-management.md`)
-2. Changes take effect in new Claude Code sessions
-3. Existing sessions may need restart to apply updates
+1. Edit module files (e.g., `token-management.md`)
+2. Restart session to apply changes
 
 ---
 
-## Version History
-
-- **1.3.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
-  - Replaced markdown links with Import syntax
-  - Supports recursive imports up to 5 levels deep
-- **1.2.0** (2026-01-15): CLAUDE.md optimization for official best practices compliance
-  - Simplified project/CLAUDE.md (212 → ~85 lines)
-  - Added emphasis expressions for key rules
-  - Created common-commands.md
-  - Optimized conditional-loading.md
-  - Split github-issue-5w1h.md with Progressive Disclosure
-- **1.1.0** (2026-01-15): Added rules, commands, agents, MCP configuration
-- **1.0.0** (2025-12-03): Initial release with Skills system
-
----
-
-*Last updated: 2026-01-22*
-*Version: 1.3.0*
+*Version: 1.4.0 | Last updated: 2026-01-22*

--- a/global/VERSION_HISTORY.md
+++ b/global/VERSION_HISTORY.md
@@ -1,0 +1,23 @@
+# Global Configuration Version History
+
+## Changelog
+
+- **1.4.0** (2026-01-22): Simplified CLAUDE.md following official best practices
+  - Reduced global/CLAUDE.md from 67 to 34 lines
+  - Moved version history to separate file
+  - Focused on essential information only
+
+- **1.3.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
+  - Replaced markdown links with Import syntax
+  - Supports recursive imports up to 5 levels deep
+
+- **1.2.0** (2026-01-15): CLAUDE.md optimization for official best practices compliance
+  - Simplified project/CLAUDE.md (212 to ~85 lines)
+  - Added emphasis expressions for key rules
+  - Created common-commands.md
+  - Optimized conditional-loading.md
+  - Split github-issue-5w1h.md with Progressive Disclosure
+
+- **1.1.0** (2026-01-15): Added rules, commands, agents, MCP configuration
+
+- **1.0.0** (2025-12-03): Initial release with Skills system

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -1,15 +1,10 @@
 # Universal Development Guidelines
 
-Version: 1.4.0
-Last Updated: 2026-01-22
-
-These guidelines define general conventions and practices for working in this repository. They emphasize clear procedures, maintainability, and security while allowing language‑specific details to be handled by the appropriate official guidelines.
-
-> **Note**: This project configuration works together with global settings in `~/.claude/CLAUDE.md`. When conflicts occur, project settings take precedence.
+Universal conventions for this repository. Works with global settings in `~/.claude/CLAUDE.md`.
 
 ## Core Guidelines (Import Syntax)
 
-**CRITICAL:** Always consult environment settings first for timezone and locale context.
+**CRITICAL:** Always check environment settings first for timezone and locale.
 
 ### Environment & Workflow
 @claude-guidelines/environment.md
@@ -47,51 +42,26 @@ These guidelines define general conventions and practices for working in this re
 
 ## Module Loading
 
-Modules are auto-loaded via conditional loading based on task keywords and file types.
+Auto-loaded via conditional loading based on task keywords and file types.
 @claude-guidelines/conditional-loading.md
 
 **Manual override:** `@load: security, performance` | `@skip: documentation` | `@focus: memory`
 
-## Global vs Project Settings
+## Settings Priority
 
 | Scope | Controls |
 |-------|----------|
-| **Global** (`~/.claude/CLAUDE.md`) | Token display, conversation language, git identity |
-| **Project** (this file) | Code standards, commit format, testing requirements |
+| **Global** | Token display, conversation language, git identity |
+| **Project** | Code standards, commit format, testing requirements |
 
-**Priority:** Project settings override global settings when conflicts occur.
+Project settings override global when conflicts occur.
 
 ## Usage Notes
 
-- **Token Efficiency**: Reference only relevant guidelines for your specific task
-- **Language-Specific**: These are universal guidelines; defer to language-specific conventions (e.g., PEP 8 for Python, C++ Core Guidelines) when appropriate
-- **Examples**: Each guideline includes detailed, language-specific examples
-- **Progressive Depth**: Guidelines use collapsible sections for detailed examples
-- **Output Token Limit**: File generation may be interrupted due to output token limits. Use these strategies for large files:
-  1. Split files into logical sections and generate across multiple turns
-  2. Create basic structure first, then add content section by section using Edit tool
-  3. Generate within output token limit (~16,000 tokens) per response
-  4. Use clear markers to continue writing if generation is interrupted
-
-## Contributing
-
-When adding new guidelines:
-1. Follow the established format with collapsible example sections
-2. Include examples for multiple languages (TypeScript, Python, Kotlin, C++)
-3. Provide both good and bad examples
-4. Update this index with the new guideline
-
-## Version History
-
-- **1.4.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
-  - Replaced markdown links with Import syntax for better token efficiency
-  - Supports recursive imports up to 5 levels deep
-- **1.3.0** (2026-01-15): Split github-issue-5w1h.md (1,214 → 225 lines) with reference/ directory
-- **1.2.1** (2026-01-15): Optimized conditional-loading.md (309 → 209 lines) for token efficiency
-- **1.2.0** (2026-01-15): Simplified CLAUDE.md (212 → ~85 lines) for token efficiency
-- **1.1.0** (2025-12-03): Refactored workflow.md into 5 focused sub-modules for token efficiency
-- **1.0.0** (2025-12-03): Initial unified release with full guidelines
+- Defer to language-specific conventions (PEP 8, C++ Core Guidelines, etc.)
+- Guidelines include collapsible example sections
+- For large files: split across turns or use Edit tool incrementally
 
 ---
 
-*These guidelines emphasize clear procedures, maintainability, and security while allowing language‑specific details to be handled by official language style guides (C++ Core Guidelines, Kotlin conventions, PEP 8, etc.).*
+*Version: 1.5.0 | Last updated: 2026-01-22*

--- a/project/VERSION_HISTORY.md
+++ b/project/VERSION_HISTORY.md
@@ -1,0 +1,23 @@
+# Project Guidelines Version History
+
+## Changelog
+
+- **1.5.0** (2026-01-22): Simplified CLAUDE.md following official best practices
+  - Reduced project/CLAUDE.md from 97 to 67 lines
+  - Moved version history to separate file
+  - Removed redundant sections (Contributing, Output Token Limit details)
+  - Focused on essential information only
+
+- **1.4.0** (2026-01-22): Adopted Import syntax (`@path/to/file`) for modular references
+  - Replaced markdown links with Import syntax for better token efficiency
+  - Supports recursive imports up to 5 levels deep
+
+- **1.3.0** (2026-01-15): Split github-issue-5w1h.md (1,214 to 225 lines) with reference/ directory
+
+- **1.2.1** (2026-01-15): Optimized conditional-loading.md (309 to 209 lines) for token efficiency
+
+- **1.2.0** (2026-01-15): Simplified CLAUDE.md (212 to ~85 lines) for token efficiency
+
+- **1.1.0** (2025-12-03): Refactored workflow.md into 5 focused sub-modules for token efficiency
+
+- **1.0.0** (2025-12-03): Initial unified release with full guidelines


### PR DESCRIPTION
## Summary
- Reduce global/CLAUDE.md from 67 to 34 lines (49% reduction)
- Reduce project/CLAUDE.md from 97 to 67 lines (31% reduction)
- Move version history to separate VERSION_HISTORY.md files
- Remove redundant sections while preserving core instructions

## Changes
| File | Before | After | Reduction |
|------|--------|-------|-----------|
| global/CLAUDE.md | 67 lines | 34 lines | 49% |
| project/CLAUDE.md | 97 lines | 67 lines | 31% |

## Test Plan
- [x] Verify global/CLAUDE.md is under 50 lines
- [x] Verify project/CLAUDE.md is under 100 lines
- [x] Run verification script to ensure structure integrity
- [x] Confirm Import syntax references are preserved

Closes #62