### PR TITLE
docs: fix missing documentation updates (v1.9.1)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -309,9 +309,20 @@ claude_config_backup/
 │
 ├── hooks/                       # Git hooks
 │   ├── pre-commit              # 커밋 전 스킬 검증
-│   └── install-hooks.sh        # Hook 설치 스크립트
+│   ├── pre-push                # 보호 브랜치 직접 푸시 차단
+│   ├── pre-push.ps1            # Pre-push (PowerShell)
+│   ├── commit-msg              # 커밋 메시지 형식 검증
+│   ├── install-hooks.sh/.ps1   # Hook 설치 스크립트
+│   └── lib/
+│       └── validate-commit-message.sh  # 공유 검증 라이브러리
+│
+├── .github/
+│   └── workflows/
+│       ├── validate-skills.yml # CI 스킬 검증 (main 대상 PR만)
+│       └── validate-hooks.yml  # CI 훅 검증 (main 대상 PR만)
 │
 ├── docs/                        # 설계 문서 및 가이드
+│   ├── branching-strategy.md   # 브랜치 모델, CI 정책, 릴리스 워크플로우
 │   ├── TOKEN_OPTIMIZATION.md
 │   ├── SKILL_TOKEN_REPORT.md
 │   ├── CUSTOM_EXTENSIONS.md

--- a/README.md
+++ b/README.md
@@ -328,13 +328,18 @@ claude_config_backup/
 │   ├── pre-commit              # Pre-commit skill validation
 │   ├── pre-push                # Pre-push protected branch guard
 │   ├── pre-push.ps1            # Pre-push (PowerShell variant)
-│   └── install-hooks.sh/.ps1   # Hook installation script
+│   ├── commit-msg              # Commit message format validation
+│   ├── install-hooks.sh/.ps1   # Hook installation script
+│   └── lib/
+│       └── validate-commit-message.sh  # Shared validation library
 │
 ├── .github/
 │   └── workflows/
-│       └── validate-skills.yml # CI skill validation
+│       ├── validate-skills.yml # CI skill validation (main-targeting PRs only)
+│       └── validate-hooks.yml  # CI hook validation (main-targeting PRs only)
 │
 ├── docs/                        # Design docs and guides
+│   ├── branching-strategy.md   # Branch model, CI policy, release workflow
 │   ├── TOKEN_OPTIMIZATION.md
 │   ├── SKILL_TOKEN_REPORT.md
 │   ├── CUSTOM_EXTENSIONS.md

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -54,7 +54,7 @@ main ← develop ← feature/*
 
 2. **Open a pull request** targeting `develop`.
 
-3. **Wait for CI checks** to pass. All checks must reach `completed` status before merge.
+3. **Merge via squash merge** after review. Note: CI does not run on develop-targeting PRs (see [CI/CD Policy](#cicd-policy)).
 
 4. **Request review** if required by your team's policy.
 
@@ -91,23 +91,49 @@ main ← develop ← feature/*
 | Event | CI Triggered? |
 |-------|---------------|
 | Pull request to `main` | Yes — full validation (skills, hooks, shellcheck) |
-| Pull request to `develop` | Yes — same checks as `main` |
-| Push to feature branch | No |
+| Pull request to `develop` | No — code review only |
+| Push to any branch | No |
 | Tag push (`v*`) | No (releases are created manually) |
+
+Both workflows use **path filters** — they only trigger when relevant files change:
+- `validate-skills.yml`: triggers on changes to `global/skills/**`, `project/.claude/skills/**`, `plugin/skills/**`
+- `validate-hooks.yml`: triggers on changes to `global/hooks/**`, `tests/hooks/**`
 
 ### CI Checks
 
-| Workflow | What It Validates |
-|----------|-------------------|
-| `validate-skills.yml` | SKILL.md frontmatter format, name, description length |
-| `validate-hooks.yml` | Hook script correctness (test suite + shellcheck) |
+| Workflow | What It Validates | Path Filter |
+|----------|-------------------|-------------|
+| `validate-skills.yml` | SKILL.md frontmatter format, name, description length | `**/skills/**` |
+| `validate-hooks.yml` | Hook script correctness (test suite + shellcheck) | `global/hooks/**`, `tests/hooks/**` |
 
 ### Merge Rules
 
-- **All CI checks must pass** before merging. No exceptions.
-- **Squash merge** is the preferred merge strategy to keep history clean.
+**Release PRs (develop → main):**
+- All triggered CI checks must pass before merging.
+- **Squash merge** is the only allowed merge strategy.
 - **Never merge** while any check is `queued` or `in_progress`.
-- **CI failures must be investigated** — do not dismiss failures as flaky or unrelated.
+- CI failures must be investigated — do not dismiss failures as flaky or unrelated.
+
+**Feature PRs (feature → develop):**
+- CI does not run. Code review is the quality gate.
+- **Squash merge** is the only allowed merge strategy.
+
+### Branch Protection Configuration
+
+| Setting | `main` | `develop` |
+|---------|--------|-----------|
+| PR required | Yes | Yes |
+| Required status checks | None (path-filtered CI runs when triggered) | None |
+| Enforce admins | Yes | Yes |
+| Force pushes | Blocked | Blocked |
+| Branch deletion | Blocked | Blocked |
+| Merge method | Squash only | Squash only |
+
+> **Note**: Required status checks are not enforced at the branch protection level because
+> path-filtered CI workflows do not trigger on every PR. When a workflow doesn't trigger,
+> its required check would remain pending indefinitely, blocking all merges. Instead, CI
+> runs as advisory checks — they execute when path filters match and block merge only when
+> they fail.
 
 ## Enforcement Layers
 
@@ -115,7 +141,7 @@ main ← develop ← feature/*
 |-------|------|-------|
 | GitHub branch protection | Server-side | Blocks direct push to `main` and `develop` |
 | `pre-push` git hook | Client-side | Blocks direct push to `main` and `develop` locally |
-| Squash merge policy | Convention | Enforced by team practice and PR review |
+| Squash merge only | Server-side | Only squash merge allowed in GitHub settings |
 | Auto-delete branches | Server-side | Cleans up feature branches after PR merge |
 
 ## FAQ

--- a/global/VERSION_HISTORY.md
+++ b/global/VERSION_HISTORY.md
@@ -2,10 +2,19 @@
 
 ## Changelog
 
-- **1.9.0** (2026-04-13): Branching strategy and CI policy documentation
+- **1.9.1** (2026-04-13): Documentation completeness fixes
+  - Fixed `docs/branching-strategy.md`: corrected CI policy table (develop PRs do not trigger CI)
+  - Added branch protection configuration table and path-filter explanation
+  - Updated `README.md` directory structure: added commit-msg hook, lib/, validate-hooks.yml, branching-strategy.md
+  - Updated `README.ko.md` directory structure: added pre-push, commit-msg, lib/, .github/workflows, branching-strategy.md
+
+- **1.9.0** (2026-04-13): Simplified git-flow branching strategy (Epic #258)
   - Added `project/.claude/rules/workflow/branching-strategy.md` with branch model, workflow, and CI policy
   - Updated `global/CLAUDE.md` Standard Workflows with branching strategy and protected branch rules
   - Updated `project/CLAUDE.md` Auto-Loaded Rules to reference new branching-strategy rule
+  - Restricted CI triggers to main-targeting PRs only (`validate-skills.yml`, `validate-hooks.yml`)
+  - Updated skills for develop-based workflow: `/issue-work`, `/release`, `/branch-cleanup`
+  - Created `docs/branching-strategy.md` contributor reference document
   - Bumped CLAUDE.md version from 3.0.0 to 3.1.0
 
 - **1.8.0** (2026-04-13): Pre-push hook for protected branch enforcement


### PR DESCRIPTION
## Summary

Fix documentation gaps identified after the v1.8.0 release (Epic #258).
Cherry-picked from develop (commit 97e1ab6) to avoid squash merge history divergence.

### Changes
- **docs/branching-strategy.md**: Fixed CI policy table — develop PRs do not trigger CI. Added branch protection configuration table.
- **README.md**: Added commit-msg, lib/, validate-hooks.yml, branching-strategy.md to directory tree.
- **README.ko.md**: Added pre-push, commit-msg, workflows, branching-strategy.md to directory tree.
- **global/VERSION_HISTORY.md**: Consolidated v1.9.0 and added v1.9.1 entry.

## Test Plan
- [x] CI policy table matches actual workflow configuration
- [x] Directory trees match actual repo structure
- [x] Both README languages consistent