### PR TITLE
feat(skills): add chunked confirmation gate every 5 items

### DIFF
--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -48,6 +48,8 @@ Automate GitHub issue workflow with project name as argument.
 
 - `[--force-large]`: Allow `--limit > 10`. Required to bypass the safe-batch cap.
 
+- `[--no-confirm]`: Skip the chunked confirmation gate fired every 5 items in batch mode. Intended for CI-driven or fully unattended batches; interactive sessions should leave it off so the gate can serve as both a user-control checkpoint and an attention refresh for accumulated context.
+
 - `[--dry-run]`: Show batch plan only, do not execute
 
 - `[--priority <level>]`: Filter batch to this priority level and above
@@ -60,14 +62,16 @@ Parse `$ARGUMENTS` and extract project, organization, issue number, and batch fl
 ```bash
 ARGS="$ARGUMENTS"
 ISSUE_NUMBER="" PROJECT="" ORG="" EXEC_MODE=""
-BATCH_MODE="single"  BATCH_LIMIT=5  DRY_RUN=false  PRIORITY_FILTER="all"  FORCE_LARGE=false
+BATCH_MODE="single"  BATCH_LIMIT=5  DRY_RUN=false  PRIORITY_FILTER="all"  FORCE_LARGE=false  NO_CONFIRM=false
 MAX_LIMIT=10
+CONFIRM_INTERVAL=5
 
 # Extract flags
 if [[ "$ARGS" == *"--solo"* ]]; then EXEC_MODE="solo"; ARGS=$(echo "$ARGS" | sed 's/--solo//g'); fi
 if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed 's/--team//g'); fi
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
 if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
+if [[ "$ARGS" == *"--no-confirm"* ]]; then NO_CONFIRM=true; ARGS=$(echo "$ARGS" | sed 's/--no-confirm//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --priority[[:space:]]+(critical|high|medium|low|all) ]]; then PRIORITY_FILTER="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--priority[[:space:]]+\w+//g'); fi
 

--- a/global/skills/issue-work/reference/batch-mode.md
+++ b/global/skills/issue-work/reference/batch-mode.md
@@ -108,6 +108,7 @@ If `--dry-run` is set, display the plan and exit without prompting.
 Process each item one at a time:
 
 ```
+PROCESSED=0
 for each item in approved batch plan:
     1. Log progress: "[N/TOTAL] Starting: $REPO #$ISSUE_NUMBER — $TITLE ($MODE)"
 
@@ -131,7 +132,47 @@ for each item in approved batch plan:
     6. Log completion: "[N/TOTAL] Completed: $REPO #$ISSUE_NUMBER — $RESULT"
 
     7. Pause 2 seconds between items (rate limiting)
+
+    8. PROCESSED=$((PROCESSED + 1))
+       Chunked confirmation gate (see B-4.1) — fires every CONFIRM_INTERVAL
+       items and only when more items remain.
 ```
+
+### B-4.1. Chunked Confirmation Gate
+
+After every `CONFIRM_INTERVAL` items (default 5), and only while items remain in the batch, halt execution and prompt the user via `AskUserQuestion`. Skip the gate entirely when `--no-confirm` was passed.
+
+```
+if [[ "$NO_CONFIRM" != "true" ]] \
+   && (( PROCESSED % CONFIRM_INTERVAL == 0 )) \
+   && (( PROCESSED < TOTAL )); then
+    decision=$(AskUserQuestion
+        question="Processed ${PROCESSED}/${TOTAL} items. Continue, pause, or cancel?"
+        header="Batch gate"
+        options=(
+            "Continue (Recommended)" "Resume the next chunk of ${CONFIRM_INTERVAL} items."
+            "Pause and save resume state" "Write .claude/resume.md and exit; the next session can pick up from item $((PROCESSED + 1))."
+            "Cancel batch" "Stop now without writing resume state. Already-completed items stay completed."
+        )
+    )
+    case "$decision" in
+        Pause*) write_resume_md_for_batch; exit 0 ;;
+        Cancel*) exit 0 ;;
+        Continue*) : ;;  # fall through to next item
+    esac
+fi
+```
+
+**Why the gate matters beyond user control**: Each `AskUserQuestion` prompt produces a fresh user message in the conversation. That message acts as an attention anchor — when the model responds, recently-buried `CLAUDE.md` rules and skill instructions regain salience. The gate doubles as both an interactive checkpoint and a context-refresh mechanism for long-running batches.
+
+**Resume state on pause**: When the user chooses "Pause", write `.claude/resume.md` per the `session-resume` workflow. Use the **Batch Workflow Resume Format** described in `workflow/reference/session-resume-templates.md` so a future session can pick up at item `$((PROCESSED + 1))`.
+
+**`--no-confirm` use cases**:
+- CI-driven batch invocations where no human is at the terminal
+- `--dry-run` follow-up runs already pre-approved by the operator
+- Scripts that orchestrate `issue-work` programmatically
+
+In interactive sessions, leave it off — the attention-refresh side effect is one of the strongest available drift mitigations.
 
 **Failure handling per item:**
 - Build/test/CI failure after 3 retries → mark FAILED, create draft PR if code was written, continue to next

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -56,6 +56,8 @@ Analyze and fix failed CI/CD workflows for a pull request.
 
 - `[--force-large]`: Allow `--limit > 10`. Required to bypass the safe-batch cap.
 
+- `[--no-confirm]`: Skip the chunked confirmation gate fired every 5 items in batch mode. Intended for CI-driven or fully unattended batches; interactive sessions should leave it off so the gate can serve as both a user-control checkpoint and an attention refresh for accumulated context.
+
 - `[--dry-run]`: Show batch plan only, do not execute
 
 - `[--org <organization>]`: Scope to a specific GitHub organization
@@ -75,8 +77,10 @@ EXEC_MODE=""
 BATCH_MODE="single"   # single | single-repo | cross-repo
 BATCH_LIMIT=5
 MAX_LIMIT=10
+CONFIRM_INTERVAL=5
 DRY_RUN=false
 FORCE_LARGE=false
+NO_CONFIRM=false
 
 # Extract flags
 ORIGINAL_ARGS="$ARGS"
@@ -84,6 +88,7 @@ if [[ "$ARGS" == *"--solo"* ]]; then EXEC_MODE="solo"; ARGS=$(echo "$ARGS" | sed
 if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed 's/--team//g'); fi
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
 if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
+if [[ "$ARGS" == *"--no-confirm"* ]]; then NO_CONFIRM=true; ARGS=$(echo "$ARGS" | sed 's/--no-confirm//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --org[[:space:]]+([^[:space:]]+) ]]; then ORG="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--org[[:space:]]+[^[:space:]]+//g'); fi
 

--- a/global/skills/pr-work/reference/batch-mode.md
+++ b/global/skills/pr-work/reference/batch-mode.md
@@ -115,6 +115,7 @@ If `--dry-run` is set, display the plan and exit without prompting.
 Process each item one at a time:
 
 ```
+PROCESSED=0
 for each item in approved batch plan:
     1. Log progress: "[N/TOTAL] Starting: $REPO PR #$PR_NUMBER -- $TITLE ($MODE)"
 
@@ -138,7 +139,47 @@ for each item in approved batch plan:
     6. Log completion: "[N/TOTAL] Completed: $REPO PR #$PR_NUMBER -- $RESULT"
 
     7. Pause 2 seconds between items (rate limiting)
+
+    8. PROCESSED=$((PROCESSED + 1))
+       Chunked confirmation gate (see B-4.1) -- fires every CONFIRM_INTERVAL
+       items and only when more items remain.
 ```
+
+## B-4.1. Chunked Confirmation Gate
+
+After every `CONFIRM_INTERVAL` items (default 5), and only while items remain in the batch, halt execution and prompt the user via `AskUserQuestion`. Skip the gate entirely when `--no-confirm` was passed.
+
+```
+if [[ "$NO_CONFIRM" != "true" ]] \
+   && (( PROCESSED % CONFIRM_INTERVAL == 0 )) \
+   && (( PROCESSED < TOTAL )); then
+    decision=$(AskUserQuestion
+        question="Processed ${PROCESSED}/${TOTAL} PRs. Continue, pause, or cancel?"
+        header="Batch gate"
+        options=(
+            "Continue (Recommended)" "Resume the next chunk of ${CONFIRM_INTERVAL} PRs."
+            "Pause and save resume state" "Write .claude/resume.md and exit; the next session can pick up from item $((PROCESSED + 1))."
+            "Cancel batch" "Stop now without writing resume state. Already-fixed PRs stay fixed."
+        )
+    )
+    case "$decision" in
+        Pause*) write_resume_md_for_batch; exit 0 ;;
+        Cancel*) exit 0 ;;
+        Continue*) : ;;  # fall through to next item
+    esac
+fi
+```
+
+**Why the gate matters beyond user control**: Each `AskUserQuestion` prompt produces a fresh user message in the conversation. That message acts as an attention anchor -- when the model responds, recently-buried `CLAUDE.md` rules and skill instructions regain salience. The gate doubles as both an interactive checkpoint and a context-refresh mechanism for long-running batches, which is particularly valuable in `pr-work` where each item involves dense CI log analysis.
+
+**Resume state on pause**: When the user chooses "Pause", write `.claude/resume.md` per the `session-resume` workflow. Use the **Batch Workflow Resume Format** described in `workflow/reference/session-resume-templates.md` so a future session can pick up at item `$((PROCESSED + 1))`.
+
+**`--no-confirm` use cases**:
+- CI-driven `pr-work` invocations where a separate orchestrator monitors the run
+- Recovery scripts that retry transient CI failures programmatically
+- `--dry-run` follow-up runs already pre-approved by the operator
+
+In interactive sessions, leave it off -- the attention-refresh side effect is one of the strongest available drift mitigations for long PR-fixing batches.
 
 **Failure handling per item:**
 - CI failure after 3 retries -> mark FAILED, add escalation comment to PR, continue to next


### PR DESCRIPTION
## What

Insert a mandatory user confirmation gate after every 5 items in batch mode for both `issue-work` and `pr-work` skills. The gate halts execution and uses `AskUserQuestion` to ask whether to continue, pause-with-resume, or cancel. A new `--no-confirm` flag bypasses the gate for CI-driven or unattended batches.

Affected files:
- `global/skills/issue-work/SKILL.md`
- `global/skills/issue-work/reference/batch-mode.md`
- `global/skills/pr-work/SKILL.md`
- `global/skills/pr-work/reference/batch-mode.md`

## Why

Beyond the obvious user-control benefit, the gate has a structural side effect: each `AskUserQuestion` prompt produces a fresh user message in the conversation, which acts as an attention anchor. When the model responds, recently-buried `CLAUDE.md` rules and skill instructions regain salience.

This is one of the strongest available mitigations for the rule-drift problem documented in epic #287, and it pairs naturally with the lower default batch limit (#288 — already merged): a default 5-item batch finishes without ever needing the gate, while larger batches (`--limit 6+` or `--force-large`) hit the gate at predictable, recoverable checkpoints.

Part of #287.

## How

1. **Both `SKILL.md` files**: added `--no-confirm` flag parsing, `NO_CONFIRM=false` default, `CONFIRM_INTERVAL=5` constant, and inline documentation of the flag in the argument tables. Also documented the attention-refresh rationale so readers understand why the gate matters even when not interactively useful.
2. **Both `batch-mode.md` files**: added a new step 8 to the sequential execution loop (`PROCESSED=$((PROCESSED + 1))`) and a new section **B-4.1 Chunked Confirmation Gate** that defines the gate logic, the `AskUserQuestion` invocation with three options (Continue / Pause-and-save / Cancel), the resume-state hand-off via `.claude/resume.md`, and the `--no-confirm` use cases.
3. **Pause path**: explicitly references the **Batch Workflow Resume Format** in `workflow/reference/session-resume-templates.md` so the existing session-resume infrastructure handles continuation.

## Acceptance Criteria

- [x] Gate fires every 5 items in batch mode (`CONFIRM_INTERVAL=5`, modulo check in B-4.1)
- [x] User can choose: continue / pause-and-write-resume / cancel (3-option `AskUserQuestion`)
- [x] Gate is bypassable with `--no-confirm` for CI-driven batches (parsed in both SKILL.md, checked in B-4.1)
- [x] Pause writes `.claude/resume.md` per existing `session-resume` workflow (links to `session-resume-templates.md` Batch Workflow Resume Format)
- [x] Documentation update in both `batch-mode.md` files (new B-4.1 section)

## Test Plan

The gate logic in each `batch-mode.md` is bash pseudocode interpreted by Claude during batch execution. Reviewers can verify the contract by:

- Reading the new B-4.1 section in `global/skills/issue-work/reference/batch-mode.md` (lines after the sequential execution loop) and confirming the modulo check (`PROCESSED % CONFIRM_INTERVAL == 0`) plus the `PROCESSED < TOTAL` guard prevents firing on the final item.
- Verifying both `SKILL.md` argument tables document `--no-confirm` and that the parsing block sets `NO_CONFIRM=true` when present.
- Confirming the gate's three actions correspond to the workflow contract: Continue (fall through), Pause (write resume file + exit), Cancel (exit without resume file).

Closes #289