### PR TITLE
feat(hooks): add TaskCompleted and ConfigChange lifecycle hooks

### DIFF
--- a/global/hooks/config-change-logger.sh
+++ b/global/hooks/config-change-logger.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Config Change Logger Hook
+# Logs configuration file changes during session
+#
+# Hook Type: ConfigChange
+# Input: JSON via stdin with source, file_path
+# Decision control: JSON response ({"decision": "allow"})
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+SOURCE=$(echo "$INPUT" | jq -r '.source // "unknown"')
+FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // "unknown"')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/session.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${TIMESTAMP}] Session ${SESSION_ID}: CONFIG_CHANGED source=${SOURCE} file=${FILE_PATH}" >> "$LOG_FILE"
+
+echo '{"decision": "allow"}'
+exit 0

--- a/global/hooks/task-completed-logger.sh
+++ b/global/hooks/task-completed-logger.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Task Completed Logger Hook
+# Logs task completion events for audit trail
+#
+# Hook Type: TaskCompleted
+# Input: JSON via stdin with task_id, task_subject, task_description
+# Decision control: exit code (0=allow, 2=block)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+TASK_ID=$(echo "$INPUT" | jq -r '.task_id // "unknown"')
+TASK_SUBJECT=$(echo "$INPUT" | jq -r '.task_subject // "unknown"')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/tasks.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${TIMESTAMP}] Session ${SESSION_ID}: Task #${TASK_ID} completed - ${TASK_SUBJECT}" >> "$LOG_FILE"
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.10.0",
+  "version": "1.11.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -195,6 +195,29 @@
             "command": "~/.claude/hooks/worktree-remove.sh",
             "timeout": 10,
             "async": true
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/task-completed-logger.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/config-change-logger.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
Closes #184

## Summary
- Add `TaskCompleted` hook handler that logs task completions to `~/.claude/logs/tasks.log`
- Add `ConfigChange` hook handler that logs configuration file changes to `~/.claude/logs/session.log`
- Bump global settings version to 1.11.0
- Hook event coverage increases from 11 to 13 events in global template (15 of 17 total across all config layers)

## Changes

### New Files

| File | Purpose |
|------|---------|
| `global/hooks/task-completed-logger.sh` | Logs task_id, task_subject, session_id on task completion |
| `global/hooks/config-change-logger.sh` | Logs source type, file_path, session_id on config changes |

### Modified Files

| File | Change |
|------|--------|
| `global/settings.json` | Added `TaskCompleted` (async) and `ConfigChange` hook entries, version 1.10.0 -> 1.11.0 |

### Hook Configuration Details

| Hook Event | Type | Timeout | Async | Decision Control |
|------------|------|---------|-------|-----------------|
| `TaskCompleted` | command | 5s | yes | Exit code (0=allow, 2=block) |
| `ConfigChange` | command | 5s | no | JSON `{"decision": "allow"}` |

### Hook Input Schema

Both hooks parse stdin JSON with common fields (`session_id`, `hook_event_name`, `cwd`) plus event-specific fields:

- **TaskCompleted**: `task_id`, `task_subject`, `task_description`
- **ConfigChange**: `source` (user_settings/project_settings/skills/etc.), `file_path`

## Verification Results

### Repository Validation

| # | Test | Result | Details |
|---|------|--------|---------|
| 1 | JSON validity | PASS | `python3 json.load()` succeeds |
| 2 | `scripts/verify.sh` | PASS | 52/52 checks passed |
| 3 | task-completed-logger functional test | PASS | Logs to `~/.claude/logs/tasks.log` correctly |
| 4 | config-change-logger functional test | PASS | Logs to `~/.claude/logs/session.log`, returns `{"decision": "allow"}` |
| 5 | Scripts executable | PASS | `chmod +x` applied |
| 6 | Existing hooks unaffected | PASS | All 11 prior hook entries unchanged |

### System Deployment Verification

Deployed to live system (`~/.claude/`) and verified:

| # | Test | Result | Details |
|---|------|--------|---------|
| 1 | Hook scripts deployed | PASS | 2 scripts copied to `~/.claude/hooks/`, executable permissions confirmed |
| 2 | Settings.json deployed | PASS | Version 1.11.0, 13 hook events present |
| 3 | Repo vs system sync | PASS | All 13 hook events match between template and deployed |
| 4 | task-completed-logger (deployed) | PASS | Logs `[timestamp] Session deploy-test: Task #42 completed - Deploy verification task` |
| 5 | config-change-logger (deployed) | PASS | Logs `CONFIG_CHANGED source=user_settings`, returns `{"decision": "allow"}` |
| 6 | Existing hooks intact | PASS | All 13 hook scripts present in `~/.claude/hooks/` (11 existing + 2 new) |

## Test Plan
- [x] JSON syntax valid in `global/settings.json`
- [x] `scripts/verify.sh` passes (52/52)
- [x] `task-completed-logger.sh` logs task completion with correct format
- [x] `config-change-logger.sh` logs config change and returns allow decision
- [x] Both scripts are executable
- [x] Existing hooks are unaffected
- [x] Hooks trigger correctly after deployment to `~/.claude/`