### PR TITLE
feat(rules): add behavioral-guardrails.md for LLM behavior correction

### DIFF
--- a/project/.claude/rules/core/behavioral-guardrails.md
+++ b/project/.claude/rules/core/behavioral-guardrails.md
@@ -4,32 +4,32 @@ alwaysApply: true
 
 # Behavioral Guardrails
 
-Correct common LLM coding pitfalls. Derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876).
+Correct common LLM coding pitfalls. Inspired by [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876).
 
-## Surface Assumptions
+> Complements `problem-solving.md` (process) and `question-handling.md` (flow).
+> This file focuses on **what NOT to do** — behavioral anti-patterns specific to LLMs.
 
-- **State assumptions explicitly**: If uncertain about scope, format, or approach, ask before implementing
-- **Present alternatives**: When multiple interpretations exist, list them — don't pick silently
+## Challenge the Request
+
 - **Push back**: If a simpler approach exists than what was requested, say so
-- **Stop when confused**: Name what's unclear and ask for clarification rather than guessing
+- **Present alternatives**: When multiple interpretations exist, list them — don't pick silently
 
 ## Minimize Code
 
-- **Nothing speculative**: No features, abstractions, or error handling beyond what was asked
 - **No premature abstraction**: Three similar lines are better than an unnecessary helper
 - **Rewrite if bloated**: If 200 lines could be 50, rewrite it
 - **Self-check**: "Would a senior engineer say this is overcomplicated?" If yes, simplify
 
 ## Surgical Edits
 
-- **Don't improve adjacent code**: Leave surrounding comments, formatting, and style untouched
-- **Don't refactor what isn't broken**: Match existing patterns, even if you'd do it differently
+- **Don't touch adjacent code**: Leave surrounding comments, formatting, and style untouched
 - **Clean up only your own mess**: Remove orphans YOUR changes created, not pre-existing dead code
 - **Self-check**: "Does every changed line trace directly to the user's request?"
 
-## Verify Outcomes
+## Test-First Verification
 
-- **Define success criteria before coding**: Transform tasks into verifiable goals
-- **Test-first when possible**: "Fix the bug" becomes "write a test that reproduces it, then make it pass"
-- **State verification steps**: For multi-step tasks, define what "done" looks like at each step
-- **Loop until verified**: Don't move on until success criteria are met
+- **Reproduce before fixing**: "Fix the bug" becomes "write a test that reproduces it, then make it pass"
+- **Define done**: For multi-step tasks, state what "done" looks like at each step before coding
+
+---
+*Part of the core behavioral rules module*


### PR DESCRIPTION
Closes #128

## Summary
- Add `behavioral-guardrails.md` to `project/.claude/rules/core/` with `alwaysApply: true`
- Covers 4 key LLM behavioral corrections derived from Andrej Karpathy's observations:
  - **Challenge the Request**: Push back with simpler alternatives; don't pick silently
  - **Minimize Code**: No premature abstractions; rewrite if bloated
  - **Surgical Edits**: Touch only what the user requested; clean up only your own mess
  - **Test-First Verification**: Reproduce before fixing; define done before coding
- Concise format (35 lines) for minimal token cost (~300 tokens per session)
- Complements existing `problem-solving.md` (process) and `question-handling.md` (flow) without duplication

## Test Plan
- [x] Verify YAML frontmatter loads correctly (`alwaysApply: true`)
- [x] Confirm no content overlap with `core/problem-solving.md`
- [x] Confirm no content overlap with `workflow/question-handling.md`
- [x] Validate file follows existing core rule style conventions
- [x] Check file is under 50 lines (currently 35)