### PR TITLE
feat(hooks): add git commit-msg hook with shared validator

### DIFF
--- a/global/hooks/commit-message-guard.sh
+++ b/global/hooks/commit-message-guard.sh
@@ -8,12 +8,8 @@
 # Replaces the non-deterministic type:"prompt" validator (see #241).
 # Same input always yields same output — safe as a validation gate.
 #
-# Rules enforced:
-#   1. Conventional Commits format: type(scope)?: description
-#   2. Description must start with a lowercase letter
-#   3. Description must not end with a period
-#   4. No AI/Claude attribution
-#   5. No emojis
+# Sources shared validation rules from hooks/lib/validate-commit-message.sh
+# (single source of truth shared with the git commit-msg hook — see #242).
 #
 # NOTE on parsing limits: -m arguments using $(...) command substitution or
 # containing embedded double quotes are not reliably parseable at this layer.
@@ -48,6 +44,24 @@ allow_response() {
 EOF
     exit 0
 }
+
+# --- Source shared validation library ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR=""
+
+# Try 1: repo-relative path (development / CI testing)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
+if [ -f "$REPO_ROOT/hooks/lib/validate-commit-message.sh" ]; then
+    VALIDATOR="$REPO_ROOT/hooks/lib/validate-commit-message.sh"
+# Try 2: sibling lib/ directory (deployed to ~/.claude/hooks/)
+elif [ -f "$SCRIPT_DIR/lib/validate-commit-message.sh" ]; then
+    VALIDATOR="$SCRIPT_DIR/lib/validate-commit-message.sh"
+fi
+
+if [ -n "$VALIDATOR" ]; then
+    # shellcheck source=../../hooks/lib/validate-commit-message.sh
+    . "$VALIDATOR"
+fi
 
 # --- Read input from stdin ---
 INPUT=$(cat)
@@ -91,41 +105,34 @@ if [ -z "$MSG" ]; then
     allow_response
 fi
 
-# --- Rule 1: Conventional Commits format ---
-if ! printf '%s' "$MSG" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|security)(\([a-z0-9._-]+\))?: .+'; then
-    deny_response "Commit message must follow Conventional Commits: 'type(scope): description' or 'type: description'. Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security."
-fi
+# --- Validate using shared library (if available) or inline fallback ---
+if [ -n "$VALIDATOR" ]; then
+    REASON=$(validate_commit_message "$MSG" 2>&1) || deny_response "$REASON"
+else
+    # Inline fallback when the shared library is not available.
+    # Keep rules in sync with hooks/lib/validate-commit-message.sh.
+    if ! printf '%s' "$MSG" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|security)(\([a-z0-9._-]+\))?: .+'; then
+        deny_response "Commit message must follow Conventional Commits: 'type(scope): description' or 'type: description'. Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security."
+    fi
 
-# --- Rule 2: Description starts with lowercase letter ---
-# Everything after the first ': ' is the description.
-DESC=$(printf '%s' "$MSG" | sed -E 's/^[^:]*:[[:space:]]*//')
-FIRST_CHAR=$(printf '%s' "$DESC" | head -c1)
-# NOTE: enumerate characters explicitly — bash case with [a-z] is locale-dependent
-# and can match uppercase under en_US.UTF-8 collation. This is ASCII-only by design.
-case "$FIRST_CHAR" in
-    a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z) ;;
-    *)
-        deny_response "Commit message description must start with a lowercase letter."
-        ;;
-esac
+    DESC=$(printf '%s' "$MSG" | sed -E 's/^[^:]*:[[:space:]]*//')
+    FIRST_CHAR=$(printf '%s' "$DESC" | head -c1)
+    case "$FIRST_CHAR" in
+        a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z) ;;
+        *) deny_response "Commit message description must start with a lowercase letter." ;;
+    esac
 
-# --- Rule 3: No trailing period ---
-case "$DESC" in
-    *.)
-        deny_response "Commit message description must not end with a period."
-        ;;
-esac
+    case "$DESC" in
+        *.) deny_response "Commit message description must not end with a period." ;;
+    esac
 
-# --- Rule 4: No AI/Claude attribution ---
-if printf '%s' "$MSG" | grep -iqE '(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'; then
-    deny_response "Commit message must not contain AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude)."
-fi
+    if printf '%s' "$MSG" | grep -iqE '(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'; then
+        deny_response "Commit message must not contain AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude)."
+    fi
 
-# --- Rule 5: No emojis ---
-# Use perl for portable Unicode range matching on macOS/Linux.
-# perl exits 1 when a match is found; 0 otherwise.
-if ! printf '%s' "$MSG" | perl -CSD -ne 'exit 1 if /[\x{1F300}-\x{1F9FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}\x{1F1E0}-\x{1F1FF}]/' 2>/dev/null; then
-    deny_response "Commit message must not contain emojis."
+    if ! printf '%s' "$MSG" | perl -CSD -ne 'exit 1 if /[\x{1F300}-\x{1F9FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}\x{1F1E0}-\x{1F1FF}]/' 2>/dev/null; then
+        deny_response "Commit message must not contain emojis."
+    fi
 fi
 
 # All rules passed

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,41 @@
+#!/bin/bash
+# commit-msg — git hook for commit message validation
+# Receives the commit message file path as $1.
+# Sources the shared validator from hooks/lib/validate-commit-message.sh.
+#
+# Install: hooks/install-hooks.sh copies this to .git/hooks/commit-msg
+# Bypass:  git commit --no-verify (forbidden by global CLAUDE.md policy)
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Source the shared validation library
+VALIDATOR="$SCRIPT_DIR/lib/validate-commit-message.sh"
+if [ ! -f "$VALIDATOR" ]; then
+    echo "commit-msg hook: validator library not found at $VALIDATOR" >&2
+    echo "Run hooks/install-hooks.sh to reinstall." >&2
+    exit 1
+fi
+# shellcheck source=lib/validate-commit-message.sh
+. "$VALIDATOR"
+
+# Read the first line (subject) of the commit message.
+# Ignore lines starting with '#' (git comments) and blank lines.
+MSG=$(sed '/^#/d;/^$/d' "$COMMIT_MSG_FILE" | head -n1)
+
+# Allow empty messages — git itself will reject them.
+if [ -z "$MSG" ]; then
+    exit 0
+fi
+
+# Validate
+if ! validate_commit_message "$MSG"; then
+    echo "" >&2
+    echo "commit-msg hook rejected the commit." >&2
+    echo "Fix the message and try again, or use --no-verify to bypass (not recommended)." >&2
+    exit 1
+fi
+
+exit 0

--- a/hooks/install-hooks.ps1
+++ b/hooks/install-hooks.ps1
@@ -62,6 +62,46 @@ if (-not $IsWindows) {
 
 Write-SuccessMessage "pre-commit hook 설치 완료!"
 
+# ── Install commit-msg hook ─────────────────────────────────
+
+Write-Host ""
+Write-InfoMessage "commit-msg hook 설치 중..."
+
+$commitMsgDst = Join-Path $GitHooksDir 'commit-msg'
+
+if (Test-Path -LiteralPath $commitMsgDst) {
+    Write-WarningMessage "기존 commit-msg hook이 존재합니다."
+    $reply = Read-Host "덮어쓰시겠습니까? (y/n)"
+    if ($reply -ne 'y' -and $reply -ne 'Y') {
+        Write-InfoMessage "commit-msg 설치를 건너뜁니다."
+    } else {
+        $commitMsgSrc = Join-Path $ScriptDir 'commit-msg'
+        Copy-Item -LiteralPath $commitMsgSrc -Destination $commitMsgDst -Force
+        if (-not $IsWindows) { & chmod +x $commitMsgDst 2>$null }
+        Write-SuccessMessage "commit-msg hook 설치 완료!"
+    }
+} else {
+    $commitMsgSrc = Join-Path $ScriptDir 'commit-msg'
+    Copy-Item -LiteralPath $commitMsgSrc -Destination $commitMsgDst -Force
+    if (-not $IsWindows) { & chmod +x $commitMsgDst 2>$null }
+    Write-SuccessMessage "commit-msg hook 설치 완료!"
+}
+
+# ── Install shared validation library ───────────────────────
+
+Write-InfoMessage "검증 라이브러리 설치 중..."
+
+$libDstDir = Join-Path $GitHooksDir 'lib'
+if (-not (Test-Path -LiteralPath $libDstDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $libDstDir -Force | Out-Null
+}
+
+$validatorSrc = Join-Path $ScriptDir 'lib' 'validate-commit-message.sh'
+$validatorDst = Join-Path $libDstDir 'validate-commit-message.sh'
+Copy-Item -LiteralPath $validatorSrc -Destination $validatorDst -Force
+if (-not $IsWindows) { & chmod +x $validatorDst 2>$null }
+Write-SuccessMessage "검증 라이브러리 설치 완료!"
+
 Write-Host ""
 Write-InfoMessage "설치된 hooks:"
 Get-ChildItem -LiteralPath $GitHooksDir -File |
@@ -72,4 +112,4 @@ Get-ChildItem -LiteralPath $GitHooksDir -File |
 
 Write-Host ""
 Write-SuccessMessage "Git hooks 설치가 완료되었습니다."
-Write-InfoMessage "SKILL.md 파일을 커밋할 때 자동으로 검증이 실행됩니다."
+Write-InfoMessage "커밋 시 SKILL.md 검증과 커밋 메시지 검증이 자동으로 실행됩니다."

--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -64,10 +64,38 @@ chmod +x "$GIT_HOOKS_DIR/pre-commit"
 
 success "pre-commit hook 설치 완료!"
 
+# commit-msg hook 설치
+echo ""
+info "commit-msg hook 설치 중..."
+
+if [ -f "$GIT_HOOKS_DIR/commit-msg" ]; then
+    warning "기존 commit-msg hook이 존재합니다."
+    read -p "덮어쓰시겠습니까? (y/n): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        info "commit-msg 설치를 건너뜁니다."
+    else
+        cp "$SCRIPT_DIR/commit-msg" "$GIT_HOOKS_DIR/commit-msg"
+        chmod +x "$GIT_HOOKS_DIR/commit-msg"
+        success "commit-msg hook 설치 완료!"
+    fi
+else
+    cp "$SCRIPT_DIR/commit-msg" "$GIT_HOOKS_DIR/commit-msg"
+    chmod +x "$GIT_HOOKS_DIR/commit-msg"
+    success "commit-msg hook 설치 완료!"
+fi
+
+# 공유 검증 라이브러리 설치
+info "검증 라이브러리 설치 중..."
+mkdir -p "$GIT_HOOKS_DIR/lib"
+cp "$SCRIPT_DIR/lib/validate-commit-message.sh" "$GIT_HOOKS_DIR/lib/"
+chmod +x "$GIT_HOOKS_DIR/lib/validate-commit-message.sh"
+success "검증 라이브러리 설치 완료!"
+
 echo ""
 info "설치된 hooks:"
 ls -la "$GIT_HOOKS_DIR" | grep -v ".sample"
 
 echo ""
 success "Git hooks 설치가 완료되었습니다."
-info "SKILL.md 파일을 커밋할 때 자동으로 검증이 실행됩니다."
+info "커밋 시 SKILL.md 검증과 커밋 메시지 검증이 자동으로 실행됩니다."

--- a/hooks/lib/validate-commit-message.sh
+++ b/hooks/lib/validate-commit-message.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# validate-commit-message.sh
+# Shared commit message validation library
+# Single source of truth for commit message rules.
+#
+# Sourced by:
+#   - hooks/commit-msg          (git hook — terminal-side gate)
+#   - global/hooks/commit-message-guard.sh (PreToolUse — Claude-side feedback loop)
+#
+# Usage:
+#   . /path/to/validate-commit-message.sh
+#   if ! validate_commit_message "feat: add feature"; then
+#       echo "invalid" >&2
+#   fi
+
+# Allowed commit types (Conventional Commits)
+readonly CMV_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|security"
+
+# validate_commit_message <message>
+# Returns 0 on valid, 1 on invalid.
+# On failure, prints reason to stderr.
+validate_commit_message() {
+    local msg="$1"
+
+    # Rule 1: Conventional Commits format — type(scope)?: description
+    if ! printf '%s' "$msg" | grep -qE "^($CMV_TYPES)(\([a-z0-9._-]+\))?: .+"; then
+        echo "Commit message must follow Conventional Commits: 'type(scope): description' or 'type: description'. Allowed types: ${CMV_TYPES//|/, }." >&2
+        return 1
+    fi
+
+    # Extract description (everything after the first ': ')
+    local desc
+    desc=$(printf '%s' "$msg" | sed -E 's/^[^:]*:[[:space:]]*//')
+
+    # Rule 2: Description starts with a lowercase ASCII letter
+    local first_char
+    first_char=$(printf '%s' "$desc" | head -c1)
+    case "$first_char" in
+        a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z) ;;
+        *)
+            echo "Commit message description must start with a lowercase letter." >&2
+            return 1
+            ;;
+    esac
+
+    # Rule 3: No trailing period
+    case "$desc" in
+        *.)
+            echo "Commit message description must not end with a period." >&2
+            return 1
+            ;;
+    esac
+
+    # Rule 4: No AI/Claude attribution
+    if printf '%s' "$msg" | grep -iqE '(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'; then
+        echo "Commit message must not contain AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude)." >&2
+        return 1
+    fi
+
+    # Rule 5: No emojis
+    # perl exits 1 when a match is found; 0 otherwise.
+    if ! printf '%s' "$msg" | perl -CSD -ne 'exit 1 if /[\x{1F300}-\x{1F9FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}\x{1F1E0}-\x{1F1FF}]/' 2>/dev/null; then
+        echo "Commit message must not contain emojis." >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -318,6 +318,14 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
             success "Hook 스크립트 (hooks/) 설치 완료!"
         fi
 
+        # 공유 검증 라이브러리 설치 (commit-message-guard.sh에서 사용)
+        if [ -f "$BACKUP_DIR/hooks/lib/validate-commit-message.sh" ]; then
+            ensure_dir "$HOME/.claude/hooks/lib"
+            cp "$BACKUP_DIR/hooks/lib/validate-commit-message.sh" "$HOME/.claude/hooks/lib/"
+            chmod +x "$HOME/.claude/hooks/lib/validate-commit-message.sh"
+            success "공유 검증 라이브러리 설치 완료!"
+        fi
+
         # scripts 디렉토리 설치 (statusline 등)
         if [ -d "$BACKUP_DIR/global/scripts" ]; then
             ensure_dir "$HOME/.claude/scripts"

--- a/tests/hooks/test-commit-msg.sh
+++ b/tests/hooks/test-commit-msg.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Test suite for hooks/commit-msg (git hook) and hooks/lib/validate-commit-message.sh
+# Run: bash tests/hooks/test-commit-msg.sh
+
+HOOK="hooks/commit-msg"
+VALIDATOR_LIB="hooks/lib/validate-commit-message.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Verify scripts exist
+if [ ! -f "$HOOK" ]; then
+    echo "ERROR: $HOOK not found"
+    exit 1
+fi
+if [ ! -f "$VALIDATOR_LIB" ]; then
+    echo "ERROR: $VALIDATOR_LIB not found"
+    exit 1
+fi
+
+# Helper: create a temp commit message file and run the hook
+run_hook() {
+    local msg="$1"
+    local tmpfile
+    tmpfile=$(mktemp)
+    printf '%s\n' "$msg" > "$tmpfile"
+    bash "$HOOK" "$tmpfile" 2>&1
+    local rc=$?
+    rm -f "$tmpfile"
+    return $rc
+}
+
+assert_accept() {
+    local msg="$1" label="$2"
+    if run_hook "$msg" >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected accept (exit 0)")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_reject() {
+    local msg="$1" label="$2"
+    if run_hook "$msg" >/dev/null 2>&1; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected reject (exit 1)")
+        echo "  FAIL: $label"
+    else
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    fi
+}
+
+echo "=== commit-msg hook tests ==="
+echo ""
+
+echo "[valid conventional commits]"
+assert_accept "feat: add new feature" "feat: basic"
+assert_accept "fix(auth): handle null token" "fix(scope): with scope"
+assert_accept "docs(readme): update installation steps" "docs(readme): docs type"
+assert_accept "security: patch credential leak" "security: security type"
+assert_accept "refactor: simplify config loader" "refactor: refactor type"
+assert_accept "chore: update dependencies" "chore: chore type"
+assert_accept "test(unit): add parser tests" "test(scope): test type"
+assert_accept "build: upgrade cmake to 3.28" "build: build type"
+assert_accept "ci: add shellcheck workflow" "ci: ci type"
+assert_accept "perf: optimize hot loop" "perf: perf type"
+assert_accept "style: fix indentation" "style: style type"
+
+echo ""
+echo "[format violations]"
+assert_reject "added new feature" "no type prefix"
+assert_reject "feat add new feature" "missing colon"
+assert_reject "wip: some stuff" "invalid type 'wip'"
+assert_reject "feat(BadScope): desc" "uppercase scope"
+assert_reject "update: things" "invalid type 'update'"
+
+echo ""
+echo "[description rules]"
+assert_reject "feat: Added new feature" "uppercase first char"
+assert_reject "fix: resolve issue." "trailing period"
+
+echo ""
+echo "[AI attribution]"
+assert_reject "feat: add claude integration" "claude keyword"
+assert_reject "fix: anthropic API fallback" "anthropic keyword"
+assert_reject "fix: ai-assisted refactor" "ai-assisted"
+assert_reject "feat: add feature generated with claude code" "generated with"
+
+echo ""
+echo "[emoji detection]"
+EMOJI_PARTY=$(printf '\xf0\x9f\x8e\x89')
+assert_reject "feat: ${EMOJI_PARTY} party hat" "emoji party face"
+
+echo ""
+echo "[edge cases]"
+assert_accept "" "empty message (git rejects separately)"
+assert_accept "# This is a comment" "comment-only message"
+
+echo ""
+echo "[git comment stripping]"
+# Simulate a message file with git comments
+TMPFILE=$(mktemp)
+printf 'feat: add feature\n# Please enter the commit message\n# Changes:\n#   modified: file.txt\n' > "$TMPFILE"
+if bash "$HOOK" "$TMPFILE" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: message with git comments accepted"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: message with git comments — expected accept")
+    echo "  FAIL: message with git comments"
+fi
+rm -f "$TMPFILE"
+
+echo ""
+echo "[shared lib direct test]"
+# shellcheck source=../../hooks/lib/validate-commit-message.sh
+. "$VALIDATOR_LIB"
+
+if validate_commit_message "feat: direct lib call" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: validate_commit_message direct call — valid"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: direct lib call valid message — expected 0")
+    echo "  FAIL: validate_commit_message direct call — valid"
+fi
+
+if validate_commit_message "bad message" 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: direct lib call invalid message — expected 1")
+    echo "  FAIL: validate_commit_message direct call — invalid"
+else
+    PASS=$((PASS + 1))
+    echo "  PASS: validate_commit_message direct call — invalid"
+fi
+
+echo ""
+echo "[determinism — 3 identical runs]"
+TMPFILE=$(mktemp)
+printf 'feat: deterministic check\n' > "$TMPFILE"
+R1=$(bash "$HOOK" "$TMPFILE" 2>&1; echo "RC=$?")
+R2=$(bash "$HOOK" "$TMPFILE" 2>&1; echo "RC=$?")
+R3=$(bash "$HOOK" "$TMPFILE" 2>&1; echo "RC=$?")
+rm -f "$TMPFILE"
+if [ "$R1" = "$R2" ] && [ "$R2" = "$R3" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: 3 runs produced identical output"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: non-deterministic output across runs")
+    echo "  FAIL: 3 runs differed"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #242

## What

### Summary
Adds a real `commit-msg` git hook and a shared validation library (`hooks/lib/validate-commit-message.sh`) that serves as the single source of truth for commit message rules. The PreToolUse `commit-message-guard.sh` is refactored to source this shared library.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `hooks/lib/validate-commit-message.sh` — shared validation library (new)
- `hooks/commit-msg` — git commit-msg hook (new)
- `hooks/install-hooks.sh` — install script (updated)
- `hooks/install-hooks.ps1` — install script (updated)
- `global/hooks/commit-message-guard.sh` — PreToolUse hook (refactored)
- `scripts/install.sh` — main installer (updated)
- `tests/hooks/test-commit-msg.sh` — test suite (new)

## Why

### Problem Solved
After #241, commit message enforcement only covers Claude's Bash tool invocations via PreToolUse. Direct `git commit` from terminal, IDE, or CI bypasses it entirely. The `commit-msg` git hook closes this gap as the unbypassable terminal-side gate.

### Related Issues
- Closes #242 (install real git commit-msg hook)
- Depends on #241 (deterministic commit validator — merged in PR #244)

## Where

### Architecture

| Layer | Artifact | Role | Bypassable? |
|-------|----------|------|-------------|
| PreToolUse (Claude-only) | `commit-message-guard.sh` | Feedback loop — lets Claude self-correct | Yes (outside Claude) |
| git `commit-msg` (this PR) | `hooks/commit-msg` | Terminal gate — git rejects the commit | Only via `--no-verify` |
| Shared library | `hooks/lib/validate-commit-message.sh` | Single source of truth for rules | N/A |

### Path Resolution
- **In repo (dev/CI)**: `commit-message-guard.sh` finds lib at `../../hooks/lib/validate-commit-message.sh`
- **Deployed (`~/.claude/hooks/`)**: finds lib at `./lib/validate-commit-message.sh`
- **Fallback**: inline validation if lib is unavailable

## How

### Implementation Highlights
1. Shared `validate_commit_message()` function with 5 rules (format, lowercase, no period, no AI, no emoji)
2. Git hook reads first non-comment line from commit message file
3. Install scripts copy both `commit-msg` and `lib/` to `.git/hooks/`
4. Main installer deploys shared lib to `~/.claude/hooks/lib/` for PreToolUse hook

### Testing Done
- [x] Unit tests: 29/29 passing (test-commit-msg.sh)
- [x] Existing tests: 27/27 passing (test-commit-message-guard.sh)
- [x] Full test suite: 166/166 passing (test-runner.sh)
- [ ] CI: Validate Hooks workflow
- [ ] Manual test: reject bad commit from terminal

### Test Plan
1. Run `bash tests/hooks/test-runner.sh` — all 166 tests pass
2. Run `bash hooks/install-hooks.sh` — installs both hooks
3. Try `git commit -m "bad message"` — rejected
4. Try `git commit -m "feat: valid message"` — accepted

### Breaking Changes
None — new hooks only. Existing pre-commit hook unchanged.