### PR TITLE
fix(settings): remove unrecognized CLAUDE_AUTO_FORMAT env variable

### DIFF
--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -38,9 +38,5 @@
         ]
       }
     ]
-  },
-
-  "env": {
-    "CLAUDE_AUTO_FORMAT": "true"
   }
 }


### PR DESCRIPTION
Closes #165

## Summary
- Remove `CLAUDE_AUTO_FORMAT: "true"` from `project/.claude/settings.json` — not an officially recognized Claude Code environment variable
- Validate remaining env vars in `global/settings.json` against latest Claude Code documentation (March 2026)

### Validation Results

| Variable | Value | Status | Notes |
|----------|-------|--------|-------|
| `ENABLE_TOOL_SEARCH` | `"auto:10"` | Valid | MCP Tool Search activates at 10% context threshold |
| `MAX_THINKING_TOKENS` | `"8000"` | Valid | Extended thinking token budget |
| `MAX_MCP_OUTPUT_TOKENS` | `"50000"` | Valid | Above default 25,000; allows larger MCP responses |
| `CLAUDE_AUTO_FORMAT` | `"true"` | **Removed** | Not recognized; auto-formatting handled by PostToolUse hook |

### Why CLAUDE_AUTO_FORMAT is unnecessary
Auto-formatting is already properly configured via the `PostToolUse` hook with `Edit|Write` matcher, which runs language-specific formatters (black, prettier, clang-format, ktlint, gofmt, rustfmt). The env var was a no-op.

## Test Plan
- [x] JSON validation: `jq . project/.claude/settings.json` succeeds
- [x] `ENABLE_TOOL_SEARCH` format verified against official MCP documentation
- [x] `MAX_THINKING_TOKENS` verified as supported env var
- [x] `MAX_MCP_OUTPUT_TOKENS` verified as supported env var (default: 25,000)
- [x] Verify auto-formatting still works after env var removal (PostToolUse hook unchanged)