### PR TITLE
refactor(settings): deduplicate project settings.json by removing global defaults

### DIFF
--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -1,74 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Claude Code project settings - auto-formatting, code quality, and permissions",
-  "version": "1.7.0",
-
-  "respectGitignore": true,
-  "cleanupPeriodDays": 30,
-
-  "language": "korean",
-
-  "outputStyle": "Explanatory",
-
-  "showTurnDuration": true,
-
-  "attribution": {
-    "commit": "",
-    "pr": "",
-    "issue": ""
-  },
-
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "allowUnsandboxedCommands": true,
-    "excludedCommands": ["docker", "watchman"],
-    "network": {
-      "allowedDomains": [
-        "github.com",
-        "api.github.com",
-        "npmjs.org",
-        "*.npmjs.org",
-        "registry.npmjs.org",
-        "pypi.org",
-        "*.pypi.org"
-      ],
-      "allowLocalBinding": true
-    }
-  },
-
-  "spinnerVerbs": {
-    "mode": "append",
-    "verbs": ["Analyzing", "Reviewing", "Composing"]
-  },
-
-  "alwaysThinkingEnabled": true,
+  "description": "Project-specific overrides only. Inherits defaults from global settings (~/.claude/settings.json).",
+  "version": "1.8.0",
 
   "permissions": {
     "defaultMode": "default",
     "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)",
-      "Read(**/.env)",
-      "Read(**/.env.*)",
-      "Read(**/secrets/**)",
-      "Read(**/credentials/**)",
-      "Read(**/*.pem)",
-      "Read(**/*.key)",
-      "Read(**/*.p12)",
-      "Read(**/*password*)",
       "Read(./.npm-cache/**)",
       "Read(**/node_modules/**)",
       "Read(**/dist/**)",
-      "Read(**/build/**)",
-      "Write(./.env)",
-      "Write(./.env.*)",
-      "Write(**/.env)",
-      "Write(**/.env.*)",
-      "Edit(./.env)",
-      "Edit(./.env.*)",
-      "Edit(**/.env)",
-      "Edit(**/.env.*)"
+      "Read(**/build/**)"
     ]
   },
 
@@ -96,52 +37,10 @@
           }
         ]
       }
-    ],
-    "PostToolUseFailure": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Tool failure: ${CLAUDE_TOOL_NAME:-unknown}\" >> \"${LOG_DIR}/tool-failures.log\"'",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "SubagentStart": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent start: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "SubagentStop": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'LOG_DIR=\"${HOME}/.claude/logs\"; mkdir -p \"$LOG_DIR\"; echo \"[$(date \"+%Y-%m-%d %H:%M:%S\")] Subagent stop: ${CLAUDE_SUBAGENT_TYPE:-unknown}\" >> \"${LOG_DIR}/subagents.log\"'",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
     ]
   },
 
   "env": {
-    "CLAUDE_AUTO_FORMAT": "true",
-    "MAX_THINKING_TOKENS": "8000",
-    "MAX_MCP_OUTPUT_TOKENS": "50000",
-    "ENABLE_TOOL_SEARCH": "auto:10"
+    "CLAUDE_AUTO_FORMAT": "true"
   }
 }


### PR DESCRIPTION
Closes #164

## Summary
- Remove 10+ duplicate configuration fields from `project/.claude/settings.json` that are identical to `global/settings.json` defaults
- Remove 3 duplicate hook definitions (`PostToolUseFailure`, `SubagentStart`, `SubagentStop`) that replicate global external script hooks with inline bash equivalents
- Remove shared `permissions.deny` rules (env file protection) already defined in global settings
- Reduce file size from 147 to 48 lines (~67% reduction)

### Fields Removed (inherited from global)
| Field | Reason |
|-------|--------|
| `language`, `outputStyle`, `showTurnDuration` | Identical to global |
| `attribution` block | Identical to global |
| `sandbox` block (16 lines) | Identical to global |
| `spinnerVerbs` block | Identical to global |
| `alwaysThinkingEnabled` | Identical to global |
| `respectGitignore`, `cleanupPeriodDays` | Identical to global |
| `env.MAX_THINKING_TOKENS`, `MAX_MCP_OUTPUT_TOKENS`, `ENABLE_TOOL_SEARCH` | Identical to global |
| `permissions.deny` (env/secrets patterns) | Identical to global |
| `PostToolUseFailure` hook | Same logging as global `tool-failure-logger.sh` |
| `SubagentStart/Stop` hooks | Same logging as global `subagent-logger.sh` |

### Fields Retained (project-specific)
- `hooks.SessionStart` — TZ=Asia/Seoul export
- `hooks.PostToolUse` — Multi-language auto-formatting
- `permissions.deny` — Project-specific: `.npm-cache`, `node_modules`, `dist`, `build`
- `env.CLAUDE_AUTO_FORMAT` — Project-specific flag

## Test Plan
- [x] JSON validation: `jq . project/.claude/settings.json` succeeds
- [x] Verify project settings inherit global defaults when deployed together
- [x] Verify auto-formatting hook still triggers on Edit/Write
- [x] Verify project-specific permission deny rules are applied