### PR TITLE
fix(skills): update reference symlinks for rules v3.0.0 consolidation

### DIFF
--- a/project/.claude/skills/api-design/reference/logging.md
+++ b/project/.claude/skills/api-design/reference/logging.md
@@ -1,1 +1,1 @@
-../../../rules/api/logging.md
+../../../rules/api/observability.md

--- a/project/.claude/skills/coding-guidelines/reference/concurrency.md
+++ b/project/.claude/skills/coding-guidelines/reference/concurrency.md
@@ -1,1 +1,1 @@
-../../../rules/coding/concurrency.md
+../../../rules/coding/safety.md

--- a/project/.claude/skills/coding-guidelines/reference/general.md
+++ b/project/.claude/skills/coding-guidelines/reference/general.md
@@ -1,1 +1,1 @@
-../../../rules/coding/general.md
+../../../rules/coding/standards.md

--- a/project/.claude/skills/coding-guidelines/reference/memory.md
+++ b/project/.claude/skills/coding-guidelines/reference/memory.md
@@ -1,1 +1,1 @@
-../../../rules/coding/memory.md
+../../../rules/coding/safety.md

--- a/project/.claude/skills/coding-guidelines/reference/quality.md
+++ b/project/.claude/skills/coding-guidelines/reference/quality.md
@@ -1,1 +1,1 @@
-../../../rules/coding/quality.md
+../../../rules/coding/standards.md

--- a/project/.claude/skills/documentation/reference/cleanup.md
+++ b/project/.claude/skills/documentation/reference/cleanup.md
@@ -1,1 +1,1 @@
-../../../rules/operations/cleanup.md
+../../../rules/operations/ops.md

--- a/project/.claude/skills/performance-review/reference/concurrency.md
+++ b/project/.claude/skills/performance-review/reference/concurrency.md
@@ -1,1 +1,1 @@
-../../../rules/coding/concurrency.md
+../../../rules/coding/safety.md

--- a/project/.claude/skills/performance-review/reference/memory.md
+++ b/project/.claude/skills/performance-review/reference/memory.md
@@ -1,1 +1,1 @@
-../../../rules/coding/memory.md
+../../../rules/coding/safety.md

--- a/project/.claude/skills/performance-review/reference/monitoring.md
+++ b/project/.claude/skills/performance-review/reference/monitoring.md
@@ -1,1 +1,1 @@
-../../../rules/operations/monitoring.md
+../../../rules/operations/ops.md

--- a/project/.claude/skills/project-workflow/reference/problem-solving.md
+++ b/project/.claude/skills/project-workflow/reference/problem-solving.md
@@ -1,1 +1,1 @@
-../../../rules/core/problem-solving.md
+../../../rules/core/principles.md

--- a/project/.claude/skills/project-workflow/reference/question-handling.md
+++ b/project/.claude/skills/project-workflow/reference/question-handling.md
@@ -1,1 +1,0 @@
-../../../rules/workflow/question-handling.md

--- a/project/.claude/skills/project-workflow/reference/workflow-problem-solving.md
+++ b/project/.claude/skills/project-workflow/reference/workflow-problem-solving.md
@@ -1,1 +1,1 @@
-../../../rules/workflow/problem-solving.md
+../../../rules/core/principles.md

--- a/project/.claude/skills/project-workflow/reference/workflow.md
+++ b/project/.claude/skills/project-workflow/reference/workflow.md
@@ -1,1 +1,0 @@
-../../../rules/workflow/workflow.md


### PR DESCRIPTION
## Summary
- Fix 13 broken symlinks in `project/.claude/skills/*/reference/` caused by rules restructuring in #152
- Re-point 11 symlinks to their merged rule file targets
- Remove 2 orphaned symlinks pointing to deleted rule files

## Context

The principles-first architecture consolidation (#152) merged and renamed several rule files but did not update the corresponding skill reference symlinks, leaving them broken.

### Symlink Re-mapping

| Old Target | New Target | Affected Skills |
|---|---|---|
| `coding/general.md` | `coding/standards.md` | coding-guidelines |
| `coding/quality.md` | `coding/standards.md` | coding-guidelines |
| `coding/memory.md` | `coding/safety.md` | coding-guidelines, performance-review |
| `coding/concurrency.md` | `coding/safety.md` | coding-guidelines, performance-review |
| `operations/cleanup.md` | `operations/ops.md` | documentation |
| `operations/monitoring.md` | `operations/ops.md` | performance-review |
| `api/logging.md` | `api/observability.md` | api-design |
| `core/problem-solving.md` | `core/principles.md` | project-workflow |
| `workflow/problem-solving.md` | `core/principles.md` | project-workflow |

### Removed (no v3.0.0 equivalent)
- `project-workflow/reference/question-handling.md`
- `project-workflow/reference/workflow.md`

## Test Plan
- [x] All 28 symlinks verified as valid (`find -type l -exec test -e`)
- [x] Zero broken symlinks remain
- [x] `install.sh` deployment produces clean skills directory