### PR TITLE
feat(hooks): add PreCompact hook for context preservation

### DIFF
--- a/global/hooks/pre-compact-snapshot.sh
+++ b/global/hooks/pre-compact-snapshot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Pre-Compact Snapshot Hook
+# Captures working state before automatic context compaction
+#
+# Hook Type: PreCompact (async)
+# Triggers when context window reaches ~95% and auto-compaction begins
+#
+# Environment variables available:
+# - CLAUDE_SESSION_ID: Current session ID
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/compact-snapshots.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S %Z')
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+WORKING_DIR="$(pwd 2>/dev/null || echo 'unknown')"
+
+{
+    echo "=== PreCompact Snapshot ==="
+    echo "Time: ${TIMESTAMP}"
+    echo "Session: ${SESSION_ID}"
+    echo "Working Dir: ${WORKING_DIR}"
+    echo "==========================="
+} >> "$LOG_FILE"
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.8.0",
+  "version": "1.9.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -159,6 +159,18 @@
             "type": "command",
             "command": "~/.claude/hooks/subagent-logger.sh stop",
             "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-compact-snapshot.sh",
+            "timeout": 10,
             "async": true
           }
         ]


### PR DESCRIPTION
Closes #169

## Summary
- Add `pre-compact-snapshot.sh` hook script that captures session state (timestamp, session ID, working directory) before automatic context compaction
- Register `PreCompact` async hook in `global/settings.json`
- Bump settings version to 1.9.0

## Test Plan
- [x] Verify hook script is executable and runs without errors: `bash global/hooks/pre-compact-snapshot.sh`
- [x] Verify snapshot is written to `~/.claude/logs/compact-snapshots.log`
- [x] Verify script handles missing `CLAUDE_SESSION_ID` gracefully (defaults to "unknown")
- [x] Verify async execution does not delay compaction process