### PR TITLE
feat(project): add CLAUDE.local.md template for personal settings

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -271,6 +271,70 @@ Enterprise 설정은 조직의 모든 개발자에게 적용되는 조직 전체
 
 ---
 
+## 개인 설정 (CLAUDE.local.md)
+
+버전 관리에 포함되지 않아야 하는 머신별 또는 개인 설정은 `CLAUDE.local.md`를 사용하세요.
+
+### CLAUDE.local.md란?
+
+| 항목 | 설명 |
+|------|------|
+| **목적** | 개인 프로젝트별 설정 |
+| **커밋 여부** | 아니오 (gitignore됨) |
+| **우선순위** | 낮음 (프로젝트/팀 설정에 의해 오버라이드됨) |
+| **위치** | 프로젝트 루트의 `./CLAUDE.local.md` |
+
+### CLAUDE.local.md 생성하기
+
+```bash
+# 템플릿 복사
+cp project/CLAUDE.local.md.template CLAUDE.local.md
+
+# 또는 설치 시
+./scripts/install.sh
+# 프로젝트 설치를 선택하고 CLAUDE.local.md 생성에 'y' 응답
+```
+
+### CLAUDE.local.md에 포함할 내용
+
+| 포함할 것 | 포함하지 말 것 |
+|-----------|----------------|
+| 로컬 서버 URL 및 포트 | 실제 자격 증명이나 비밀 정보 |
+| 머신별 경로 | 팀원들에게 필요한 정보 |
+| 개인 워크플로우 선호도 | 중요한 프로젝트 설정 |
+| 디버그/개발 오버라이드 | API 키 또는 토큰 |
+
+### 예시 내용
+
+```markdown
+# 개인 프로젝트 설정
+
+## 로컬 환경
+- API 서버: http://localhost:3000
+- 데이터베이스: localhost:5432
+
+## 개인 선호도
+- 에디터: VSCode
+- 테마: Dark+
+
+## 임시 오버라이드
+- 작업 중: feature/authentication
+- 상세 로깅: 활성화
+```
+
+### .gitignore 확인하기
+
+`CLAUDE.local.md`가 제대로 무시되는지 확인:
+
+```bash
+# gitignore 확인
+git check-ignore CLAUDE.local.md
+
+# 출력: CLAUDE.local.md
+```
+
+---
+
 ## 글로벌 명령어
 
 글로벌 명령어는 `~/.claude/commands/`에 설치되어 모든 프로젝트에서 사용 가능합니다.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,70 @@ Customize `enterprise/CLAUDE.md` according to your organization's policies befor
 
 ---
 
+## Personal Settings (CLAUDE.local.md)
+
+For machine-specific or personal settings that shouldn't be committed to version control, use `CLAUDE.local.md`.
+
+### What is CLAUDE.local.md?
+
+| Aspect | Description |
+|--------|-------------|
+| **Purpose** | Personal project-specific settings |
+| **Committed** | No (gitignored) |
+| **Priority** | Low (overridden by project/team settings) |
+| **Location** | `./CLAUDE.local.md` in project root |
+
+### Creating CLAUDE.local.md
+
+```bash
+# Copy the template
+cp project/CLAUDE.local.md.template CLAUDE.local.md
+
+# Or during installation
+./scripts/install.sh
+# Select project installation and answer 'y' to create CLAUDE.local.md
+```
+
+### What to Put in CLAUDE.local.md
+
+| Do Include | Do NOT Include |
+|------------|----------------|
+| Local server URLs and ports | Actual credentials or secrets |
+| Machine-specific paths | Information needed by team members |
+| Personal workflow preferences | Critical project configuration |
+| Debug/development overrides | API keys or tokens |
+
+### Example Content
+
+```markdown
+# Personal Project Settings
+
+## Local Environment
+- API Server: http://localhost:3000
+- Database: localhost:5432
+
+## Personal Preferences
+- Editor: VSCode
+- Theme: Dark+
+
+## Temporary Overrides
+- Working on: feature/authentication
+- Verbose logging: enabled
+```
+
+### Verifying .gitignore
+
+Ensure `CLAUDE.local.md` is properly ignored:
+
+```bash
+# Check if gitignored
+git check-ignore CLAUDE.local.md
+
+# Should output: CLAUDE.local.md
+```
+
+---
+
 ## Rules
 
 Rules are modular configuration files in `.claude/rules/` that are conditionally loaded based on file paths.

--- a/project/CLAUDE.local.md.template
+++ b/project/CLAUDE.local.md.template
@@ -1,47 +1,52 @@
-# Local Claude Code Configuration
+# Personal Project Settings
 
-This file contains personal settings that should NOT be committed to version control.
-Copy this file to `CLAUDE.local.md` and customize as needed.
-
-## Personal Preferences
-
-### Response Language
-- Preferred language: [Korean/English/etc.]
-
-### Communication Style
-- [Add your preferred communication style]
+> This file is gitignored and contains personal/machine-specific settings.
+> DO NOT commit this file to version control.
 
 ## Local Environment
 
-### Project Paths
-- Working directory: [your-path]
-- Build output: [your-path]
-
-### Local Services
+### Development Servers
+- API Server: http://localhost:3000
 - Database: localhost:5432
-- API: localhost:3000
+- Redis: localhost:6379
 
-## Personal Shortcuts
+### Environment Variables
+- NODE_ENV: development
+- DEBUG: true
 
-### Frequently Used Commands
-```bash
-# Add your common commands here
-npm run dev
-npm run test
-```
+## Personal Preferences
 
-### Custom Aliases
-- [Define any personal aliases or shortcuts]
+### IDE Configuration
+- Editor: VSCode
+- Theme: Dark+
+- Extensions: ESLint, Prettier
 
-## Notes
+### Workflow Preferences
+- Branch naming: feature/[initials]-[issue-number]-[description]
+- Commit style: Conventional Commits
 
-### Current Tasks
-- [ ] Task 1
-- [ ] Task 2
+## Machine-Specific Settings
 
-### Reminders
-- [Add personal reminders here]
+### Installed Tools
+- Node.js: v20.x
+- Python: 3.11
+- Docker: 24.x
+
+### Local Paths
+- Project data: ~/Development/data
+- Logs: ~/Development/logs
+
+## Temporary Overrides
+
+### Current Focus
+- Working on: [current feature/bug]
+- Skip: [modules to skip during development]
+
+### Debug Settings
+- Verbose logging: enabled
+- Mock external services: true
 
 ---
 
-*This file is ignored by git. Keep sensitive information here.*
+*Note: This file supports the same @import syntax as CLAUDE.md*
+*Copy this template to `CLAUDE.local.md` and customize as needed.*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,6 +66,33 @@ ensure_dir() {
     fi
 }
 
+# 함수: CLAUDE.local.md 생성
+create_local_claude() {
+    local project_dir="$1"
+    local local_file="$project_dir/CLAUDE.local.md"
+    local template_file="$BACKUP_DIR/project/CLAUDE.local.md.template"
+
+    # Create CLAUDE.local.md from template if not exists
+    if [ ! -f "$local_file" ]; then
+        if [ -f "$template_file" ]; then
+            cp "$template_file" "$local_file"
+            success "Created $local_file from template"
+        fi
+    else
+        info "CLAUDE.local.md already exists, skipping..."
+    fi
+
+    # Ensure gitignore entry
+    if [ -f "$project_dir/.gitignore" ]; then
+        if ! grep -q "CLAUDE.local.md" "$project_dir/.gitignore"; then
+            echo "" >> "$project_dir/.gitignore"
+            echo "# Claude Code local settings (personal, do not commit)" >> "$project_dir/.gitignore"
+            echo "CLAUDE.local.md" >> "$project_dir/.gitignore"
+            success "Added CLAUDE.local.md to .gitignore"
+        fi
+    fi
+}
+
 # 함수: Enterprise 경로 감지
 get_enterprise_dir() {
     case "$(uname -s)" in
@@ -301,6 +328,14 @@ if [ "$INSTALL_TYPE" = "2" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         success "Agents 디렉토리 설치 완료!"
     fi
 
+    # CLAUDE.local.md 생성 (개인 설정용)
+    echo ""
+    read -p "개인용 CLAUDE.local.md를 생성하시겠습니까? (y/n) [기본값: y]: " CREATE_LOCAL
+    CREATE_LOCAL=${CREATE_LOCAL:-y}
+    if [ "$CREATE_LOCAL" = "y" ]; then
+        create_local_claude "$PROJECT_DIR"
+    fi
+
     success "프로젝트 설정 설치 완료!"
 
     # 프로젝트별 커스터마이징 안내
@@ -308,6 +343,7 @@ if [ "$INSTALL_TYPE" = "2" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     info "프로젝트에 맞게 설정을 커스터마이즈하세요:"
     echo "  - CLAUDE.md: 프로젝트 개요 수정"
     echo "  - .claude/rules/: 프로젝트별 코딩 표준 조정"
+    echo "  - CLAUDE.local.md: 개인 환경 설정 (커밋 제외)"
 fi
 
 # 설치 완료 요약


### PR DESCRIPTION
## Summary
- Enhanced `CLAUDE.local.md.template` with comprehensive examples for local environment, personal preferences, and machine-specific settings
- Added `create_local_claude` function to `install.sh` for automatic template copying and .gitignore management
- Added Personal Settings documentation section to both README.md and README.ko.md

Closes #74

## Changes

### CLAUDE.local.md.template
- Added Local Environment section (Development Servers, Environment Variables)
- Added Personal Preferences section (IDE Configuration, Workflow Preferences)
- Added Machine-Specific Settings section (Installed Tools, Local Paths)
- Added Temporary Overrides section (Current Focus, Debug Settings)

### install.sh
- Added `create_local_claude()` function that:
  - Creates CLAUDE.local.md from template if not exists
  - Ensures .gitignore entry for CLAUDE.local.md
- Integrated function into project installation flow with user prompt

### Documentation
- Added "Personal Settings (CLAUDE.local.md)" section to README.md
- Added Korean translation to README.ko.md
- Included usage examples and best practices

## Test Plan
- [x] Verify template file content is correct
- [x] Run `./scripts/verify.sh` - passed (98% success rate, unrelated existing issue)
- [x] Verify .gitignore already contains CLAUDE.local.md entry
- [ ] Test install.sh with project installation option