### PR TITLE
fix(skills): update symlinks to use new .claude/rules paths

### DIFF
--- a/project/.claude/skills/api-design/reference/api-design.md
+++ b/project/.claude/skills/api-design/reference/api-design.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/api-architecture/api-design.md
+../../../rules/api/api-design.md

--- a/project/.claude/skills/api-design/reference/architecture.md
+++ b/project/.claude/skills/api-design/reference/architecture.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/api-architecture/architecture.md
+../../../rules/api/architecture.md

--- a/project/.claude/skills/api-design/reference/logging.md
+++ b/project/.claude/skills/api-design/reference/logging.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/api-architecture/logging.md
+../../../rules/api/logging.md

--- a/project/.claude/skills/api-design/reference/observability.md
+++ b/project/.claude/skills/api-design/reference/observability.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/api-architecture/observability.md
+../../../rules/api/observability.md

--- a/project/.claude/skills/coding-guidelines/reference/concurrency.md
+++ b/project/.claude/skills/coding-guidelines/reference/concurrency.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/concurrency.md
+../../../rules/coding/concurrency.md

--- a/project/.claude/skills/coding-guidelines/reference/error-handling.md
+++ b/project/.claude/skills/coding-guidelines/reference/error-handling.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/error-handling.md
+../../../rules/coding/error-handling.md

--- a/project/.claude/skills/coding-guidelines/reference/general.md
+++ b/project/.claude/skills/coding-guidelines/reference/general.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/general.md
+../../../rules/coding/general.md

--- a/project/.claude/skills/coding-guidelines/reference/memory.md
+++ b/project/.claude/skills/coding-guidelines/reference/memory.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/memory.md
+../../../rules/coding/memory.md

--- a/project/.claude/skills/coding-guidelines/reference/performance.md
+++ b/project/.claude/skills/coding-guidelines/reference/performance.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/performance.md
+../../../rules/coding/performance.md

--- a/project/.claude/skills/coding-guidelines/reference/quality.md
+++ b/project/.claude/skills/coding-guidelines/reference/quality.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/quality.md
+../../../rules/coding/quality.md

--- a/project/.claude/skills/documentation/reference/cleanup.md
+++ b/project/.claude/skills/documentation/reference/cleanup.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/operations/cleanup.md
+../../../rules/operations/cleanup.md

--- a/project/.claude/skills/documentation/reference/communication.md
+++ b/project/.claude/skills/documentation/reference/communication.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/communication.md
+../../../rules/core/communication.md

--- a/project/.claude/skills/documentation/reference/documentation.md
+++ b/project/.claude/skills/documentation/reference/documentation.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/project-management/documentation.md
+../../../rules/project-management/documentation.md

--- a/project/.claude/skills/performance-review/reference/concurrency.md
+++ b/project/.claude/skills/performance-review/reference/concurrency.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/concurrency.md
+../../../rules/coding/concurrency.md

--- a/project/.claude/skills/performance-review/reference/memory.md
+++ b/project/.claude/skills/performance-review/reference/memory.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/memory.md
+../../../rules/coding/memory.md

--- a/project/.claude/skills/performance-review/reference/monitoring.md
+++ b/project/.claude/skills/performance-review/reference/monitoring.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/operations/monitoring.md
+../../../rules/operations/monitoring.md

--- a/project/.claude/skills/performance-review/reference/performance.md
+++ b/project/.claude/skills/performance-review/reference/performance.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/performance.md
+../../../rules/coding/performance.md

--- a/project/.claude/skills/project-workflow/reference/build.md
+++ b/project/.claude/skills/project-workflow/reference/build.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/project-management/build.md
+../../../rules/project-management/build.md

--- a/project/.claude/skills/project-workflow/reference/git-commit-format.md
+++ b/project/.claude/skills/project-workflow/reference/git-commit-format.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/git-commit-format.md
+../../../rules/workflow/git-commit-format.md

--- a/project/.claude/skills/project-workflow/reference/github-issue-5w1h.md
+++ b/project/.claude/skills/project-workflow/reference/github-issue-5w1h.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow/github-issue-5w1h.md
+../../../rules/workflow/github-issue-5w1h.md

--- a/project/.claude/skills/project-workflow/reference/github-pr-5w1h.md
+++ b/project/.claude/skills/project-workflow/reference/github-pr-5w1h.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow/github-pr-5w1h.md
+../../../rules/workflow/github-pr-5w1h.md

--- a/project/.claude/skills/project-workflow/reference/performance-analysis.md
+++ b/project/.claude/skills/project-workflow/reference/performance-analysis.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow/performance-analysis.md
+../../../rules/workflow/performance-analysis.md

--- a/project/.claude/skills/project-workflow/reference/problem-solving.md
+++ b/project/.claude/skills/project-workflow/reference/problem-solving.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/problem-solving.md
+../../../rules/core/problem-solving.md

--- a/project/.claude/skills/project-workflow/reference/question-handling.md
+++ b/project/.claude/skills/project-workflow/reference/question-handling.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow/question-handling.md
+../../../rules/workflow/question-handling.md

--- a/project/.claude/skills/project-workflow/reference/testing.md
+++ b/project/.claude/skills/project-workflow/reference/testing.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/project-management/testing.md
+../../../rules/project-management/testing.md

--- a/project/.claude/skills/project-workflow/reference/workflow-problem-solving.md
+++ b/project/.claude/skills/project-workflow/reference/workflow-problem-solving.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow/problem-solving.md
+../../../rules/workflow/problem-solving.md

--- a/project/.claude/skills/project-workflow/reference/workflow.md
+++ b/project/.claude/skills/project-workflow/reference/workflow.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/workflow.md
+../../../rules/workflow/workflow.md

--- a/project/.claude/skills/security-audit/reference/api-design.md
+++ b/project/.claude/skills/security-audit/reference/api-design.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/api-architecture/api-design.md
+../../../rules/api/api-design.md

--- a/project/.claude/skills/security-audit/reference/error-handling.md
+++ b/project/.claude/skills/security-audit/reference/error-handling.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/coding-standards/error-handling.md
+../../../rules/coding/error-handling.md

--- a/project/.claude/skills/security-audit/reference/security.md
+++ b/project/.claude/skills/security-audit/reference/security.md
@@ -1,1 +1,1 @@
-../../../../claude-guidelines/security.md
+../../../rules/security.md


### PR DESCRIPTION
## Summary
- Update all skill reference symlinks to use the new `.claude/rules/` directory structure
- This completes the directory migration for skills started in #73

## What Changed
| Skill | Symlinks Updated |
|-------|------------------|
| api-design | 4 |
| coding-guidelines | 6 |
| documentation | 3 |
| performance-review | 4 |
| project-workflow | 10 |
| security-audit | 3 |

**Total**: 30 symlinks updated

## Why
The previous symlinks pointed to the legacy `claude-guidelines/` paths which are now consolidated into `.claude/rules/`. Although backward compatibility was maintained through a symlink (`claude-guidelines` -> `.claude/rules`), the nested directory structure changed:
- `api-architecture/` -> `api/`
- `coding-standards/` -> `coding/`
- Root files moved to `core/` or `workflow/`

This caused the skills reference symlinks to break.

## Test Plan
- [x] Verify all symlinks resolve correctly
- [x] Test reading files through symlinks

```bash
cat project/.claude/skills/api-design/reference/api-design.md | head -10
cat project/.claude/skills/coding-guidelines/reference/general.md | head -10
```

Closes #73