### PR TITLE
feat(hooks): modernize hook response format to use hookSpecificOutput

### DIFF
--- a/global/hooks/cleanup.sh
+++ b/global/hooks/cleanup.sh
@@ -3,9 +3,18 @@
 # Cleans up temporary files created during session
 # Hook Type: SessionEnd
 # Exit codes: 0=success
+# Response format: hookSpecificOutput (modern format)
 
 # Clean up temporary Claude files (older than 60 minutes)
 find /tmp -maxdepth 1 -name "claude_*" -mmin +60 -delete 2>/dev/null
 find /tmp -maxdepth 1 -name "tmp.*" -user "$(whoami)" -mmin +60 -delete 2>/dev/null
 
+# Output modern response format
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
 exit 0

--- a/global/hooks/dangerous-command-guard.sh
+++ b/global/hooks/dangerous-command-guard.sh
@@ -3,25 +3,45 @@
 # Blocks dangerous bash commands
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0=allow, 2=block
+# Response format: hookSpecificOutput (modern format)
 
 CMD="${CLAUDE_TOOL_INPUT:-}"
 
+# Helper function for deny response
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 2
+}
+
 # Block recursive delete at root
 if echo "$CMD" | grep -qE 'rm\s+(-rf|--recursive)\s+/($|[^a-zA-Z])'; then
-    echo "[BLOCKED] Dangerous delete command blocked" >&2
-    exit 2
+    deny_response "Dangerous recursive delete at root directory blocked for safety"
 fi
 
 # Block dangerous chmod
 if echo "$CMD" | grep -qE 'chmod\s+(777|a\+rwx)'; then
-    echo "[BLOCKED] Dangerous permission change blocked" >&2
-    exit 2
+    deny_response "Dangerous permission change (777/a+rwx) blocked for security"
 fi
 
 # Block remote script execution
 if echo "$CMD" | grep -qE '(curl|wget).*\|.*sh'; then
-    echo "[BLOCKED] Remote script execution blocked" >&2
-    exit 2
+    deny_response "Remote script execution via pipe blocked for security"
 fi
 
+# Allow the command
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
 exit 0

--- a/global/hooks/prompt-validator.sh
+++ b/global/hooks/prompt-validator.sh
@@ -3,17 +3,44 @@
 # Validates user prompts for dangerous operations
 # Hook Type: UserPromptSubmit
 # Exit codes: 0=allow (with optional warning)
+# Response format: hookSpecificOutput (modern format)
 
 PROMPT="${CLAUDE_USER_PROMPT:-}"
 
+# Helper function for allow response with warning
+allow_with_warning() {
+    local warning="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  },
+  "systemMessage": "$warning"
+}
+EOF
+    exit 0
+}
+
+# Helper function for allow response
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
 # Skip if no prompt provided
 if [ -z "$PROMPT" ]; then
-    exit 0
+    allow_response
 fi
 
 # Check for dangerous operation requests
 if echo "$PROMPT" | grep -qiE '(delete|remove|drop)\s+(all|entire|whole|database|table|production)'; then
-    echo "[WARNING] Dangerous operation request detected. Proceed with caution." >&2
+    allow_with_warning "Warning: Dangerous operation request detected. Proceed with caution and verify the scope of changes."
 fi
 
-exit 0
+allow_response

--- a/global/hooks/sensitive-file-guard.sh
+++ b/global/hooks/sensitive-file-guard.sh
@@ -3,24 +3,49 @@
 # Blocks access to sensitive files
 # Hook Type: PreToolUse (Edit|Write|Read)
 # Exit codes: 0=allow, 2=block
+# Response format: hookSpecificOutput (modern format)
 
 FILE="${CLAUDE_FILE_PATH:-}"
 
-# Skip if no file path provided
-if [ -z "$FILE" ]; then
+# Helper function for deny response
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 2
+}
+
+# Helper function for allow response
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
     exit 0
+}
+
+# Skip if no file path provided (allow by default)
+if [ -z "$FILE" ]; then
+    allow_response
 fi
 
 # Check sensitive file extensions
 if echo "$FILE" | grep -qE '\.(env|pem|key|p12|pfx)$'; then
-    echo "[BLOCKED] Sensitive file access blocked: $FILE" >&2
-    exit 2
+    deny_response "Access to sensitive file blocked: $FILE (protected extension)"
 fi
 
 # Check sensitive directories
 if echo "$FILE" | grep -qiE '(secrets|credentials|passwords|private)[/\\]'; then
-    echo "[BLOCKED] Sensitive directory access blocked: $FILE" >&2
-    exit 2
+    deny_response "Access to sensitive directory blocked: $FILE (protected path)"
 fi
 
-exit 0
+allow_response

--- a/global/hooks/session-logger.sh
+++ b/global/hooks/session-logger.sh
@@ -3,6 +3,7 @@
 # Logs session start/end events
 # Hook Type: SessionStart, SessionEnd, Stop
 # Usage: session-logger.sh [start|end|stop]
+# Response format: hookSpecificOutput (modern format)
 
 LOG_FILE="${HOME}/.claude/session.log"
 TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
@@ -25,4 +26,12 @@ case "${1:-}" in
         ;;
 esac
 
+# Output modern response format
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
 exit 0


### PR DESCRIPTION
Closes #99

## Summary
- Update all hook scripts to use modern `hookSpecificOutput` JSON response format
- Replace simple exit codes + stderr messages with structured JSON responses
- Add clear `permissionDecision` and `permissionDecisionReason` fields for deny cases
- Add `systemMessage` support for warnings in prompt-validator

## Changes

| Script | Before | After |
|--------|--------|-------|
| dangerous-command-guard.sh | `echo "[BLOCKED]..." >&2; exit 2` | JSON with deny reason |
| sensitive-file-guard.sh | `echo "[BLOCKED]..." >&2; exit 2` | JSON with deny reason |
| prompt-validator.sh | `echo "[WARNING]..." >&2` | JSON with systemMessage |
| session-logger.sh | Simple exit 0 | JSON response |
| cleanup.sh | Simple exit 0 | JSON response |

## New Response Format

Allow response:
```json
{
  "hookSpecificOutput": {
    "permissionDecision": "allow"
  }
}
```

Deny response:
```json
{
  "hookSpecificOutput": {
    "permissionDecision": "deny",
    "permissionDecisionReason": "Explanation of why blocked"
  }
}
```

## Test Plan
- [x] All scripts pass bash syntax check (`bash -n`)
- [x] dangerous-command-guard.sh: Allows safe commands, blocks `rm -rf /`
- [x] sensitive-file-guard.sh: Allows normal files, blocks `.env` and sensitive paths
- [x] All JSON outputs validated with `jq`