### PR TITLE
docs(mcp): add .mcp.json template for project-level MCP server configuration

### DIFF
--- a/project/.claudeignore
+++ b/project/.claudeignore
@@ -65,6 +65,9 @@ agents/
 # Skills (load when needed)
 skills/
 
+# MCP template (example only, not active config)
+.mcp.json.example
+
 # Settings
 settings.json
 settings.local.json

--- a/project/.mcp.json.example
+++ b/project/.mcp.json.example
@@ -1,0 +1,45 @@
+{
+  "mcpServers": {
+    "example-http": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "_note": "HTTP Streamable transport (recommended for remote servers). Supports OAuth 2.0."
+    },
+
+    "example-http-with-auth": {
+      "type": "http",
+      "url": "${API_BASE_URL}/mcp",
+      "headers": {
+        "Authorization": "Bearer ${API_TOKEN}"
+      },
+      "_note": "HTTP with environment variable references. Never hardcode secrets."
+    },
+
+    "example-http-oauth": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "clientId": "your-oauth-client-id",
+        "callbackPort": 8080
+      },
+      "_note": "OAuth 2.0 flow. Client secret is stored in system keychain, not here."
+    },
+
+    "example-stdio": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": {
+        "DATABASE_URL": "${DATABASE_URL}",
+        "CACHE_DIR": "${CACHE_DIR:-.cache}"
+      },
+      "_note": "Stdio transport for local tools. Best for development and system access."
+    },
+
+    "example-sse-deprecated": {
+      "type": "sse",
+      "url": "https://mcp.legacy.example.com/sse",
+      "_note": "SSE transport is DEPRECATED. Migrate to HTTP Streamable transport."
+    }
+  }
+}

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -5,3 +5,9 @@ Universal conventions for this repository. Works with global settings in `~/.cla
 Rules use YAML frontmatter (`alwaysApply`, `paths`) for automatic loading.
 Reference docs in `rules/*/reference/` are excluded via `.claudeignore` — load with `@load:`.
 Defer to language-specific conventions (PEP 8, C++ Core Guidelines, etc.).
+
+## MCP Server Configuration
+
+Use `.mcp.json` at the project root for team-shared MCP server definitions (committed to Git).
+See `.mcp.json.example` for transport examples (HTTP, stdio, SSE) and environment variable patterns.
+Never hardcode secrets — use `${VAR}` references and store values in `.env` (not committed).


### PR DESCRIPTION
Closes #168

## Summary

- Add `project/.mcp.json.example` template demonstrating all three MCP transport types
- Update `project/CLAUDE.md` with MCP server configuration reference section
- Exclude template from `.claudeignore` context loading (template only, not active config)

## Transport Types Covered

| Transport | Status | Use Case |
|-----------|--------|----------|
| HTTP Streamable | **Recommended** | Remote servers, OAuth 2.0 |
| stdio | Stable | Local tools, development |
| SSE | **Deprecated** | Legacy integrations only |

## Key Design Decisions

- `.mcp.json.example` (not `.mcp.json`) to avoid activating unintended servers
- `_note` keys for inline documentation (valid JSON, ignored by Claude Code)
- `${VAR}` and `${VAR:-default}` syntax for secret management
- OAuth example shows `clientId` (public) but not `clientSecret` (stored in keychain)

## Test Plan

- [x] `.mcp.json.example` is valid JSON — Verified with `python3 json.load()`
- [x] All 3 transport types demonstrated (HTTP, stdio, SSE with deprecation note) — 5 server examples, SSE `_note` includes "DEPRECATED"
- [x] No hardcoded secrets — 4 env var references (`${API_BASE_URL}`, `${API_TOKEN}`, `${DATABASE_URL}`, `${CACHE_DIR:-.cache}`); "secret" only in `_note` text
- [x] `project/CLAUDE.md` references MCP configuration — "MCP Server Configuration" section added
- [x] `.claudeignore` excludes `.mcp.json.example` from context — Entry added at line 69