### PR TITLE
feat(settings): add explicit respectGitignore and cleanupPeriodDays settings

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.4.0",
+  "version": "1.5.0",
+
+  "respectGitignore": true,
+  "cleanupPeriodDays": 30,
 
   "language": "korean",
 

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code project settings - auto-formatting, code quality, and permissions",
-  "version": "1.4.0",
+  "version": "1.5.0",
+
+  "respectGitignore": true,
+  "cleanupPeriodDays": 30,
 
   "language": "korean",
 


### PR DESCRIPTION
## Summary
- Add `respectGitignore: true` to both global and project settings for explicit gitignore file exclusion
- Add `cleanupPeriodDays: 30` for automatic session cleanup configuration
- Bump settings version to 1.5.0

## Changes Made
These settings match the default behavior but are now explicitly documented in configuration:

| Setting | Value | Purpose |
|---------|-------|---------|
| `respectGitignore` | `true` | Skip files in .gitignore from context |
| `cleanupPeriodDays` | `30` | Auto-delete inactive sessions after 30 days |

## Files Modified
- `global/settings.json` - Global settings for all projects
- `project/.claude/settings.json` - Project-specific settings

## Test Plan
- [x] Settings are valid JSON
- [x] No breaking changes - matches existing default behavior
- [ ] Verify settings are recognized by Claude Code

Closes #100