### PR TITLE
feat(commands): update pr-work build and CI verification with background execution

### DIFF
--- a/global/commands/pr-work.md
+++ b/global/commands/pr-work.md
@@ -336,8 +336,11 @@ gh run view $RUN_ID --repo $ORG/$PROJECT --json status,conclusion -q '{status: .
 |--------|-----------|--------|
 | completed | success | Proceed to summary |
 | completed | failure | Fetch failed logs, go to Step 9 |
+| completed | cancelled | Report cancellation, investigate or re-trigger |
+| completed | timed_out | Report timeout, check workflow config |
 | in_progress | — | Poll again after 30s interval |
 | queued | — | Poll again after 30s interval |
+| waiting | — | Poll again after 30s interval (approval gate) |
 
 **Step D**: On failure, fetch specific error logs
 ```bash
@@ -587,6 +590,8 @@ warning: variable name should be camelCase
 | Push rejected | Report rejection reason | Pull latest or resolve conflicts |
 | CI failure detected via poll | Fetch failed logs immediately, start next attempt | No wait for full timeout |
 | CI poll timeout (10min) | Report last known status, escalate | Check CI health or increase poll duration |
+| CI run cancelled | Report cancellation, investigate cause | Re-trigger workflow or check repo settings |
+| CI run timed out | Report workflow timeout, check config | Increase workflow timeout or optimize CI |
 | CI status unknown | Report API response, suggest manual check | Run `gh run view` manually |
 | Max retries exceeded | Escalate with PR comment and label, report final status | Review failures manually |
 | API rate limit | Report "GitHub API rate limit exceeded, resets at [time]" | Wait or authenticate with different token |


### PR DESCRIPTION
Closes #157

## Summary
- Update Section 6 (Verify Fix Locally) with inline vs background build strategy, consistent with #156 pattern
- Replace `gh run watch` in Section 8 (Push and Verify) with non-blocking `gh run view --json` polling at 30s intervals
- Replace `timeout 600 gh run watch` in Section 9 (Iterate if Needed) with CI status polling loop (max 20 iterations x 30s)
- Update Error Handling table with entries for local build (short/long), CI poll failure, CI timeout, and CI status unknown
- Update Policies table with CI poll interval and max poll duration settings
- Add comprehensive CI status handling for cancelled, timed_out, and waiting states

## Test Plan
- [x] Verify `gh run watch` is no longer used as an actual command (only in "Do NOT use" warnings)
- [x] Verify Section 6 matches issue-work.md pattern from #156 (inline vs background + TaskOutput polling)
- [x] Verify Section 8 polling flow covers all CI status combinations (completed/success, completed/failure, completed/cancelled, completed/timed_out, in_progress, queued, waiting)
- [x] Verify Section 9 polling loop math is correct (20 iterations x 30s = 10 minutes)
- [x] Verify Error Handling table covers all three verification stages (local build, CI monitor, retry)
- [x] Verify system file (~/.claude/commands/pr-work.md) is synced with repo