### PR TITLE
docs: align commit-hook documentation with enforcement mechanism

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -17,6 +17,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Limit concurrent Agent Teams | [Team Limit Guard](#6-team-limit-guard-pretooluse) |
 | Log session activity | [Session Logging](#3-session-logging-sessionstartsessionend) |
 | Check for known Claude Code bugs | [Version Check](#8-version-check-sessionstart) |
+| Validate commit messages before git commit | [Commit Message Guard](#10-commit-message-guard-pretooluse) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
 
@@ -198,6 +199,29 @@ Hooks are user-defined commands that automatically execute during specific Claud
 |-----------|--------|
 | `0` | Accept task completion |
 | `2` | Block completion — stderr message sent as feedback to teammate |
+
+### 10. Commit Message Guard (PreToolUse)
+
+*Blocks non-conventional commit messages at Claude's Bash tool boundary — deterministic, same input always yields same decision.*
+
+**Purpose**: Validate git commit messages against Conventional Commits rules before Claude invokes `git commit`.
+
+**Trigger**: Bash commands matching `git commit ... -m ...` only.
+
+**Rules enforced**:
+- Conventional Commits format: `type(scope): description` or `type: description`
+- Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
+- Description starts with lowercase, no trailing period
+- No AI/Claude attribution
+- No emojis
+
+**Behavior**:
+- Returns JSON with `permissionDecision: "deny"` listing the failed rule
+- Defers to the git `commit-msg` hook for command-substitution messages (`-m "$(..."`)
+- Timeout: 5 seconds
+- Cross-platform: `commit-message-guard.sh` and `commit-message-guard.ps1`
+
+**Shared validation library**: Both this PreToolUse hook and the git `commit-msg` hook (installed by `hooks/install-hooks.sh`) source the same validator at `hooks/lib/validate-commit-message.sh`, ensuring rule consistency across enforcement layers.
 
 ### Hook Response Format
 

--- a/global/commit-settings.md
+++ b/global/commit-settings.md
@@ -1,6 +1,6 @@
 # Commit, Issue, and PR Settings
 
 No AI/Claude attribution in commits, issues, or PRs.
-Enforced by `settings.json` (`attribution: ""`) and `commit-msg` hook.
+Enforced by `settings.json` (`attribution: ""`), the `commit-message-guard` PreToolUse hook (Claude-side feedback loop), and the `commit-msg` git hook installed by `hooks/install-hooks.sh` (terminal-side gate).
 
 All GitHub Issues and Pull Requests must be written in English.

--- a/project/.claude/rules/workflow/git-commit-format.md
+++ b/project/.claude/rules/workflow/git-commit-format.md
@@ -11,7 +11,7 @@ Use **Conventional Commits**: `type(scope): description`
 
 ## Types
 
-feat, fix, docs, style, refactor, perf, test, build, ci, chore
+feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
 
 ## Rules
 

--- a/project/.claude/rules/workflow/reference/commit-hooks.md
+++ b/project/.claude/rules/workflow/reference/commit-hooks.md
@@ -8,60 +8,25 @@ alwaysApply: false
 
 ## Git Hook Setup
 
-### macOS commit-msg hook
+The canonical `commit-msg` hook script lives at `hooks/commit-msg` and is installed by `hooks/install-hooks.sh` on macOS/Linux or `hooks/install-hooks.ps1` on Windows. It sources shared validation logic from `hooks/lib/validate-commit-message.sh` — the same library used by the PreToolUse-layer `commit-message-guard` hook.
+
+To install:
 
 ```bash
-mkdir -p .git/hooks
-
-cat > .git/hooks/commit-msg << 'EOF'
-#!/bin/bash
-# Remove Claude-related references and emojis from commit messages
-
-COMMIT_MSG_FILE=$1
-
-# Remove Claude Code attribution
-sed -i '' '/🤖 Generated with \[Claude Code\]/d' "$COMMIT_MSG_FILE"
-sed -i '' '/Generated with Claude Code/d' "$COMMIT_MSG_FILE"
-
-# Remove Co-Authored-By: Claude
-sed -i '' '/Co-Authored-By: Claude/d' "$COMMIT_MSG_FILE"
-
-# Remove common AI assistant references
-sed -i '' '/AI-assisted/d' "$COMMIT_MSG_FILE"
-sed -i '' '/Anthropic Claude/d' "$COMMIT_MSG_FILE"
-sed -i '' '/claude.ai/d' "$COMMIT_MSG_FILE"
-
-# Remove all emojis (Unicode ranges for common emojis)
-perl -i -pe 's/[\x{1F300}-\x{1F9FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]|[\x{1F1E0}-\x{1F1FF}]//g' "$COMMIT_MSG_FILE"
-
-# Remove empty lines at the end
-sed -i '' -e :a -e '/^\s*$/d;N;ba' "$COMMIT_MSG_FILE"
-EOF
-
-chmod +x .git/hooks/commit-msg
+./hooks/install-hooks.sh
 ```
 
-### Linux/WSL commit-msg hook
+Do not copy inline scripts from prior versions of this document — they are deprecated and drift from the canonical validator.
 
-```bash
-cat > .git/hooks/commit-msg << 'EOF'
-#!/bin/bash
-COMMIT_MSG_FILE=$1
+### Enforcement Layers
 
-sed -i '/🤖 Generated with \[Claude Code\]/d' "$COMMIT_MSG_FILE"
-sed -i '/Generated with Claude Code/d' "$COMMIT_MSG_FILE"
-sed -i '/Co-Authored-By: Claude/d' "$COMMIT_MSG_FILE"
-sed -i '/AI-assisted/d' "$COMMIT_MSG_FILE"
-sed -i '/Anthropic Claude/d' "$COMMIT_MSG_FILE"
-sed -i '/claude.ai/d' "$COMMIT_MSG_FILE"
+| Layer | Artifact | Role | Bypassable? |
+|-------|----------|------|-------------|
+| Attribution config | `settings.json` `attribution: ""` | Prevents Claude from adding attribution | N/A |
+| PreToolUse (Claude-only) | `global/hooks/commit-message-guard.sh` | Feedback loop — lets Claude self-correct and retry | Yes (outside Claude) |
+| git `commit-msg` hook | `hooks/commit-msg` | Terminal gate — git itself rejects the commit | Only via `--no-verify` |
 
-perl -i -pe 's/[\x{1F300}-\x{1F9FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]|[\x{1F1E0}-\x{1F1FF}]//g' "$COMMIT_MSG_FILE"
-
-sed -i -e :a -e '/^\s*$/d;N;ba' "$COMMIT_MSG_FILE"
-EOF
-
-chmod +x .git/hooks/commit-msg
-```
+All enforcement layers share rules from `hooks/lib/validate-commit-message.sh` to prevent drift.
 
 ## CI/CD Verification
 
@@ -92,50 +57,6 @@ jobs:
           fi
 
           echo "No Claude references or emojis found"
-```
-
-## Cross-Platform Hook Setup Script
-
-```bash
-#!/bin/bash
-# scripts/setup-git-hooks.sh
-
-HOOKS_DIR=".git/hooks"
-COMMIT_MSG_HOOK="$HOOKS_DIR/commit-msg"
-
-cat > "$COMMIT_MSG_HOOK" << 'HOOKEOF'
-#!/bin/bash
-COMMIT_MSG_FILE=$1
-
-PATTERNS=(
-    "🤖 Generated with \[Claude Code\]"
-    "Generated with Claude Code"
-    "Co-Authored-By: Claude"
-    "AI-assisted"
-    "Anthropic Claude"
-    "claude.ai"
-    "claude code"
-)
-
-for pattern in "${PATTERNS[@]}"; do
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "/$pattern/d" "$COMMIT_MSG_FILE"
-    else
-        sed -i "/$pattern/d" "$COMMIT_MSG_FILE"
-    fi
-done
-
-perl -i -pe 's/[\x{1F300}-\x{1F9FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]|[\x{1F1E0}-\x{1F1FF}]//g' "$COMMIT_MSG_FILE"
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' -e :a -e '/^\s*$/d;N;ba' "$COMMIT_MSG_FILE"
-else
-    sed -i -e :a -e '/^\s*$/d;N;ba' "$COMMIT_MSG_FILE"
-fi
-HOOKEOF
-
-chmod +x "$COMMIT_MSG_HOOK"
-echo "Git hooks installed successfully"
 ```
 
 ## Verification Commands


### PR DESCRIPTION
Closes #243

## Summary
- Corrected false enforcement claim in `commit-settings.md` to describe all three layers (attribution config, PreToolUse guard, git commit-msg hook)
- Added `security` to the allowed commit types in `git-commit-format.md` to match the shared validator regex
- Added commit-message-guard section (#10) to `HOOKS.md` with Quick Navigation entry
- Replaced deprecated inline hook scripts in `commit-hooks.md` with a pointer to the canonical `hooks/commit-msg` and shared validator

## Test Plan
- [x] Full test suite: 166/166 passing
- [ ] CI: Validate Hooks + validate-skills workflows
- [ ] Verify markdown anchors in HOOKS.md render correctly