### PR TITLE
docs(rules): add cross-references between overlapping rule files

### DIFF
--- a/enterprise/rules/security.md
+++ b/enterprise/rules/security.md
@@ -4,6 +4,8 @@ Organization-wide security rules that apply to all projects.
 
 ## Input Validation
 
+> For detailed implementation patterns (SQL injection, XSS, path traversal), see `project/.claude/rules/security.md`.
+
 - **MUST** validate all external input
 - **MUST** sanitize data before database queries
 - **MUST** encode output to prevent XSS

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -45,6 +45,8 @@ You are a specialized code review agent. Your role is to provide thorough, const
 
 ## Output Format
 
+> For severity definitions (Critical/Major/Minor/Info), see [`commands/pr-review.md`](../commands/pr-review.md#severity-definitions).
+
 Provide feedback in a structured format:
 - Summary of changes
 - Critical issues (must fix)

--- a/project/.claude/commands/code-quality.md
+++ b/project/.claude/commands/code-quality.md
@@ -112,9 +112,11 @@ See [_policy.md](./_policy.md) for common rules.
 | Test Coverage | X% | OK/LOW |
 
 #### Issues Found
-1. [Issue description] - [Severity]
+1. [Issue description] - [Severity: Critical/Major/Minor/Info]
    - Location: line X
    - Suggestion: [How to fix]
+
+> Use the severity scale defined in [`pr-review.md`](pr-review.md#severity-definitions).
 
 #### Recommendations
 - [Prioritized list of improvements]

--- a/project/.claude/rules/api/architecture.md
+++ b/project/.claude/rules/api/architecture.md
@@ -17,6 +17,9 @@ This guideline establishes architectural patterns and SOLID design principles.
 
 ## SOLID Principles
 
+> **Scope**: SOLID principles in API/service architecture context.
+> For core SRP and modularity guidelines, see [`coding/general.md`](../coding/general.md#single-responsibility-principle).
+
 Follow SOLID principles for object-oriented design: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion.
 
 ## Layered Architecture

--- a/project/.claude/rules/api/observability.md
+++ b/project/.claude/rules/api/observability.md
@@ -13,6 +13,9 @@ paths:
 
 # Observability
 
+> **Scope**: API and microservice observability (Node.js, Python, web services).
+> For infrastructure/system-level metrics (C/C++), see [`operations/monitoring.md`](../operations/monitoring.md).
+
 This guideline establishes observability practices using metrics, logs, and traces (the three pillars of observability).
 
 ## Metrics Collection

--- a/project/.claude/rules/coding/error-handling.md
+++ b/project/.claude/rules/coding/error-handling.md
@@ -104,6 +104,9 @@ private:
 
 ## Input Validation
 
+> **Scope**: Validation as part of error handling flow.
+> For comprehensive security-focused validation (injection prevention, XSS, path traversal), see [`security.md`](../security.md).
+
 ### Validate Early
 
 **ALWAYS** validate all external input at the boundary of your system:
@@ -196,6 +199,9 @@ catch (const std::exception& e) {
 ```
 
 ### Error Context Propagation
+
+> **Scope**: Error wrapping and re-throw patterns.
+> For structured logging standards (JSON, correlation IDs), see [`api/logging.md`](../api/logging.md).
 
 **IMPORTANT**: Include sufficient context when propagating errors:
 

--- a/project/.claude/rules/coding/quality.md
+++ b/project/.claude/rules/coding/quality.md
@@ -6,6 +6,9 @@ paths: ["**/*.cpp", "**/*.cc", "**/*.h", "**/*.hpp", "**/*.py", "**/*.js", "**/*
 
 ## Single Responsibility Functions
 
+> **Scope**: Function-level SRP with practical examples.
+> For class-level SRP and modularity principles, see [`coding/general.md`](general.md#single-responsibility-principle).
+
 Each function should perform **one well-defined task**.
 
 ### Guidelines
@@ -121,6 +124,9 @@ buffer.resize(BUFFER_SIZE_BYTES);
 ```
 
 ## Error Logging
+
+> **Scope**: Brief error context in catch blocks.
+> For comprehensive structured logging standards, see [`api/logging.md`](../api/logging.md).
 
 When catching exceptions, include sufficient context for debugging.
 

--- a/project/.claude/rules/operations/monitoring.md
+++ b/project/.claude/rules/operations/monitoring.md
@@ -10,6 +10,9 @@ alwaysApply: false
 
 # Performance Metrics and Monitoring
 
+> **Scope**: Infrastructure and application metrics (C/C++, system-level).
+> For API/microservice observability (Node.js, Python), see [`api/observability.md`](../api/observability.md).
+
 ## Set Performance Targets
 
 Define clear, measurable performance goals for your application.


### PR DESCRIPTION
Closes #144

## Summary
Add explicit cross-references and scope boundaries to rule files that overlap on the same topics:

- **Error logging**: `quality.md` and `error-handling.md` now reference `api/logging.md` as authoritative source
- **Input validation**: `error-handling.md` and `enterprise/rules/security.md` now reference `security.md`
- **Code review severity**: `code-quality.md` and `code-reviewer.md` now reference `pr-review.md` severity definitions
- **Monitoring**: `operations/monitoring.md` scoped to C/C++/system-level; `api/observability.md` scoped to Node.js/Python/web
- **SRP**: `quality.md` (function-level) and `architecture.md` (API context) now reference `coding/general.md` for core principle

## Test Plan
- Each overlapping topic has one authoritative source and other files include cross-references
- Grep for `**Scope**` markers — should appear in all modified rule files
- No independent, overlapping definitions exist without explicit scope boundaries
- Severity scale in `code-quality.md` output now references `pr-review.md` definitions