### PR TITLE
feat(config): add branching strategy to CLAUDE.md and rules

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -35,6 +35,8 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 ## Standard Workflows
 
 - **Issue-to-PR lifecycle**: implement → local build/test → create PR → monitor CI → squash merge → close issue → close epic if all sub-issues done.
+- **Branching strategy**: `develop` is the default working branch. Create feature branches from `develop`, squash merge back via PR, then delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs.
+- **Protected branches**: Never push directly to `main` or `develop`. Always use PRs with squash merge.
 - Skip lengthy planning phases. Start implementation immediately, analyzing code as you go.
 - After merging, check if parent epic should be closed.
 - When using multi-agent teams, always commit work-in-progress before switching contexts or spawning new agents that modify the working directory. This prevents data loss from agent overwrites.
@@ -49,4 +51,4 @@ Edit module files, then restart session to apply changes.
 
 ---
 
-*Version: 3.0.0 | Last updated: 2026-04-10*
+*Version: 3.1.0 | Last updated: 2026-04-13*

--- a/global/VERSION_HISTORY.md
+++ b/global/VERSION_HISTORY.md
@@ -2,6 +2,12 @@
 
 ## Changelog
 
+- **1.9.0** (2026-04-13): Branching strategy and CI policy documentation
+  - Added `project/.claude/rules/workflow/branching-strategy.md` with branch model, workflow, and CI policy
+  - Updated `global/CLAUDE.md` Standard Workflows with branching strategy and protected branch rules
+  - Updated `project/CLAUDE.md` Auto-Loaded Rules to reference new branching-strategy rule
+  - Bumped CLAUDE.md version from 3.0.0 to 3.1.0
+
 - **1.8.0** (2026-04-13): Pre-push hook for protected branch enforcement
   - Added `hooks/pre-push` (bash) and `hooks/pre-push.ps1` (PowerShell) to block direct pushes to `main` and `develop`
   - Updated `hooks/install-hooks.sh` and `hooks/install-hooks.ps1` to install the pre-push hook

--- a/project/.claude/rules/workflow/branching-strategy.md
+++ b/project/.claude/rules/workflow/branching-strategy.md
@@ -1,0 +1,26 @@
+---
+description: "Git branching strategy and CI policy"
+alwaysApply: true
+---
+
+# Branching Strategy
+
+## Branch Model
+
+| Branch | Purpose | Protection |
+|--------|---------|------------|
+| `main` | Production releases only | PR required, CI must pass |
+| `develop` | Integration branch (default) | PR required |
+| `feature/*`, `fix/*`, `chore/*` | Work branches | None |
+
+## Workflow
+
+1. Create work branch from `develop`
+2. Squash merge to `develop` via PR
+3. Delete work branch after merge
+4. Release: squash merge `develop` → `main` via PR (CI gate)
+5. `develop` is never deleted
+
+## CI Policy
+
+CI runs only on PRs targeting `main`. Feature PRs to `develop` do not trigger CI.

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -11,6 +11,7 @@ Loaded every session via `alwaysApply: true`:
 - `core/environment.md` -- KST timezone, Korean locale, platform notes
 - `workflow/git-commit-format.md` -- Conventional Commits format
 - `workflow/session-resume.md` -- Resume interrupted workflows
+- `workflow/branching-strategy.md` -- Branch model, CI policy
 
 ## On-Demand Rules (path-triggered)
 

--- a/project/VERSION_HISTORY.md
+++ b/project/VERSION_HISTORY.md
@@ -2,6 +2,10 @@
 
 ## Changelog
 
+- **1.8.0** (2026-04-13): Add branching strategy rule
+  - Added `workflow/branching-strategy.md` with branch model, workflow, and CI policy (`alwaysApply: true`)
+  - Updated `CLAUDE.md` Auto-Loaded Rules to reference new branching-strategy rule
+
 - **1.7.0** (2026-04-08): Sync behavioral guardrails and platform fixes from global v1.7.0
   - Added behavioral guardrails to core/principles.md (focus, 3-failure escape hatch, bias toward execution)
   - Added platform notes to core/environment.md (UTF-8 BOM for PowerShell, Mermaid preference)


### PR DESCRIPTION
## What

### Summary
Add branching strategy documentation to global CLAUDE.md and create a new auto-loaded
rule file (`branching-strategy.md`) so Claude Code sessions are aware of the
develop-based branching model and CI policy.

### Change Type
- [x] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Test
- [ ] Chore

### Affected Components
- `global/CLAUDE.md` -- Standard Workflows section
- `project/.claude/rules/workflow/branching-strategy.md` -- New rule file
- `project/CLAUDE.md` -- Auto-Loaded Rules reference
- `global/VERSION_HISTORY.md` -- v1.9.0 entry
- `project/VERSION_HISTORY.md` -- v1.8.0 entry

## Why

### Related Issues
- Closes #263

### Motivation
Claude Code sessions need branching awareness so automated workflows (`/issue-work`,
`/pr-work`, `/release`) follow the correct branching model. Without this, Claude
defaults to creating branches from and targeting `main` instead of `develop`.

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/` | 2 | Modified (CLAUDE.md, VERSION_HISTORY.md) |
| `project/.claude/rules/workflow/` | 1 | New (branching-strategy.md) |
| `project/` | 2 | Modified (CLAUDE.md, VERSION_HISTORY.md) |

## How

### Implementation Details
1. Added two bullet points to `global/CLAUDE.md` Standard Workflows:
   - **Branching strategy**: develop as default, feature branches, squash merge, CI on main-targeting PRs
   - **Protected branches**: no direct push to main/develop
2. Created `branching-strategy.md` with `alwaysApply: true` frontmatter containing:
   - Branch model table (main, develop, feature/fix/chore)
   - 5-step workflow
   - CI policy
3. Updated `project/CLAUDE.md` Auto-Loaded Rules to reference the new file
4. Bumped global CLAUDE.md version from 3.0.0 to 3.1.0
5. Added version history entries to both global (v1.9.0) and project (v1.8.0)

### Testing Done
- [x] Verified YAML frontmatter validity
- [x] Verified content matches issue #263 specification
- [x] Verified all 6 acceptance criteria pass

### Breaking Changes
None