### PR TITLE
feat(settings): add permissions.defaultMode for explicit permission control

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -163,6 +163,7 @@
   },
 
   "permissions": {
+    "defaultMode": "default",
     "deny": [
       "Read(.env)",
       "Read(.env.*)",

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -45,6 +45,7 @@
   "alwaysThinkingEnabled": true,
 
   "permissions": {
+    "defaultMode": "default",
     "deny": [
       "Read(./.env)",
       "Read(./.env.*)",


### PR DESCRIPTION
## Summary
- Add `permissions.defaultMode: "default"` to global/settings.json
- Add `permissions.defaultMode: "default"` to project/.claude/settings.json
- Makes permission behavior explicit rather than relying on implicit defaults

## Changes
| File | Change |
|------|--------|
| `global/settings.json` | Added `defaultMode: "default"` to permissions |
| `project/.claude/settings.json` | Added `defaultMode: "default"` to permissions |

## Why This Change
- **Explicit is better than implicit**: Configuration clarity
- **Future-proofing**: If default behavior changes, explicit setting maintains expected behavior
- **Self-documenting**: Configuration files clearly state their intent

## Test Plan
- [x] JSON validation passes for both files
- [x] No change in existing permission behavior (setting explicit default)

Closes #113