### PR TITLE
feat(hooks): add PostToolUseFailure and Subagent monitoring hooks

### DIFF
--- a/global/hooks/subagent-logger.sh
+++ b/global/hooks/subagent-logger.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Subagent Logger Hook
+# Logs subagent start/stop events for monitoring
+#
+# Usage: subagent-logger.sh <start|stop>
+#
+# Environment variables available:
+# - CLAUDE_SUBAGENT_TYPE: Type of subagent (e.g., "Bash", "Explore", "Plan")
+# - CLAUDE_SESSION_ID: Current session ID
+
+set -euo pipefail
+
+ACTION="${1:-unknown}"
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/subagents.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+SUBAGENT_TYPE="${CLAUDE_SUBAGENT_TYPE:-unknown}"
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+
+echo "[${TIMESTAMP}] Session ${SESSION_ID}: Subagent ${ACTION} - ${SUBAGENT_TYPE}" >> "$LOG_FILE"
+
+exit 0

--- a/global/hooks/tool-failure-logger.sh
+++ b/global/hooks/tool-failure-logger.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Tool Failure Logger Hook
+# Logs tool execution failures for debugging and analysis
+#
+# Environment variables available:
+# - CLAUDE_TOOL_NAME: Name of the tool that failed
+# - CLAUDE_TOOL_INPUT: Input provided to the tool (JSON)
+# - CLAUDE_TOOL_ERROR: Error message from the tool
+# - CLAUDE_SESSION_ID: Current session ID
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/tool-failures.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+TOOL_NAME="${CLAUDE_TOOL_NAME:-unknown}"
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+
+{
+    echo "=== Tool Failure at ${TIMESTAMP} ==="
+    echo "Session: ${SESSION_ID}"
+    echo "Tool: ${TOOL_NAME}"
+    if [ -n "${CLAUDE_TOOL_ERROR:-}" ]; then
+        echo "Error: ${CLAUDE_TOOL_ERROR}"
+    fi
+    echo "---"
+} >> "$LOG_FILE"
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.5.0",
+  "version": "1.6.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -90,6 +90,42 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/session-logger.sh stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/tool-failure-logger.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/subagent-logger.sh start",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/subagent-logger.sh stop",
             "timeout": 5
           }
         ]

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code project settings - auto-formatting, code quality, and permissions",
-  "version": "1.5.0",
+  "version": "1.6.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -71,6 +71,42 @@
             "type": "command",
             "command": "bash -c 'FILE=\"${CLAUDE_FILE_PATH:-}\"; if [ -z \"$FILE\" ] || [ ! -f \"$FILE\" ]; then exit 0; fi; EXT=\"${FILE##*.}\"; case \"$EXT\" in py) if command -v black >/dev/null 2>&1; then black --quiet \"$FILE\" 2>/dev/null; fi; if command -v isort >/dev/null 2>&1; then isort --quiet \"$FILE\" 2>/dev/null; fi;; ts|tsx|js|jsx|json|md) if command -v npx >/dev/null 2>&1 && [ -f \"$(dirname \"$FILE\")/node_modules/.bin/prettier\" ] || command -v prettier >/dev/null 2>&1; then npx prettier --write \"$FILE\" 2>/dev/null; fi;; cpp|cc|cxx|h|hpp|hxx) if command -v clang-format >/dev/null 2>&1; then clang-format -i \"$FILE\" 2>/dev/null; fi;; kt|kts) if command -v ktlint >/dev/null 2>&1; then ktlint -F \"$FILE\" 2>/dev/null; fi;; go) if command -v gofmt >/dev/null 2>&1; then gofmt -w \"$FILE\" 2>/dev/null; fi;; rs) if command -v rustfmt >/dev/null 2>&1; then rustfmt \"$FILE\" 2>/dev/null; fi;; esac; exit 0'",
             "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Tool failure: ${CLAUDE_TOOL_NAME:-unknown}\" >> \"${LOG_DIR}/tool-failures.log\"'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent start: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent stop: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `PostToolUseFailure` hook for logging tool execution failures
- Add `SubagentStart` and `SubagentStop` hooks for monitoring subagent activity
- Create dedicated hook scripts for global settings

## Changes Made

### New Hook Events

| Event | Purpose | Log Location |
|-------|---------|--------------|
| `PostToolUseFailure` | Log tool failures for debugging | `~/.claude/logs/tool-failures.log` |
| `SubagentStart` | Track when subagents spawn | `~/.claude/logs/subagents.log` |
| `SubagentStop` | Track when subagents complete | `~/.claude/logs/subagents.log` |

### New Hook Scripts

- `global/hooks/tool-failure-logger.sh` - Detailed failure logging with timestamp, tool name, and error
- `global/hooks/subagent-logger.sh` - Subagent lifecycle tracking

### Implementation Notes

- Global settings use external script files for maintainability
- Project settings use inline bash commands for portability
- All hooks use async-safe logging (append to file)
- Logs are stored in `~/.claude/logs/` directory

## Files Modified
- `global/settings.json` - Add new hook configurations
- `project/.claude/settings.json` - Add new hook configurations
- `global/hooks/tool-failure-logger.sh` - New script
- `global/hooks/subagent-logger.sh` - New script

## Test Plan
- [ ] Verify JSON validity
- [ ] Verify hook scripts are executable
- [ ] Trigger tool failure to test PostToolUseFailure hook
- [ ] Spawn subagent to test SubagentStart/Stop hooks

Closes #101