### PR TITLE
feat(api): unify error response format between api-design.md and rest-api.md

### DIFF
--- a/project/.claude/rules/api/rest-api.md
+++ b/project/.claude/rules/api/rest-api.md
@@ -59,12 +59,20 @@ paths:
 
 ## Error Responses
 
+Follow the standard error response format defined in [api-design.md](api-design.md) (see Error Handling section).
+
+Canonical format (flat, top-level fields):
+
 ```json
 {
-  "error": {
-    "code": "VALIDATION_ERROR",
-    "message": "Human readable message",
-    "details": []
-  }
+  "error": "ValidationError",
+  "message": "Human readable message",
+  "code": "VALIDATION_ERROR",
+  "timestamp": "2025-01-15T10:30:00Z",
+  "path": "/api/v1/resource",
+  "requestId": "req_abc123",
+  "details": {}
 }
 ```
+
+See `api-design.md` for full interface definition, middleware implementation, and custom error classes.


### PR DESCRIPTION
Closes #143

## Summary
- Replace independent nested error format in `rest-api.md` with reference to canonical flat format in `api-design.md`
- `api-design.md` remains the single source of truth for API error response structure
- `rest-api.md` now includes a brief canonical format summary and cross-reference to the full definition

## Changes
- **Before**: `rest-api.md` defined a nested format (`{error: {code, message, details}}`) that conflicted with the flat format in `api-design.md`
- **After**: `rest-api.md` references `api-design.md` and shows the canonical flat format (`{error, message, code, timestamp, path, requestId, details}`)

## Test Plan
- Grep for nested error object pattern (`"error": {`) in API rules directory — should return zero results
- Verify `rest-api.md` references `api-design.md` as the canonical source
- Verify only one independent error format definition exists across both files