### PR TITLE
feat(skills): update skills for develop-based workflow

### DIFF
--- a/global/skills/branch-cleanup/SKILL.md
+++ b/global/skills/branch-cleanup/SKILL.md
@@ -71,8 +71,12 @@ git fetch --prune origin
 # Get current branch
 CURRENT_BRANCH=$(git branch --show-current)
 
-# List branches merged into main/master
-MERGED_BRANCHES=$(git branch --merged main 2>/dev/null || git branch --merged master)
+# List branches merged into develop, main, or master
+MERGED_BRANCHES=$(
+  { git branch --merged develop 2>/dev/null; \
+    git branch --merged main 2>/dev/null; \
+    git branch --merged master 2>/dev/null; } | sort -u
+)
 
 # Filter out protected branches and current branch
 echo "$MERGED_BRANCHES" | grep -v -E "^\*|main|master|develop|release/|hotfix/"

--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -223,7 +223,7 @@ If splitting required:
 ```bash
 cd $PROJECT
 git fetch origin
-git checkout main && git pull origin main
+git checkout develop && git pull origin develop
 
 # Extract issue title for branch name
 ISSUE_TITLE=$(gh issue view $ISSUE_NUMBER --repo $ORG/$PROJECT --json title -q '.title')

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -223,17 +223,63 @@ Structure the changelog with categories:
 - chore: maintenance task (stu5678)
 ```
 
-### 5. Create Git Tag
+### 5. Create Release PR (develop -> main)
+
+Create a pull request from `develop` to `main` with the changelog as the PR body:
 
 ```bash
-# Create annotated tag
+# Ensure we are on the develop branch with latest changes
+git checkout develop
+git pull origin develop
+
+# Create release PR targeting main
+PR_URL=$(gh pr create --repo $ORG/$PROJECT \
+  --base main --head develop \
+  --title "release: v$VERSION" \
+  --body "$CHANGELOG")
+
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+echo "Created release PR #$PR_NUMBER: $PR_URL"
+```
+
+### 6. Monitor CI and Merge
+
+Wait for CI to pass on the release PR, then squash merge:
+
+```bash
+# Wait briefly for workflows to register
+sleep 8
+
+# Poll CI checks (30s intervals, 10min max)
+# See issue-work reference for full CI monitoring protocol
+gh pr checks $PR_NUMBER --repo $ORG/$PROJECT
+
+# ALL checks must pass before proceeding
+gh pr merge $PR_NUMBER --repo $ORG/$PROJECT --squash
+```
+
+**IMPORTANT**: Do NOT use `--delete-branch` — the `develop` branch must be retained.
+
+If CI fails, diagnose and fix on `develop`, push, and re-poll. Max 3 attempts.
+
+### 7. Create Git Tag on main
+
+```bash
+# Switch to main and pull the merged commit
+git checkout main
+git pull origin main
+
+# Create annotated tag on main
 git tag -a "v$VERSION" -m "Release v$VERSION"
 
 # Push tag to remote
 git push origin "v$VERSION"
+
+# Return to develop branch
+git checkout develop
 ```
 
-### 6. Create GitHub Release
+### 8. Create GitHub Release
 
 ```bash
 # Build release command


### PR DESCRIPTION
Closes #262

## What

### Summary
Updates skill files to support a develop-based branching workflow (Git Flow variant) where feature branches are created from and merged into `develop`, while `main` remains the production-only branch updated via release PRs.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `global/skills/issue-work/SKILL.md` — branch creation from develop
- `global/skills/release/SKILL.md` — develop-to-main release PR workflow
- `global/skills/branch-cleanup/SKILL.md` — merged branch detection against develop+main

## Why

### Problem Solved
Skills previously assumed a trunk-based workflow where all feature work branched from and merged into `main`. This change aligns the skills with a develop-based workflow where `main` is reserved for production releases.

### Related Issues
- Closes #262

## Where

### Files Changed Summary
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/skills/issue-work/` | 1 | Branch base changed from main to develop |
| `global/skills/release/` | 1 | Added develop-to-main PR + CI + merge workflow |
| `global/skills/branch-cleanup/` | 1 | Extended merged branch detection to include develop |

### Note on pr-work
`pr-work/SKILL.md` was intentionally NOT modified — it operates on existing PR branches via `headRefName` and does not set base branches.

## How

### Implementation Highlights
1. **issue-work**: Changed `git checkout main` to `git checkout develop` in Git Environment Setup (Step 3)
2. **release**: Replaced direct tagging with a multi-step release process:
   - Step 5: Create PR from `develop` to `main`
   - Step 6: Monitor CI and squash merge (without `--delete-branch`)
   - Step 7: Tag on `main`, return to `develop`
   - Step 8: Create GitHub Release (renumbered)
3. **branch-cleanup**: Extended merged branch detection to check `develop`, `main`, and `master` with deduplication via `sort -u`

### Review Criteria Verified
- [x] `/issue-work` creates branches from `develop`
- [x] `/issue-work` targets PRs to `develop` (repo default branch)
- [x] `/pr-work` unchanged (operates on existing PR branches)
- [x] `/release` creates develop-to-main PR before tagging
- [x] `/release` retains `develop` after merge
- [x] `/branch-cleanup` checks merges against both `develop` and `main`
- [x] `main` correctly retained in release/CI contexts
- [x] No remaining hardcoded `main` as working branch in feature-work contexts

### Breaking Changes
None — these are skill instruction changes, not runtime code.

## Test Plan
1. Verify `/issue-work` creates branches from `develop` by inspecting Step 3
2. Verify `/release` flow creates develop-to-main PR, merges without deleting develop, tags on main
3. Verify `/branch-cleanup` checks merged status against develop, main, and master
4. Confirm `main` still appears correctly in release contexts (Step 5 --base main, Step 7 git checkout main)