### PR TITLE
feat(plugin): verify and update plugin manifests for latest Claude Code plugin system

### DIFF
--- a/plugin-lite/.claude-plugin/plugin.json
+++ b/plugin-lite/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-lite",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Core behavioral guardrails for LLM coding, derived from Andrej Karpathy's observations. Minimal footprint, maximum impact.",
   "author": {
     "name": "kcenon",

--- a/plugin-lite/README.md
+++ b/plugin-lite/README.md
@@ -16,7 +16,8 @@ A single skill (`behavioral-guardrails`) with 4 principles:
 ## Installation
 
 ```bash
-claude plugins add kcenon/claude-config-lite
+# Install from git repository (subdirectory source)
+claude plugin install claude-config-lite --source git-subdir --url https://github.com/kcenon/claude-config --subdir plugin-lite
 ```
 
 Or test locally:

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Comprehensive Claude Code configuration with coding guidelines, security, and performance skills for software development best practices",
   "author": {
     "name": "kcenon",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,20 +4,26 @@ A Claude Code Plugin providing comprehensive development guidelines and best pra
 
 ## Installation
 
-### Via Plugin System (Recommended)
+### Via CLI (Recommended)
 
 ```bash
-# Add marketplace
-/plugin marketplace add kcenon/claude-config
+# Install from git repository (subdirectory source)
+claude plugin install claude-config --source git-subdir --url https://github.com/kcenon/claude-config --subdir plugin
 
-# Install plugin
-/plugin install claude-config@kcenon/claude-config
+# Or install with scope
+claude plugin install claude-config --source git-subdir --url https://github.com/kcenon/claude-config --subdir plugin -s project
 ```
 
 ### Via Direct Loading (Development)
 
 ```bash
 claude --plugin-dir ./plugin
+```
+
+Multiple plugins can be loaded simultaneously:
+
+```bash
+claude --plugin-dir ./plugin --plugin-dir ./plugin-lite
 ```
 
 ## Skills Included
@@ -30,6 +36,7 @@ claude --plugin-dir ./plugin
 | `performance-review` | Performance optimization and monitoring guidelines |
 | `project-workflow` | Git, testing, build, and workflow management |
 | `documentation` | Documentation and communication standards |
+| `ci-debugging` | Systematic CI/CD failure diagnosis and resolution |
 
 ## Hooks
 
@@ -52,15 +59,24 @@ plugin/
 │   ├── security-audit/
 │   ├── performance-review/
 │   ├── project-workflow/
-│   └── documentation/
+│   ├── documentation/
+│   └── ci-debugging/
 ├── hooks/
 │   └── hooks.json            # Security and formatting hooks
 └── README.md
 ```
 
+## Plugin Manifest Compatibility
+
+Verified against Claude Code plugin system (March 2026). The `plugin.json` manifest
+uses the standard schema with `skills` and `hooks` component paths.
+
+Additional manifest fields (`agents`, `mcpServers`, `lspServers`) are supported by the
+plugin system but not used by this plugin as it does not bundle those components.
+
 ## Requirements
 
-- Claude Code with Plugin support (v1.0.0+)
+- Claude Code v2.1.0+
 
 ## License
 


### PR DESCRIPTION
Closes #171

## Summary
- Verify both `plugin.json` manifests against March 2026 Claude Code plugin spec — all fields compatible
- Add missing `ci-debugging` skill to plugin README skills table
- Update installation instructions to use `git-subdir` source type (v2.1.64)
- Bump plugin version 2.0.0 → 2.1.0, plugin-lite version 1.0.0 → 1.1.0
- Verify `hooks/hooks.json` format is compatible with latest hook system

## Compatibility Findings
- All existing manifest fields (`name`, `version`, `skills`, `hooks`, etc.) remain valid
- New optional fields (`agents`, `mcpServers`, `lspServers`) are not added as the plugin does not bundle those components
- Plugin-level `settings.json` (v2.1.51) currently only supports `agent` key — not applicable
- Hook format with `PostToolUse`/`PreToolUse` matchers and inline commands is fully supported

## Test Plan

**Verified locally (2026-03-04)**

- [x] `plugin.json` is valid JSON with correct version (2.1.0) and component paths
- [x] `plugin-lite/plugin.json` is valid JSON with correct version (1.1.0)
- [x] `hooks.json` is valid JSON with 1 PostToolUse and 2 PreToolUse matchers
- [x] Plugin structure integrity verified (plugin.json, hooks.json, skills/ all present)
- [x] All 7 skills in README match actual skill directories (7/7 with SKILL.md)
- [x] Plugin-lite structure verified (behavioral-guardrails skill present)