### PR TITLE
feat(workflow): add shared batch infrastructure for skills

### DIFF
--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -6,3 +6,6 @@
 - Use closing keywords (`Closes #N`) in PR descriptions when applicable
 - All builds must pass before PR; all CI checks before merge
 - See `rules/workflow/build-verification.md` for verification patterns
+- Batch processing: 2-second pause between items, 0.3-second pause between API calls during discovery
+- Batch mode: max 200 repos for cross-repo discovery, max 100 items per repo
+- Batch failure: continue to next item on failure, present summary at end

--- a/project/.claude/rules/workflow/session-resume.md
+++ b/project/.claude/rules/workflow/session-resume.md
@@ -59,6 +59,46 @@ At session start, if `.claude/resume.md` exists in the working directory:
 3. If yes, proceed from the documented "Next Action"
 4. After completing the workflow, delete the resume file
 
+## Batch Resume Format
+
+When a batch workflow (`issue-work` or `pr-work` without a specific number) is interrupted,
+include the full batch progress table so the next session can resume from the correct item:
+
+```markdown
+# Session Resume State
+
+**Saved**: YYYY-MM-DD HH:MM KST
+**Workflow**: issue-work (batch) | pr-work (batch)
+
+## Batch Context
+
+| Field | Value |
+|-------|-------|
+| Batch Mode | single-repo / cross-repo |
+| Total Items | N |
+| Completed | M |
+| Current Item | K |
+
+## Batch Progress
+
+| # | Repo | Item | Mode | Status |
+|---|------|------|------|--------|
+| 1 | org/repo-a | #12 | solo | DONE (PR #89) |
+| 2 | org/repo-a | #8 | team | DONE (PR #90) |
+| 3 | org/repo-b | #45 | solo | IN PROGRESS |
+| 4 | org/repo-c | #3 | solo | PENDING |
+
+## Next Action
+
+Continue batch from item K: org/repo-b #45. Solo mode. Branch: feat/issue-45-fix-links.
+```
+
+When resuming a batch:
+1. Read the batch progress table
+2. Skip items with status `DONE`
+3. Restart the `IN PROGRESS` item from its last known phase
+4. Continue with `PENDING` items in order
+
 ## Rules
 
 - **One resume file per project** — overwrite if a new workflow starts


### PR DESCRIPTION
Closes #205
Part of #202

## Summary

Add shared infrastructure that supports batch processing in both `issue-work` and `pr-work` skills:

1. **`global/skills/_policy.md`** — batch rate-limiting rules (2s between items, 0.3s between API calls, max 200 repos)
2. **`project/.claude/rules/workflow/session-resume.md`** — batch resume format with progress table for interrupted sessions

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `global/skills/_policy.md` | +3 | Batch rate-limiting and failure handling rules |
| `project/.claude/rules/workflow/session-resume.md` | +40 | Batch progress table format and resume instructions |

## Test Plan

- [x] `_policy.md` syntax valid (markdown)
- [x] `session-resume.md` new section integrates with existing format
- [x] Resume instructions consistent with batch execution loop in issue-work/pr-work