### PR TITLE
docs: add missing doc-index skill and conflict-guard hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -18,6 +18,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Log session activity | [Session Logging](#3-session-logging-sessionstartsessionend) |
 | Check for known Claude Code bugs | [Version Check](#8-version-check-sessionstart) |
 | Validate commit messages before git commit | [Commit Message Guard](#10-commit-message-guard-pretooluse) |
+| Prevent git merge/rebase on dirty trees | [Conflict Guard](#11-conflict-guard-pretooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -223,6 +224,24 @@ Hooks are user-defined commands that automatically execute during specific Claud
 - Cross-platform: `commit-message-guard.sh` and `commit-message-guard.ps1`
 
 **Shared validation library**: Both this PreToolUse hook and the git `commit-msg` hook (installed by `hooks/install-hooks.sh`) source the same validator at `hooks/lib/validate-commit-message.sh`, ensuring rule consistency across enforcement layers.
+
+### 11. Conflict Guard (PreToolUse)
+
+*Prevents git merge/rebase/cherry-pick/pull when the working tree is dirty or another operation is already in progress.*
+
+**Purpose**: Block conflict-prone git operations when conditions would cause data loss or nested conflicts.
+
+**Trigger**: Bash commands matching `git merge`, `git rebase`, `git cherry-pick`, or `git pull`.
+
+**Checks performed**:
+1. **Existing operation**: Denies if `MERGE_HEAD`, `REBASE_HEAD`, or `CHERRY_PICK_HEAD` exists (another operation is in progress)
+2. **Uncommitted changes**: Denies if `git status --porcelain` is non-empty (dirty working tree)
+
+**Behavior**:
+- Returns JSON with `permissionDecision: "deny"` describing the blocking condition
+- Fail-open: if parsing fails or git is not available, the command is allowed
+- Advisory only (conflict prevention), not security-critical
+- Cross-platform: `conflict-guard.sh` and `conflict-guard.ps1`
 
 ### Hook Response Format
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -221,6 +221,7 @@ claude_config_backup/
 │   │   └── weekly-usage.sh
 │   └── skills/                 # 글로벌 Skills (사용자 호출형)
 │       ├── branch-cleanup/     # 병합/오래된 브랜치 정리
+│       ├── doc-index/          # 문서 인덱스 파일 생성
 │       ├── doc-review/         # 마크다운 문서 리뷰
 │       ├── implement-all-levels/ # 완전 구현 강제
 │       ├── issue-create/       # GitHub 이슈 생성 (5W1H)
@@ -512,6 +513,7 @@ Claude Code에서 명령어를 입력하여 스킬을 실행할 수 있습니다
 | 명령어 | 기능 |
 |--------|------|
 | `/harness` | Agent team 설계 및 모든 도메인에 대한 스킬 생성 |
+| `/doc-index` | 문서 인덱스 파일 생성 (manifest, bundles, graph, router) |
 | `/doc-review` | 정확성, 앵커, 상호 참조에 대한 마크다운 문서 리뷰 |
 | `/git-status` | 실행 가능한 인사이트가 포함된 저장소 상태 |
 | `/implement-all-levels` | 계층형 기능의 모든 티어에 대한 완전한 구현 강제 |

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ claude_config_backup/
 │   │   └── weekly-usage.sh/.ps1
 │   └── skills/                 # Global skills (user-invocable)
 │       ├── branch-cleanup/     # Clean merged/stale branches
+│       ├── doc-index/          # Generate documentation index files
 │       ├── doc-review/         # Markdown document review
 │       ├── implement-all-levels/ # Enforce complete implementation
 │       ├── issue-create/       # Create GitHub issues (5W1H)
@@ -528,6 +529,7 @@ Invoke any skill by typing its command in Claude Code.
 | Command | What it does |
 |---------|-------------|
 | `/harness` | Design agent teams and generate skills for any domain |
+| `/doc-index` | Generate documentation index files (manifest, bundles, graph, router) |
 | `/doc-review` | Review markdown documents for accuracy, anchors, cross-references |
 | `/git-status` | Repository status with actionable insights |
 | `/implement-all-levels` | Enforce complete implementation of all tiers for tiered features |


### PR DESCRIPTION
## Summary
- Add conflict-guard hook documentation to HOOKS.md (section 11 + quick nav)
- Add doc-index skill to README.md and README.ko.md (directory tree + skills table)

## Test Plan
- [x] HOOKS.md quick nav links to new section
- [x] Both READMEs list all 9 global skills
- [x] Korean and English versions are consistent