### PR TITLE
feat(install): add Windows PowerShell installation support

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -98,6 +98,89 @@ Deny rules defined in `global/settings.json`:
 }
 ```
 
+## Windows Support (PowerShell)
+
+### Overview
+
+All hooks have PowerShell (`.ps1`) equivalents for native Windows support without Git Bash.
+
+| Configuration | File |
+|---------------|------|
+| **macOS/Linux** | `global/settings.json` (runs `.sh` hooks via bash) |
+| **Windows** | `global/settings.windows.json` (runs `.ps1` hooks via `pwsh`) |
+
+### How It Works
+
+The `install.ps1` script automatically:
+1. Copies `settings.windows.json` as `~/.claude/settings.json`
+2. Installs all `.ps1` hook scripts to `~/.claude/hooks/`
+
+Hook commands use `pwsh -NoProfile -File` for fast, profile-independent execution:
+```json
+{
+  "type": "command",
+  "command": "pwsh -NoProfile -File ~/.claude/hooks/sensitive-file-guard.ps1",
+  "timeout": 5
+}
+```
+
+### PowerShell Hook Scripts
+
+| Hook | File | Description |
+|------|------|-------------|
+| Sensitive File Guard | `sensitive-file-guard.ps1` | Blocks `.env`, `.pem`, `.key` access |
+| Dangerous Command Guard | `dangerous-command-guard.ps1` | Blocks `rm -rf /`, `chmod 777`, pipe execution |
+| Session Logger | `session-logger.ps1` | Logs session start/end/stop events |
+| Cleanup | `cleanup.ps1` | Removes old temp files from `$env:TEMP` |
+| Prompt Validator | `prompt-validator.ps1` | Warns on dangerous operation requests |
+| GitHub API Preflight | `github-api-preflight.ps1` | Tests GitHub API connectivity |
+| Tool Failure Logger | `tool-failure-logger.ps1` | Logs tool execution failures |
+| Subagent Logger | `subagent-logger.ps1` | Logs subagent start/stop events |
+| Pre-Compact Snapshot | `pre-compact-snapshot.ps1` | Captures state before compaction |
+| Worktree Create | `worktree-create.ps1` | Creates isolated worktree directory |
+| Worktree Remove | `worktree-remove.ps1` | Logs worktree removal events |
+| Task Completed Logger | `task-completed-logger.ps1` | Logs task completion events |
+| Config Change Logger | `config-change-logger.ps1` | Logs configuration changes |
+
+### Key Differences from Bash Hooks
+
+| Feature | Bash (`.sh`) | PowerShell (`.ps1`) |
+|---------|-------------|---------------------|
+| JSON parsing | `jq` (external dependency) | `ConvertFrom-Json` (built-in) |
+| Temp file cleanup | `find /tmp -mmin +60` | `Get-ChildItem $env:TEMP` |
+| Pattern matching | `grep -qE` | `-match` operator |
+| HTTP requests | `curl` | `Invoke-WebRequest` |
+| Timestamps | `date +"%Y-%m-%d"` | `Get-Date -Format` |
+
+### Prerequisites
+
+- **PowerShell 7+** (`pwsh`): Recommended for full compatibility
+  ```powershell
+  winget install Microsoft.PowerShell
+  ```
+- **Execution Policy**: Must allow running local scripts
+  ```powershell
+  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+  ```
+
+### Troubleshooting (Windows)
+
+#### "File cannot be loaded because running scripts is disabled"
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+#### Hooks not executing
+1. Verify `pwsh` is installed: `pwsh --version`
+2. Verify JSON syntax: `Get-Content ~/.claude/settings.json | ConvertFrom-Json`
+3. Check hook files exist: `Get-ChildItem ~/.claude/hooks/*.ps1`
+4. Restart Claude Code
+
+#### "pwsh is not recognized"
+Install PowerShell 7+: `winget install Microsoft.PowerShell`
+
+---
+
 ## Customization
 
 ### Disabling Hooks

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,6 +21,7 @@ claude_config_backup/
 
 ### Step 1: Copy (30 seconds)
 
+**macOS/Linux:**
 ```bash
 # Copy via USB, cloud, or network
 cp -r claude_config_backup ~/
@@ -29,11 +30,23 @@ cp -r claude_config_backup ~/
 git clone https://github.com/kcenon/claude-config.git ~/claude_config_backup
 ```
 
+**Windows (PowerShell):**
+```powershell
+git clone https://github.com/kcenon/claude-config.git ~\claude_config_backup
+```
+
 ### Step 2: Install (1 minute)
 
+**macOS/Linux:**
 ```bash
 cd ~/claude_config_backup
 ./scripts/install.sh
+```
+
+**Windows (PowerShell 7+):**
+```powershell
+cd ~\claude_config_backup
+.\scripts\install.ps1
 ```
 
 **Selection:**
@@ -48,9 +61,14 @@ Selection (1-3) [default: 3]: 3
 
 ### Step 3: Personalize (1 minute)
 
+**macOS/Linux:**
 ```bash
-# Change Git identity to your information
 vi ~/.claude/git-identity.md
+```
+
+**Windows:**
+```powershell
+notepad $HOME\.claude\git-identity.md
 ```
 
 **Example changes:**
@@ -106,8 +124,14 @@ git pull
 
 ### Scripts won't run
 
+**macOS/Linux:**
 ```bash
 chmod +x scripts/*.sh
+```
+
+**Windows (Execution Policy):**
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
 ### File not found

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ vi ~/.claude/git-identity.md
 
 **Common Tasks:**
 
-| Task | Command |
-|------|---------|
-| Backup settings | `./scripts/backup.sh` |
-| Sync settings | `./scripts/sync.sh` |
-| Verify backup | `./scripts/verify.sh` |
+| Task | macOS/Linux | Windows (PowerShell) |
+|------|-------------|----------------------|
+| Install settings | `./scripts/install.sh` | `.\scripts\install.ps1` |
+| Backup settings | `./scripts/backup.sh` | — |
+| Sync settings | `./scripts/sync.sh` | — |
+| Verify backup | `./scripts/verify.sh` | — |
 
 For detailed scenarios, see [Use Cases](#use-cases).
 
@@ -77,6 +78,23 @@ cd ~/claude_config_backup
 # 3. Personalize Git identity (Required!)
 vi ~/.claude/git-identity.md
 ```
+
+### Windows (PowerShell)
+
+```powershell
+# 1. Clone repository
+git clone https://github.com/kcenon/claude-config.git ~\claude_config_backup
+
+# 2. Run install script (PowerShell 7+ recommended)
+cd ~\claude_config_backup
+.\scripts\install.ps1
+
+# 3. Personalize Git identity (Required!)
+notepad $HOME\.claude\git-identity.md
+```
+
+> **Note**: Requires PowerShell 7+ (`pwsh`). Install via `winget install Microsoft.PowerShell`.
+> If you get an execution policy error, run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
 ### Plugin Installation (Beta)
 
@@ -206,7 +224,8 @@ claude_config_backup/
 │
 ├── global/                      # Global settings backup (~/.claude/)
 │   ├── CLAUDE.md               # Main configuration file
-│   ├── settings.json           # Hook settings (security, session, UserPromptSubmit, Stop)
+│   ├── settings.json           # Hook settings (macOS/Linux)
+│   ├── settings.windows.json   # Hook settings (Windows PowerShell)
 │   ├── commit-settings.md      # Commit/PR attribution policy
 │   ├── conversation-language.md # Conversation language settings
 │   ├── git-identity.md         # Git user information
@@ -285,7 +304,8 @@ claude_config_backup/
 │               └── SKILL.md
 │
 ├── scripts/                     # Automation scripts
-│   ├── install.sh              # Install to new system
+│   ├── install.sh              # Install to new system (macOS/Linux)
+│   ├── install.ps1             # Install to new system (Windows PowerShell)
 │   ├── backup.sh               # Backup current settings
 │   ├── sync.sh                 # Sync settings
 │   ├── verify.sh               # Verify backup integrity
@@ -723,7 +743,7 @@ allowed-tools: Read, Grep, Glob  # Optional: restrict tools
 
 ## Scripts
 
-### 1. install.sh
+### 1. install.sh / install.ps1
 
 **Purpose:** Install backed up settings to a new system
 
@@ -732,16 +752,21 @@ allowed-tools: Read, Grep, Glob  # Optional: restrict tools
 - Install project settings (specified directory)
 - Install skills directory (`.claude/skills/`)
 - Auto-backup existing files
-- Select installation type (global/project/both)
+- Select installation type (global/project/both/enterprise/all)
 
 **Usage:**
 ```bash
+# macOS/Linux
 ./scripts/install.sh
+
+# Windows (PowerShell 7+)
+.\scripts\install.ps1
 ```
 
 **Notes:**
-- ⚠️ After installation, you MUST modify `git-identity.md` with your personal info!
+- After installation, you MUST modify `git-identity.md` with your personal info!
 - Existing files are backed up with `.backup_YYYYMMDD_HHMMSS` format
+- Windows: `install.ps1` deploys `settings.windows.json` and `.ps1` hook scripts automatically
 
 ---
 

--- a/global/hooks/cleanup.ps1
+++ b/global/hooks/cleanup.ps1
@@ -1,0 +1,27 @@
+# cleanup.ps1
+# Cleans up temporary files created during session
+# Hook Type: SessionEnd
+# Exit codes: 0=success
+# Response format: hookSpecificOutput (modern format)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+# Clean up temporary Claude files (older than 60 minutes)
+$cutoff = (Get-Date).AddMinutes(-60)
+Get-ChildItem -Path $env:TEMP -Filter "claude_*" -File |
+    Where-Object { $_.LastWriteTime -lt $cutoff } |
+    Remove-Item -Force
+
+Get-ChildItem -Path $env:TEMP -Filter "tmp.*" -File |
+    Where-Object { $_.LastWriteTime -lt $cutoff } |
+    Remove-Item -Force
+
+# Output modern response format
+@'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+exit 0

--- a/global/hooks/config-change-logger.ps1
+++ b/global/hooks/config-change-logger.ps1
@@ -1,0 +1,28 @@
+# config-change-logger.ps1
+# Logs configuration file changes during session
+# Hook Type: ConfigChange
+# Input: JSON via stdin with source, file_path
+# Decision control: JSON response ({"decision": "allow"})
+
+$ErrorActionPreference = 'Stop'
+
+$input_data = $input | Out-String
+$json = $input_data | ConvertFrom-Json
+
+$Source = if ($json.source) { $json.source } else { 'unknown' }
+$FilePath = if ($json.file_path) { $json.file_path } else { 'unknown' }
+$SessionId = if ($json.session_id) { $json.session_id } else { 'unknown' }
+
+$LogDir = Join-Path $HOME ".claude/logs"
+$LogFile = Join-Path $LogDir "session.log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+Add-Content -Path $LogFile -Value "[$Timestamp] Session ${SessionId}: CONFIG_CHANGED source=$Source file=$FilePath"
+
+Write-Output '{"decision": "allow"}'
+exit 0

--- a/global/hooks/dangerous-command-guard.ps1
+++ b/global/hooks/dangerous-command-guard.ps1
@@ -1,0 +1,45 @@
+# dangerous-command-guard.ps1
+# Blocks dangerous bash commands
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0=allow, 2=block
+# Response format: hookSpecificOutput (modern format)
+
+$CMD = $env:CLAUDE_TOOL_INPUT
+
+function Deny-Response {
+    param([string]$Reason)
+    @"
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$Reason"
+  }
+}
+"@
+    exit 2
+}
+
+# Block recursive delete at root
+if ($CMD -match 'rm\s+(-rf|--recursive)\s+/($|[^a-zA-Z])') {
+    Deny-Response "Dangerous recursive delete at root directory blocked for safety"
+}
+
+# Block dangerous chmod
+if ($CMD -match 'chmod\s+(777|a\+rwx)') {
+    Deny-Response "Dangerous permission change (777/a+rwx) blocked for security"
+}
+
+# Block remote script execution
+if ($CMD -match '(curl|wget).*\|.*sh') {
+    Deny-Response "Remote script execution via pipe blocked for security"
+}
+
+# Allow the command
+@'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+exit 0

--- a/global/hooks/github-api-preflight.ps1
+++ b/global/hooks/github-api-preflight.ps1
@@ -1,0 +1,60 @@
+# github-api-preflight.ps1
+# Checks GitHub API connectivity before executing GitHub-related commands
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0=allow (always, warning only)
+# Response format: hookSpecificOutput (modern format)
+
+$CMD = $env:CLAUDE_TOOL_INPUT
+
+# Only check GitHub-related commands
+if ($CMD -notmatch '(gh |github\.com|api\.github\.com)') {
+    @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+    exit 0
+}
+
+# Test GitHub API connectivity with short timeout
+try {
+    $response = Invoke-WebRequest -Uri 'https://api.github.com/zen' -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+} catch {
+    @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "message": "GitHub API may be unreachable (sandbox/TLS issue detected). Suggestions: Use local git operations if possible, check network/certificate settings, consider /sandbox to manage restrictions."
+  }
+}
+'@
+    exit 0
+}
+
+# Check GitHub CLI auth status for gh commands
+if ($CMD -match '^gh ') {
+    $ghAuth = & gh auth status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "message": "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
+  }
+}
+'@
+        exit 0
+    }
+}
+
+# All checks passed
+@'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+exit 0

--- a/global/hooks/pre-compact-snapshot.ps1
+++ b/global/hooks/pre-compact-snapshot.ps1
@@ -1,0 +1,32 @@
+# pre-compact-snapshot.ps1
+# Captures working state before automatic context compaction
+# Hook Type: PreCompact (async)
+# Triggers when context window reaches ~95% and auto-compaction begins
+#
+# Environment variables available:
+# - CLAUDE_SESSION_ID: Current session ID
+
+$ErrorActionPreference = 'Stop'
+
+$LogDir = Join-Path $HOME ".claude/logs"
+$LogFile = Join-Path $LogDir "compact-snapshots.log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss K'
+$SessionId = if ($env:CLAUDE_SESSION_ID) { $env:CLAUDE_SESSION_ID } else { 'unknown' }
+$WorkingDir = try { (Get-Location).Path } catch { 'unknown' }
+
+$entry = @"
+=== PreCompact Snapshot ===
+Time: $Timestamp
+Session: $SessionId
+Working Dir: $WorkingDir
+===========================
+"@
+
+Add-Content -Path $LogFile -Value $entry
+
+exit 0

--- a/global/hooks/prompt-validator.ps1
+++ b/global/hooks/prompt-validator.ps1
@@ -1,0 +1,41 @@
+# prompt-validator.ps1
+# Validates user prompts for dangerous operations
+# Hook Type: UserPromptSubmit
+# Exit codes: 0=allow (with optional warning)
+# Response format: hookSpecificOutput (modern format)
+
+$PROMPT = $env:CLAUDE_USER_PROMPT
+
+# Skip if no prompt provided
+if ([string]::IsNullOrEmpty($PROMPT)) {
+    @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+    exit 0
+}
+
+# Check for dangerous operation requests
+if ($PROMPT -match '(?i)(delete|remove|drop)\s+(all|entire|whole|database|table|production)') {
+    @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  },
+  "systemMessage": "Warning: Dangerous operation request detected. Proceed with caution and verify the scope of changes."
+}
+'@
+    exit 0
+}
+
+@'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+exit 0

--- a/global/hooks/sensitive-file-guard.ps1
+++ b/global/hooks/sensitive-file-guard.ps1
@@ -1,0 +1,48 @@
+# sensitive-file-guard.ps1
+# Blocks access to sensitive files
+# Hook Type: PreToolUse (Edit|Write|Read)
+# Exit codes: 0=allow, 2=block
+# Response format: hookSpecificOutput (modern format)
+
+$FILE = $env:CLAUDE_FILE_PATH
+
+function Deny-Response {
+    param([string]$Reason)
+    @"
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$Reason"
+  }
+}
+"@
+    exit 2
+}
+
+function Allow-Response {
+    @'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+    exit 0
+}
+
+# Skip if no file path provided (allow by default)
+if ([string]::IsNullOrEmpty($FILE)) {
+    Allow-Response
+}
+
+# Check sensitive file extensions
+if ($FILE -match '\.(env|pem|key|p12|pfx)$') {
+    Deny-Response "Access to sensitive file blocked: $FILE (protected extension)"
+}
+
+# Check sensitive directories
+if ($FILE -match '(?i)(secrets|credentials|passwords|private)[/\\]') {
+    Deny-Response "Access to sensitive directory blocked: $FILE (protected path)"
+}
+
+Allow-Response

--- a/global/hooks/session-logger.ps1
+++ b/global/hooks/session-logger.ps1
@@ -1,0 +1,36 @@
+# session-logger.ps1
+# Logs session start/end events
+# Hook Type: SessionStart, SessionEnd, Stop
+# Usage: session-logger.ps1 [start|end|stop|teammate-idle]
+# Response format: hookSpecificOutput (modern format)
+
+$LogFile = Join-Path $HOME ".claude/session.log"
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+# Ensure log directory exists
+$logDir = Split-Path $LogFile -Parent
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+$action = if ($args.Count -gt 0) { $args[0] } else { '' }
+
+$message = switch ($action) {
+    'start'         { "[Session] Claude Code session started: $Timestamp" }
+    'end'           { "[Session] Claude Code session ended: $Timestamp" }
+    'stop'          { "[Stop] Claude Code task stopped: $Timestamp" }
+    'teammate-idle' { "[Session] Teammate idle detected: $Timestamp" }
+    default         { "[Session] Claude Code event: $Timestamp" }
+}
+
+Add-Content -Path $LogFile -Value $message -ErrorAction SilentlyContinue
+
+# Output modern response format
+@'
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow"
+  }
+}
+'@
+exit 0

--- a/global/hooks/subagent-logger.ps1
+++ b/global/hooks/subagent-logger.ps1
@@ -1,0 +1,27 @@
+# subagent-logger.ps1
+# Logs subagent start/stop events for monitoring
+# Hook Type: SubagentStart, SubagentStop (async)
+#
+# Usage: subagent-logger.ps1 <start|stop>
+#
+# Environment variables available:
+# - CLAUDE_SUBAGENT_TYPE: Type of subagent
+# - CLAUDE_SESSION_ID: Current session ID
+
+$ErrorActionPreference = 'Stop'
+
+$Action = if ($args.Count -gt 0) { $args[0] } else { 'unknown' }
+$LogDir = Join-Path $HOME ".claude/logs"
+$LogFile = Join-Path $LogDir "subagents.log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$SubagentType = if ($env:CLAUDE_SUBAGENT_TYPE) { $env:CLAUDE_SUBAGENT_TYPE } else { 'unknown' }
+$SessionId = if ($env:CLAUDE_SESSION_ID) { $env:CLAUDE_SESSION_ID } else { 'unknown' }
+
+Add-Content -Path $LogFile -Value "[$Timestamp] Session ${SessionId}: Subagent $Action - $SubagentType"
+
+exit 0

--- a/global/hooks/task-completed-logger.ps1
+++ b/global/hooks/task-completed-logger.ps1
@@ -1,0 +1,26 @@
+# task-completed-logger.ps1
+# Logs task completion events for audit trail
+# Hook Type: TaskCompleted (async)
+# Input: JSON via stdin with task_id, task_subject, task_description
+
+$ErrorActionPreference = 'Stop'
+
+$input_data = $input | Out-String
+$json = $input_data | ConvertFrom-Json
+
+$TaskId = if ($json.task_id) { $json.task_id } else { 'unknown' }
+$TaskSubject = if ($json.task_subject) { $json.task_subject } else { 'unknown' }
+$SessionId = if ($json.session_id) { $json.session_id } else { 'unknown' }
+
+$LogDir = Join-Path $HOME ".claude/logs"
+$LogFile = Join-Path $LogDir "tasks.log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+Add-Content -Path $LogFile -Value "[$Timestamp] Session ${SessionId}: Task #${TaskId} completed - $TaskSubject"
+
+exit 0

--- a/global/hooks/tool-failure-logger.ps1
+++ b/global/hooks/tool-failure-logger.ps1
@@ -1,0 +1,37 @@
+# tool-failure-logger.ps1
+# Logs tool execution failures for debugging and analysis
+# Hook Type: PostToolUseFailure (async)
+#
+# Environment variables available:
+# - CLAUDE_TOOL_NAME: Name of the tool that failed
+# - CLAUDE_TOOL_INPUT: Input provided to the tool (JSON)
+# - CLAUDE_TOOL_ERROR: Error message from the tool
+# - CLAUDE_SESSION_ID: Current session ID
+
+$ErrorActionPreference = 'Stop'
+
+$LogDir = Join-Path $HOME ".claude/logs"
+$LogFile = Join-Path $LogDir "tool-failures.log"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$ToolName = if ($env:CLAUDE_TOOL_NAME) { $env:CLAUDE_TOOL_NAME } else { 'unknown' }
+$SessionId = if ($env:CLAUDE_SESSION_ID) { $env:CLAUDE_SESSION_ID } else { 'unknown' }
+
+$entry = @"
+=== Tool Failure at $Timestamp ===
+Session: $SessionId
+Tool: $ToolName
+"@
+
+if ($env:CLAUDE_TOOL_ERROR) {
+    $entry += "`nError: $($env:CLAUDE_TOOL_ERROR)"
+}
+$entry += "`n---"
+
+Add-Content -Path $LogFile -Value $entry
+
+exit 0

--- a/global/hooks/worktree-create.ps1
+++ b/global/hooks/worktree-create.ps1
@@ -1,0 +1,43 @@
+# worktree-create.ps1
+# Creates an isolated worktree directory for non-git environments
+# Hook Type: WorktreeCreate (synchronous, type: command only)
+# Triggers when worktree isolation is requested outside a git repository
+#
+# IMPORTANT: Must print the absolute path of the created worktree to stdout.
+# Non-zero exit code fails the worktree creation.
+#
+# Input (stdin): JSON with worktree creation context
+# Output (stdout): Absolute path to the created worktree directory
+
+$ErrorActionPreference = 'Stop'
+
+$LogDir = Join-Path $HOME ".claude/logs"
+$WorktreeBase = Join-Path $HOME ".claude/worktrees"
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+if (-not (Test-Path $WorktreeBase)) {
+    New-Item -ItemType Directory -Path $WorktreeBase -Force | Out-Null
+}
+
+$Timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$SessionId = if ($env:CLAUDE_SESSION_ID) { $env:CLAUDE_SESSION_ID } else { 'unknown' }
+$SourceDir = if ($env:CLAUDE_PROJECT_DIR) { $env:CLAUDE_PROJECT_DIR } else { (Get-Location).Path }
+
+# Create unique worktree directory
+$WorktreeDir = Join-Path $WorktreeBase "${Timestamp}_$PID"
+New-Item -ItemType Directory -Path $WorktreeDir -Force | Out-Null
+
+# Log creation event
+$logTimestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$logEntry = @"
+[$logTimestamp] Worktree created
+  Path: $WorktreeDir
+  Source: $SourceDir
+  Session: $SessionId
+"@
+Add-Content -Path (Join-Path $LogDir "worktrees.log") -Value $logEntry
+
+# Output the created worktree path (REQUIRED by WorktreeCreate contract)
+Write-Output $WorktreeDir

--- a/global/hooks/worktree-remove.ps1
+++ b/global/hooks/worktree-remove.ps1
@@ -1,0 +1,38 @@
+# worktree-remove.ps1
+# Cleans up and logs worktree removal events
+# Hook Type: WorktreeRemove (async, type: command only)
+# Triggers when a worktree is being removed/cleaned up
+# Cannot block removal - cleanup and logging only
+#
+# Input (stdin): JSON with worktree_path field
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$LogDir = Join-Path $HOME ".claude/logs"
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+# Read worktree path from stdin JSON if available
+$WorktreePath = ''
+try {
+    $input_data = $input | Out-String
+    if ($input_data) {
+        $json = $input_data | ConvertFrom-Json
+        $WorktreePath = $json.worktree_path
+    }
+} catch {}
+
+if ([string]::IsNullOrEmpty($WorktreePath)) {
+    $WorktreePath = if ($env:CLAUDE_WORKTREE_PATH) { $env:CLAUDE_WORKTREE_PATH } else { 'unknown' }
+}
+
+# Log removal event
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$logEntry = @"
+[$Timestamp] Worktree removed
+  Path: $WorktreePath
+"@
+Add-Content -Path (Join-Path $LogDir "worktrees.log") -Value $logEntry
+
+exit 0

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
+  "version": "1.11.0",
+
+  "respectGitignore": true,
+  "cleanupPeriodDays": 30,
+
+  "language": "korean",
+
+  "outputStyle": "Explanatory",
+
+  "showTurnDuration": true,
+
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "issue": ""
+  },
+
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "allowUnsandboxedCommands": true,
+    "excludedCommands": ["docker", "watchman"],
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "api.github.com",
+        "npmjs.org",
+        "*.npmjs.org",
+        "registry.npmjs.org",
+        "pypi.org",
+        "*.pypi.org"
+      ],
+      "allowLocalBinding": true
+    }
+  },
+
+  "spinnerVerbs": {
+    "mode": "append",
+    "verbs": ["Analyzing", "Reviewing", "Composing"]
+  },
+
+  "alwaysThinkingEnabled": true,
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/sensitive-file-guard.ps1",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/dangerous-command-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/github-api-preflight.ps1",
+            "timeout": 10
+          },
+          {
+            "type": "prompt",
+            "prompt": "You are a git commit message validator. Examine the Bash command input. If the command is NOT a git commit command (does not contain 'git commit'), respond ONLY with: {\"decision\": \"allow\"}. If it IS a git commit with a -m flag, extract the commit message and validate against ALL these rules: 1) Format must be 'type(scope): description' or 'type: description' where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security. 2) Description must start with lowercase letter, use imperative mood, have no trailing period, and be meaningful (not just 'update', 'fix', 'changes', 'wip'). 3) Must NOT contain AI/Claude attribution (Claude, Anthropic, AI-assisted, Co-Authored-By, Generated with). 4) Must NOT contain emojis. 5) Must be in English. If ALL rules pass, respond ONLY with: {\"decision\": \"allow\"}. If ANY rule fails, respond ONLY with: {\"decision\": \"block\", \"reason\": \"Commit message validation failed: <specific violation>\"}.",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/session-logger.ps1 start",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -Command \"& ~/.claude/hooks/session-logger.ps1 end; & ~/.claude/hooks/cleanup.ps1\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/prompt-validator.ps1",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/session-logger.ps1 stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/tool-failure-logger.ps1",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/subagent-logger.ps1 start",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/subagent-logger.ps1 stop",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-compact-snapshot.ps1",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/worktree-create.ps1",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/worktree-remove.ps1",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/task-completed-logger.ps1",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/config-change-logger.ps1",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/session-logger.ps1 teammate-idle",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ]
+  },
+
+  "env": {
+    "MAX_THINKING_TOKENS": "8000",
+    "MAX_MCP_OUTPUT_TOKENS": "50000",
+    "ENABLE_TOOL_SEARCH": "auto:10"
+  },
+
+  "permissions": {
+    "defaultMode": "default",
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/secrets/**)",
+      "Read(**/credentials/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/*password*)",
+      "Write(.env)",
+      "Write(.env.*)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Edit(.env)",
+      "Edit(.env.*)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)"
+    ]
+  }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,432 @@
+# Claude Configuration Auto-Installer (PowerShell)
+# =================================================
+# Installs backed up CLAUDE.md settings to a new Windows system
+# Requires: PowerShell 7+ (pwsh) recommended
+
+#Requires -Version 5.1
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Script and backup directory paths
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BackupDir = Split-Path -Parent $ScriptDir
+
+# ── Helper functions ──────────────────────────────────────────
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "  $Message" -ForegroundColor Blue
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "  $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "  $Message" -ForegroundColor Yellow
+}
+
+function Write-Err {
+    param([string]$Message)
+    Write-Host "  $Message" -ForegroundColor Red
+}
+
+function New-Backup {
+    param([string]$Target)
+    if (Test-Path $Target) {
+        $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+        $backupName = "${Target}.backup_${timestamp}"
+        Copy-Item -Path $Target -Destination $backupName -Recurse -Force
+        Write-Info "Existing file backed up: $backupName"
+    }
+}
+
+function Ensure-Directory {
+    param([string]$Dir)
+    if (-not (Test-Path $Dir)) {
+        New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+        Write-Success "Directory created: $Dir"
+    }
+}
+
+function New-LocalClaude {
+    param([string]$ProjectDir)
+    $localFile = Join-Path $ProjectDir "CLAUDE.local.md"
+    $templateFile = Join-Path $BackupDir "project/CLAUDE.local.md.template"
+
+    # Create CLAUDE.local.md from template if not exists
+    if (-not (Test-Path $localFile)) {
+        if (Test-Path $templateFile) {
+            Copy-Item -Path $templateFile -Destination $localFile -Force
+            Write-Success "Created $localFile from template"
+        }
+    } else {
+        Write-Info "CLAUDE.local.md already exists, skipping..."
+    }
+
+    # Ensure gitignore entry
+    $gitignore = Join-Path $ProjectDir ".gitignore"
+    if (Test-Path $gitignore) {
+        $content = Get-Content $gitignore -Raw -ErrorAction SilentlyContinue
+        if ($content -notmatch 'CLAUDE\.local\.md') {
+            Add-Content -Path $gitignore -Value "`n# Claude Code local settings (personal, do not commit)`nCLAUDE.local.md"
+            Write-Success "Added CLAUDE.local.md to .gitignore"
+        }
+    }
+}
+
+function Get-EnterpriseDir {
+    if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
+        return "C:\Program Files\ClaudeCode"
+    } elseif ($IsMacOS) {
+        return "/Library/Application Support/ClaudeCode"
+    } else {
+        return "/etc/claude-code"
+    }
+}
+
+function Test-Administrator {
+    if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } else {
+        return ($(id -u) -eq 0)
+    }
+}
+
+# ── Enterprise installation ──────────────────────────────────
+
+function Install-Enterprise {
+    $enterpriseDir = Get-EnterpriseDir
+
+    Write-Host ""
+    Write-Host "======================================================"
+    Write-Info "Enterprise settings installation..."
+    Write-Host "======================================================"
+    Write-Host ""
+
+    # Check if template has been customized
+    $enterpriseMd = Join-Path $BackupDir "enterprise/CLAUDE.md"
+    if (Test-Path $enterpriseMd) {
+        $content = Get-Content $enterpriseMd -Raw -ErrorAction SilentlyContinue
+        if ($content -match '^\*This is a template\.') {
+            Write-Host ""
+            Write-Warn "============================================================"
+            Write-Warn "enterprise/CLAUDE.md has NOT been customized yet!"
+            Write-Warn "============================================================"
+            Write-Host ""
+            Write-Host "The managed policy path has the HIGHEST priority in Claude Code." -ForegroundColor Yellow
+            Write-Host "Deploying an uncustomized template will enforce requirements" -ForegroundColor Yellow
+            Write-Host "that have no supporting implementation:" -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "  - GPG signing for all commits (no guidance configured)"
+            Write-Host "  - Sign-off required (--signoff not mentioned elsewhere)"
+            Write-Host "  - 80% test coverage minimum (conflicts with testing.md)"
+            Write-Host "  - Security team approval (no process defined)"
+            Write-Host "  - Squash merge preferred (not in PR guidelines)"
+            Write-Host ""
+            Write-Host "Recommendation: Customize enterprise/CLAUDE.md first, then re-run." -ForegroundColor Yellow
+            Write-Host ""
+
+            $deployTemplate = Read-Host "Deploy uncustomized template anyway? (y/n) [default: n]"
+            if ([string]::IsNullOrEmpty($deployTemplate)) { $deployTemplate = 'n' }
+            if ($deployTemplate -ne 'y') {
+                Write-Info "Enterprise installation skipped. Customize enterprise/CLAUDE.md first."
+                return
+            }
+            Write-Warn "Proceeding with uncustomized template deployment."
+        }
+    }
+
+    Write-Info "Enterprise path: $enterpriseDir"
+    Write-Warn "Administrator privileges may be required."
+    Write-Host ""
+
+    # Check admin rights on Windows
+    if (($IsWindows -or ($env:OS -eq 'Windows_NT')) -and -not (Test-Administrator)) {
+        Write-Err "This operation requires administrator privileges."
+        Write-Info "Please run PowerShell as Administrator and try again."
+        Write-Info "  Right-click PowerShell -> 'Run as administrator'"
+        return
+    }
+
+    # Create directories
+    New-Item -ItemType Directory -Path $enterpriseDir -Force | Out-Null
+    $rulesDir = Join-Path $enterpriseDir "rules"
+    New-Item -ItemType Directory -Path $rulesDir -Force | Out-Null
+
+    # Copy files
+    Copy-Item -Path $enterpriseMd -Destination $enterpriseDir -Force
+    Write-Success "CLAUDE.md installed"
+
+    # Copy rules directory
+    $sourceRules = Join-Path $BackupDir "enterprise/rules"
+    if (Test-Path $sourceRules) {
+        Copy-Item -Path "$sourceRules\*" -Destination $rulesDir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Success "rules directory installed"
+    }
+
+    Write-Success "Enterprise settings installation complete!"
+    Write-Host ""
+    Write-Warn "Important: Customize enterprise/CLAUDE.md for your organization's policies!"
+}
+
+# ── Banner ────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "==================================================" -ForegroundColor Blue
+Write-Host "                                                    " -ForegroundColor Blue
+Write-Host "    Claude Configuration Auto-Installer             " -ForegroundColor Blue
+Write-Host "    (PowerShell Edition)                            " -ForegroundColor Blue
+Write-Host "                                                    " -ForegroundColor Blue
+Write-Host "==================================================" -ForegroundColor Blue
+Write-Host ""
+
+# ── Installation type selection ───────────────────────────────
+
+Write-Info "Select installation type:"
+Write-Host "  1) Global settings only (~/.claude/)"
+Write-Host "  2) Project settings only (current directory)"
+Write-Host "  3) Both (recommended)"
+Write-Host "  4) Enterprise settings only (admin required)"
+Write-Host "  5) All (Enterprise + Global + Project)"
+Write-Host ""
+
+$installType = Read-Host "Selection (1-5) [default: 3]"
+if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
+
+# ── Enterprise installation ──────────────────────────────────
+
+if ($installType -eq '4' -or $installType -eq '5') {
+    Install-Enterprise
+}
+
+# ── Global settings installation ──────────────────────────────
+
+if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
+    Write-Host ""
+    Write-Host "======================================================"
+    Write-Info "Global settings installation..."
+    Write-Host "======================================================"
+    Write-Host ""
+
+    # Create ~/.claude directory
+    $claudeDir = Join-Path $HOME ".claude"
+    Ensure-Directory $claudeDir
+
+    # Check for existing files
+    $backupExisting = 'y'
+    $existingMd = Join-Path $claudeDir "CLAUDE.md"
+    if (Test-Path $existingMd) {
+        Write-Warn "Existing CLAUDE.md found."
+        $backupExisting = Read-Host "Backup and overwrite? (y/n) [default: y]"
+        if ([string]::IsNullOrEmpty($backupExisting)) { $backupExisting = 'y' }
+    }
+
+    if ($backupExisting -eq 'y') {
+        # Backup existing files
+        New-Backup (Join-Path $claudeDir "CLAUDE.md")
+        New-Backup (Join-Path $claudeDir "conversation-language.md")
+        New-Backup (Join-Path $claudeDir "git-identity.md")
+        New-Backup (Join-Path $claudeDir "token-management.md")
+
+        # Copy configuration files
+        Copy-Item -Path (Join-Path $BackupDir "global/CLAUDE.md") -Destination $claudeDir -Force
+        Copy-Item -Path (Join-Path $BackupDir "global/conversation-language.md") -Destination $claudeDir -Force
+        Copy-Item -Path (Join-Path $BackupDir "global/git-identity.md") -Destination $claudeDir -Force
+        Copy-Item -Path (Join-Path $BackupDir "global/token-management.md") -Destination $claudeDir -Force
+
+        # Install settings.windows.json as settings.json
+        $settingsSource = Join-Path $BackupDir "global/settings.windows.json"
+        if (Test-Path $settingsSource) {
+            New-Backup (Join-Path $claudeDir "settings.json")
+            Copy-Item -Path $settingsSource -Destination (Join-Path $claudeDir "settings.json") -Force
+            Write-Success "Hook settings (settings.json) installed! [Windows version]"
+        }
+
+        # Install PowerShell hook scripts
+        $hooksSource = Join-Path $BackupDir "global/hooks"
+        if (Test-Path $hooksSource) {
+            $hooksDir = Join-Path $claudeDir "hooks"
+            Ensure-Directory $hooksDir
+            Copy-Item -Path "$hooksSource\*.ps1" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
+            Write-Success "PowerShell hook scripts (hooks/*.ps1) installed!"
+        }
+
+        Write-Success "Global settings installation complete!"
+
+        # Git identity personalization notice
+        Write-Host ""
+        Write-Warn "Important: Modify git-identity.md with your personal info!"
+        Write-Host "  Edit: notepad `$HOME\.claude\git-identity.md"
+    } else {
+        Write-Info "Global settings installation skipped"
+    }
+}
+
+# ── Project settings installation ─────────────────────────────
+
+if ($installType -eq '2' -or $installType -eq '3' -or $installType -eq '5') {
+    Write-Host ""
+    Write-Host "======================================================"
+    Write-Info "Project settings installation..."
+    Write-Host "======================================================"
+    Write-Host ""
+
+    # Project directory
+    $defaultProjectDir = (Get-Location).Path
+    $projectDir = Read-Host "Project directory path [default: $defaultProjectDir]"
+    if ([string]::IsNullOrEmpty($projectDir)) { $projectDir = $defaultProjectDir }
+
+    if (-not (Test-Path $projectDir)) {
+        Write-Err "Directory does not exist: $projectDir"
+        exit 1
+    }
+
+    Write-Info "Install path: $projectDir"
+
+    # Backup existing files
+    $existingProjectMd = Join-Path $projectDir "CLAUDE.md"
+    if (Test-Path $existingProjectMd) {
+        New-Backup $existingProjectMd
+    }
+    $existingRules = Join-Path $projectDir ".claude/rules"
+    if (Test-Path $existingRules) {
+        New-Backup $existingRules
+    }
+
+    # Copy files
+    Copy-Item -Path (Join-Path $BackupDir "project/CLAUDE.md") -Destination $projectDir -Force
+
+    # .claude directory
+    $projectClaudeDir = Join-Path $projectDir ".claude"
+    Ensure-Directory $projectClaudeDir
+
+    # settings.json
+    $projectSettings = Join-Path $BackupDir "project/.claude/settings.json"
+    if (Test-Path $projectSettings) {
+        New-Backup (Join-Path $projectClaudeDir "settings.json")
+        Copy-Item -Path $projectSettings -Destination $projectClaudeDir -Force
+        Write-Success "Project hook settings (.claude/settings.json) installed!"
+    }
+
+    # rules directory
+    $sourceRules = Join-Path $BackupDir "project/.claude/rules"
+    if (Test-Path $sourceRules) {
+        Copy-Item -Path $sourceRules -Destination $projectClaudeDir -Recurse -Force
+        Write-Success "Rules directory installed!"
+    }
+
+    # Skills directory
+    $sourceSkills = Join-Path $BackupDir "project/.claude/skills"
+    if (Test-Path $sourceSkills) {
+        $existingSkills = Join-Path $projectClaudeDir "skills"
+        if (Test-Path $existingSkills) { New-Backup $existingSkills }
+        Copy-Item -Path $sourceSkills -Destination $projectClaudeDir -Recurse -Force
+        Write-Success "Skills directory installed!"
+    }
+
+    # commands directory
+    $sourceCommands = Join-Path $BackupDir "project/.claude/commands"
+    if (Test-Path $sourceCommands) {
+        $existingCommands = Join-Path $projectClaudeDir "commands"
+        if (Test-Path $existingCommands) { New-Backup $existingCommands }
+        Copy-Item -Path $sourceCommands -Destination $projectClaudeDir -Recurse -Force
+        Write-Success "Commands directory installed!"
+    }
+
+    # agents directory
+    $sourceAgents = Join-Path $BackupDir "project/.claude/agents"
+    if (Test-Path $sourceAgents) {
+        $existingAgents = Join-Path $projectClaudeDir "agents"
+        if (Test-Path $existingAgents) { New-Backup $existingAgents }
+        Copy-Item -Path $sourceAgents -Destination $projectClaudeDir -Recurse -Force
+        Write-Success "Agents directory installed!"
+    }
+
+    # CLAUDE.local.md creation
+    Write-Host ""
+    $createLocal = Read-Host "Create personal CLAUDE.local.md? (y/n) [default: y]"
+    if ([string]::IsNullOrEmpty($createLocal)) { $createLocal = 'y' }
+    if ($createLocal -eq 'y') {
+        New-LocalClaude $projectDir
+    }
+
+    Write-Success "Project settings installation complete!"
+
+    # Project customization notice
+    Write-Host ""
+    Write-Info "Customize settings for your project:"
+    Write-Host "  - CLAUDE.md: Modify project overview"
+    Write-Host "  - .claude/rules/: Adjust coding standards"
+    Write-Host "  - CLAUDE.local.md: Personal settings (not committed)"
+}
+
+# ── Installation summary ──────────────────────────────────────
+
+Write-Host ""
+Write-Host "======================================================"
+Write-Success "Installation complete!"
+Write-Host "======================================================"
+Write-Host ""
+
+Write-Info "Installed files:"
+if ($installType -eq '4' -or $installType -eq '5') {
+    $ed = Get-EnterpriseDir
+    Write-Host "  Enterprise settings:"
+    Write-Host "    - $ed\CLAUDE.md"
+    Write-Host "    - $ed\rules\"
+}
+
+if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
+    Write-Host "  Global settings:"
+    Write-Host "    - ~/.claude/CLAUDE.md"
+    Write-Host "    - ~/.claude/conversation-language.md"
+    Write-Host "    - ~/.claude/git-identity.md"
+    Write-Host "    - ~/.claude/token-management.md"
+    Write-Host "    - ~/.claude/settings.json (Hook settings - Windows)"
+    Write-Host "    - ~/.claude/hooks/ (PowerShell hook scripts)"
+}
+
+if ($installType -eq '2' -or $installType -eq '3' -or $installType -eq '5') {
+    Write-Host "  Project settings:"
+    Write-Host "    - $projectDir\CLAUDE.md"
+    Write-Host "    - $projectDir\.claude\rules\ (Guidelines)"
+    Write-Host "    - $projectDir\.claude\settings.json (Hook settings)"
+    $sourceSkills = Join-Path $BackupDir "project/.claude/skills"
+    if (Test-Path $sourceSkills) {
+        Write-Host "    - $projectDir\.claude\skills\ (Skills)"
+    }
+    $sourceCommands = Join-Path $BackupDir "project/.claude/commands"
+    if (Test-Path $sourceCommands) {
+        Write-Host "    - $projectDir\.claude\commands\ (Commands)"
+    }
+    $sourceAgents = Join-Path $BackupDir "project/.claude/agents"
+    if (Test-Path $sourceAgents) {
+        Write-Host "    - $projectDir\.claude\agents\ (Agents)"
+    }
+}
+
+Write-Host ""
+Write-Host "======================================================"
+Write-Info "Next steps"
+Write-Host "======================================================"
+Write-Host ""
+Write-Host "1. Personalize Git identity (Required!):"
+Write-Host "     notepad `$HOME\.claude\git-identity.md"
+Write-Host ""
+Write-Host "2. Set PowerShell execution policy (if needed):"
+Write-Host "     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser"
+Write-Host ""
+Write-Host "3. Restart Claude Code:"
+Write-Host "     Open a new terminal or restart current session"
+Write-Host ""
+Write-Host "4. Verify settings:"
+Write-Host "     Get-Content `$HOME\.claude\CLAUDE.md"
+Write-Host ""
+
+Write-Success "Installation complete!"


### PR DESCRIPTION
## Summary

- Add native Windows PowerShell support with 13 `.ps1` hook scripts, `install.ps1`, and `settings.windows.json`
- Eliminates Git Bash dependency for Windows users by replacing `jq`/`python3` with PowerShell-native `ConvertFrom-Json`
- Update README.md, QUICKSTART.md, and HOOKS.md with Windows installation instructions and troubleshooting

## What

### New Files (15)

| Category | Files | Description |
|----------|-------|-------------|
| Hook scripts | `global/hooks/*.ps1` (13) | PowerShell ports of all bash hooks |
| Settings | `global/settings.windows.json` | Windows hook settings with `pwsh -NoProfile -File` commands |
| Installer | `scripts/install.ps1` | PowerShell mirror of install.sh (5 install types) |

### Modified Files (3)

| File | Changes |
|------|---------|
| `README.md` | Windows install method, Common Tasks table, directory structure, Scripts section |
| `QUICKSTART.md` | PowerShell alternatives for Step 1-4, Execution Policy troubleshooting |
| `HOOKS.md` | Full Windows Support section (hook list, Bash/PS comparison, prerequisites) |

## Why

Windows users currently need Git Bash to run installation scripts and hooks. This PR adds native PowerShell support so Windows users can install and use claude-config without additional dependencies.

### Design Decisions

- **Separate `settings.windows.json`**: Preserves existing macOS/Linux setup without any changes
- **`pwsh -NoProfile`**: Skips profile loading for faster, more predictable hook execution
- **PowerShell 7+ recommended**: PS 5.1 has known module loading issues in Claude Code hook context
- **No external dependencies**: `jq` and `python3` replaced by built-in `ConvertFrom-Json`

## Test plan

### Static validation
- [x] `settings.windows.json` passes JSON validation (`python3 -m json.tool`)
- [x] All 13 `.ps1` file references in settings match actual files on disk
- [x] Existing `verify.sh` passes all 57 checks (100%)
- [x] All 14 `.ps1` files pass PowerShell syntax validation (`Parser::ParseFile`)

### Runtime hook tests (PowerShell 7.5.4 on macOS)
- [x] `sensitive-file-guard.ps1`: allow normal files, deny `.env`, deny `secrets/` directory (exit code 0/2/2)
- [x] `dangerous-command-guard.ps1`: allow `ls`, deny `rm -rf /`, deny `curl|sh` (exit code 0/2/2)
- [x] `session-logger.ps1`: start/end/stop events written to `session.log` with correct timestamps
- [x] `prompt-validator.ps1`: allow normal prompts, warn on "delete all production", allow empty prompt
- [x] `cleanup.ps1`: executes without error, returns allow response
- [x] `tool-failure-logger.ps1`: writes tool name, session ID, and error to `tool-failures.log`
- [x] `subagent-logger.ps1`: writes subagent type and action to `subagents.log`
- [x] `pre-compact-snapshot.ps1`: writes session/working-dir snapshot to `compact-snapshots.log`
- [x] `worktree-create.ps1`: creates directory, outputs path to stdout, logs to `worktrees.log`
- [x] `worktree-remove.ps1`: reads env var fallback, logs removal to `worktrees.log`
- [x] `task-completed-logger.ps1`: parses stdin JSON, writes task ID/subject to `tasks.log`
- [x] `config-change-logger.ps1`: parses stdin JSON, writes to `logs/session.log`, outputs `{"decision":"allow"}`
- [x] `github-api-preflight.ps1`: fast-allow non-GitHub commands, connectivity check for GitHub commands

### Pending (requires Windows environment)
- [ ] End-to-end: Run `install.ps1` on Windows with PowerShell 7+
- [ ] End-to-end: Verify hooks execute correctly within Claude Code on Windows