### PR TITLE
feat(plugin): add .lsp.json template for code intelligence support

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Comprehensive Claude Code configuration with coding guidelines, security, and performance skills for software development best practices",
   "author": {
     "name": "kcenon",
@@ -19,5 +19,6 @@
   ],
   "agents": "./agents/",
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/plugin/.lsp.json
+++ b/plugin/.lsp.json
@@ -1,0 +1,61 @@
+{
+  "typescript": {
+    "command": "typescript-language-server",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".mts": "typescript",
+      ".cts": "typescript",
+      ".mjs": "javascript",
+      ".cjs": "javascript"
+    },
+    "initializationOptions": {
+      "preferences": {
+        "includeInlayParameterNameHints": "all"
+      }
+    }
+  },
+  "python": {
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python"
+    }
+  },
+  "go": {
+    "command": "gopls",
+    "args": ["serve"],
+    "extensionToLanguage": {
+      ".go": "go"
+    },
+    "initializationOptions": {
+      "usePlaceholders": true,
+      "completeUnimported": true
+    }
+  },
+  "rust": {
+    "command": "rust-analyzer",
+    "extensionToLanguage": {
+      ".rs": "rust"
+    }
+  },
+  "cpp": {
+    "command": "clangd",
+    "args": ["--background-index"],
+    "extensionToLanguage": {
+      ".c": "c",
+      ".h": "c",
+      ".cc": "cpp",
+      ".cpp": "cpp",
+      ".cxx": "cpp",
+      ".hpp": "cpp",
+      ".hxx": "cpp",
+      ".m": "objective-c",
+      ".mm": "objective-cpp"
+    }
+  }
+}

--- a/project/.lsp.json.example
+++ b/project/.lsp.json.example
@@ -1,0 +1,72 @@
+{
+  "_comment": "LSP server configuration for Claude Code. Copy to .lsp.json and keep only the servers you need. Each server binary must be installed separately.",
+
+  "typescript": {
+    "_install": "npm install -g typescript-language-server typescript",
+    "command": "typescript-language-server",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".mts": "typescript",
+      ".cts": "typescript",
+      ".mjs": "javascript",
+      ".cjs": "javascript"
+    },
+    "initializationOptions": {
+      "preferences": {
+        "includeInlayParameterNameHints": "all"
+      }
+    }
+  },
+
+  "python": {
+    "_install": "pip install pyright",
+    "command": "pyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python",
+      ".pyi": "python"
+    }
+  },
+
+  "go": {
+    "_install": "go install golang.org/x/tools/gopls@latest",
+    "command": "gopls",
+    "args": ["serve"],
+    "extensionToLanguage": {
+      ".go": "go"
+    },
+    "initializationOptions": {
+      "usePlaceholders": true,
+      "completeUnimported": true
+    }
+  },
+
+  "rust": {
+    "_install": "rustup component add rust-analyzer",
+    "command": "rust-analyzer",
+    "extensionToLanguage": {
+      ".rs": "rust"
+    }
+  },
+
+  "cpp": {
+    "_install": "brew install llvm (macOS) / apt install clangd (Linux)",
+    "command": "clangd",
+    "args": ["--background-index"],
+    "extensionToLanguage": {
+      ".c": "c",
+      ".h": "c",
+      ".cc": "cpp",
+      ".cpp": "cpp",
+      ".cxx": "cpp",
+      ".hpp": "cpp",
+      ".hxx": "cpp",
+      ".m": "objective-c",
+      ".mm": "objective-cpp"
+    }
+  }
+}


### PR DESCRIPTION
Closes #186

## Summary
- Add `plugin/.lsp.json` with 5 LSP server configurations (TypeScript, Python, Go, Rust, C++)
- Add `project/.lsp.json.example` with install instructions for each server
- Add `"lspServers": "./.lsp.json"` to `plugin.json` manifest
- Bump plugin version to 2.3.0

## Changes

### New Files

| File | Purpose |
|------|---------|
| `plugin/.lsp.json` | Active LSP configuration bundled with plugin |
| `project/.lsp.json.example` | Template with `_install` hints for project-level usage |

### Modified Files

| File | Change |
|------|--------|
| `plugin/.claude-plugin/plugin.json` | Added `lspServers` field, version 2.2.0 -> 2.3.0 |

### LSP Server Configurations

| Server | Command | Extensions | Install Command |
|--------|---------|------------|-----------------|
| TypeScript | `typescript-language-server --stdio` | .ts, .tsx, .js, .jsx, .mts, .cts, .mjs, .cjs | `npm install -g typescript-language-server typescript` |
| Python | `pyright-langserver --stdio` | .py, .pyi | `pip install pyright` |
| Go | `gopls serve` | .go | `go install golang.org/x/tools/gopls@latest` |
| Rust | `rust-analyzer` | .rs | `rustup component add rust-analyzer` |
| C++ | `clangd --background-index` | .c, .h, .cc, .cpp, .cxx, .hpp, .hxx, .m, .mm | `brew install llvm` / `apt install clangd` |

### Schema Notes

The `.lsp.json` schema uses `extensionToLanguage` (file extension to language ID mapping), not `languages` as originally proposed in the issue. This matches the actual Claude Code LSP specification confirmed against marketplace plugin implementations.

## Verification Results

### Repository Validation

| # | Test | Result | Details |
|---|------|--------|---------|
| 1 | `plugin/.lsp.json` JSON validity | PASS | Valid JSON, 5 servers |
| 2 | `project/.lsp.json.example` JSON validity | PASS | Valid JSON, 5 servers + `_comment` |
| 3 | `plugin.json` JSON validity | PASS | `lspServers: "./.lsp.json"` |
| 4 | Schema compliance (all 5 servers) | PASS | All have `command` + `extensionToLanguage` |
| 5 | Plugin ↔ example server parity | PASS | Both contain identical 5 servers |
| 6 | Install hints in example | PASS | All 5 servers have `_install` field |
| 7 | `scripts/verify.sh` | PASS | 51/51 checks |
| 8 | `scripts/validate_skills.sh` | PASS | 104/104 passed |

### System Deployment Verification

| # | Test | Result | Details |
|---|------|--------|---------|
| 1 | LSP server availability (system) | 2/5 | `clangd` (Apple v17.0.0), `rust-analyzer` (shim only) installed |
| 2 | `clangd` binary functional | PASS | `clangd --version` returns v17.0.0 |
| 3 | Marketplace LSP plugin comparison | PASS | Marketplace uses built-in handling (README only); our plugin uses standard `lspServers` manifest field |
| 4 | No conflicting `.lsp.json` at project/user level | PASS | No existing `.lsp.json` found |

### Plugin Installation Note

`claude plugin install` does not support local file paths in this environment. Marketplace LSP plugins (clangd-lsp, typescript-lsp, etc.) use a built-in mechanism with README-only structure, different from standard plugin format. Our plugin uses the documented `lspServers` manifest field for third-party plugin distribution.

## Test Plan
- [x] `plugin/.lsp.json` exists with valid JSON
- [x] At least 5 language server configurations included (TS, Python, Go, Rust, C++)
- [x] All servers have required fields (`command`, `extensionToLanguage`)
- [x] `project/.lsp.json.example` exists with install documentation
- [x] `plugin.json` references LSP config via `lspServers` field
- [x] Plugin and example contain identical server sets
- [x] `scripts/verify.sh` passes (51/51)
- [x] `scripts/validate_skills.sh` passes (104/104)
- [ ] LSP servers activate after plugin marketplace publish (requires binary installation)