### PR TITLE
feat(enterprise): add enterprise policy file support

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -107,6 +107,12 @@ claude --plugin-dir ./plugin
 
 ```
 claude_config_backup/
+├── enterprise/                  # Enterprise 설정 (시스템 전체)
+│   ├── CLAUDE.md               # 조직 전체 정책
+│   └── rules/                  # Enterprise 규칙
+│       ├── security.md         # 보안 규칙 템플릿
+│       └── compliance.md       # 컴플라이언스 규칙 템플릿
+│
 ├── global/                      # 글로벌 설정 백업 (~/.claude/)
 │   ├── CLAUDE.md               # 메인 설정 파일
 │   ├── settings.json           # Hook 설정 (보안, 세션, UserPromptSubmit, Stop)
@@ -220,6 +226,52 @@ claude_config_backup/
 ```
 
 </details>
+
+---
+
+## Enterprise 설정
+
+Enterprise 설정은 조직의 모든 개발자에게 적용되는 조직 전체 정책을 제공합니다. Claude Code의 메모리 계층에서 **가장 높은 우선순위**를 가집니다.
+
+### 메모리 계층
+
+| 레벨 | 위치 | 범위 | 우선순위 |
+|------|------|------|----------|
+| **Enterprise Policy** | 시스템 전체 | 조직 | **최고** |
+| Project Memory | `./CLAUDE.md` | 팀 | 높음 |
+| Project Rules | `./.claude/rules/*.md` | 팀 | 높음 |
+| User Memory | `~/.claude/CLAUDE.md` | 개인 | 중간 |
+| Project Local | `./CLAUDE.local.md` | 개인 | 낮음 |
+
+### OS별 Enterprise 경로
+
+| OS | 경로 |
+|----|------|
+| **macOS** | `/Library/Application Support/ClaudeCode/CLAUDE.md` |
+| **Linux** | `/etc/claude-code/CLAUDE.md` |
+| **Windows** | `C:\Program Files\ClaudeCode\CLAUDE.md` |
+
+### Enterprise 설정 설치
+
+```bash
+./scripts/install.sh
+
+# 옵션 선택:
+#   4) Enterprise 설정만 설치 (관리자 권한 필요)
+#   5) 전체 설치 (Enterprise + Global + Project)
+```
+
+**참고**: Enterprise 설치는 관리자 권한이 필요합니다 (macOS/Linux에서 `sudo`).
+
+### Enterprise 템플릿 내용
+
+기본 enterprise 템플릿에는 다음이 포함됩니다:
+- **보안 요구사항**: 커밋 서명, 비밀 정보 보호, 접근 제어
+- **컴플라이언스**: 데이터 처리, 감사 요구사항, 규정 준수
+- **승인된 도구**: 패키지 레지스트리, 컨테이너 이미지, 의존성
+- **코드 표준**: 품질 게이트, 리뷰 요구사항, 브랜치 보호
+
+배포 전에 조직의 정책에 맞게 `enterprise/CLAUDE.md`를 커스터마이즈하세요.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ See [plugin/README.md](plugin/README.md) for more details.
 
 ```
 claude_config_backup/
+├── enterprise/                  # Enterprise settings (system-wide)
+│   ├── CLAUDE.md               # Organization-wide policies
+│   └── rules/                  # Enterprise rules
+│       ├── security.md         # Security rules template
+│       └── compliance.md       # Compliance rules template
+│
 ├── global/                      # Global settings backup (~/.claude/)
 │   ├── CLAUDE.md               # Main configuration file
 │   ├── settings.json           # Hook settings (security, session, UserPromptSubmit, Stop)
@@ -259,6 +265,52 @@ This configuration includes automated Hook settings for enhanced security and pr
 - Rust: `rustfmt`
 
 For detailed configuration, see [HOOKS.md](HOOKS.md).
+
+---
+
+## Enterprise Settings
+
+Enterprise settings provide organization-wide policies that apply to all developers in your organization. These have the **highest priority** in Claude Code's memory hierarchy.
+
+### Memory Hierarchy
+
+| Level | Location | Scope | Priority |
+|-------|----------|-------|----------|
+| **Enterprise Policy** | System-wide | Organization | **Highest** |
+| Project Memory | `./CLAUDE.md` | Team | High |
+| Project Rules | `./.claude/rules/*.md` | Team | High |
+| User Memory | `~/.claude/CLAUDE.md` | Personal | Medium |
+| Project Local | `./CLAUDE.local.md` | Personal | Low |
+
+### Enterprise Paths by OS
+
+| OS | Path |
+|----|------|
+| **macOS** | `/Library/Application Support/ClaudeCode/CLAUDE.md` |
+| **Linux** | `/etc/claude-code/CLAUDE.md` |
+| **Windows** | `C:\Program Files\ClaudeCode\CLAUDE.md` |
+
+### Installing Enterprise Settings
+
+```bash
+./scripts/install.sh
+
+# Select option:
+#   4) Enterprise settings only (admin required)
+#   5) All (Enterprise + Global + Project)
+```
+
+**Note**: Enterprise installation requires administrator privileges (`sudo` on macOS/Linux).
+
+### Enterprise Template Contents
+
+The default enterprise template includes:
+- **Security Requirements**: Commit signing, secret protection, access control
+- **Compliance**: Data handling, audit requirements, regulatory compliance
+- **Approved Tools**: Package registries, container images, dependencies
+- **Code Standards**: Quality gates, review requirements, branch protection
+
+Customize `enterprise/CLAUDE.md` according to your organization's policies before deployment.
 
 ---
 

--- a/enterprise/CLAUDE.md
+++ b/enterprise/CLAUDE.md
@@ -1,0 +1,83 @@
+# Organization Policy
+
+This is the enterprise-level Claude Code configuration that applies to all users
+in the organization. Settings here have the highest priority in the memory hierarchy.
+
+> **Note**: This file should be placed in the system-wide location:
+> - **macOS**: `/Library/Application Support/ClaudeCode/CLAUDE.md`
+> - **Linux**: `/etc/claude-code/CLAUDE.md`
+> - **Windows**: `C:\Program Files\ClaudeCode\CLAUDE.md`
+
+## Security Requirements
+
+### Code Security
+- All commits must be signed with GPG keys
+- No secrets, API keys, or credentials in source code
+- Use environment variables or secret management tools for sensitive data
+- Required: security review for authentication-related changes
+
+### Access Control
+- Follow principle of least privilege
+- Document all permission requirements
+- Regular access audits required
+
+## Compliance
+
+### Data Handling
+- Follow organization's data classification policy
+- GDPR compliance for personal data
+- Audit logging for sensitive operations
+- Data retention policies must be followed
+
+### Documentation
+- All public APIs must be documented
+- Security-relevant decisions require ADR (Architecture Decision Records)
+- Change logs must be maintained
+
+## Approved Tools and Libraries
+
+### Package Management
+- Use only approved package registries
+- All dependencies must pass security scanning
+- Version pinning required for production dependencies
+
+### Container Images
+- Docker images must be from approved registry
+- Base images must be scanned and approved
+- No `latest` tags in production
+
+## Code Standards
+
+### Quality Gates
+- All code must pass linting before merge
+- Test coverage minimum: 80%
+- No high/critical security vulnerabilities
+
+### Review Requirements
+- All changes require code review
+- Security-sensitive changes require security team approval
+- Breaking changes require architecture review
+
+## Communication
+
+### Language Policy
+- Code comments: English
+- Documentation: English
+- Commit messages: English
+
+## Version Control
+
+### Branch Protection
+- Main branch is protected
+- Force push is prohibited
+- Squash merge preferred
+
+### Commit Standards
+- Conventional commits format required
+- Reference issue/ticket in commits
+- Sign-off required
+
+---
+
+*This is a template. Customize according to your organization's policies.*
+*Last updated: 2026-01-22*

--- a/enterprise/rules/compliance.md
+++ b/enterprise/rules/compliance.md
@@ -1,0 +1,51 @@
+# Compliance Rules
+
+Organization-wide compliance rules that apply to all projects.
+
+## Data Protection
+
+### Personal Data (GDPR/Privacy)
+- **MUST** obtain consent before collecting personal data
+- **MUST** provide data deletion capability
+- **MUST** encrypt personal data at rest and in transit
+- **MUST** document data processing activities
+
+### Data Classification
+- **MUST** classify data according to organization policy
+- **MUST** apply appropriate controls per classification
+- **MUST NOT** mix data of different classification levels
+
+## Audit Requirements
+
+### Logging
+- **MUST** log all data access events
+- **MUST** retain logs according to retention policy
+- **MUST** protect logs from tampering
+
+### Traceability
+- **MUST** maintain audit trail for sensitive operations
+- **MUST** link changes to authorized requests
+- **MUST** document security decisions
+
+## Regulatory Compliance
+
+### Industry Standards
+- **MUST** follow applicable industry standards (SOC2, ISO27001, etc.)
+- **MUST** document compliance status
+- **MUST** address compliance gaps timely
+
+### Legal Requirements
+- **MUST** comply with applicable laws and regulations
+- **MUST** consult legal team for uncertain cases
+- **MUST** document legal decisions
+
+## Third-Party Risk
+
+### Vendor Assessment
+- **MUST** assess third-party security before integration
+- **MUST** document third-party data flows
+- **MUST** review third-party agreements for compliance
+
+---
+
+*Customize these rules according to your organization's compliance requirements.*

--- a/enterprise/rules/security.md
+++ b/enterprise/rules/security.md
@@ -1,0 +1,37 @@
+# Security Rules
+
+Organization-wide security rules that apply to all projects.
+
+## Input Validation
+
+- **MUST** validate all external input
+- **MUST** sanitize data before database queries
+- **MUST** encode output to prevent XSS
+
+## Authentication
+
+- **MUST** use organization-approved authentication methods
+- **MUST NOT** store passwords in plain text
+- **MUST** implement rate limiting on auth endpoints
+
+## Secrets Management
+
+- **MUST NOT** commit secrets to version control
+- **MUST** use approved secret management tools
+- **MUST** rotate secrets according to policy
+
+## Dependencies
+
+- **MUST** scan dependencies for vulnerabilities
+- **MUST** keep dependencies updated
+- **MUST NOT** use deprecated packages with known vulnerabilities
+
+## Logging
+
+- **MUST** log security-relevant events
+- **MUST NOT** log sensitive data (passwords, tokens, PII)
+- **MUST** use structured logging format
+
+---
+
+*Customize these rules according to your organization's security policy.*


### PR DESCRIPTION
Closes #64

## Summary
- Add `enterprise/` directory with organization-wide policy templates
- Extend `install.sh` with Enterprise installation options (4, 5)
- Extend `backup.sh` with Enterprise backup capability
- Extend `sync.sh` with Enterprise sync capability
- Add OS-specific path detection for macOS, Linux, and Windows
- Update README documentation (English and Korean)

## Test Plan
- [ ] Verify `install.sh` option 4 installs Enterprise settings correctly
- [ ] Verify `install.sh` option 5 installs all settings
- [ ] Verify `backup.sh` option 4/5 backs up Enterprise settings
- [ ] Verify `sync.sh` handles Enterprise settings comparison and sync
- [ ] Verify scripts detect correct OS-specific paths
- [ ] Verify sudo permission handling works on macOS/Linux