### PR TITLE
feat(skills): lower default batch limit to 5

### DIFF
--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -43,7 +43,10 @@ Automate GitHub issue workflow with project name as argument.
   - If omitted in single-item mode: auto-recommend based on issue size, then ask user
   - If omitted in batch mode: auto-decide per item using weighted scoring (no per-item prompt)
 
-- `[--limit N]`: Maximum number of items to process in batch mode (default: 20, max: 50)
+- `[--limit N]`: Maximum number of items to process in batch mode (default: 5, max: 10)
+  - Values above 10 require `--force-large` to acknowledge rule drift risk. Empirically, drift becomes visible around items 15-25 in long batches; the conservative default keeps batches inside the safe zone.
+
+- `[--force-large]`: Allow `--limit > 10`. Required to bypass the safe-batch cap.
 
 - `[--dry-run]`: Show batch plan only, do not execute
 
@@ -57,14 +60,26 @@ Parse `$ARGUMENTS` and extract project, organization, issue number, and batch fl
 ```bash
 ARGS="$ARGUMENTS"
 ISSUE_NUMBER="" PROJECT="" ORG="" EXEC_MODE=""
-BATCH_MODE="single"  BATCH_LIMIT=20  DRY_RUN=false  PRIORITY_FILTER="all"
+BATCH_MODE="single"  BATCH_LIMIT=5  DRY_RUN=false  PRIORITY_FILTER="all"  FORCE_LARGE=false
+MAX_LIMIT=10
 
 # Extract flags
 if [[ "$ARGS" == *"--solo"* ]]; then EXEC_MODE="solo"; ARGS=$(echo "$ARGS" | sed 's/--solo//g'); fi
 if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed 's/--team//g'); fi
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
+if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --priority[[:space:]]+(critical|high|medium|low|all) ]]; then PRIORITY_FILTER="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--priority[[:space:]]+\w+//g'); fi
+
+# Hard cap on batch size to mitigate rule drift in long batches.
+# Drift becomes empirically visible around items 15-25; default 5 keeps the
+# operator inside the safe zone, and bypassing requires explicit acknowledgment.
+if (( BATCH_LIMIT > MAX_LIMIT )) && [[ "$FORCE_LARGE" != "true" ]]; then
+    echo "Error: --limit ${BATCH_LIMIT} exceeds safe cap of ${MAX_LIMIT}." >&2
+    echo "Long batches risk rule drift around items 15-25." >&2
+    echo "Either split the batch into smaller runs or pass --force-large to override." >&2
+    exit 1
+fi
 
 # Extract issue number if present (numeric argument)
 if [[ "$ARGS" =~ [[:space:]]([0-9]+)([[:space:]]|$) ]]; then

--- a/global/skills/issue-work/reference/batch-mode.md
+++ b/global/skills/issue-work/reference/batch-mode.md
@@ -55,7 +55,8 @@ Sort ALL_ISSUES by: score ascending → `createdAt` ascending → repo name asce
 
 Apply filters:
 - `--priority <level>`: exclude issues below the specified priority level
-- `--limit N`: take only the first N items after sorting (default: 20, max: 50)
+- `--limit N`: take only the first N items after sorting (default: 5, max: 10)
+  - Values above 10 require `--force-large` to bypass the safe-batch cap. The cap exists because rule drift becomes empirically visible around items 15-25 in long batches; keeping batches at 5 by default preserves rule fidelity, and large runs require explicit operator acknowledgment.
 
 If no issues found after filtering, report "No open issues found matching criteria" and exit.
 

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -51,7 +51,10 @@ Analyze and fix failed CI/CD workflows for a pull request.
   - If omitted in single-item mode: auto-recommend based on failure complexity, then ask user
   - If omitted in batch mode: auto-decide per item using weighted scoring (no per-item prompt)
 
-- `[--limit N]`: Maximum number of items to process in batch mode (default: 20, max: 50)
+- `[--limit N]`: Maximum number of items to process in batch mode (default: 5, max: 10)
+  - Values above 10 require `--force-large` to acknowledge rule drift risk. Empirically, drift becomes visible around items 15-25 in long batches; the conservative default keeps batches inside the safe zone.
+
+- `[--force-large]`: Allow `--limit > 10`. Required to bypass the safe-batch cap.
 
 - `[--dry-run]`: Show batch plan only, do not execute
 
@@ -70,16 +73,29 @@ PROJECT=""
 ORG=""
 EXEC_MODE=""
 BATCH_MODE="single"   # single | single-repo | cross-repo
-BATCH_LIMIT=20
+BATCH_LIMIT=5
+MAX_LIMIT=10
 DRY_RUN=false
+FORCE_LARGE=false
 
 # Extract flags
 ORIGINAL_ARGS="$ARGS"
 if [[ "$ARGS" == *"--solo"* ]]; then EXEC_MODE="solo"; ARGS=$(echo "$ARGS" | sed 's/--solo//g'); fi
 if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed 's/--team//g'); fi
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
+if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --org[[:space:]]+([^[:space:]]+) ]]; then ORG="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--org[[:space:]]+[^[:space:]]+//g'); fi
+
+# Hard cap on batch size to mitigate rule drift in long batches.
+# Drift becomes empirically visible around items 15-25; default 5 keeps the
+# operator inside the safe zone, and bypassing requires explicit acknowledgment.
+if (( BATCH_LIMIT > MAX_LIMIT )) && [[ "$FORCE_LARGE" != "true" ]]; then
+    echo "Error: --limit ${BATCH_LIMIT} exceeds safe cap of ${MAX_LIMIT}." >&2
+    echo "Long batches risk rule drift around items 15-25." >&2
+    echo "Either split the batch into smaller runs or pass --force-large to override." >&2
+    exit 1
+fi
 
 # Trim remaining args
 ARGS=$(echo "$ARGS" | xargs)

--- a/global/skills/pr-work/reference/batch-mode.md
+++ b/global/skills/pr-work/reference/batch-mode.md
@@ -65,7 +65,7 @@ Assign each failing PR a severity score:
 
 Sort FAILING_PRS by: score ascending -> `createdAt` ascending -> repo name ascending.
 
-Apply `--limit N` (default: 20, max: 50). If no failing PRs found, report "No open PRs with failed CI found" and exit.
+Apply `--limit N` (default: 5, max: 10). Values above 10 require `--force-large` to bypass the safe-batch cap. The cap exists because rule drift becomes empirically visible around items 15-25 in long batches; keeping batches at 5 by default preserves rule fidelity, and large runs require explicit operator acknowledgment. If no failing PRs found, report "No open PRs with failed CI found" and exit.
 
 ## B-2. Auto Size/Mode Estimation per Item
 


### PR DESCRIPTION
## What

Lower the default `BATCH_LIMIT` from 20 to 5 and cap the `--limit` maximum at 10 across both `issue-work` and `pr-work` skills. Values above 10 now require an explicit `--force-large` opt-in flag.

Affected files:
- `global/skills/issue-work/SKILL.md`
- `global/skills/issue-work/reference/batch-mode.md`
- `global/skills/pr-work/SKILL.md`
- `global/skills/pr-work/reference/batch-mode.md`

## Why

Empirically, rule drift becomes visible around items 15-25 in long batches. The previous defaults (20 default, 50 max) sat directly in or above the drift zone, so the typical batch invocation produced degraded output for items past the midpoint.

Lowering the default to 5 keeps the operator inside the safe zone by default. Capping the max at 10 forces a deliberate decision (`--force-large`) before entering the drift-prone region, ensuring the operator is aware of the risk rather than discovering it after the run.

Part of #287.

## How

1. Both `SKILL.md` files: changed `BATCH_LIMIT=20` to `BATCH_LIMIT=5`, added `MAX_LIMIT=10`, added `FORCE_LARGE=false`, added `--force-large` flag parsing, and added a hard-cap check that exits with a clear error message when `BATCH_LIMIT > MAX_LIMIT` without `--force-large`.
2. Both `reference/batch-mode.md` files: updated the `--limit` documentation to reflect the new default (5) and max (10), plus the rationale and the `--force-large` escape hatch.
3. Both `SKILL.md` argument tables: documented the new `--force-large` flag inline with `--limit`.

## Acceptance Criteria

- [x] `BATCH_LIMIT` default is 5 in both skills
- [x] `--limit` max is 10 without `--force-large` opt-out
- [x] Documentation in `SKILL.md` reflects new defaults and rationale
- [x] Smoke-test review: invocation with `--limit 5` (or default) passes the guard; `--limit 11` is blocked with an actionable error message; `--limit 11 --force-large` bypasses the guard

## Test Plan

The argument-parsing block in each `SKILL.md` is a bash snippet executed (or interpreted) by Claude when the skill runs. Reviewers can verify behavior by reading lines 60-83 of `global/skills/issue-work/SKILL.md` and lines 73-99 of `global/skills/pr-work/SKILL.md`:

- With no `--limit` flag, `BATCH_LIMIT` defaults to 5; the hard-cap check is skipped (5 <= 10).
- With `--limit 5`, the guard is skipped (5 <= 10).
- With `--limit 11`, the guard fires and exits with the rule-drift error.
- With `--limit 11 --force-large`, `FORCE_LARGE=true` short-circuits the guard, allowing the larger batch.

Closes #288