### PR TITLE
docs(quickstart): add What's Next section after installation

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -167,4 +167,35 @@ See `README.md` for detailed information:
 
 ---
 
+## What's Next
+
+### Try a skill
+
+````bash
+# Check your repo status
+/git-status
+
+# Review code quality of a file or directory
+/code-quality src/
+
+# Create a well-structured GitHub issue
+/issue-create my-project --type feature
+
+# Automate an issue from start to PR
+/issue-work my-project 42
+````
+
+### Choose your path
+
+| I want to... | Go to |
+|--------------|-------|
+| Understand what I just installed | [What You Get](README.md#what-you-get) |
+| See all available skills | [Skills](README.md#skills--what-you-can-do) |
+| Customize hooks and settings | [HOOKS.md](HOOKS.md) |
+| Set up for my team | [Enterprise Settings](README.md#enterprise-settings) |
+| Understand token optimization | [Token Optimization](README.md#token-optimization) |
+| Design multi-agent teams | Run `/harness` in Claude Code |
+
+---
+
 **Installation complete! Now enjoy Claude Code!**


### PR DESCRIPTION
## Summary

- Add a "What's Next" section to QUICKSTART.md between "Learn More" and the closing line
- Include "Try a skill" subsection with example slash commands (`/git-status`, `/code-quality`, `/issue-create`, `/issue-work`)
- Include "Choose your path" table linking to relevant documentation sections (README, HOOKS.md, enterprise settings, etc.)

Closes #230

## Test plan

- [ ] Verify QUICKSTART.md renders correctly on GitHub (especially the nested code block with 4 backticks)
- [ ] Verify all links in the "Choose your path" table resolve to valid anchors
- [ ] Confirm the closing line "Installation complete! Now enjoy Claude Code!" remains at the bottom