### PR TITLE
fix(settings): remove unrecognized CLAUDE_AUTO_FORMAT environment variable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,9 +18,5 @@
         ]
       }
     ]
-  },
-
-  "env": {
-    "CLAUDE_AUTO_FORMAT": "true"
   }
 }


### PR DESCRIPTION
Closes #182

## Summary
- Remove the `CLAUDE_AUTO_FORMAT` environment variable from `.claude/settings.json`
- This variable is not recognized by Claude Code and serves no functional purpose
- Auto-formatting is handled by the `PostToolUse` hook with `matcher: "Edit|Write"` in the same file
- Previously removed from `global/settings.json` in commit `afeafab` but was missed in the project-level settings

## Changes
| File | Change |
|------|--------|
| `.claude/settings.json` | Remove `env.CLAUDE_AUTO_FORMAT` block (4 lines) |

## Verification Results

All test plan items verified against the live system:

| # | Test | Result | Method |
|---|------|--------|--------|
| 1 | JSON validation | PASS | `python3 json.load()` on `.claude/settings.json` |
| 2 | `CLAUDE_AUTO_FORMAT` removed | PASS | `env` block no longer exists in file |
| 3 | PostToolUse hook intact | PASS | `matcher: "Edit\|Write"` hook confirmed present |
| 4 | No remaining references | PASS | `grep -r CLAUDE_AUTO_FORMAT` across entire codebase returns 0 results |
| 5 | Cross-layer consistency | PASS | All 4 config layers clean: `~/.claude/settings.json`, `global/settings.json`, `.claude/settings.json`, `project/.claude/settings.json` |
| 6 | System sync check | PASS | `scripts/sync.sh` (compare mode): global settings identical between system and template |
| 7 | Full integrity check | PASS | `scripts/verify.sh`: 51/51 checks passed (100%) |

### Cross-layer CLAUDE_AUTO_FORMAT status

```
clean  | ~/.claude/settings.json (system global)
clean  | global/settings.json (global template)
clean  | .claude/settings.json (repo project)       ← fixed in this PR
clean  | project/.claude/settings.json (project template)
```

### System sync verification

```
MATCH | version: 1.10.0
MATCH | language: korean
MATCH | outputStyle: Explanatory
MATCH | alwaysThinkingEnabled: true
MATCH | hooks count: 11
MATCH | permissions.deny count: 18
```

## Test Plan
- [x] `jq . .claude/settings.json` produces valid JSON output
- [x] `CLAUDE_AUTO_FORMAT` no longer exists in any config layer
- [x] PostToolUse auto-formatting hook is unaffected
- [x] No remaining `CLAUDE_AUTO_FORMAT` references in codebase
- [x] System settings in sync with templates (`scripts/sync.sh`)
- [x] Full integrity verification passes (`scripts/verify.sh` — 51/51)