### PR TITLE
chore(workflow): recreate develop from main after release merge

### DIFF
--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -73,7 +73,7 @@ main ← develop ← feature/*
 
 2. **Review the changelog** — use `/release` to generate it automatically from commit history.
 
-3. **Merge into `main`** after CI passes.
+3. **Merge into `main`** via squash merge after CI passes.
 
 4. **Tag the release** on `main`:
 
@@ -85,6 +85,27 @@ main ← develop ← feature/*
    ```
 
 5. **Create a GitHub Release** from the tag.
+
+6. **Recreate `develop` from `main`** to synchronize histories:
+
+   ```bash
+   # Delete the old develop branch (remote and local)
+   git push origin --delete develop
+   git branch -D develop
+
+   # Recreate develop from the updated main
+   git checkout -b develop main
+   git push -u origin develop
+
+   # Set develop as default branch (if not already)
+   gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=develop
+   ```
+
+> **Why recreate develop?** Squash merging develop → main produces a single commit on
+> `main` with a different SHA than the original commits on `develop`. This causes the
+> two branches to diverge in git history, making subsequent develop → main PRs show
+> conflicts on already-merged content. Deleting and recreating `develop` from `main`
+> after each release keeps the histories aligned.
 
 ## CI/CD Policy
 

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -35,7 +35,7 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 ## Standard Workflows
 
 - **Issue-to-PR lifecycle**: implement → local build/test → create PR → monitor CI → squash merge → close issue → close epic if all sub-issues done.
-- **Branching strategy**: `develop` is the default working branch. Create feature branches from `develop`, squash merge back via PR, then delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs.
+- **Branching strategy**: `develop` is the default working branch. Create feature branches from `develop`, squash merge back via PR, then delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs. After release merge, delete `develop` and recreate from `main` to avoid history divergence.
 - **Protected branches**: Never push directly to `main` or `develop`. Always use PRs with squash merge.
 - Skip lengthy planning phases. Start implementation immediately, analyzing code as you go.
 - After merging, check if parent epic should be closed.

--- a/global/VERSION_HISTORY.md
+++ b/global/VERSION_HISTORY.md
@@ -2,6 +2,11 @@
 
 ## Changelog
 
+- **1.9.2** (2026-04-13): Release flow — recreate develop from main after squash merge
+  - Changed release procedure: delete and recreate `develop` from `main` after each release
+  - Prevents history divergence caused by squash merge producing different commit SHAs
+  - Updated: `docs/branching-strategy.md`, `global/skills/release/SKILL.md`, `global/CLAUDE.md`, branching-strategy rule
+
 - **1.9.1** (2026-04-13): Documentation completeness fixes
   - Fixed `docs/branching-strategy.md`: corrected CI policy table (develop PRs do not trigger CI)
   - Added branch protection configuration table and path-filter explanation

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -258,8 +258,6 @@ gh pr checks $PR_NUMBER --repo $ORG/$PROJECT
 gh pr merge $PR_NUMBER --repo $ORG/$PROJECT --squash
 ```
 
-**IMPORTANT**: Do NOT use `--delete-branch` — the `develop` branch must be retained.
-
 If CI fails, diagnose and fix on `develop`, push, and re-poll. Max 3 attempts.
 
 ### 7. Create Git Tag on main
@@ -274,9 +272,37 @@ git tag -a "v$VERSION" -m "Release v$VERSION"
 
 # Push tag to remote
 git push origin "v$VERSION"
+```
 
-# Return to develop branch
-git checkout develop
+### 7.5. Recreate develop from main
+
+After squash merge, `develop` and `main` have diverged histories. Delete and recreate
+`develop` from `main` to resynchronize:
+
+```bash
+# Delete old develop (remote + local)
+git push origin --delete develop
+git branch -D develop 2>/dev/null
+
+# Recreate from main
+git checkout -b develop main
+git push -u origin develop
+
+# Restore default branch setting
+gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=develop
+
+# Restore branch protection on develop
+gh api -X PUT repos/$ORG/$PROJECT/branches/develop/protection \
+  --input - <<'PROTECTION'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0
+  },
+  "restrictions": null
+}
+PROTECTION
 ```
 
 ### 8. Create GitHub Release

--- a/project/.claude/rules/workflow/branching-strategy.md
+++ b/project/.claude/rules/workflow/branching-strategy.md
@@ -19,7 +19,7 @@ alwaysApply: true
 2. Squash merge to `develop` via PR
 3. Delete work branch after merge
 4. Release: squash merge `develop` → `main` via PR (CI gate)
-5. `develop` is never deleted
+5. After release merge: delete `develop`, recreate from `main`
 
 ## CI Policy
 


### PR DESCRIPTION
## Summary

Change the release procedure so that `develop` is deleted and recreated from `main`
after each squash merge release. This prevents history divergence.

### Problem
Squash merging develop → main produces a single commit with a different SHA than the
original commits on develop. This causes the two branches to diverge, making subsequent
develop → main PRs show merge conflicts on already-merged content.

### Solution
After each release merge to main:
1. Delete `develop` branch (remote + local)
2. Recreate `develop` from updated `main`
3. Restore branch protection on `develop`

### Files Changed
- `project/.claude/rules/workflow/branching-strategy.md` — step 5 updated
- `docs/branching-strategy.md` — release workflow step 6 + explanation added
- `global/skills/release/SKILL.md` — step 7.5 added
- `global/CLAUDE.md` — standard workflows updated
- `global/VERSION_HISTORY.md` — v1.9.2 entry

## Test Plan
- [x] All 4 documentation/config locations consistently describe the new flow
- [x] Release skill includes branch protection restoration after recreation