### PR TITLE
feat(hooks): add multi-layered branch defense for main protection

### DIFF
--- a/.github/workflows/validate-pr-target.yml
+++ b/.github/workflows/validate-pr-target.yml
@@ -1,0 +1,57 @@
+name: Validate PR Target
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch is develop
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const headBranch = pr.head.ref;
+            const baseBranch = pr.base.ref;
+
+            if (baseBranch !== 'main') {
+              return;
+            }
+
+            if (headBranch === 'develop') {
+              core.info(`Release PR from develop to main -- allowed.`);
+              return;
+            }
+
+            const message = [
+              `## Branch Policy Violation`,
+              ``,
+              `This PR targets \`main\` from \`${headBranch}\`, but only \`develop\` may merge into \`main\`.`,
+              ``,
+              `### Required Workflow`,
+              `1. Create a PR from your branch to \`develop\``,
+              `2. After merging to \`develop\`, create a release PR using \`/release <version>\``,
+              ``,
+              `This PR has been closed automatically.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: message,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });
+
+            core.setFailed(
+              `PR #${pr.number} targets main from ${headBranch} (only develop is allowed). PR has been closed.`
+            );

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -19,6 +19,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Check for known Claude Code bugs | [Version Check](#8-version-check-sessionstart) |
 | Validate commit messages before git commit | [Commit Message Guard](#10-commit-message-guard-pretooluse) |
 | Prevent git merge/rebase on dirty trees | [Conflict Guard](#11-conflict-guard-pretooluse) |
+| Block PRs targeting main from non-develop branches | [PR Target Guard](#12-pr-target-guard-pretooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -242,6 +243,39 @@ Hooks are user-defined commands that automatically execute during specific Claud
 - Fail-open: if parsing fails or git is not available, the command is allowed
 - Advisory only (conflict prevention), not security-critical
 - Cross-platform: `conflict-guard.sh` and `conflict-guard.ps1`
+
+## 12. PR Target Guard (PreToolUse)
+
+*Enforces branching policy: only `develop` may merge into `main`.*
+
+**Purpose**: Intercepts `gh pr create` commands and blocks those targeting `main` unless the source branch is `develop` (a legitimate release PR).
+
+**Trigger**: `Bash` tool calls containing `gh pr create`
+
+**Files**: `global/hooks/pr-target-guard.sh`, `global/hooks/pr-target-guard.ps1`
+
+**Logic**:
+1. Scope gate: only process `gh pr create` commands (all others pass through)
+2. Extract `--base` value (`--base main`, `--base=main`, `-B main`)
+3. If `--base main` detected:
+   - Allow if `--head develop` is also present (release PR via `/release`)
+   - Deny otherwise with guidance message
+4. If no `--base` flag: allow (defaults to `develop`)
+
+**Fail policy**: Fail-closed (deny if JSON parsing fails)
+
+**Complements**:
+- `pre-push` git hook: blocks `git push origin main/develop`
+- `validate-pr-target.yml` GitHub Actions: auto-closes non-develop PRs to main (server-side)
+
+**Configuration**:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/pr-target-guard.sh",
+  "timeout": 5
+}
+```
 
 ### Hook Response Format
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -214,6 +214,9 @@ claude_config_backup/
 │   │   ├── worktree-create.sh/.ps1
 │   │   ├── worktree-remove.sh/.ps1
 │   │   ├── team-limit-guard.sh/.ps1
+│   │   ├── commit-message-guard.sh/.ps1
+│   │   ├── conflict-guard.sh/.ps1
+│   │   ├── pr-target-guard.sh/.ps1
 │   │   ├── version-check.sh/.ps1
 │   │   └── cleanup.sh/.ps1
 │   ├── scripts/                # 유틸리티 스크립트
@@ -319,8 +322,9 @@ claude_config_backup/
 │
 ├── .github/
 │   └── workflows/
-│       ├── validate-skills.yml # CI 스킬 검증 (main 대상 PR만)
-│       └── validate-hooks.yml  # CI 훅 검증 (main 대상 PR만)
+│       ├── validate-skills.yml     # CI 스킬 검증 (main 대상 PR만)
+│       ├── validate-hooks.yml      # CI 훅 검증 (main 대상 PR만)
+│       └── validate-pr-target.yml  # develop 외 브랜치의 main 머지 차단
 │
 ├── docs/                        # 설계 문서 및 가이드
 │   ├── branching-strategy.md   # 브랜치 모델, CI 정책, 릴리스 워크플로우
@@ -381,6 +385,11 @@ claude_config_backup/
 - 알려진 문제가 있는 Claude Code 버전에 대해 경고가 표시됩니다
 - 세션 종료 시 오래된 임시 파일이 정리됩니다
 - 자동 압축 전 컨텍스트가 스냅샷됩니다
+
+### PR을 생성할 때
+- `develop` 외 브랜치에서 `main`을 타겟하는 PR이 차단됩니다 (PreToolUse hook)
+- 서버 측: GitHub Actions가 위반 PR을 자동으로 닫고 안내 코멘트를 남깁니다
+- 릴리즈 PR (`develop` → `main`)은 `/release` 스킬을 통해 허용됩니다
 
 ### Agent Teams 사용 시
 - 동시 팀 수가 제한됩니다 (`MAX_TEAMS`로 설정 가능)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ claude_config_backup/
 │   │   ├── worktree-create.sh/.ps1
 │   │   ├── worktree-remove.sh/.ps1
 │   │   ├── team-limit-guard.sh/.ps1
+│   │   ├── commit-message-guard.sh/.ps1
+│   │   ├── conflict-guard.sh/.ps1
+│   │   ├── pr-target-guard.sh/.ps1
 │   │   ├── version-check.sh/.ps1
 │   │   ├── cleanup.sh/.ps1
 │   │   └── lib/               # Shared libraries
@@ -336,8 +339,9 @@ claude_config_backup/
 │
 ├── .github/
 │   └── workflows/
-│       ├── validate-skills.yml # CI skill validation (main-targeting PRs only)
-│       └── validate-hooks.yml  # CI hook validation (main-targeting PRs only)
+│       ├── validate-skills.yml     # CI skill validation (main-targeting PRs only)
+│       ├── validate-hooks.yml      # CI hook validation (main-targeting PRs only)
+│       └── validate-pr-target.yml  # Enforce develop-only merges to main
 │
 ├── docs/                        # Design docs and guides
 │   ├── branching-strategy.md   # Branch model, CI policy, release workflow
@@ -398,6 +402,11 @@ These behaviors activate immediately after installation — no configuration nee
 - Known problematic Claude Code versions trigger a warning
 - Old temporary files are cleaned up on session end
 - Context is snapshot before auto-compaction
+
+### When you create PRs
+- PRs targeting `main` from non-`develop` branches are blocked (PreToolUse hook)
+- Server-side: GitHub Actions auto-closes violating PRs with an explanatory comment
+- Release PRs (`develop` → `main`) are allowed through the `/release` skill
 
 ### When using Agent Teams
 - Concurrent team count is limited (configurable via `MAX_TEAMS`)

--- a/global/hooks/pr-target-guard.ps1
+++ b/global/hooks/pr-target-guard.ps1
@@ -1,0 +1,80 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# pr-target-guard.ps1
+# Blocks PRs targeting 'main' from non-develop branches
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Branching policy: only 'develop' may merge into 'main'.
+# Feature/fix branches must target 'develop'.
+# Release PRs (develop -> main) are created via /release skill.
+
+# Read input from stdin (Claude Code passes JSON via stdin)
+$json = Read-HookInput
+
+# Fail-closed: deny if stdin is empty or missing
+if (-not $json) {
+    New-HookDenyResponse -Reason 'Failed to parse hook input — denying for safety (fail-closed)'
+    exit 0
+}
+
+# Extract command from tool_input
+$CMD = $null
+try {
+    $CMD = $json.tool_input.command
+} catch {}
+
+# Fallback to environment variable for backward compatibility
+if (-not $CMD) {
+    $CMD = $env:CLAUDE_TOOL_INPUT
+}
+
+# Scope gate: only check 'gh pr create' commands
+if ($CMD -notmatch 'gh\s+pr\s+create') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract --base value (supports: --base main, --base=main, -B main)
+$base = $null
+$baseMatch = [regex]::Match($CMD, '(?:--base[= ]|-B\s*)["\x27]?([a-zA-Z0-9._/-]+)')
+if ($baseMatch.Success) {
+    $base = $baseMatch.Groups[1].Value
+}
+
+# If no --base flag found, the PR uses the repo default branch (develop).
+# Allow it -- this is the normal feature-to-develop workflow.
+if (-not $base) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Strip surrounding quotes if present
+$base = $base -replace '^["\x27]|["\x27]$', ''
+
+# Only block if base is exactly 'main'
+if ($base -ne 'main') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Base is 'main' -- check if this is a release PR (--head develop)
+$head = $null
+$headMatch = [regex]::Match($CMD, '(?:--head[= ]|-H\s*)["\x27]?([a-zA-Z0-9._/-]+)')
+if ($headMatch.Success) {
+    $head = $headMatch.Groups[1].Value
+    $head = $head -replace '^["\x27]|["\x27]$', ''
+}
+
+# Allow release PRs: develop -> main
+if ($head -eq 'develop') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Deny: non-develop branch targeting main
+New-HookDenyResponse -Reason "PR targeting 'main' is blocked by branching policy. Feature/fix branches must target 'develop'. For release PRs (develop -> main), use: /release <version>"
+exit 0

--- a/global/hooks/pr-target-guard.sh
+++ b/global/hooks/pr-target-guard.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# pr-target-guard.sh
+# Blocks PRs targeting 'main' from non-develop branches
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Branching policy: only 'develop' may merge into 'main'.
+# Feature/fix branches must target 'develop'.
+# Release PRs (develop → main) are created via /release skill.
+
+# Helper function for deny response
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+# Helper function for allow response
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+# Read input from stdin (Claude Code passes JSON via stdin)
+INPUT=$(cat)
+
+# Fail-closed: deny if stdin is empty or missing
+if [ -z "$INPUT" ]; then
+    deny_response "Failed to parse hook input — denying for safety (fail-closed)"
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Fail-closed: deny if jq parsing failed
+if [ $? -ne 0 ]; then
+    deny_response "Failed to parse hook input JSON — denying for safety (fail-closed)"
+fi
+
+# Fallback to environment variable for backward compatibility
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+# Scope gate: only check 'gh pr create' commands
+if ! echo "$CMD" | grep -qE 'gh\s+pr\s+create'; then
+    allow_response
+fi
+
+# Extract --base value (supports: --base main, --base=main, -B main)
+BASE=""
+if echo "$CMD" | grep -qE '(--base[= ]|--base$|-B\s)'; then
+    BASE=$(echo "$CMD" | grep -oE '(--base[= ]|-B\s*)["\x27]?([a-zA-Z0-9._/-]+)' | head -1 | sed -E "s/(--base[= ]|-B\s*)[\"']?//")
+fi
+
+# If no --base flag found, the PR uses the repo default branch (develop).
+# Allow it — this is the normal feature-to-develop workflow.
+if [ -z "$BASE" ]; then
+    allow_response
+fi
+
+# Strip surrounding quotes if present
+BASE=$(echo "$BASE" | sed -E "s/^[\"']//;s/[\"']$//")
+
+# Only block if base is exactly 'main' (not 'main-backup', 'maintain', etc.)
+if [ "$BASE" != "main" ]; then
+    allow_response
+fi
+
+# Base is 'main' — check if this is a release PR (--head develop)
+HEAD=""
+if echo "$CMD" | grep -qE '(--head[= ]|-H\s)'; then
+    HEAD=$(echo "$CMD" | grep -oE '(--head[= ]|-H\s*)["\x27]?([a-zA-Z0-9._/-]+)' | head -1 | sed -E "s/(--head[= ]|-H\s*)[\"']?//")
+    HEAD=$(echo "$HEAD" | sed -E "s/^[\"']//;s/[\"']$//")
+fi
+
+# Allow release PRs: develop → main
+if [ "$HEAD" = "develop" ]; then
+    allow_response
+fi
+
+# Deny: non-develop branch targeting main
+deny_response "PR targeting 'main' is blocked by branching policy. Feature/fix branches must target 'develop'. For release PRs (develop -> main), use: /release <version>"

--- a/global/settings.json
+++ b/global/settings.json
@@ -75,6 +75,11 @@
             "type": "command",
             "command": "~/.claude/hooks/conflict-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pr-target-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/commit-message-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-target-guard.ps1",
+            "timeout": 5
           }
         ]
       },

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -125,6 +125,29 @@ Store the result in `$EXEC_MODE` (solo | team).
 
 ## Solo Mode
 
+### 0. Branch Integrity Check
+
+Before starting the release, verify that `main` has not diverged from `develop`
+due to unauthorized direct merges:
+
+```bash
+git fetch origin main develop
+
+# Verify all commits on main are ancestors of develop
+if ! git merge-base --is-ancestor origin/main origin/develop; then
+    echo "WARNING: main contains commits not present on develop."
+    echo "This indicates unauthorized direct merges to main."
+    echo ""
+    echo "Divergent commits on main:"
+    git log origin/develop..origin/main --oneline
+    echo ""
+    echo "Resolution: cherry-pick divergent commits to develop or reset main to last release tag."
+fi
+```
+
+**If divergence is detected**: Stop and ask the user how to resolve before proceeding.
+Do NOT create a release PR while main and develop have diverged.
+
 ### 1. Validate Version Format
 
 Ensure version follows semantic versioning:

--- a/project/.claude/rules/workflow/branching-strategy.md
+++ b/project/.claude/rules/workflow/branching-strategy.md
@@ -24,3 +24,12 @@ alwaysApply: true
 ## CI Policy
 
 CI runs only on PRs targeting `main`. Feature PRs to `develop` do not trigger CI.
+
+## Enforcement Layers
+
+| Layer | Mechanism | Scope |
+|-------|-----------|-------|
+| Pre-push hook | `hooks/pre-push` | Blocks direct push to `main`/`develop` |
+| PreToolUse hook | `pr-target-guard` | Blocks `gh pr create --base main` (unless `--head develop`) |
+| GitHub Actions | `validate-pr-target.yml` | Auto-closes non-develop PRs targeting `main` |
+| Release skill | integrity check | Warns if `main` diverged from `develop` before release |

--- a/tests/hooks/test-pr-target-guard.sh
+++ b/tests/hooks/test-pr-target-guard.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Test suite for pr-target-guard.sh
+# Run: bash tests/hooks/test-pr-target-guard.sh
+
+HOOK="global/hooks/pr-target-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+assert_deny() {
+    local input="$1" label="$2"
+    local result
+    result=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local input="$1" label="$2"
+    local result
+    result=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== pr-target-guard.sh tests ==="
+echo ""
+
+echo "[Fail-closed]"
+assert_deny '' "Empty input → deny"
+assert_deny 'INVALID_JSON' "Malformed JSON → deny"
+
+echo ""
+echo "[Scope: non-gh commands pass through]"
+assert_allow '{"tool_input":{"command":"ls -la"}}' "ls -la → allow"
+assert_allow '{"tool_input":{"command":"git push origin main"}}' "git push → allow (handled by pre-push hook)"
+assert_allow '{"tool_input":{"command":"gh issue create --title test"}}' "gh issue create → allow"
+assert_allow '{"tool_input":{"command":"gh pr view 123"}}' "gh pr view → allow"
+assert_allow '{"tool_input":{"command":"gh pr checks 42"}}' "gh pr checks → allow"
+assert_allow '{"tool_input":{"command":"gh pr merge 42 --squash"}}' "gh pr merge → allow (not gh pr create)"
+
+echo ""
+echo "[gh pr create targeting main: deny]"
+assert_deny '{"tool_input":{"command":"gh pr create --base main --title \"fix: something\""}}' "--base main → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --base=main --title \"fix: something\""}}' "--base=main → deny"
+assert_deny '{"tool_input":{"command":"gh pr create -B main --title \"fix: something\""}}' "-B main → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --title \"fix: something\" --base main --body \"desc\""}}' "--base main (mid-command) → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --base main --head fix/some-branch"}}' "--head fix/some-branch to main → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --base main --head feature/issue-42"}}' "--head feature/ to main → deny"
+
+echo ""
+echo "[Release exception: develop → main allowed]"
+assert_allow '{"tool_input":{"command":"gh pr create --base main --head develop --title \"release: v1.0.0\""}}' "--base main --head develop → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --head develop --base main --title \"release: v2.0.0\""}}' "reversed order → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --base=main --head=develop --title \"release\""}}' "equals form → allow"
+
+echo ""
+echo "[Normal workflow: allow]"
+assert_allow '{"tool_input":{"command":"gh pr create --base develop --title \"feat: new feature\""}}' "--base develop → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --title \"feat: something\""}}' "no --base (defaults to develop) → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --base develop --head feat/issue-42"}}' "--base develop --head feat/ → allow"
+
+echo ""
+echo "[Edge cases]"
+assert_allow '{"tool_input":{"command":"gh pr create --base main-backup --title \"test\""}}' "--base main-backup → allow (not exact main)"
+assert_allow '{"tool_input":{"command":"gh pr create --base maintain --title \"test\""}}' "--base maintain → allow (not exact main)"
+assert_deny '{"tool_input":{"command":"cd repo && gh pr create --base main --title \"fix\""}}' "chained command with --base main → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --repo org/repo --base main --title \"fix\""}}' "--repo with --base main → deny"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

### Summary
Add four enforcement layers to prevent non-release merges to `main`, closing the gap
that allowed PR #277 to bypass `develop` and merge directly to `main`.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `global/hooks/` - New PreToolUse hook (bash + PowerShell)
- `.github/workflows/` - New PR target validation workflow
- `global/skills/release/` - Branch integrity check
- `project/.claude/rules/workflow/` - Enforcement documentation

## Why

### Problem Solved
Existing safeguards (pre-push hook, CLAUDE.md rules, branch protection) only blocked
`git push origin main` but not `gh pr create --base main` followed by `gh pr merge`.
This allowed a CI fix to be merged directly to `main`, bypassing `develop`.

### Related Issues
- Addresses branching policy gap exposed by PR #277

### Alternatives Considered
1. Branch protection required reviews (impractical for solo developer)
2. Required status checks (path-filtered CI causes indefinite pending)
3. Multi-layered defense (chosen) - each layer independently enforces the policy

## Where

### Files Changed
| File | Type |
|------|------|
| `global/hooks/pr-target-guard.sh` | New - bash PreToolUse hook |
| `global/hooks/pr-target-guard.ps1` | New - PowerShell PreToolUse hook |
| `tests/hooks/test-pr-target-guard.sh` | New - test suite (24 cases) |
| `.github/workflows/validate-pr-target.yml` | New - GitHub Actions workflow |
| `global/settings.json` | Modified - hook registration |
| `global/settings.windows.json` | Modified - hook registration |
| `global/skills/release/SKILL.md` | Modified - integrity check step |
| `project/.claude/rules/workflow/branching-strategy.md` | Modified - enforcement table |
| `HOOKS.md` | Modified - hook documentation |

## How

### Implementation Details

**Layer 1 - PreToolUse Hook** (`pr-target-guard`):
- Intercepts `gh pr create` commands via stdin JSON parsing
- Extracts `--base` value; denies if `main` unless `--head develop` present
- Fail-closed design following `dangerous-command-guard` pattern
- Cross-platform: bash + PowerShell

**Layer 2 - GitHub Actions** (`validate-pr-target.yml`):
- Triggers on all PRs targeting `main` (no path filter)
- Verifies source branch is `develop`; auto-closes violating PRs with comment
- Uses `actions/github-script@v7`

**Layer 3 - Release Skill** (Step 0):
- `git merge-base --is-ancestor` check before release
- Detects unauthorized main/develop divergence
- Advisory warning (not hard block)

**Layer 4 - Documentation**:
- Enforcement layers table in `branching-strategy.md`
- Hook reference in `HOOKS.md`

### Testing Done
- [x] PowerShell hook tested locally (7/7 key scenarios pass)
- [x] Bash test suite created (24 cases; requires jq, verified in CI)
- [x] YAML syntax validated with PyYAML
- [ ] CI verification (this PR)

### Test Plan
1. Verify `validate-hooks.yml` CI passes (hook tests)
2. After merge: test `validate-pr-target.yml` by opening a dummy PR from a feature branch to `main` (expect auto-close)

### Breaking Changes
None