### PR TITLE
feat(skill): add /research skill for structured topic investigation

### DIFF
--- a/global/skills/research/SKILL.md
+++ b/global/skills/research/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: research
+description: "Conduct structured research on any topic: web search, codebase analysis, and document synthesis into organized reports. Use when investigating technologies, analyzing alternatives, gathering reference materials, fact-checking claims, or producing technical documentation from research. Use this skill whenever the user asks to research, investigate, compare, or survey a topic."
+user-invocable: true
+argument-hint: "<topic> [--depth shallow|standard|deep] [--output file.md] [--sources web|code|both] [--lang en|ko|ja|...] [--template auto|plain] [--integrate]"
+allowed-tools:
+  - WebSearch
+  - WebFetch
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - Agent
+---
+
+# Research Command
+
+Conduct structured research on any topic and produce organized reference documents.
+
+## Usage
+
+```
+/research "WebSocket vs SSE for real-time updates"
+/research "OAuth 2.0 PKCE flow" --depth deep --output docs/reference/oauth-pkce.md
+/research "error handling patterns" --sources code
+/research "DICOM SR TID 1500" --output docs/reference/dicom-sr-tid-1500.md --integrate
+/research "React Server Components" --lang ko
+/research "gRPC vs REST performance" --template plain
+```
+
+## Arguments
+
+- `<topic>` (required): Research topic. Accepts any natural language query.
+
+- `[--depth <level>]` (default: `standard`):
+  - `shallow` — Quick overview. 1-2 web searches, scan codebase. 3-5 sources. Short report.
+  - `standard` — Balanced investigation. 3-5 web searches, pattern analysis. 5-10 sources.
+  - `deep` — Thorough investigation. 8-12 web searches, full codebase analysis. 10-20 sources.
+
+- `[--output <path>]` (default: none — output to conversation):
+  - File path for saving the report as `.md` file.
+  - Triggers context detection (Phase 0-B) to adapt output format.
+
+- `[--sources <type>]` (default: `both`):
+  - `web` — Web search and external documentation only.
+  - `code` — Codebase analysis only (grep, glob, read).
+  - `both` — Combine web and codebase sources.
+
+- `[--lang <code>]` (default: auto-detect, fallback `en`):
+  - Override output language. Examples: `en`, `ko`, `ja`, `zh`.
+  - If omitted: detect from existing docs in `--output` directory.
+
+- `[--template <mode>]` (default: `auto`):
+  - `auto` — Detect conventions from existing docs in output directory.
+  - `plain` — Force generic English markdown (no frontmatter adaptation).
+
+- `[--integrate]`:
+  - Register the output document in project's document index system.
+  - Requires `docs/.index/` or `.index/` to exist.
+  - Updates manifest, bundles, and router files.
+
+## Instructions
+
+### Phase 0: Context Analysis
+
+#### 0-A. Topic Analysis
+
+1. Parse the topic into 3-5 core research questions.
+2. Determine investigation strategy based on `--depth`:
+
+| Depth | Web Searches | Codebase Scope | Target Sources | Report Sections |
+|-------|-------------|----------------|----------------|-----------------|
+| `shallow` | 1-2 queries | Related files scan | 3-5 | 4-5 sections |
+| `standard` | 3-5 queries | Pattern/usage analysis | 5-10 | 6-8 sections |
+| `deep` | 8-12 queries | Full architecture analysis | 10-20 | 8+ sections |
+
+3. If the topic implies comparison (e.g., "A vs B", "comparison", "alternatives"):
+   - Plan a comparison matrix in the output.
+4. If the topic implies investigation (e.g., "how does X work", "why"):
+   - Plan a deep-dive explanation structure.
+
+#### 0-B. Output Context Detection (when `--output` is specified)
+
+Sample up to 3 existing `.md` files in the output directory:
+
+```bash
+# Find existing markdown files in the output directory
+OUTDIR=$(dirname "$OUTPUT_PATH")
+SAMPLES=$(find "$OUTDIR" -maxdepth 1 -name "*.md" -type f | head -3)
+```
+
+Detect from samples:
+
+| Item | Detection Method | Fallback |
+|------|-----------------|----------|
+| **Language** | Character ratio analysis (Korean > 30% → `ko`, etc.) | `en` (or `--lang`) |
+| **Frontmatter** | Check first lines for `---` YAML block | No frontmatter |
+| **Frontmatter schema** | Extract YAML keys (e.g., `doc_id`, `doc_version`, `approval`) | Skip |
+| **Section pattern** | Check heading style (`## 1. Title` vs `## Title`) | Numbered sections |
+| **Markers** | Scan for `> **SSOT**:`, `> **Cross-reference**:` patterns | Skip |
+| **File naming** | Check sibling files (kebab-case, snake_case, etc.) | kebab-case |
+| **Citation style** | Check last section for reference format | Numbered list |
+
+Store detected conventions as the **output profile** for Phase 3.
+
+**Override rules**:
+- `--lang` always overrides detected language.
+- `--template plain` skips all context detection.
+
+#### 0-C. Index System Detection (when `--integrate` is specified)
+
+```bash
+# Search for document index system
+INDEX_DIR=""
+if [ -d "docs/.index" ]; then INDEX_DIR="docs/.index"
+elif [ -d ".index" ]; then INDEX_DIR=".index"
+fi
+```
+
+If found:
+1. Read `manifest.yaml` to understand existing document registry.
+2. Read `bundles.yaml` to identify related bundles.
+3. Read `router.yaml` to check existing keyword routes.
+4. Determine next available document ID (if ID pattern exists).
+
+If not found and `--integrate` was specified:
+- Warn: "No index system detected. Skipping integration. Run `/doc-index` to create one."
+
+#### 0-D. Existing Document Check
+
+Before creating a new document:
+1. Search the output directory for documents on the same topic.
+2. If found, ask whether to **update** existing or **create new**.
+
+### Phase 1: Discovery (Information Gathering)
+
+Execute in parallel where possible using the Agent tool for independent searches.
+
+#### 1-A. Web Sources (when `--sources` includes `web`)
+
+1. Formulate search queries based on core research questions.
+   - Include the current year for time-sensitive topics.
+   - Use domain-specific terminology for technical topics.
+
+2. Execute `WebSearch` for each query.
+
+3. For promising results, use `WebFetch` to extract detailed content.
+   - Prioritize: official documentation, peer-reviewed sources, authoritative blogs.
+   - Skip: forums with unverified answers, outdated content (> 2 years for fast-moving tech).
+
+4. Record for each source:
+   - URL, title, access date
+   - Key findings extracted
+   - Confidence level (High / Medium / Low)
+
+#### 1-B. Codebase Sources (when `--sources` includes `code`)
+
+1. Use `Grep` and `Glob` to find topic-related code, configuration, and documentation.
+
+2. Use `Read` to examine relevant files.
+
+3. Record:
+   - File path and line ranges
+   - Patterns, implementations, or configurations found
+   - How the codebase relates to the research topic
+
+#### 1-C. Existing Documentation Sources
+
+1. If an index system was detected (Phase 0-C):
+   - Use manifest/router to find related existing documents.
+   - Read relevant sections for cross-reference material.
+
+2. If no index system:
+   - Scan `docs/`, `reference/`, `README.md` for related content.
+
+### Phase 2: Analysis
+
+#### 2-A. Cross-Validation
+
+- Every factual claim must have at least 2 independent sources.
+- Mark single-source claims with confidence indicator.
+- Flag contradictory information between sources explicitly.
+
+See `reference/source-evaluation.md` for confidence scoring criteria.
+
+#### 2-B. Synthesis
+
+1. Group findings by research question.
+2. Identify key themes and patterns across sources.
+3. For comparison topics: build evaluation matrix.
+   - Use symbols: `✅` (supported), `⚠️` (partial/conditional), `❌` (not supported).
+   - Include numeric scores (1-5) where applicable.
+4. For investigation topics: build explanation chain.
+
+#### 2-C. Codebase Relevance (when `--sources` includes `code`)
+
+- Map findings to specific project files, patterns, or decisions.
+- Note how research results apply to or conflict with current codebase.
+
+### Phase 3: Synthesis (Document Generation)
+
+#### 3-A. Template Selection
+
+| Condition | Template |
+|-----------|----------|
+| `--template plain` | Generic English markdown (Template A) |
+| `--template auto` + context detected | Adapted template matching existing docs (Template B) |
+| `--template auto` + no context | Generic English markdown (Template A) |
+| No `--output` (conversation) | Generic English markdown (Template A) |
+
+See `reference/output-templates.md` for complete template definitions.
+
+#### 3-B. Document Assembly
+
+1. Apply the selected template.
+2. Write sections in order, populating with Phase 2 analysis results.
+3. For context-adapted output (Template B):
+   - Replicate detected frontmatter schema with appropriate values.
+   - Match section numbering pattern.
+   - Include detected markers (SSOT, cross-reference) where applicable.
+   - Match citation/reference style.
+4. **Language application**:
+   - Body text: determined language (`--lang` or detected).
+   - Technical terms, acronyms, code identifiers, URLs: always English.
+   - Source titles and authors in citations: original language preserved.
+
+#### 3-C. Output
+
+- If `--output` specified: write file using `Write` tool.
+  - Verify parent directory exists.
+  - If file already exists: confirm overwrite with user.
+- If no `--output`: output the full report in the conversation.
+
+### Phase 4: Integration (when `--integrate` is specified)
+
+Requires index system detected in Phase 0-C.
+
+1. **manifest**: Add entry with document metadata (id, file, title, keywords, sections).
+2. **bundles**: Add document to relevant existing bundles or suggest new bundle.
+3. **router**: Add keyword routes for the new document's topics.
+4. Validate all index files after modification.
+
+If integration fails, warn the user and suggest running `/doc-index` for full regeneration.
+
+## Post-Research Workflow
+
+After research output is saved with `--output`:
+
+```
+/research "<topic>" --output docs/reference/topic.md    # Generate
+/doc-review docs/reference/topic.md                     # Validate
+/doc-index                                              # Re-index (alternative to --integrate)
+```
+
+### Skill Ecosystem Integration
+
+| Workflow | Usage |
+|----------|-------|
+| Pre-implementation | `/research` → `/issue-create` → `/issue-work` |
+| Documentation | `/research` → `/doc-update` → `/doc-review` → `/doc-index` |
+| Security investigation | `/research` → `/security-audit` |
+| Performance investigation | `/research` → `/performance-review` |
+| Architecture design | `/research` → `/harness` |
+| API design | `/research` → `/api-design` guidance |
+
+## Policies
+
+See [_policy.md](../_policy.md) for common rules.
+
+### Command-Specific Rules
+
+| Item | Rule |
+|------|------|
+| **Default language** | English. Auto-detect from output directory. `--lang` overrides. |
+| **Source attribution** | Every factual claim must cite at least one source. |
+| **Cross-validation** | Claims must have 2+ independent sources. Single-source claims marked. |
+| **Date awareness** | Web searches include current year for time-sensitive topics. |
+| **Bias prevention** | Never rely on a single source. Present multiple perspectives. |
+| **Existing doc preservation** | Confirm before overwriting existing files. |
+| **Technical terms** | Keep in English regardless of output language. |
+| **Frontmatter keys** | Keep in English regardless of output language. |
+| **Citation originals** | Preserve original language of source titles and authors. |
+
+## Output
+
+### Conversation Output (no `--output`)
+
+A complete research report rendered in the conversation using the generic template.
+
+### File Output (`--output` specified)
+
+A `.md` file matching the detected document conventions of the output directory.
+
+### Summary (always shown)
+
+```markdown
+## Research Summary
+
+| Item | Value |
+|------|-------|
+| Topic | <topic> |
+| Depth | shallow / standard / deep |
+| Sources | N web, M codebase |
+| Output | conversation / <file-path> |
+| Language | en / ko / ... |
+| Template | plain / adapted |
+| Integrated | yes / no / skipped |
+```
+
+## Error Handling
+
+### Prerequisite Errors
+
+| Condition | Action |
+|-----------|--------|
+| Empty topic | Error: "Topic is required" |
+| `--output` directory does not exist | Error: "Output directory not found: `<path>`" |
+| `--integrate` without index system | Warn and skip integration |
+| `--sources web` but WebSearch unavailable | Warn, fall back to `--sources code` |
+
+### Runtime Errors
+
+| Condition | Action |
+|-----------|--------|
+| WebSearch returns no results | Try alternative queries. If all fail, report and continue with available sources. |
+| WebFetch fails for a URL | Skip URL, note in report as "[Inaccessible]". Continue with other sources. |
+| Insufficient sources found | Warn in report summary. Lower confidence ratings. |
+| Output file already exists | Ask user: overwrite / rename / cancel |
+| Index integration fails | Warn and suggest `/doc-index` |
+
+### Quality Gates
+
+Before finalizing the report, verify:
+
+- [ ] All research questions addressed (or explicitly noted as unresolved)
+- [ ] Source count meets depth requirement minimum
+- [ ] No unsupported claims (every finding has at least one citation)
+- [ ] Comparison matrix complete (if applicable)
+- [ ] Cross-references to existing project docs included (if `--sources code`)
+- [ ] Output language consistent throughout

--- a/global/skills/research/reference/output-templates.md
+++ b/global/skills/research/reference/output-templates.md
@@ -1,0 +1,220 @@
+# Output Templates
+
+Templates for research report generation. Template A is the generic default;
+Template B adapts to detected document conventions.
+
+## Template A: Generic (Plain)
+
+Used when `--template plain`, no `--output`, or no existing docs detected.
+
+```markdown
+# Research Report: {Topic}
+
+**Date**: YYYY-MM-DD
+**Depth**: shallow | standard | deep
+**Sources**: N web, M codebase
+
+---
+
+## 1. Overview
+
+### 1.1 Research Objective
+
+[What questions this research aims to answer]
+
+### 1.2 Scope and Methodology
+
+| Item | Value |
+|------|-------|
+| **Depth** | shallow / standard / deep |
+| **Web searches** | N queries |
+| **Pages analyzed** | M pages |
+| **Codebase files** | K files |
+
+## 2. Background
+
+[Technical context and foundational concepts]
+
+## 3. Findings
+
+### 3.1 [Finding Title]
+
+[Detailed finding with evidence]
+
+> Source: [Title](URL) | Accessed: YYYY-MM-DD | Confidence: High
+
+### 3.2 [Finding Title]
+
+[Detailed finding with evidence]
+
+## 4. Comparative Analysis
+
+| Criteria | Option A | Option B | Option C |
+|----------|:--------:|:--------:|:--------:|
+| **Criterion 1** | ✅ | ⚠️ | ❌ |
+| **Criterion 2** | 4/5 | 3/5 | 5/5 |
+| **Criterion 3** | ✅ | ✅ | ⚠️ |
+
+## 5. Codebase Relevance
+
+[How findings relate to the current project — included when --sources includes code]
+
+- `path/to/file.ext:line` — [Observation]
+- `path/to/other.ext` — [Pattern found]
+
+## 6. Recommendations
+
+1. **[Recommendation 1]**: [Rationale with source reference]
+2. **[Recommendation 2]**: [Rationale with source reference]
+
+## 7. Open Questions
+
+- [ ] [Unresolved question requiring further investigation]
+- [ ] [Area needing additional data]
+
+## 8. References
+
+1. Author (Year), *Title*, Publisher/URL
+2. Author (Year), *Title*, Publisher/URL
+3. [Web Source Title](https://url), accessed YYYY-MM-DD
+```
+
+### Section Inclusion Rules
+
+| Section | Shallow | Standard | Deep |
+|---------|:-------:|:--------:|:----:|
+| 1. Overview | ✅ | ✅ | ✅ |
+| 2. Background | Optional | ✅ | ✅ |
+| 3. Findings | ✅ | ✅ | ✅ |
+| 4. Comparative Analysis | If comparison topic | ✅ | ✅ |
+| 5. Codebase Relevance | If `--sources code/both` | If `--sources code/both` | ✅ |
+| 6. Recommendations | ✅ | ✅ | ✅ |
+| 7. Open Questions | Optional | ✅ | ✅ |
+| 8. References | ✅ | ✅ | ✅ |
+
+## Template B: Context-Adapted
+
+Used when `--template auto` and existing document conventions are detected.
+
+Template B is not a fixed template — it is dynamically constructed by replicating
+the patterns detected during Phase 0-B. The following describes what to replicate.
+
+### Frontmatter Replication
+
+If existing documents use YAML frontmatter, construct matching frontmatter:
+
+```yaml
+---
+# Replicate all keys found in existing docs.
+# Example detected schema:
+doc_id: "[pattern]-NNN"          # Use detected ID pattern, assign next number
+doc_title: "[Topic title]"       # In detected language
+doc_version: "0.1.0"             # Always start at 0.1.0 for new docs
+doc_date: "YYYY-MM-DD"           # Current date
+doc_status: "Draft"              # Always "Draft" for new research docs
+# ... replicate any additional keys found (classification, product, approval, etc.)
+---
+```
+
+**Rules**:
+- Replicate the exact key structure (including nesting depth).
+- For ID fields: detect the pattern (e.g., `STM-REF-NNN`) and assign next sequential number.
+- For approval/author blocks: leave date fields empty (pending review).
+- For fixed fields (classification, product): copy verbatim from existing docs.
+
+### Context Block Replication
+
+If existing documents have post-title context blockquotes, replicate the pattern:
+
+```markdown
+# [Title in detected language]
+
+> **[Key 1]**: [Value matching detected pattern]
+> **[Key 2]**: [Related document links using detected separator]
+> **[Key 3]**: 0.1.0
+> **[Key 4]**: YYYY-MM-DD
+```
+
+### Section Structure Replication
+
+Match the detected heading and numbering style:
+
+| Detected Pattern | Replicate |
+|-----------------|-----------|
+| `## 1. Title` | Numbered H2 sections |
+| `## Title` | Unnumbered H2 sections |
+| `### 1.1 Title` | Numbered H3 subsections |
+| Horizontal rules between sections | Include `***` separators |
+| Table of contents section | Include linked TOC |
+
+### Marker Replication
+
+If existing documents use special markers, include them where appropriate:
+
+| Detected Marker | When to Include |
+|----------------|-----------------|
+| `> **SSOT**: ...` | When the research section is the authoritative source for a topic |
+| `> **Cross-reference**: ...` | When referencing other existing documents |
+| `> **Note**: ...` | For advisory asides |
+
+### Citation Style Replication
+
+Match the reference/bibliography format of existing documents:
+
+| Detected Style | Format |
+|---------------|--------|
+| Numbered list | `1. Author (Year), *Title*, URL` |
+| Linked references | `- [Title](URL)` |
+| Academic style | `Author et al. (Year), *Title*, Journal, DOI` |
+| Table format | `\| # \| Title \| URL \| Type \| Date \|` |
+
+### Symbol Convention
+
+If existing documents use evaluation symbols, match them:
+
+- `✅` / `⚠️` / `❌` — Binary/ternary evaluation
+- `●` / `○` — Required/optional
+- Numeric scores (1-5) — Quantitative rating
+- Custom symbols — Replicate as found
+
+## Comparison Matrix Formats
+
+### Technology Comparison (Feature-Based)
+
+```markdown
+| Feature | Tech A | Tech B | Tech C |
+|---------|:------:|:------:|:------:|
+| **Feature 1** | ✅ | ⚠️ | ❌ |
+| **Feature 2** | ❌ | ✅ | ✅ |
+| **Maturity** | High | Medium | Low |
+| **Community** | Large | Medium | Small |
+```
+
+### Scored Evaluation
+
+```markdown
+| Criteria | Weight | Tech A | Tech B | Tech C |
+|----------|:------:|:------:|:------:|:------:|
+| **Performance** | 30% | 4.5 | 3.0 | 5.0 |
+| **Ecosystem** | 25% | 5.0 | 4.0 | 2.0 |
+| **Learning curve** | 20% | 3.0 | 4.5 | 2.5 |
+| **Maintenance** | 15% | 4.0 | 4.0 | 3.0 |
+| **Cost** | 10% | 5.0 | 3.0 | 4.0 |
+| **Weighted Total** | | **4.25** | **3.70** | **3.55** |
+```
+
+### Pros/Cons Format
+
+```markdown
+### Option A: [Name]
+
+**Advantages**:
+- [Advantage 1] — [Source]
+- [Advantage 2] — [Source]
+
+**Disadvantages**:
+- [Disadvantage 1] — [Source]
+- [Disadvantage 2] — [Source]
+
+**Best for**: [Use case description]
+```

--- a/global/skills/research/reference/research-methodology.md
+++ b/global/skills/research/reference/research-methodology.md
@@ -1,0 +1,131 @@
+# Research Methodology Guide
+
+Detailed guidance for each research depth level and search strategies.
+
+## Depth Level Specifications
+
+### Shallow
+
+**Goal**: Quick overview for orientation or simple fact-checking.
+
+**Search strategy**:
+1. Formulate 1-2 broad queries covering the topic.
+2. Scan top 3-5 results for key facts.
+3. In codebase: run 1-2 targeted `Grep` searches.
+
+**Time budget**: Under 5 minutes of active research.
+
+**Output scope**: 4-5 sections, 200-400 lines.
+
+**When to use**:
+- Quick technology name lookups
+- Verifying a single claim or version number
+- Getting a high-level overview before deeper research
+
+### Standard
+
+**Goal**: Balanced investigation suitable for technical decisions.
+
+**Search strategy**:
+1. Formulate 3-5 queries from different angles:
+   - Direct topic query
+   - Comparison/alternatives query
+   - Best practices/patterns query
+   - Known issues/limitations query
+   - Recent developments query (include current year)
+2. Deep-read 3-5 authoritative pages via `WebFetch`.
+3. In codebase: pattern analysis with `Grep` + `Glob`, read key files.
+
+**Time budget**: 10-20 minutes of active research.
+
+**Output scope**: 6-8 sections, 400-800 lines.
+
+**When to use**:
+- Technology selection decisions
+- Implementation approach research
+- Pre-issue research for medium features
+- Security or performance pre-investigation
+
+### Deep
+
+**Goal**: Comprehensive investigation for critical decisions or reference documentation.
+
+**Search strategy**:
+1. Formulate 8-12 queries systematically:
+   - Core concept queries (2-3)
+   - Implementation/architecture queries (2-3)
+   - Comparison/alternatives queries (2-3)
+   - Edge cases/limitations queries (1-2)
+   - Future direction/roadmap queries (1-2)
+2. Deep-read 8-12 pages, including academic papers or RFCs where relevant.
+3. In codebase: full architecture analysis, dependency mapping, usage patterns.
+
+**Time budget**: 30-60 minutes of active research.
+
+**Output scope**: 8+ sections, 800+ lines.
+
+**When to use**:
+- Architecture decisions with long-term impact
+- Regulatory or compliance research
+- Creating permanent reference documentation
+- Competitive landscape analysis
+
+## Search Query Formulation
+
+### Effective Query Patterns
+
+| Pattern | Example | When to Use |
+|---------|---------|-------------|
+| Direct | `"WebSocket protocol specification"` | Looking for authoritative source |
+| Comparative | `"WebSocket vs SSE vs long polling comparison 2026"` | Evaluating alternatives |
+| Problem-oriented | `"WebSocket scaling challenges production"` | Understanding limitations |
+| Implementation | `"WebSocket implementation best practices Node.js"` | Finding practical guidance |
+| Recent | `"WebSocket developments 2026"` | Time-sensitive information |
+
+### Query Refinement
+
+If initial queries return insufficient results:
+
+1. **Broaden**: Remove specific qualifiers (e.g., drop version numbers).
+2. **Rephrase**: Use alternative terminology (e.g., "real-time communication" instead of "WebSocket").
+3. **Decompose**: Split complex topic into sub-queries.
+4. **Domain-filter**: Add domain-specific terms (e.g., "medical device" for regulatory topics).
+
+### Year-Aware Searching
+
+For technology topics, include the current year in at least one query to capture recent developments. Avoid queries that return only outdated results.
+
+## Codebase Research Strategies
+
+### Pattern Discovery
+
+```
+1. Glob: Find files matching the topic (e.g., *.config.*, *auth*, *websocket*)
+2. Grep: Search for topic-related keywords in source code
+3. Read: Examine key files for implementation details
+4. Trace: Follow imports/dependencies for architecture understanding
+```
+
+### Architecture Mapping
+
+For `--depth deep` with `--sources code` or `--sources both`:
+
+1. Identify entry points related to the topic.
+2. Trace call chains and data flow.
+3. Map dependencies (internal and external).
+4. Document configuration and environment dependencies.
+5. Note test coverage for the topic area.
+
+## Parallel Research Execution
+
+For `standard` and `deep` depths, use the `Agent` tool to parallelize independent research streams:
+
+```
+Example: Researching "gRPC vs REST for microservices"
+
+Stream 1 (Agent): Web search for gRPC advantages, performance benchmarks
+Stream 2 (Agent): Web search for REST maturity, tooling ecosystem
+Stream 3 (main): Codebase analysis for existing API patterns
+```
+
+Merge results after all streams complete. Resolve any contradictions found between streams.

--- a/global/skills/research/reference/source-evaluation.md
+++ b/global/skills/research/reference/source-evaluation.md
@@ -1,0 +1,169 @@
+# Source Evaluation Guide
+
+Criteria for evaluating source reliability, assigning confidence levels,
+and handling conflicting information.
+
+## Confidence Levels
+
+### High Confidence
+
+The claim is well-supported and can be stated as fact.
+
+**Criteria** (at least 2 must be met):
+- Official documentation from the technology vendor/maintainer
+- Peer-reviewed paper or RFC/specification
+- 2+ independent authoritative sources agree
+- Verified by codebase evidence (implementation matches claim)
+- Published by recognized domain expert with verifiable credentials
+
+**Markers in report**: No special marker needed. State directly.
+
+### Medium Confidence
+
+The claim is supported but has limited verification.
+
+**Criteria**:
+- Single authoritative source without independent confirmation
+- Multiple non-authoritative sources agree (blogs, tutorials)
+- Source is recent but from a less established author
+- Codebase evidence is partial or indirect
+
+**Markers in report**: Append `[Medium confidence — single source]` or similar qualifier.
+
+### Low Confidence
+
+The claim has weak support and should be treated as preliminary.
+
+**Criteria**:
+- Single non-authoritative source
+- Information is outdated (> 2 years for fast-moving tech)
+- Source has known bias or commercial interest
+- Contradicted by other sources without clear resolution
+
+**Markers in report**: Append `[Low confidence — unverified]` and note the limitation.
+
+## Source Type Hierarchy
+
+Sources are ranked by general reliability (higher = more reliable):
+
+| Rank | Source Type | Examples | Typical Confidence |
+|------|-----------|----------|-------------------|
+| 1 | Standards/Specifications | RFC, ISO, IEC, W3C specs | High |
+| 2 | Official documentation | Language docs, framework docs, API refs | High |
+| 3 | Academic papers | Peer-reviewed journals, conference papers | High |
+| 4 | Vendor technical blogs | Engineering blogs from major tech companies | High-Medium |
+| 5 | Recognized expert content | Known practitioners, core contributors | Medium-High |
+| 6 | Community documentation | Wiki, community guides, curated lists | Medium |
+| 7 | Tutorial/blog posts | Individual developer blogs, tutorials | Medium-Low |
+| 8 | Forum answers | Stack Overflow, GitHub discussions | Low-Medium |
+| 9 | AI-generated content | LLM outputs, AI summaries | Low |
+| 10 | Unverified claims | Social media, comments, anonymous posts | Very Low |
+
+**Note**: Rank is a starting point. A well-researched blog post may be more reliable
+than a poorly maintained official doc. Use judgment.
+
+## Cross-Validation Rules
+
+### Mandatory Cross-Validation
+
+The following claim types **must** be verified by 2+ independent sources:
+
+- Performance benchmarks or metrics
+- Security vulnerability assessments
+- Compatibility or support claims (e.g., "supports X")
+- Cost or pricing information
+- Licensing terms
+
+### Single-Source Acceptable
+
+These can be cited from a single authoritative source:
+
+- API signatures and syntax (from official docs)
+- Version numbers and release dates
+- Specification requirements (from the spec itself)
+- Mathematical formulas or algorithms (from academic papers)
+
+### Handling Contradictions
+
+When sources disagree:
+
+1. **Identify the conflict clearly** in the report.
+2. **Present both perspectives** with their sources.
+3. **Assess which is more likely correct** based on:
+   - Source authority (higher-ranked source preferred)
+   - Recency (newer information preferred for tech topics)
+   - Specificity (more specific claim preferred over general)
+   - Codebase evidence (if available, strongly preferred)
+4. **State your assessment** but mark it as such:
+
+```markdown
+> **Note**: Sources disagree on this point. [Source A](url) claims X,
+> while [Source B](url) claims Y. Based on [reasoning], X appears more
+> likely, but independent verification is recommended.
+```
+
+## Citation Format
+
+### In-Text Citation
+
+For inline references within findings:
+
+```markdown
+According to [the official documentation](https://url), the maximum
+connection limit is 1000 concurrent WebSocket connections per server instance.
+```
+
+### Source Block
+
+For detailed source attribution after a finding:
+
+```markdown
+> Source: [Title](URL) | Accessed: YYYY-MM-DD | Confidence: High
+```
+
+### References Section
+
+Numbered list at the end of the report:
+
+```markdown
+## References
+
+1. Mozilla Developer Network (2026), *WebSocket API*, https://developer.mozilla.org/en-US/docs/Web/API/WebSocket, accessed 2026-04-13
+2. Grigorik, I. (2013), *High Performance Browser Networking*, O'Reilly Media
+3. IETF (2011), RFC 6455: *The WebSocket Protocol*, https://tools.ietf.org/html/rfc6455
+```
+
+**Rules**:
+- Number sequentially (do not skip numbers).
+- Include access date for web sources.
+- Preserve original language of titles.
+- Include DOI for academic papers when available.
+
+## Freshness Assessment
+
+| Topic Domain | Freshness Threshold | Action if Stale |
+|-------------|--------------------|--------------------|
+| Web frameworks/libraries | 1 year | Search for newer sources |
+| Programming languages | 2 years | Acceptable if stable feature |
+| Security vulnerabilities | 6 months | Must find current assessment |
+| Cloud services/pricing | 3 months | Warn about potential changes |
+| Standards/specifications | 5 years | Usually stable, check for amendments |
+| Academic research | 5 years | Acceptable, note newer developments |
+| Hardware/performance | 2 years | Benchmarks may be outdated |
+
+## Bias Detection
+
+Flag potential bias when:
+
+- Source is a vendor comparing their product to competitors
+- Source has commercial interest in the conclusion
+- Source is affiliated with one side of a technical debate
+- Source presents only positive or only negative aspects
+- Multiple sources share the same original source (echo chamber)
+
+When bias is detected, note it:
+
+```markdown
+> **Note**: This comparison is from [Vendor]'s blog and may favor their product.
+> Cross-referenced with independent benchmarks where available.
+```


### PR DESCRIPTION
Closes #284

## What

### Summary
Add a new global skill `/research` that conducts structured research on any topic using web search, codebase analysis, and document synthesis into organized reference documents.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `global/skills/research/SKILL.md` — Core skill definition with phase-based workflow
- `global/skills/research/reference/research-methodology.md` — Depth levels and search strategies
- `global/skills/research/reference/output-templates.md` — Generic and context-adapted templates
- `global/skills/research/reference/source-evaluation.md` — Confidence scoring and citation guidelines

## Why

### Problem Solved
The skill ecosystem has 27+ skills covering code quality, documentation, issues, CI/CD, and releases — but no capability for systematic topic investigation. This skill fills the upstream gap, enabling better-informed decisions before implementation, documentation, or architecture work.

### Related Issues
- Closes #284

### Skill Ecosystem Integration
```
/research → /doc-update → /doc-review → /doc-index  (documentation pipeline)
/research → /issue-create → /issue-work              (implementation pipeline)
/research → /security-audit, /performance-review      (quality gate pipeline)
/research → /harness                                  (architecture pipeline)
```

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/skills/research/` | 1 | New skill definition |
| `global/skills/research/reference/` | 3 | New reference documents |

## How

### Key Design Decisions
1. **Context-adaptive output**: Detects existing doc conventions (frontmatter, language, markers) from output directory and replicates them — works with any project, not hardcoded to one
2. **Language auto-detection**: Default English, auto-detects from sibling docs, overridable with `--lang`
3. **Index system integration**: `--integrate` flag registers new docs in existing `docs/.index/` manifest/bundle/router
4. **Three depth levels**: shallow (quick), standard (balanced), deep (comprehensive)
5. **Phase-based workflow**: Context analysis → Discovery → Analysis → Synthesis → Integration

### Testing Done
- [x] Skill appears in `/` skill list after file creation
- [x] SKILL.md follows established frontmatter and section conventions
- [x] Reference docs follow existing `reference/` patterns (doc-review, harness)
- [x] No modifications to existing files

### Test Plan
1. Verify `/research` appears in skill list
2. Test basic invocation: `/research "test topic"`
3. Test with `--output` to verify file generation
4. Test with `--template plain` to verify generic output
5. Test in a project with existing docs to verify context detection

### Breaking Changes
None — new skill only, no modifications to existing skills or configuration.