### PR TITLE
feat(settings): add official settings.json options for language and attribution

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -19,14 +19,26 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 
 ## Quick Reference
 
-| Setting | Value | Override |
-|---------|-------|----------|
-| Response language | Korean | Project `communication.md` |
-| Git identity | System config | Not overridable |
-| Claude attribution | Disabled | Not overridable |
-| Token display | Always | Not overridable |
+| Setting | Source | Value | Override |
+|---------|--------|-------|----------|
+| Response language | `settings.json` | Korean | Project `settings.json` |
+| Git identity | System git config | User's config | Not overridable |
+| Claude attribution | `settings.json` | Disabled | Not overridable |
+| Output style | `settings.json` | Explanatory | Project `settings.json` |
 
-**NEVER** include Claude/AI attribution in commits, issues, or PRs (see `commit-settings.md`).
+## Official Settings (settings.json)
+
+Key behaviors are now configured via official `settings.json` options:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `language` | `"korean"` | Default response language |
+| `attribution.commit` | `""` | No Claude attribution in commits |
+| `attribution.pr` | `""` | No Claude attribution in PRs |
+| `outputStyle` | `"Explanatory"` | Detailed explanations |
+| `showTurnDuration` | `true` | Display turn timing |
+
+See `settings.json` for the complete configuration.
 
 ## Token Optimization
 
@@ -52,4 +64,4 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 
 ---
 
-*Version: 1.4.0 | Last updated: 2026-01-22*
+*Version: 1.5.0 | Last updated: 2026-02-03*

--- a/global/commit-settings.md
+++ b/global/commit-settings.md
@@ -1,5 +1,20 @@
 # Commit, Issue, and PR Settings
 
+## Official Attribution Setting
+
+Attribution is now disabled via official `settings.json`:
+
+```json
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}
+```
+
+This setting removes Claude attribution from all commits and PRs automatically.
+
 ## Claude Attribution Policy
 
 **NEVER** include Claude-related information in commits, issues, and pull requests.
@@ -78,9 +93,10 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 ## Implementation
 
 This policy is enforced through:
-1. This configuration file (instruction to Claude Code)
-2. Optional git hooks (see `git-commit-format.md` for hook setup)
+1. Official `settings.json` attribution setting (primary)
+2. This configuration file (backup instruction to Claude Code)
+3. Optional git hooks (see `git-commit-format.md` for hook setup)
 
 ---
 
-*Version: 1.0.0*
+*Version: 1.1.0*

--- a/global/conversation-language.md
+++ b/global/conversation-language.md
@@ -3,6 +3,18 @@
 > **Scope**: This file controls Claude's **conversation language only**.
 > **For code/documentation languages**: See project-specific `communication.md`
 
+## Official Setting
+
+Language is now configured via official `settings.json`:
+
+```json
+{
+  "language": "korean"
+}
+```
+
+This setting is applied in both `global/settings.json` and `project/.claude/settings.json`.
+
 ## Core Principle
 
 Claude communicates with users in their preferred language while maintaining technical accuracy.
@@ -10,7 +22,7 @@ Claude communicates with users in their preferred language while maintaining tec
 ## Language Configuration
 
 ### User Interaction
-- **Default response language**: Korean
+- **Default response language**: Korean (via `settings.json`)
 - **YOU MUST** respond in Korean unless the user explicitly requests English
 - **Language switching**: Honor explicit user requests to change language
 - **Consistency**: Maintain chosen language throughout session
@@ -59,4 +71,4 @@ Claude communicates with users in their preferred language while maintaining tec
 3. Technical accuracy > Language preference (when conflict exists)
 
 ---
-*Part of Claude's global configuration. Version 1.1.0*
+*Part of Claude's global configuration. Version 1.2.0*

--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.3.0",
+  "version": "1.4.0",
+
+  "language": "korean",
+
+  "outputStyle": "Explanatory",
+
+  "showTurnDuration": true,
+
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+
+  "spinnerVerbs": {
+    "mode": "append",
+    "verbs": ["Analyzing", "Reviewing", "Composing"]
+  },
 
   "statusLine": {
     "type": "command",

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -1,7 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code project settings - auto-formatting, code quality, and permissions",
-  "version": "1.2.0",
+  "version": "1.3.0",
+
+  "language": "korean",
+
+  "outputStyle": "Explanatory",
+
+  "showTurnDuration": true,
+
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+
+  "spinnerVerbs": {
+    "mode": "append",
+    "verbs": ["Analyzing", "Reviewing", "Composing"]
+  },
 
   "alwaysThinkingEnabled": true,
 


### PR DESCRIPTION
Closes #90

## Summary

- Add official `settings.json` options for language, attribution, and output style
- Replace CLAUDE.md instruction-based configuration with official settings
- Update documentation to reference the new settings

## Changes Made

### settings.json Updates (both global and project)

| Setting | Value | Purpose |
|---------|-------|---------|
| `language` | `"korean"` | Default response language |
| `attribution.commit` | `""` | Disable Claude attribution in commits |
| `attribution.pr` | `""` | Disable Claude attribution in PRs |
| `outputStyle` | `"Explanatory"` | Detailed explanations |
| `showTurnDuration` | `true` | Display turn timing |
| `spinnerVerbs` | Custom verbs | Enhanced spinner feedback |

### Documentation Updates

- `global/CLAUDE.md`: Added "Official Settings" section with settings reference
- `global/conversation-language.md`: Added reference to `settings.json` language setting
- `global/commit-settings.md`: Added reference to official attribution setting

## Test Plan

- [ ] Verify language setting works (responses in Korean)
- [ ] Verify attribution is removed from commits
- [ ] Verify attribution is removed from PRs
- [ ] Verify showTurnDuration displays timing
- [ ] Verify spinnerVerbs appear in spinner