### PR TITLE
feat(hooks): add GitHub API preflight check for early sandbox detection

### DIFF
--- a/global/hooks/github-api-preflight.sh
+++ b/global/hooks/github-api-preflight.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# github-api-preflight.sh
+# Checks GitHub API connectivity before executing GitHub-related commands
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0=allow (always, warning only)
+# Response format: hookSpecificOutput (modern format)
+
+CMD="${CLAUDE_TOOL_INPUT:-}"
+
+# Only check GitHub-related commands
+if ! echo "$CMD" | grep -qE '(gh |github\.com|api\.github\.com)'; then
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+fi
+
+# Test GitHub API connectivity with short timeout
+HTTP_CODE=$(curl -s --connect-timeout 3 -o /dev/null -w "%{http_code}" https://api.github.com/zen 2>/dev/null)
+CURL_EXIT=$?
+
+if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" = "000" ]; then
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "message": "GitHub API may be unreachable (sandbox/TLS issue detected). Suggestions: Use local git operations if possible, check network/certificate settings, consider /sandbox to manage restrictions."
+  }
+}
+EOF
+    exit 0
+fi
+
+# Check GitHub CLI auth status for gh commands
+if echo "$CMD" | grep -qE '^gh '; then
+    if ! gh auth status >/dev/null 2>&1; then
+        cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "message": "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
+  }
+}
+EOF
+        exit 0
+    fi
+fi
+
+# All checks passed
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+EOF
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -67,6 +67,11 @@
             "type": "command",
             "command": "~/.claude/hooks/dangerous-command-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/github-api-preflight.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
Closes #121

## Summary
- Add `github-api-preflight.sh` PreToolUse hook that checks GitHub API connectivity before executing GitHub-related Bash commands
- Detects TLS/sandbox issues early and warns the user with fallback suggestions
- Checks `gh` CLI authentication status for `gh` commands
- Warning-only design: never blocks operations (always exits 0)

## Hook Behavior

| Condition | Action |
|-----------|--------|
| Not a GitHub command | Skip (silent allow) |
| API unreachable | Warn with fallback suggestions |
| gh CLI not authenticated | Warn with auth instructions |
| All checks pass | Silent allow |

## Files Changed
- `global/hooks/github-api-preflight.sh` - New preflight hook script
- `global/settings.json` - Added hook to existing Bash PreToolUse matcher

## Test Plan
- [x] Bash syntax validation passes (`bash -n`)
- [x] Non-GitHub commands skip check (exit 0 immediately)
- [x] Uses `hookSpecificOutput` modern format
- [ ] Manual test: verify warning when GitHub API is unreachable
- [ ] Manual test: verify warning when gh CLI is not authenticated