### PR TITLE
ci(workflows): restrict CI triggers to main-targeting PRs

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -1,11 +1,8 @@
 name: Validate Hooks
 
 on:
-  push:
-    paths:
-      - 'global/hooks/**'
-      - 'tests/hooks/**'
   pull_request:
+    branches: [main]
     paths:
       - 'global/hooks/**'
       - 'tests/hooks/**'

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,13 +1,8 @@
 name: Validate Skills
 
 on:
-  push:
-    paths:
-      - 'project/.claude/skills/**'
-      - 'plugin/skills/**'
-      - 'global/skills/**'
-      - 'scripts/validate_skills.sh'
   pull_request:
+    branches: [main]
     paths:
       - 'project/.claude/skills/**'
       - 'plugin/skills/**'


### PR DESCRIPTION
## What

### Summary
Remove `push` triggers from `validate-skills.yml` and `validate-hooks.yml`, and add `branches: [main]` filter to `pull_request` triggers. CI now only runs on PRs targeting the `main` branch.

### Change Type
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [x] Chore

## Why

### Related Issues
- Closes #261

### Motivation
Previously, CI workflows fired on every push to any branch and every PR, causing unnecessary workflow runs. Restricting triggers to main-targeting PRs reduces noise and conserves CI minutes.

## Where

### Files Changed
| File | Change |
|------|--------|
| `.github/workflows/validate-skills.yml` | Removed `push` trigger, added `branches: [main]` to `pull_request` |
| `.github/workflows/validate-hooks.yml` | Removed `push` trigger, added `branches: [main]` to `pull_request` |

## How

### Implementation Details
- Removed the entire `push:` trigger block (with its `paths:` filters) from both workflows
- Added `branches: [main]` under the existing `pull_request:` trigger
- Path filters under `pull_request` are preserved exactly as before

### Acceptance Criteria
- [x] `validate-skills.yml` has no `push` trigger
- [x] `validate-skills.yml` `pull_request` has `branches: [main]`
- [x] `validate-hooks.yml` has no `push` trigger
- [x] `validate-hooks.yml` `pull_request` has `branches: [main]`
- [x] Path filters preserved unchanged
- [x] Job definitions preserved unchanged
- [x] Valid YAML syntax