### PR TITLE
feat(skills): add context, model, and argument-hint frontmatter fields

### DIFF
--- a/plugin/skills/api-design/SKILL.md
+++ b/plugin/skills/api-design/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: api-design
 description: Provides API design guidelines for REST, GraphQL, versioning, logging, observability, and architecture patterns. Use when designing APIs, reviewing architecture, implementing microservices, or setting up monitoring.
+model: sonnet
+argument-hint: "<endpoint-or-file>"
 ---
 
 # API Design Skill

--- a/plugin/skills/ci-debugging/SKILL.md
+++ b/plugin/skills/ci-debugging/SKILL.md
@@ -2,6 +2,9 @@
 name: ci-debugging
 description: Provides systematic CI/CD failure diagnosis and resolution. Use when CI builds fail, GitHub Actions errors occur, TLS/auth issues block pipelines, or platform-specific failures need debugging.
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
+model: sonnet
+context: fork
+argument-hint: "<run-id-or-url>"
 ---
 
 # CI/CD Debugging Skill

--- a/plugin/skills/coding-guidelines/SKILL.md
+++ b/plugin/skills/coding-guidelines/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: coding-guidelines
 description: Provides comprehensive coding standards for quality, naming conventions, error handling, concurrency, and memory management. Use when writing new code, reviewing code, fixing bugs, or refactoring existing code.
+model: sonnet
+argument-hint: "<file-path>"
 ---
 
 # Coding Guidelines Skill

--- a/plugin/skills/documentation/SKILL.md
+++ b/plugin/skills/documentation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: documentation
 description: Provides documentation standards for README, API docs, code comments, changelogs, and project cleanup. Use when writing documentation, README files, API references, or cleaning up project files.
+model: haiku
+argument-hint: "<file-or-topic>"
 ---
 
 # Documentation Skill

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: performance-review
 description: Provides performance optimization guidelines for profiling, caching, memory management, and concurrency. Use when optimizing slow code, fixing memory leaks, improving throughput, or conducting performance reviews.
+model: sonnet
+context: fork
+argument-hint: "<file-or-directory>"
 ---
 
 # Performance Review Skill

--- a/plugin/skills/security-audit/SKILL.md
+++ b/plugin/skills/security-audit/SKILL.md
@@ -2,6 +2,9 @@
 name: security-audit
 description: Provides security guidelines for input validation, authentication, authorization, and secure coding practices. Use when implementing auth, handling user input, working with credentials, or conducting security reviews.
 allowed-tools: Read, Grep, Glob
+model: sonnet
+context: fork
+argument-hint: "<file-or-directory>"
 ---
 
 # Security Audit Skill

--- a/project/.claude/skills/api-design/SKILL.md
+++ b/project/.claude/skills/api-design/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Grep
   - Bash
 model: sonnet
+argument-hint: "<endpoint-or-file>"
 ---
 
 # API Design Skill

--- a/project/.claude/skills/ci-debugging/SKILL.md
+++ b/project/.claude/skills/ci-debugging/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Glob
   - WebFetch
 model: sonnet
+context: fork
+argument-hint: "<run-id-or-url>"
 ---
 
 # CI/CD Debugging Skill

--- a/project/.claude/skills/coding-guidelines/SKILL.md
+++ b/project/.claude/skills/coding-guidelines/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools:
   - Glob
   - Grep
 model: sonnet
+argument-hint: "<file-path>"
 ---
 
 # Coding Guidelines Skill

--- a/project/.claude/skills/documentation/SKILL.md
+++ b/project/.claude/skills/documentation/SKILL.md
@@ -6,7 +6,8 @@ allowed-tools:
   - Write
   - Edit
   - Glob
-model: sonnet
+model: haiku
+argument-hint: "<file-or-topic>"
 ---
 
 # Documentation Skill

--- a/project/.claude/skills/performance-review/SKILL.md
+++ b/project/.claude/skills/performance-review/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Grep
   - Bash
 model: sonnet
+context: fork
+argument-hint: "<file-or-directory>"
 ---
 
 # Performance Review Skill

--- a/project/.claude/skills/security-audit/SKILL.md
+++ b/project/.claude/skills/security-audit/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools:
   - Grep
   - Glob
 model: sonnet
+context: fork
+argument-hint: "<file-or-directory>"
 ---
 
 # Security Audit Skill


### PR DESCRIPTION
Closes #167

## Summary
- Update 12 SKILL.md files (6 project + 6 plugin) with latest Claude Code frontmatter fields
- Add `context: fork` to 3 heavy-analysis skills for context window isolation
- Change `documentation` skill model from `sonnet` to `haiku` for cost efficiency
- Add `argument-hint` to 6 skills for CLI autocomplete guidance
- Add missing `model` field to plugin skills for consistency with project skills

### Changes by Skill

| Skill | `context: fork` | `model` | `argument-hint` |
|-------|:---------------:|:-------:|:---------------:|
| security-audit | Added | sonnet (kept) | `<file-or-directory>` |
| performance-review | Added | sonnet (kept) | `<file-or-directory>` |
| ci-debugging | Added | sonnet (kept) | `<run-id-or-url>` |
| coding-guidelines | — | sonnet (kept) | `<file-path>` |
| api-design | — | sonnet (kept) | `<endpoint-or-file>` |
| documentation | — | sonnet → **haiku** | `<file-or-topic>` |
| project-workflow | — | sonnet (kept) | — |

## Test Plan
- [x] `./scripts/validate_skills.sh` passes: 104/104 checks, 0 failures
- [x] `context: fork` present in 6 files (3 project + 3 plugin)
- [x] `argument-hint` present in 12 files (6 project + 6 plugin)
- [x] `model: haiku` present in 2 files (project + plugin documentation)
- [x] Plugin skills mirror project skills for all new fields