### PR TITLE
fix(statusline): handle lock and remove block-timer widget

### DIFF
--- a/global/ccstatusline/settings.json
+++ b/global/ccstatusline/settings.json
@@ -6,8 +6,6 @@
       { "id": "2", "type": "separator" },
       { "id": "5", "type": "session-cost", "color": "yellow" },
       { "id": "6", "type": "separator" },
-      { "id": "7", "type": "block-timer", "color": "cyan" },
-      { "id": "8", "type": "separator" },
       { "id": "9", "type": "git-branch", "color": "magenta" },
       { "id": "10", "type": "separator" },
       { "id": "11", "type": "git-changes", "color": "yellow" }

--- a/global/scripts/statusline-command.ps1
+++ b/global/scripts/statusline-command.ps1
@@ -60,14 +60,33 @@ if (Get-Command ccstatusline -ErrorAction SilentlyContinue) {
 # off a background ccstatusline run with rate_limits stripped from stdin to
 # force fetchUsageData(). The next status bar refresh picks up the fresh file.
 $UsageCache = Join-Path $HOME ".cache" "ccstatusline" "usage.json"
+$UsageLock = Join-Path $HOME ".cache" "ccstatusline" "usage.lock"
 $UsageCacheTtl = 180
+
+# Detect ccstatusline's own rate-limit lock. When the OAuth usage API returns
+# 429, ccstatusline writes {"blockedUntil":<epoch>} into usage.lock; until that
+# timestamp passes, any spawned ccstatusline is a no-op. Skip the background
+# refresh in that window to avoid spawning wasted jobs every 30s, and expose
+# $lockRemaining so the Extra line can show the reason the values are stale.
+$lockRemaining = 0
+if (Test-Path $UsageLock) {
+    try {
+        $lockData = Get-Content $UsageLock -Raw | ConvertFrom-Json
+        $blockedUntil = [int64]$lockData.blockedUntil
+        $nowEpoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+        if ($blockedUntil -gt $nowEpoch) {
+            $lockRemaining = [int]($blockedUntil - $nowEpoch)
+        }
+    } catch { }
+}
+
 if ($CcslExe -and $StdinData) {
     $needsRefresh = $true
     if (Test-Path $UsageCache) {
         $cacheAge = (New-TimeSpan -Start (Get-Item $UsageCache).LastWriteTimeUtc -End ([DateTime]::UtcNow)).TotalSeconds
         if ($cacheAge -lt $UsageCacheTtl) { $needsRefresh = $false }
     }
-    if ($needsRefresh) {
+    if ($needsRefresh -and $lockRemaining -eq 0) {
         try {
             $stripped = $StdinData | Select-Object -Property * -ExcludeProperty rate_limits | ConvertTo-Json -Depth 32 -Compress
             Start-Job -ScriptBlock {
@@ -89,7 +108,20 @@ if (Test-Path $UsageCache) {
             $remainPct = [math]::Floor(100 - $usage.extraUsageUtilization)
             $ESC = [char]0x1B
             $c = if ($remainPct -gt 50) { '32' } elseif ($remainPct -gt 20) { '33' } else { '31' }
-            Write-Output "${ESC}[${c}mExtra: `$$usedUsd/`$$limitUsd (${remainPct}%)${ESC}[0m | ${ESC}[${c}mRemain: `$$remainUsd${ESC}[0m"
+
+            # When ccstatusline's usage lock is active, the cached values above
+            # are frozen until the lock expires. Append a dim-gray "(locked Nm)"
+            # marker so the user can tell the stale values are intentional.
+            $lockedSuffix = ""
+            if ($lockRemaining -gt 0) {
+                if ($lockRemaining -ge 60) {
+                    $lockedSuffix = " ${ESC}[90m(locked $([math]::Floor($lockRemaining / 60))m)${ESC}[0m"
+                } else {
+                    $lockedSuffix = " ${ESC}[90m(locked ${lockRemaining}s)${ESC}[0m"
+                }
+            }
+
+            Write-Output "${ESC}[${c}mExtra: `$$usedUsd/`$$limitUsd (${remainPct}%)${ESC}[0m | ${ESC}[${c}mRemain: `$$remainUsd${ESC}[0m${lockedSuffix}"
         }
     } catch { }
 }

--- a/global/scripts/statusline-command.sh
+++ b/global/scripts/statusline-command.sh
@@ -53,8 +53,21 @@ fi
 # off a background ccstatusline run with rate_limits stripped from stdin to
 # force fetchUsageData(). The next status bar refresh picks up the fresh file.
 USAGE_CACHE="$HOME/.cache/ccstatusline/usage.json"
+USAGE_LOCK="$HOME/.cache/ccstatusline/usage.lock"
 USAGE_CACHE_TTL=180
+lock_remaining=0
 if command -v jq &> /dev/null; then
+    # Detect ccstatusline's own rate-limit lock. When the OAuth usage API returns
+    # 429, ccstatusline writes {"blockedUntil":<epoch>} into usage.lock; until that
+    # timestamp passes, any spawned ccstatusline is a no-op. Skip the background
+    # refresh in that window to avoid spawning wasted processes every 30s, and
+    # expose lock_remaining so the Extra line can show the reason it is stale.
+    if [ -f "$USAGE_LOCK" ]; then
+        blocked_until=$(jq -r '.blockedUntil // 0' "$USAGE_LOCK" 2>/dev/null)
+        now=$(date +%s)
+        [ "$blocked_until" -gt "$now" ] 2>/dev/null && lock_remaining=$(( blocked_until - now ))
+    fi
+
     needs_refresh=1
     if [ -f "$USAGE_CACHE" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -65,7 +78,7 @@ if command -v jq &> /dev/null; then
         cache_age=$(( $(date +%s) - cache_mtime ))
         [ "$cache_age" -lt "$USAGE_CACHE_TTL" ] && needs_refresh=0
     fi
-    if [ "$needs_refresh" -eq 1 ]; then
+    if [ "$needs_refresh" -eq 1 ] && [ "$lock_remaining" -eq 0 ]; then
         ( echo "$INPUT" | jq -c 'del(.rate_limits)' 2>/dev/null \
             | $CCSL_CMD >/dev/null 2>&1 ) &
         disown 2>/dev/null || true
@@ -96,7 +109,19 @@ if [ -f "$USAGE_CACHE" ] && command -v jq &> /dev/null; then
         fi
         reset="\033[0m"
 
-        printf "${color}Extra: \$%s/\$%s (%s%%)${reset} | ${color}Remain: \$%s${reset}\n" \
-            "$used_usd" "$limit_usd" "$remain_pct" "$remain_usd"
+        # When ccstatusline's usage lock is active, the cached values above are
+        # frozen until the lock expires. Append a dim-gray "(locked Nm)" marker
+        # so the user can tell the stale values are intentional, not a script bug.
+        locked_suffix=""
+        if [ "$lock_remaining" -gt 0 ] 2>/dev/null; then
+            if [ "$lock_remaining" -ge 60 ]; then
+                locked_suffix=$(printf " \033[90m(locked %dm)\033[0m" $((lock_remaining / 60)))
+            else
+                locked_suffix=$(printf " \033[90m(locked %ds)\033[0m" "$lock_remaining")
+            fi
+        fi
+
+        printf "${color}Extra: \$%s/\$%s (%s%%)${reset} | ${color}Remain: \$%s${reset}%b\n" \
+            "$used_usd" "$limit_usd" "$remain_pct" "$remain_usd" "$locked_suffix"
     fi
 fi


### PR DESCRIPTION
## What

- Detect ccstatusline's `usage.lock`, skip redundant background refreshes while the lock is active, and append a dim-gray `(locked Nm)` suffix to the `Extra` line so stale values are self-explanatory.
- Remove the `block-timer` widget (and its adjacent separator) from the first ccstatusline line.

### Change Type

- [x] Bugfix (lock handling)
- [x] Chore (widget cleanup)

## Why

Investigation of "the status bar is not refreshing" revealed two independent issues:

1. **Extra/Remain line stays frozen**: the OAuth usage API returns HTTP 429 when the Extra budget is exhausted; ccstatusline writes `{"blockedUntil":<epoch>}` into `~/.cache/ccstatusline/usage.lock` and turns subsequent spawns into no-ops until that timestamp passes. The script kept spawning wasteful background jobs every 30 s with no user-visible explanation.
2. **`Block: Nhr Mm` widget** was the most visually dominant element on the first line and duplicated information already implied by the session reset countdown.

A separate stdin-dump experiment (17 samples, 30 s cadence) confirmed that Claude Code's `rate_limits` stdin IS refreshed — but only after API calls. Idle-period staleness of `Session%` / `Weekly%` is by design, not a regression.

## Where

| File | Change |
|---|---|
| `global/scripts/statusline-command.sh` | Lock detection + conditional refresh + locked suffix |
| `global/scripts/statusline-command.ps1` | Same logic, PowerShell port (CRLF preserved) |
| `global/ccstatusline/settings.json` | Drop id 7 (block-timer) + id 8 (separator) from line 0 |

## How

- `usage.lock` is read via `jq` (sh) / `ConvertFrom-Json` (ps1); `lock_remaining = blockedUntil - now()` guards both the background spawn and the suffix renderer.
- Suffix renders as ` (locked Nm)` in dim gray (ANSI `\033[90m`) when `lock_remaining >= 60`, else ` (locked Ns)`.
- ccstatusline settings: removed two entries; canonical source propagates to Windows on the next `install.ps1` run (deploys to `~/.config/ccstatusline/`).

### Test Plan

- [x] Injected synthetic stdin on macOS; observed `(locked 21m)` suffix and no `Block:` segment.
- [x] Confirmed existing 180 s mtime-based TTL guard still cooperates with the new lock guard.
- [ ] PowerShell runtime validation pending (no `pwsh` on dev machine). Line-ending CRLF preserved; logic mirrors the bash version.

### Breaking Changes

None. Behavior change is only visible when a rate-limit lock is active or when the user relied on the first-line `Block:` widget.