### PR TITLE
feat(config): migrate .claudeignore to settings.json permissions.deny

### DIFF
--- a/global/.claudeignore
+++ b/global/.claudeignore
@@ -1,4 +1,11 @@
-# Claude Code Ignore File (Global Configuration)
+# DEPRECATED: .claudeignore is not an official Claude Code feature
+# See: https://github.com/anthropics/claude-code/issues/579
+#
+# Migration Status:
+# - Security-related exclusions moved to settings.json permissions.deny
+# - Token optimization exclusions remain here as .claudeignore may work in some versions
+#
+# Original: Claude Code Ignore File (Global Configuration)
 # Optimizes token usage by excluding unnecessary files from context
 
 # Session memory (past conversations)

--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Claude Code Global Settings - Applied to all projects",
-  "version": "1.2.0",
+  "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
+  "version": "1.3.0",
 
   "statusLine": {
     "type": "command",

--- a/plugin/.claudeignore
+++ b/plugin/.claudeignore
@@ -1,4 +1,11 @@
-# Claude Code Ignore File (Plugin Configuration)
+# DEPRECATED: .claudeignore is not an official Claude Code feature
+# See: https://github.com/anthropics/claude-code/issues/579
+#
+# Migration Status:
+# - Security-related exclusions moved to settings.json permissions.deny
+# - Token optimization exclusions remain here as .claudeignore may work in some versions
+#
+# Original: Claude Code Ignore File (Plugin Configuration)
 # Optimizes token usage by excluding unnecessary files from context
 
 # NPM cache

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -1,9 +1,36 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Claude Code 프로젝트 설정 - 자동 포매팅 및 코드 품질",
-  "version": "1.1.0",
+  "description": "Claude Code project settings - auto-formatting, code quality, and permissions",
+  "version": "1.2.0",
 
   "alwaysThinkingEnabled": true,
+
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/credentials/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/*password*)",
+      "Read(./.npm-cache/**)",
+      "Read(**/node_modules/**)",
+      "Read(**/dist/**)",
+      "Read(**/build/**)",
+      "Write(./.env)",
+      "Write(./.env.*)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Edit(./.env)",
+      "Edit(./.env.*)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)"
+    ]
+  },
 
   "hooks": {
     "PostToolUse": [

--- a/project/.claudeignore
+++ b/project/.claudeignore
@@ -1,4 +1,12 @@
-# Aggressive Token Optimization v1.2.0
+# DEPRECATED: .claudeignore is not an official Claude Code feature
+# See: https://github.com/anthropics/claude-code/issues/579
+#
+# Migration Status:
+# - Security-related exclusions moved to settings.json permissions.deny
+# - Token optimization exclusions remain here as .claudeignore may work in some versions
+# - See docs/TOKEN_OPTIMIZATION.md for details
+#
+# Original: Aggressive Token Optimization v1.2.0
 # Excludes EVERYTHING except core essentials
 # Command-specific modules are loaded on demand (see conditional-loading.md)
 


### PR DESCRIPTION
## Summary

- Add `permissions.deny` rules to `settings.json` for official security-focused file exclusions
- Mark `.claudeignore` files as deprecated with migration notes
- Update `TOKEN_OPTIMIZATION.md` documentation to explain official vs experimental features

## Why

`.claudeignore` is **not an official Claude Code feature** (see [GitHub Issue #579](https://github.com/anthropics/claude-code/issues/579)). This PR migrates security-related file exclusions to the official `permissions.deny` configuration while documenting the deprecated status of `.claudeignore`.

## Related Issues

Closes #87

## Changes

| File | Change |
|------|--------|
| `project/.claude/settings.json` | Added `permissions.deny` rules for security |
| `global/settings.json` | Updated version to 1.3.0 |
| `global/.claudeignore` | Marked as deprecated |
| `project/.claudeignore` | Marked as deprecated |
| `plugin/.claudeignore` | Marked as deprecated |
| `docs/TOKEN_OPTIMIZATION.md` | Updated with official feature status and migration guide |

## Key Differences

| Feature | `permissions.deny` (Official) | `.claudeignore` (Deprecated) |
|---------|-------------------------------|------------------------------|
| Purpose | Security - block sensitive files | Token optimization |
| Status | Official Claude Code feature | Experimental/Unsupported |
| Effect | Blocks tool access to files | May reduce context loading |

## Test Plan

- [x] Verify `permissions.deny` rules are valid JSON
- [x] Verify `.claudeignore` files have deprecation notices
- [x] Documentation updated with migration guide
- [ ] Manual testing in Claude Code session

## Breaking Changes

None - `.claudeignore` files are retained for backward compatibility.