### PR TITLE
docs: add third-party license notice for harness content

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1300,6 +1300,8 @@ curl -sSL -H "Authorization: token YOUR_TOKEN" \
 
 This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.
 
+This project includes third-party content. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for details.
+
 ---
 
 **Happy Coding with Claude!**

--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,8 @@ An AI agent-based software development automation platform. AD-SDLC agents can r
 
 This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.
 
+This project includes third-party content. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for details.
+
 ---
 
 **Happy Coding with Claude!**

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,26 @@
+# Third-Party Notices
+
+This project includes content adapted from the following third-party projects.
+
+---
+
+## revfactory/harness
+
+- **Source**: https://github.com/revfactory/harness
+- **License**: Apache License 2.0
+- **Copyright**: Copyright (c) Robin (revfactory)
+- **Version**: 1.0.1 (as of integration date)
+- **Files affected**:
+  - `global/skills/harness/` — adapted from `skills/harness/`
+
+### Modifications
+
+The original content was:
+1. Translated from Korean to English
+2. Restructured to conform to claude-config conventions (directory naming, YAML frontmatter, file organization)
+3. SKILL.md trimmed to <500 lines with detailed content moved to `reference/` subdirectory
+
+### License Text
+
+The full Apache License 2.0 text is available at:
+https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Summary

- Add `THIRD_PARTY_NOTICES.md` documenting the Apache 2.0 licensed content adapted from [revfactory/harness](https://github.com/revfactory/harness)
- Update `README.md` and `README.ko.md` License sections with a reference to the new notices file

## Test plan

- [ ] Verify `THIRD_PARTY_NOTICES.md` exists at repository root with correct content
- [ ] Verify `README.md` License section includes third-party notice reference link
- [ ] Verify `README.ko.md` License section includes third-party notice reference link
- [ ] Verify the link `[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)` resolves correctly on GitHub

Closes #210