### PR TITLE
feat(hooks): adopt async execution for non-blocking hooks

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -36,6 +36,8 @@ These features are part of the official Claude Code product and are portable:
 | **YAML frontmatter** | `paths` and `alwaysApply` for conditional loading | Official feature |
 | **settings.json** | Hook configuration (PreToolUse, PostToolUse, etc.) | Official feature |
 | **Hook events** | SessionStart, SessionEnd, UserPromptSubmit, Stop, etc. | Official feature |
+| **Hook types** | `command`, `prompt`, `agent` types for different validation strategies | Official feature |
+| **Async hooks** | `async: true` for non-blocking hook execution | Official feature |
 | **`.claudeignore`** | Exclude files from context loading | Official feature |
 | **Skills** | SKILL.md with name and description frontmatter | Official feature |
 | **Agents** | Agent configuration files | Official feature |
@@ -71,6 +73,63 @@ The following features exist as **design documents only** and are **NOT implemen
 These documents serve as **architectural references** for potential future implementation or as examples for other projects, but they do **not affect Claude Code behavior**.
 
 ## Detailed Breakdown
+
+### Hook Types and Async Execution (Official)
+
+**Type**: Official feature
+
+Claude Code supports three types of hooks for different validation strategies:
+
+| Hook Type | Description | Use Case |
+|-----------|-------------|----------|
+| `command` | Execute shell scripts | Complex validation, external tools |
+| `prompt` | LLM yes/no decision | Simple safety checks, no scripting needed |
+| `agent` | Multi-turn tool verification | Deep validation with Read/Grep access |
+
+**Command Hook** (default):
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/validate.sh",
+  "timeout": 30
+}
+```
+
+**Prompt Hook** (AI-based):
+```json
+{
+  "type": "prompt",
+  "prompt": "Does this action follow security best practices? Answer yes or no."
+}
+```
+
+**Agent Hook** (multi-turn):
+```json
+{
+  "type": "agent",
+  "prompt": "Verify this follows coding standards",
+  "tools": ["Read", "Grep"],
+  "timeout": 30000
+}
+```
+
+**Async Execution**:
+
+For non-blocking operations (formatting, logging), use `async: true`:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/format.sh",
+  "async": true,
+  "timeout": 30
+}
+```
+
+**When to use async**:
+- ✅ PostToolUse formatting hooks
+- ✅ Logging hooks (PostToolUseFailure, SubagentStart/Stop)
+- ❌ PreToolUse security validation (must block until verified)
+- ❌ SessionStart environment setup (must complete before use)
 
 ### Import Syntax (`@path/to/file`)
 
@@ -166,4 +225,4 @@ If a feature from this configuration doesn't work:
 
 ---
 
-*Version: 1.1.0 | Last updated: 2026-02-03*
+*Version: 1.2.0 | Last updated: 2026-02-04*

--- a/global/settings.json
+++ b/global/settings.json
@@ -122,7 +122,8 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/tool-failure-logger.sh",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }
@@ -134,7 +135,8 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/subagent-logger.sh start",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }
@@ -146,7 +148,8 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/subagent-logger.sh stop",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -90,7 +90,8 @@
           {
             "type": "command",
             "command": "bash -c 'FILE=\"${CLAUDE_FILE_PATH:-}\"; if [ -z \"$FILE\" ] || [ ! -f \"$FILE\" ]; then exit 0; fi; EXT=\"${FILE##*.}\"; case \"$EXT\" in py) if command -v black >/dev/null 2>&1; then black --quiet \"$FILE\" 2>/dev/null; fi; if command -v isort >/dev/null 2>&1; then isort --quiet \"$FILE\" 2>/dev/null; fi;; ts|tsx|js|jsx|json|md) if command -v npx >/dev/null 2>&1 && [ -f \"$(dirname \"$FILE\")/node_modules/.bin/prettier\" ] || command -v prettier >/dev/null 2>&1; then npx prettier --write \"$FILE\" 2>/dev/null; fi;; cpp|cc|cxx|h|hpp|hxx) if command -v clang-format >/dev/null 2>&1; then clang-format -i \"$FILE\" 2>/dev/null; fi;; kt|kts) if command -v ktlint >/dev/null 2>&1; then ktlint -F \"$FILE\" 2>/dev/null; fi;; go) if command -v gofmt >/dev/null 2>&1; then gofmt -w \"$FILE\" 2>/dev/null; fi;; rs) if command -v rustfmt >/dev/null 2>&1; then rustfmt \"$FILE\" 2>/dev/null; fi;; esac; exit 0'",
-            "timeout": 30
+            "timeout": 30,
+            "async": true
           }
         ]
       }
@@ -102,7 +103,8 @@
           {
             "type": "command",
             "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Tool failure: ${CLAUDE_TOOL_NAME:-unknown}\" >> \"${LOG_DIR}/tool-failures.log\"'",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }
@@ -114,7 +116,8 @@
           {
             "type": "command",
             "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent start: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }
@@ -126,7 +129,8 @@
           {
             "type": "command",
             "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent stop: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
-            "timeout": 5
+            "timeout": 5,
+            "async": true
           }
         ]
       }


### PR DESCRIPTION
Closes #112

## Summary
- Add `async: true` to PostToolUse formatting hooks for non-blocking file formatting
- Add `async: true` to logging hooks (PostToolUseFailure, SubagentStart/Stop)
- Document new hook types (command, prompt, agent) and async execution in CUSTOM_EXTENSIONS.md

## Changes

### Settings Updates
| File | Changes |
|------|---------|
| `global/settings.json` | Added async to PostToolUseFailure, SubagentStart, SubagentStop hooks |
| `project/.claude/settings.json` | Added async to PostToolUse, PostToolUseFailure, SubagentStart, SubagentStop hooks |

### Documentation Updates
| File | Changes |
|------|---------|
| `docs/CUSTOM_EXTENSIONS.md` | Added hook types and async execution documentation |

## Why Async?

| Hook | Reason for Async |
|------|------------------|
| PostToolUse (formatting) | File formatting can run in background after edit completes |
| PostToolUseFailure | Logging doesn't affect workflow execution |
| SubagentStart/Stop | Monitoring is purely observational |

## Test Plan
- [ ] Verify JSON files are valid
- [ ] Verify formatting hooks still work (non-blocking)
- [ ] Verify logging hooks still write to log files
- [ ] Confirm no regression in existing functionality