### PR TITLE
feat(skills): inline critical rules in batch mode

### DIFF
--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -140,6 +140,11 @@ fi
 
 See `reference/batch-mode.md` for the complete batch mode workflow including discovery, priority sorting, plan approval, and sequential execution.
 
+**Batch-only behaviors** (do not apply in single-item mode):
+- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each item so language/CI/attribution rules stay in the recent attention window.
+- **No `@load: reference/...` inside the per-item loop**: keep the inline reminder as the most recent context anchor.
+- **Chunked confirmation gate** (B-4.1): user confirmation prompt every 5 items, bypassable with `--no-confirm`.
+
 ---
 
 ### Phase 0: Execution Mode Selection (Single-Item Mode)

--- a/global/skills/issue-work/reference/batch-mode.md
+++ b/global/skills/issue-work/reference/batch-mode.md
@@ -103,6 +103,24 @@ Present the batch plan as a table. Use `AskUserQuestion` for a single approval:
 
 If `--dry-run` is set, display the plan and exit without prompting.
 
+### B-4.0. Per-Item Rule Reminder
+
+Before starting work on each item, emit a 5-line reminder block as a fresh tool result so the rules sit in the recent attention window instead of being buried by accumulating context. The reminder must be **exactly 5 lines or fewer** to keep the per-iteration token cost bounded.
+
+Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
+
+```
+[Item ${PROCESSED+1}/${TOTAL}] Required rules:
+- PR title/body, commit messages, issue comments: English only
+- Commit format: type(scope): description (no Claude/AI attribution, no emojis)
+- ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
+- Branch: feature off develop, squash merge back via PR
+```
+
+**Why inline instead of @load**: A `@load: reference/...` call at batch start surfaces the doc once, after which the model's attention drifts as tool results accumulate. Inlining the same invariants per iteration makes them part of the most recent tool output every time, which is where attention is strongest. The 5-line cap keeps the cumulative cost linear in batch size but still tiny (≈25 tokens per item).
+
+**No reference loads inside the loop**: Do not call `@load: reference/error-handling.md`, `@load: reference/comment-templates.md`, or any other reference file from inside the per-item loop. If the single-item workflow needs a reference doc, the Solo/Team workflow loads it on its own — keep the loop free of additional loads so the inline reminder remains the most recent context anchor.
+
 ### B-4. Sequential Execution Loop
 
 Process each item one at a time:
@@ -111,6 +129,9 @@ Process each item one at a time:
 PROCESSED=0
 for each item in approved batch plan:
     1. Log progress: "[N/TOTAL] Starting: $REPO #$ISSUE_NUMBER — $TITLE ($MODE)"
+
+    1a. Emit inline rule reminder (see B-4.0). Do NOT @load any reference
+        files inside the loop — the per-item reminder replaces that role.
 
     2. Set context variables for this item:
        - $ORG, $PROJECT from repo

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -168,6 +168,11 @@ fi
 
 See `reference/batch-mode.md` for the complete batch mode workflow including discovery, priority sorting, plan approval, and sequential execution.
 
+**Batch-only behaviors** (do not apply in single-item mode):
+- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each PR so language/CI/attribution rules stay in the recent attention window.
+- **No `@load: reference/...` inside the per-item loop**: keep the inline reminder as the most recent context anchor.
+- **Chunked confirmation gate** (B-4.1): user confirmation prompt every 5 items, bypassable with `--no-confirm`.
+
 ---
 
 ### Phase 0: Execution Mode Selection (Single-Item Mode)

--- a/global/skills/pr-work/reference/batch-mode.md
+++ b/global/skills/pr-work/reference/batch-mode.md
@@ -110,6 +110,24 @@ Present the batch plan as a table. Use `AskUserQuestion` for a single approval:
 
 If `--dry-run` is set, display the plan and exit without prompting.
 
+## B-4.0. Per-Item Rule Reminder
+
+Before starting work on each PR, emit a 5-line reminder block as a fresh tool result so the rules sit in the recent attention window instead of being buried by accumulating context. The reminder must be **exactly 5 lines or fewer** to keep the per-iteration token cost bounded.
+
+Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
+
+```
+[Item ${PROCESSED+1}/${TOTAL}] Required rules:
+- PR title/body, commit messages, issue comments: English only
+- Commit format: type(scope): description (no Claude/AI attribution, no emojis)
+- ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
+- Never rationalize a CI failure as "unrelated" or "pre-existing"
+```
+
+**Why inline instead of @load**: A `@load: reference/...` call at batch start surfaces the doc once, after which the model's attention drifts as tool results accumulate. Inlining the same invariants per iteration makes them part of the most recent tool output every time, which is where attention is strongest. The 5-line cap keeps the cumulative cost linear in batch size but still tiny (~25 tokens per item).
+
+**No reference loads inside the loop**: Do not call `@load: reference/error-handling.md`, `@load: reference/ci-debugging.md`, or any other reference file from inside the per-item loop. If the single-item workflow needs a reference doc, the Solo/Team workflow loads it on its own -- keep the loop free of additional loads so the inline reminder remains the most recent context anchor.
+
 ## B-4. Sequential Execution Loop
 
 Process each item one at a time:
@@ -118,6 +136,9 @@ Process each item one at a time:
 PROCESSED=0
 for each item in approved batch plan:
     1. Log progress: "[N/TOTAL] Starting: $REPO PR #$PR_NUMBER -- $TITLE ($MODE)"
+
+    1a. Emit inline rule reminder (see B-4.0). Do NOT @load any reference
+        files inside the loop -- the per-item reminder replaces that role.
 
     2. Set context variables for this item:
        - $ORG, $PROJECT from repo


### PR DESCRIPTION
## What

Add a per-item rule reminder (new section **B-4.0**) to both `issue-work` and `pr-work` batch modes. Before each item's execution, the loop emits a 5-line invariant block as a fresh tool result so the language, commit format, attribution, and CI gate rules sit in the recent attention window instead of being buried by accumulating context.

Affected files:
- `global/skills/issue-work/SKILL.md`
- `global/skills/issue-work/reference/batch-mode.md`
- `global/skills/pr-work/SKILL.md`
- `global/skills/pr-work/reference/batch-mode.md`

## Why

Reference docs loaded once at batch start (`@load: reference/...`) are immediately buried by the dozens of tool results that accompany each item's PR/CI work. The model's attention is biased toward recent tokens, so by the time the loop reaches item 10 or 15, the rules from item 0 have effectively dropped out of the active attention pool.

Inlining the same invariants per iteration makes them part of the most recent tool output every time, which is where attention is strongest. The 5-line cap keeps the cumulative cost linear in batch size but tiny in absolute terms (~25 tokens per item).

This complements the per-5-item user-facing gate from #289: the gate refreshes attention via fresh user messages every five items, while the inline reminder refreshes it via tool results every single item. Together they form a multi-layer drift mitigation that does not depend on model self-discipline.

Part of #287.

## How

1. **Both `batch-mode.md` files**: added a new **B-4.0 Per-Item Rule Reminder** section before B-4 with the 5-line template, the rationale (recency bias / attention pool), and an explicit prohibition on `@load:` calls inside the per-item loop.
2. **Both `batch-mode.md` files**: added a new step `1a` to the sequential execution loop that references B-4.0 and explicitly states "Do NOT @load any reference files inside the loop".
3. **Both `SKILL.md` files**: added a **Batch-only behaviors** subsection under "Batch Mode Instructions" that documents the per-item reminder, the no-@load rule, and (cross-referenced) the chunked confirmation gate from #289.
4. **Reminder content** is tailored per skill: issue-work emphasizes the develop branch / squash merge workflow, pr-work emphasizes "never rationalize a CI failure as unrelated".

## Acceptance Criteria

- [x] Batch loop emits inline rule reminder before each item (step 1a in B-4 sequential loop)
- [x] No `@load: reference/...` calls inside batch loop (explicitly forbidden in B-4.0 and step 1a)
- [x] Reminder is exactly 5 lines or fewer (header + 4 bullets = 5 lines, verified)
- [x] Documented in `SKILL.md` as batch-mode behavior (new "Batch-only behaviors" subsection)

## Test Plan

The reminder is a markdown template the model emits at runtime, so reviewers can verify the contract by:

- Reading the new B-4.0 section in `global/skills/issue-work/reference/batch-mode.md` and counting lines in the template (must be ≤ 5).
- Confirming the sequential execution loop's step 1a references B-4.0 and forbids `@load:` inside the loop.
- Checking that both `SKILL.md` files mention the per-item reminder under "Batch Mode Instructions" so a model reading SKILL.md alone (without expanding batch-mode.md) is aware the behavior exists.

Closes #290