### PR TITLE
fix(rules): set alwaysApply: true for workflow rules (#139)

### DIFF
--- a/project/.claude/rules/workflow/git-commit-format.md
+++ b/project/.claude/rules/workflow/git-commit-format.md
@@ -2,7 +2,7 @@
 paths:
   - ".git/**"
   - "**/*"
-alwaysApply: false
+alwaysApply: true
 ---
 
 # Git Commit Message Format

--- a/project/.claude/rules/workflow/github-issue-5w1h.md
+++ b/project/.claude/rules/workflow/github-issue-5w1h.md
@@ -2,7 +2,7 @@
 paths:
   - ".github/**"
   - "**/*"
-alwaysApply: false
+alwaysApply: true
 ---
 
 # GitHub Issue Guidelines (5W1H Principle)

--- a/project/.claude/rules/workflow/github-pr-5w1h.md
+++ b/project/.claude/rules/workflow/github-pr-5w1h.md
@@ -2,7 +2,7 @@
 paths:
   - ".github/**"
   - "**/*"
-alwaysApply: false
+alwaysApply: true
 ---
 
 # GitHub Pull Request Guidelines (5W1H Principle)


### PR DESCRIPTION
Closes #139

## Summary
- Change `alwaysApply: false` to `alwaysApply: true` in three workflow rule files that the documentation claims should always be loaded
- Affected files: `git-commit-format.md`, `github-issue-5w1h.md`, `github-pr-5w1h.md`
- The `paths` field is retained for reference but is now superseded by `alwaysApply: true`
- Other workflow files (`performance-analysis.md`, `reference/*.md`) intentionally remain `alwaysApply: false`

## Test Plan

| # | Test | Expected | Result |
|---|------|----------|--------|
| 1 | `git-commit-format.md` frontmatter | `alwaysApply: true` | PASS |
| 2 | `github-issue-5w1h.md` frontmatter | `alwaysApply: true` | PASS |
| 3 | `github-pr-5w1h.md` frontmatter | `alwaysApply: true` | PASS |
| 4 | No unintended changes in `performance-analysis.md` | Remains `alwaysApply: false` | PASS |
| 5 | No unintended changes in `reference/*.md` | All remain `alwaysApply: false` | PASS |
| 6 | Documentation consistency: `project/CLAUDE.md` | Claims workflow/* = always apply | Matches |
| 7 | Documentation consistency: `conditional-loading.md` | Claims workflow/* = always apply | Matches |