### PR TITLE
feat(skills): add ci-debugging skill for systematic CI/CD failure diagnosis

### DIFF
--- a/plugin/skills/ci-debugging/SKILL.md
+++ b/plugin/skills/ci-debugging/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ci-debugging
+description: Provides systematic CI/CD failure diagnosis and resolution. Use when CI builds fail, GitHub Actions errors occur, TLS/auth issues block pipelines, or platform-specific failures need debugging.
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+---
+
+# CI/CD Debugging Skill
+
+## When to Use
+
+- CI build failures
+- GitHub Actions workflow errors
+- TLS certificate or authentication issues
+- Platform-specific compilation failures
+- Dependency resolution problems
+
+## Diagnostic Flow
+
+### Step 1: Categorize Failure Type
+
+Determine which category the failure falls into:
+
+| Category | Indicators | Priority |
+|----------|------------|----------|
+| **Environment/Auth** | TLS errors, token expired, permission denied | Check first |
+| **Platform-Specific** | Works on Linux fails on Windows, vice versa | Check second |
+| **Missing Dependencies** | Module not found, package missing | Check third |
+| **Actual Code Bug** | Test assertions, logic errors | Check last |
+
+### Step 2: Environment/Auth Issues
+
+Check for sandboxed environment limitations:
+
+```bash
+# Test GitHub API connectivity
+curl -s --connect-timeout 5 https://api.github.com/zen
+
+# Check GitHub CLI auth status
+gh auth status
+
+# Verify GITHUB_TOKEN
+echo "Token present: ${GITHUB_TOKEN:+yes}"
+```
+
+**Common Issues:**
+- TLS certificate errors -> Try diagnosis with connectivity check first
+- Token expired -> Re-authenticate with `gh auth login`
+- Sandbox blocked -> Use local git operations as fallback
+
+### Step 3: Platform-Specific Issues
+
+Look for platform-specific patterns:
+
+```bash
+# Search for Unix-specific code
+grep -rn "MSG_DONTWAIT\|/dev/null\|fork()" src/
+
+# Check for Windows path issues
+grep -rn '"/tmp\|"/var' src/
+```
+
+**Fallback**: Add conditional compilation or use cross-platform alternatives.
+
+### Step 4: Dependency Issues
+
+```bash
+# Check for missing packages (Node.js)
+npm ls 2>&1 | grep "MISSING" || echo "No missing npm packages"
+
+# For Python
+pip check 2>&1 || echo "No pip issues"
+
+# For CMake/C++
+cmake --build build/ 2>&1 | grep -i "error\|not found" || echo "Build OK"
+```
+
+### Step 5: Code Bug Analysis
+
+If none of the above:
+1. Read the failing test output carefully
+2. Identify the assertion that failed
+3. Trace back to the implementation
+4. Fix the actual bug
+
+## Fallback Strategies
+
+### GitHub API Blocked
+
+```
+Priority order:
+1. Use gh CLI (preferred)
+2. Direct curl with GITHUB_TOKEN
+3. Local git operations only
+4. Manual intervention required
+```
+
+### TLS/Certificate Issues
+
+```
+Priority order:
+1. Check system certificates
+2. Verify proxy settings
+3. Use alternative connectivity check
+4. Report as environment issue
+```
+
+## Quick Commands
+
+| Issue | Command |
+|-------|---------|
+| Check CI logs | `gh run view --log-failed` |
+| Re-run failed | `gh run rerun --failed` |
+| View workflow | `gh run view` |
+| Check auth | `gh auth status` |
+| List failed runs | `gh run list --status failure` |
+
+## Reference Documents (Import Syntax)
+@./reference/common-failures.md

--- a/plugin/skills/ci-debugging/reference/common-failures.md
+++ b/plugin/skills/ci-debugging/reference/common-failures.md
@@ -1,0 +1,161 @@
+# Common CI Failure Patterns
+
+## Environment Failures
+
+### TLS Certificate Errors
+
+**Symptoms:**
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+Post "https://api.github.com/graphql": x509: OSStatus -26276
+```
+
+**Causes:**
+- Sandboxed environment without proper certificates
+- Proxy intercepting HTTPS
+- Outdated CA certificates
+
+**Solutions:**
+1. Check if running in sandbox environment
+2. Update CA certificates: `update-ca-certificates`
+3. Verify proxy settings: `echo $https_proxy`
+4. Fallback to local operations when GitHub API is blocked
+
+### GitHub Token Issues
+
+**Symptoms:**
+```
+gh: authentication required
+error: The requested URL returned error: 403
+```
+
+**Solutions:**
+1. `gh auth status` - Check current auth
+2. `gh auth refresh` - Refresh token
+3. `gh auth login` - Re-authenticate
+
+### Permission Denied
+
+**Symptoms:**
+```
+fatal: could not read Username for 'https://github.com': terminal prompts disabled
+remote: Permission to org/repo.git denied to user.
+```
+
+**Solutions:**
+1. Verify repository access permissions
+2. Check SSH key configuration: `ssh -T git@github.com`
+3. Use HTTPS with token: `git remote set-url origin https://TOKEN@github.com/org/repo.git`
+
+## Platform-Specific Failures
+
+### Windows Socket Errors
+
+**Pattern:** `MSG_DONTWAIT` not available on Windows
+
+**Solution:**
+```cpp
+#ifdef _WIN32
+    u_long mode = 1;
+    ioctlsocket(socket, FIONBIO, &mode);
+#else
+    fcntl(socket, F_SETFL, O_NONBLOCK);
+#endif
+```
+
+### Path Separator Issues
+
+**Pattern:** `/tmp/file` not found on Windows
+
+**Solution:**
+```python
+import tempfile
+temp_dir = tempfile.gettempdir()  # Cross-platform
+```
+
+```cpp
+#include <filesystem>
+auto temp = std::filesystem::temp_directory_path();  // Cross-platform
+```
+
+### Line Ending Issues
+
+**Pattern:** `\r\n` vs `\n` causing test failures
+
+**Solution:**
+```bash
+# Configure git to handle line endings
+git config core.autocrlf input  # On Linux/macOS
+git config core.autocrlf true   # On Windows
+```
+
+## Dependency Failures
+
+### Node.js
+
+```bash
+# Clear cache and reinstall
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### Python
+
+```bash
+# Reinstall in fresh venv
+python -m venv .venv --clear
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### CMake/C++
+
+```bash
+# Clean rebuild
+rm -rf build/
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build/
+```
+
+### Java/Gradle
+
+```bash
+# Check JAVA_HOME
+echo $JAVA_HOME
+# Clear Gradle cache
+./gradlew clean --refresh-dependencies
+```
+
+## GitHub Actions Specific
+
+### Runner Environment Issues
+
+**Symptoms:**
+```
+Error: Process completed with exit code 1.
+##[error]The operation was canceled.
+```
+
+**Diagnostic Steps:**
+1. Check runner OS: `runs-on` in workflow YAML
+2. Verify available tools: `which cmake`, `node --version`
+3. Check disk space: `df -h`
+4. Review timeout settings
+
+### Cache Issues
+
+**Symptoms:** Build succeeds locally but fails in CI after cache restore
+
+**Solutions:**
+1. Clear GitHub Actions cache
+2. Verify cache key includes dependency lock file hash
+3. Check cache size limits (10 GB per repository)
+
+### Secret/Environment Variable Issues
+
+**Symptoms:** API calls fail only in CI
+
+**Solutions:**
+1. Verify secrets are set in repository settings
+2. Check secret name matches workflow reference
+3. Ensure secrets are available for the trigger event (fork PRs have limited access)

--- a/project/.claude/skills/ci-debugging/SKILL.md
+++ b/project/.claude/skills/ci-debugging/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ci-debugging
+description: Provides systematic CI/CD failure diagnosis and resolution. Use when CI builds fail, GitHub Actions errors occur, TLS/auth issues block pipelines, or platform-specific failures need debugging.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - WebFetch
+model: sonnet
+---
+
+# CI/CD Debugging Skill
+
+## When to Use
+
+- CI build failures
+- GitHub Actions workflow errors
+- TLS certificate or authentication issues
+- Platform-specific compilation failures
+- Dependency resolution problems
+
+## Diagnostic Flow
+
+### Step 1: Categorize Failure Type
+
+Determine which category the failure falls into:
+
+| Category | Indicators | Priority |
+|----------|------------|----------|
+| **Environment/Auth** | TLS errors, token expired, permission denied | Check first |
+| **Platform-Specific** | Works on Linux fails on Windows, vice versa | Check second |
+| **Missing Dependencies** | Module not found, package missing | Check third |
+| **Actual Code Bug** | Test assertions, logic errors | Check last |
+
+### Step 2: Environment/Auth Issues
+
+Check for sandboxed environment limitations:
+
+```bash
+# Test GitHub API connectivity
+curl -s --connect-timeout 5 https://api.github.com/zen
+
+# Check GitHub CLI auth status
+gh auth status
+
+# Verify GITHUB_TOKEN
+echo "Token present: ${GITHUB_TOKEN:+yes}"
+```
+
+**Common Issues:**
+- TLS certificate errors -> Try diagnosis with connectivity check first
+- Token expired -> Re-authenticate with `gh auth login`
+- Sandbox blocked -> Use local git operations as fallback
+
+### Step 3: Platform-Specific Issues
+
+Look for platform-specific patterns:
+
+```bash
+# Search for Unix-specific code
+grep -rn "MSG_DONTWAIT\|/dev/null\|fork()" src/
+
+# Check for Windows path issues
+grep -rn '"/tmp\|"/var' src/
+```
+
+**Fallback**: Add conditional compilation or use cross-platform alternatives.
+
+### Step 4: Dependency Issues
+
+```bash
+# Check for missing packages (Node.js)
+npm ls 2>&1 | grep "MISSING" || echo "No missing npm packages"
+
+# For Python
+pip check 2>&1 || echo "No pip issues"
+
+# For CMake/C++
+cmake --build build/ 2>&1 | grep -i "error\|not found" || echo "Build OK"
+```
+
+### Step 5: Code Bug Analysis
+
+If none of the above:
+1. Read the failing test output carefully
+2. Identify the assertion that failed
+3. Trace back to the implementation
+4. Fix the actual bug
+
+## Fallback Strategies
+
+### GitHub API Blocked
+
+```
+Priority order:
+1. Use gh CLI (preferred)
+2. Direct curl with GITHUB_TOKEN
+3. Local git operations only
+4. Manual intervention required
+```
+
+### TLS/Certificate Issues
+
+```
+Priority order:
+1. Check system certificates
+2. Verify proxy settings
+3. Use alternative connectivity check
+4. Report as environment issue
+```
+
+## Quick Commands
+
+| Issue | Command |
+|-------|---------|
+| Check CI logs | `gh run view --log-failed` |
+| Re-run failed | `gh run rerun --failed` |
+| View workflow | `gh run view` |
+| Check auth | `gh auth status` |
+| List failed runs | `gh run list --status failure` |
+
+## Reference Documents (Import Syntax)
+@./reference/common-failures.md

--- a/project/.claude/skills/ci-debugging/reference/common-failures.md
+++ b/project/.claude/skills/ci-debugging/reference/common-failures.md
@@ -1,0 +1,161 @@
+# Common CI Failure Patterns
+
+## Environment Failures
+
+### TLS Certificate Errors
+
+**Symptoms:**
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+Post "https://api.github.com/graphql": x509: OSStatus -26276
+```
+
+**Causes:**
+- Sandboxed environment without proper certificates
+- Proxy intercepting HTTPS
+- Outdated CA certificates
+
+**Solutions:**
+1. Check if running in sandbox environment
+2. Update CA certificates: `update-ca-certificates`
+3. Verify proxy settings: `echo $https_proxy`
+4. Fallback to local operations when GitHub API is blocked
+
+### GitHub Token Issues
+
+**Symptoms:**
+```
+gh: authentication required
+error: The requested URL returned error: 403
+```
+
+**Solutions:**
+1. `gh auth status` - Check current auth
+2. `gh auth refresh` - Refresh token
+3. `gh auth login` - Re-authenticate
+
+### Permission Denied
+
+**Symptoms:**
+```
+fatal: could not read Username for 'https://github.com': terminal prompts disabled
+remote: Permission to org/repo.git denied to user.
+```
+
+**Solutions:**
+1. Verify repository access permissions
+2. Check SSH key configuration: `ssh -T git@github.com`
+3. Use HTTPS with token: `git remote set-url origin https://TOKEN@github.com/org/repo.git`
+
+## Platform-Specific Failures
+
+### Windows Socket Errors
+
+**Pattern:** `MSG_DONTWAIT` not available on Windows
+
+**Solution:**
+```cpp
+#ifdef _WIN32
+    u_long mode = 1;
+    ioctlsocket(socket, FIONBIO, &mode);
+#else
+    fcntl(socket, F_SETFL, O_NONBLOCK);
+#endif
+```
+
+### Path Separator Issues
+
+**Pattern:** `/tmp/file` not found on Windows
+
+**Solution:**
+```python
+import tempfile
+temp_dir = tempfile.gettempdir()  # Cross-platform
+```
+
+```cpp
+#include <filesystem>
+auto temp = std::filesystem::temp_directory_path();  // Cross-platform
+```
+
+### Line Ending Issues
+
+**Pattern:** `\r\n` vs `\n` causing test failures
+
+**Solution:**
+```bash
+# Configure git to handle line endings
+git config core.autocrlf input  # On Linux/macOS
+git config core.autocrlf true   # On Windows
+```
+
+## Dependency Failures
+
+### Node.js
+
+```bash
+# Clear cache and reinstall
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### Python
+
+```bash
+# Reinstall in fresh venv
+python -m venv .venv --clear
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### CMake/C++
+
+```bash
+# Clean rebuild
+rm -rf build/
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build/
+```
+
+### Java/Gradle
+
+```bash
+# Check JAVA_HOME
+echo $JAVA_HOME
+# Clear Gradle cache
+./gradlew clean --refresh-dependencies
+```
+
+## GitHub Actions Specific
+
+### Runner Environment Issues
+
+**Symptoms:**
+```
+Error: Process completed with exit code 1.
+##[error]The operation was canceled.
+```
+
+**Diagnostic Steps:**
+1. Check runner OS: `runs-on` in workflow YAML
+2. Verify available tools: `which cmake`, `node --version`
+3. Check disk space: `df -h`
+4. Review timeout settings
+
+### Cache Issues
+
+**Symptoms:** Build succeeds locally but fails in CI after cache restore
+
+**Solutions:**
+1. Clear GitHub Actions cache
+2. Verify cache key includes dependency lock file hash
+3. Check cache size limits (10 GB per repository)
+
+### Secret/Environment Variable Issues
+
+**Symptoms:** API calls fail only in CI
+
+**Solutions:**
+1. Verify secrets are set in repository settings
+2. Check secret name matches workflow reference
+3. Ensure secrets are available for the trigger event (fork PRs have limited access)


### PR DESCRIPTION
Closes #120

## Summary
- Add new `ci-debugging` skill with systematic diagnostic flow for CI/CD failures
- Cover 4 failure categories: Environment/Auth, Platform-Specific, Dependencies, Code Bugs
- Include fallback strategies for common blockers (TLS, GitHub API, sandbox)
- Add comprehensive reference document with common failure patterns and solutions

## Files Changed
- `plugin/skills/ci-debugging/SKILL.md` - New skill definition with diagnostic flow
- `plugin/skills/ci-debugging/reference/common-failures.md` - Common failure patterns reference
- `project/.claude/skills/ci-debugging/SKILL.md` - Project-level skill mirror
- `project/.claude/skills/ci-debugging/reference/common-failures.md` - Project-level reference mirror

## Test Plan
- [x] `validate_skills.sh` passes (112/112 checks)
- [x] YAML frontmatter validated
- [x] Reference directory and documents verified
- [x] Skill name format and description length validated
- [ ] Manual verification: skill triggers on CI failure keywords