### PR TITLE
refactor(rules): consolidate duplicate attribution rules into single source (#140)

### DIFF
--- a/global/commands/_policy.md
+++ b/global/commands/_policy.md
@@ -13,13 +13,7 @@ These policies apply to all commands in this directory.
 
 ## Attribution
 
-| Item | Rule |
-|------|------|
-| Claude/AI references | **Forbidden** in all outputs |
-| Co-Authored-By | **Forbidden** in commit messages |
-| Bot references | **Forbidden** in issues, PRs, comments |
-
-**Rationale**: Maintain professional commit history and documentation.
+**No AI/Claude attribution in any output.** See `commit-settings.md` for the full policy.
 
 ## Formatting
 

--- a/global/commands/issue-work.md
+++ b/global/commands/issue-work.md
@@ -226,12 +226,7 @@ gh pr create --repo $ORG/$PROJECT \
 **Required**:
 - `Closes #<NUMBER>` keyword to link issue
 - **Language: MANDATORY English only** - All PR titles and descriptions MUST be written in English
-- No Claude/AI references or emojis
-
-**CRITICAL - Forbidden in PR body**:
-- `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
-- Any AI/Claude attribution footer
-- Co-Authored-By lines
+- No Claude/AI references, emojis, or Co-Authored-By (see `commit-settings.md`)
 
 After PR creation, capture the PR URL from `gh pr create` output for the summary.
 

--- a/global/commands/pr-work.md
+++ b/global/commands/pr-work.md
@@ -266,9 +266,7 @@ Fixes CI failure: <brief explanation>"
 **Commit rules**:
 - Type: Usually `fix`, `build`, `test`, or `ci`
 - **Language: MANDATORY English only** - All commit messages MUST be written in English
-- No Claude/AI references
-- No Co-Authored-By
-- No emojis
+- No Claude/AI references, emojis, or Co-Authored-By (see `commit-settings.md`)
 
 ### 8. Push and Verify
 

--- a/project/.claude/commands/_policy.md
+++ b/project/.claude/commands/_policy.md
@@ -28,9 +28,4 @@ These policies apply to all commands in this directory.
 
 ## Attribution
 
-| Item | Rule |
-|------|------|
-| Claude/AI references | **Forbidden** in all outputs |
-| Bot references | **Forbidden** in reports and comments |
-
-**Rationale**: Maintain professional output quality.
+**No AI/Claude attribution in any output.** See global `commit-settings.md` for the full policy.

--- a/project/.claude/rules/workflow/git-commit-format.md
+++ b/project/.claude/rules/workflow/git-commit-format.md
@@ -61,22 +61,7 @@ Must be one of the following:
 
 ## AI Reference Policy
 
-**NEVER** include AI-related references in commit messages:
-
-❌ **Don't include**:
-- "🤖 Generated with Claude Code"
-- "Generated with Claude Code"
-- "Co-Authored-By: Claude <noreply@anthropic.com>"
-- "Co-Authored-By: Claude"
-- Any AI assistant mentions
-- Tool attribution in commit messages
-- **All emojis** (🔧, 📊, ✅, 🚀, etc.)
-
-✅ **ALWAYS** include:
-- Actual technical changes
-- Business rationale
-- Issue/ticket references
-- Plain text descriptions without decorative symbols
+**No AI/Claude attribution or emojis in commit messages.** See global `commit-settings.md` for the full attribution policy and examples.
 
 ## Examples
 

--- a/project/.claude/rules/workflow/github-issue-5w1h.md
+++ b/project/.claude/rules/workflow/github-issue-5w1h.md
@@ -34,7 +34,7 @@ For detailed examples and automation patterns, see:
 
 ### No AI Attribution
 
-**Exclude all AI-related references** from issues (professional appearance, focus on technical content).
+**No AI/Claude attribution in issues.** See global `commit-settings.md` for the full policy.
 
 ## 5W1H Framework
 

--- a/project/.claude/rules/workflow/github-pr-5w1h.md
+++ b/project/.claude/rules/workflow/github-pr-5w1h.md
@@ -35,34 +35,9 @@ REST API를 위한 JWT 기반 인증을 구현...
 
 ### No AI/Claude Attribution
 
-**Exclude all AI-related references** from PRs:
+**No AI/Claude attribution in PRs.** See global `commit-settings.md` for the full policy.
 
-```markdown
-<!-- ❌ Do NOT include -->
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-Created with AI assistance
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-<!-- ❌ Do NOT include in footer -->
----
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-```
-
-This policy ensures:
-- Professional appearance in public repositories
-- Focus on the technical content
-- Compliance with organizational standards
-
-### Correct PR Footer Example
-
-```markdown
-## Checklist
-- [x] Code follows project style guidelines
-- [x] Self-review completed
-- [x] Tests added/updated
-```
-
-**Do NOT add any AI attribution after the checklist.**
+Do NOT add any AI attribution footer after the PR checklist.
 
 ## 1. What
 
@@ -387,7 +362,7 @@ v2.0.0 (Sprint 15)
 - [ ] Comment added to related issue(s) with PR information
 ```
 
-> **Note**: Do NOT add any AI attribution (Claude, GPT, etc.) after this checklist.
+> **Note**: No AI attribution after this checklist. See global `commit-settings.md` for the full policy.
 
 ## Quick Reference
 


### PR DESCRIPTION
## What

### Summary
Consolidates duplicate AI attribution policy text from 7 files into cross-references pointing to `commit-settings.md` as the single authoritative source. Removes 67 lines of duplicated policy text while preserving brief inline reminders in command files.

### Change Type
- [x] Refactor (no functional changes)

### Affected Components
- `project/.claude/rules/workflow/git-commit-format.md` - Replaced 18-line AI Reference Policy section
- `project/.claude/rules/workflow/github-issue-5w1h.md` - Simplified No AI Attribution section
- `project/.claude/rules/workflow/github-pr-5w1h.md` - Replaced 30-line No AI/Claude Attribution section
- `global/commands/_policy.md` - Replaced Attribution table with cross-reference
- `project/.claude/commands/_policy.md` - Replaced Attribution table with cross-reference
- `global/commands/issue-work.md` - Simplified verbose forbidden items list
- `global/commands/pr-work.md` - Simplified verbose commit rules list

## Why

### Related Issues
- Closes #140

### Motivation
The same AI attribution policy was duplicated verbatim across 8 files, causing:
1. Maintenance burden - updating the policy requires editing 8 files
2. Inconsistency risk - slight variations existed between copies
3. Token waste - ~67 lines of redundant content loaded into context

### Approach
Designate `global/commit-settings.md` as the canonical source and replace all duplicates with one-line cross-references. Command files (issue-work.md, pr-work.md) retain brief inline mentions for self-contained usage.

## How

### Implementation Details
1. **Canonical source preserved**: `global/commit-settings.md` unchanged - contains full policy with examples
2. **Rule files** (3 files): Verbose sections replaced with single-line cross-reference
3. **Policy files** (2 files): Attribution tables replaced with one-line reference
4. **Command files** (2 files): Multi-line forbidden lists condensed to single line with cross-reference
5. **Checklist items preserved**: Reviewer checklist attribution check item in github-pr-5w1h.md kept as-is

### Testing Done
- [x] Verified all 7 files correctly reference `commit-settings.md`
- [x] Verified canonical source (`commit-settings.md`) is unchanged
- [x] Verified no orphaned references or broken cross-links
- [x] Confirmed net removal: 67 lines deleted, 9 lines added

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No sensitive data exposed
- [x] Related issue(s) linked with closing keywords