### PR TITLE
feat(hooks): add pr-language-guard pretooluse hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -20,6 +20,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Validate commit messages before git commit | [Commit Message Guard](#10-commit-message-guard-pretooluse) |
 | Prevent git merge/rebase on dirty trees | [Conflict Guard](#11-conflict-guard-pretooluse) |
 | Block PRs targeting main from non-develop branches | [PR Target Guard](#12-pr-target-guard-pretooluse) |
+| Block non-English titles/bodies in gh PR/issue commands | [PR Language Guard](#13-pr-language-guard-pretooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -274,6 +275,57 @@ Hooks are user-defined commands that automatically execute during specific Claud
   "type": "command",
   "command": "~/.claude/hooks/pr-target-guard.sh",
   "timeout": 5
+}
+```
+
+### 13. PR Language Guard (PreToolUse)
+
+*Hard-blocks non-English titles and bodies in `gh pr` and `gh issue` commands — eliminates the rule drift that lets Korean PR/issue content slip through in long-running batch workflows.*
+
+**Purpose**: Enforces the "All GitHub Issues and Pull Requests must be written in English" rule from `commit-settings.md` at the Bash tool boundary. Mirrors the `commit-message-guard` enforcement model that proved effective for commit messages.
+
+**Trigger**: `Bash` tool calls matching `gh (pr|issue) (create|edit|comment)`.
+
+**Files**: `global/hooks/pr-language-guard.sh`, `global/hooks/pr-language-guard.ps1`
+
+**Shared validation library**: `hooks/lib/validate-language.sh` (single source of truth — same pattern as `validate-commit-message.sh`).
+
+**Logic**:
+1. Scope gate: only process `gh (pr|issue) (create|edit|comment)` commands (all others pass through). Six combinations are guarded — `gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue create`, `gh issue edit`, `gh issue comment`.
+2. Skip command-substitution / heredoc bodies (`--body "$(...)"`) and `--body-file` references — these cannot be parsed at the shell layer, so the hook defers to other safeguards.
+3. Extract `--title` / `-t` and `--body` / `-b` values, supporting both double-quoted and single-quoted forms and `--flag value` / `--flag=value` layouts.
+4. Reject if any extracted value contains a byte outside ASCII printable (0x20-0x7E) or ASCII whitespace (0x09-0x0D).
+5. Deny reason includes the first offending character so Claude can self-correct (e.g. `first: '한'`).
+
+**Allowed characters**: ASCII printable (0x20-0x7E) and ASCII whitespace (tab, LF, VT, FF, CR). Anything else — accented Latin, CJK, emoji, symbols outside ASCII — is blocked.
+
+**Not covered**: `gh pr review --body` is intentionally not guarded (review comments may have different tone/content needs and would warrant a separate policy decision).
+
+**Fail policy**: Fail-open. If stdin parsing fails or the command is unrecognized, the hook returns `allow`. Server-side review and `commit-msg` hooks remain as additional layers.
+
+**Behavior**:
+- Returns JSON with `permissionDecision: "deny"` listing the first non-ASCII grapheme found
+- Defers to other layers for command-substitution and `--body-file` cases
+- Timeout: 5 seconds
+- Cross-platform: `pr-language-guard.sh` and `pr-language-guard.ps1`
+
+**Configuration**:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/pr-language-guard.sh",
+  "timeout": 5
+}
+```
+
+**Example deny response**:
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "PR/issue --body rejected: Text contains non-ASCII characters (first run: '한국어'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+  }
 }
 ```
 

--- a/global/hooks/pr-language-guard.ps1
+++ b/global/hooks/pr-language-guard.ps1
@@ -1,0 +1,136 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# pr-language-guard.ps1
+# Blocks gh pr/issue create|edit|comment commands whose --title or --body
+# contains non-ASCII characters.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "All GitHub Issues and Pull Requests must be written in
+# English" rule from commit-settings.md. Mirrors the commit-message-guard
+# enforcement model that proved effective for commit messages.
+#
+# Allowed bytes: ASCII printable (0x20-0x7E) and ASCII whitespace
+# (0x09-0x0D = tab, LF, VT, FF, CR). Anything else is rejected.
+#
+# NOTE: --body using $(...) substitution, heredocs, or --body-file is
+# not parseable at this layer and the hook returns "allow" for those.
+
+# Returns the first non-ASCII text element, or $null if all elements are ASCII.
+# Uses StringInfo to walk grapheme clusters so surrogate pairs (emoji,
+# CJK extensions in supplementary planes) are reported as a single unit.
+function Get-FirstNonAscii {
+    param([string]$Text)
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return $null
+    }
+
+    $info = [System.Globalization.StringInfo]::new($Text)
+    for ($i = 0; $i -lt $info.LengthInTextElements; $i++) {
+        $elem = $info.SubstringByTextElements($i, 1)
+        $cp = [Char]::ConvertToUtf32($elem, 0)
+        # ASCII printable (0x20-0x7E) or whitespace (0x09-0x0D)
+        if (($cp -ge 0x20 -and $cp -le 0x7E) -or ($cp -ge 0x09 -and $cp -le 0x0D)) {
+            continue
+        }
+        return $elem
+    }
+    return $null
+}
+
+# Extracts the value for a given long/short flag from a shell command string.
+# Tries double-quoted then single-quoted forms; supports --flag value,
+# --flag=value, and -f value layouts.
+function Get-FlagValue {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][string]$LongFlag,
+        [string]$ShortFlag
+    )
+
+    # Long flag, double-quoted: --title "value" or --title="value"
+    $m = [regex]::Match($Command, "$LongFlag[\s=]+`"([^`"]*)`"")
+    if ($m.Success) { return $m.Groups[1].Value }
+
+    # Long flag, single-quoted: --title 'value' or --title='value'
+    $m = [regex]::Match($Command, "$LongFlag[\s=]+'([^']*)'")
+    if ($m.Success) { return $m.Groups[1].Value }
+
+    if ($ShortFlag) {
+        # Short flag must be preceded by whitespace to avoid matching inside other tokens
+        $m = [regex]::Match($Command, "(?:^|\s)$ShortFlag\s+`"([^`"]*)`"")
+        if ($m.Success) { return $m.Groups[1].Value }
+
+        $m = [regex]::Match($Command, "(?:^|\s)$ShortFlag\s+'([^']*)'")
+        if ($m.Success) { return $m.Groups[1].Value }
+    }
+
+    return $null
+}
+
+# --- Read input from stdin ---
+$json = Read-HookInput
+
+# Empty input: fail open - nothing to validate
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract command
+$CMD = $null
+try { $CMD = $json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+
+if (-not $CMD) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Scope gate: only check 'gh (pr|issue) (create|edit|comment)' commands
+if ($CMD -notmatch 'gh\s+(pr|issue)\s+(create|edit|comment)') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Skip command-substitution / heredoc bodies — cannot parse reliably
+if ($CMD -match '(?:--body|-b|--title|-t)[\s=]+"\$\(') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Skip --body-file references — content lives in a separate file
+if ($CMD -match '--body-file[\s=]+') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract title and body
+$title = Get-FlagValue -Command $CMD -LongFlag '--title' -ShortFlag '-t'
+$body  = Get-FlagValue -Command $CMD -LongFlag '--body'  -ShortFlag '-b'
+
+# Validate title
+if ($title) {
+    $bad = Get-FirstNonAscii -Text $title
+    if ($null -ne $bad) {
+        New-HookDenyResponse -Reason "PR/issue --title rejected: Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+        exit 0
+    }
+}
+
+# Validate body
+if ($body) {
+    $bad = Get-FirstNonAscii -Text $body
+    if ($null -ne $bad) {
+        New-HookDenyResponse -Reason "PR/issue --body rejected: Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+        exit 0
+    }
+}
+
+# All checks passed
+New-HookAllowResponse
+exit 0

--- a/global/hooks/pr-language-guard.sh
+++ b/global/hooks/pr-language-guard.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# pr-language-guard.sh
+# Blocks gh pr/issue create|edit|comment commands whose --title or --body
+# contains non-ASCII characters.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "All GitHub Issues and Pull Requests must be written in
+# English" rule from commit-settings.md. Mirrors the commit-message-guard
+# enforcement model that proved effective for commit messages: a hard hook
+# gate at the Bash tool boundary catches drift in long-running batch
+# workflows where the model occasionally lapses into non-English content.
+#
+# Sources shared validation rules from hooks/lib/validate-language.sh
+# (single source of truth — see #291).
+#
+# NOTE on parsing limits: --body arguments using $(...) command substitution,
+# heredocs, or --body-file references are not parseable at this layer.
+# In such cases the hook returns "allow" and defers to other safeguards
+# (server-side review, commit hooks for committed content).
+
+set -uo pipefail
+
+# --- Response helpers ---
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+# --- Source shared validation library ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR=""
+
+# Try 1: repo-relative path (development / CI testing)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
+if [ -f "$REPO_ROOT/hooks/lib/validate-language.sh" ]; then
+    VALIDATOR="$REPO_ROOT/hooks/lib/validate-language.sh"
+# Try 2: sibling lib/ directory (deployed to ~/.claude/hooks/)
+elif [ -f "$SCRIPT_DIR/lib/validate-language.sh" ]; then
+    VALIDATOR="$SCRIPT_DIR/lib/validate-language.sh"
+fi
+
+if [ -n "$VALIDATOR" ]; then
+    # shellcheck source=../../hooks/lib/validate-language.sh
+    . "$VALIDATOR"
+fi
+
+# Inline fallback so the hook still works when the shared library is missing.
+# Keep rules in sync with hooks/lib/validate-language.sh.
+if ! command -v validate_english_only >/dev/null 2>&1; then
+    validate_english_only() {
+        local text="$1"
+        if [ -z "$text" ]; then
+            return 0
+        fi
+        if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+            local sample
+            sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
+            echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
+            return 1
+        fi
+        return 0
+    }
+fi
+
+# --- Read input from stdin ---
+INPUT=$(cat)
+
+# Empty input: fail open — nothing to validate.
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || CMD=""
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+# --- Scope: only validate gh pr|issue create|edit|comment commands ---
+if ! echo "$CMD" | grep -qE 'gh[[:space:]]+(pr|issue)[[:space:]]+(create|edit|comment)'; then
+    allow_response
+fi
+
+# --- Skip command-substitution / heredoc / file-based bodies ---
+# These cannot be parsed reliably at the shell layer.
+if echo "$CMD" | grep -qE -- '(--body|-b|--title|-t)[[:space:]=]+"\$\('; then
+    allow_response
+fi
+if echo "$CMD" | grep -qE -- '--body-file[[:space:]=]+'; then
+    allow_response
+fi
+
+# --- Extract a quoted argument value ---
+# Tries double quotes first, then single quotes. Returns the first match
+# on stdout, empty string if not found. The longest-match-safe pattern
+# [^"]* / [^']* prevents the regex from spanning subsequent arguments.
+extract_quoted_value() {
+    local cmd="$1"
+    local long_flag="$2"
+    local short_flag="$3"
+    local val=""
+
+    # Long flag, double-quoted: --title "value" or --title="value"
+    val=$(printf '%s' "$cmd" | sed -nE "s/.*${long_flag}[[:space:]=]+\"([^\"]*)\".*/\1/p" | head -n1)
+    if [ -n "$val" ]; then
+        printf '%s' "$val"
+        return
+    fi
+
+    # Long flag, single-quoted: --title 'value' or --title='value'
+    if [[ "$cmd" =~ ${long_flag}[[:space:]=]+\'([^\']*)\' ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Short flag, double-quoted: -t "value" (require leading whitespace
+    # to avoid matching inside other tokens)
+    if [ -n "$short_flag" ]; then
+        val=$(printf '%s' "$cmd" | sed -nE "s/.*[[:space:]]${short_flag}[[:space:]]+\"([^\"]*)\".*/\1/p" | head -n1)
+        if [ -n "$val" ]; then
+            printf '%s' "$val"
+            return
+        fi
+        if [[ "$cmd" =~ [[:space:]]${short_flag}[[:space:]]+\'([^\']*)\' ]]; then
+            printf '%s' "${BASH_REMATCH[1]}"
+            return
+        fi
+    fi
+}
+
+TITLE=$(extract_quoted_value "$CMD" "--title" "-t")
+BODY=$(extract_quoted_value "$CMD" "--body"  "-b")
+
+# --- Validate ---
+if [ -n "$TITLE" ]; then
+    REASON=$(validate_english_only "$TITLE" 2>&1) || \
+        deny_response "PR/issue --title rejected: $REASON"
+fi
+
+if [ -n "$BODY" ]; then
+    REASON=$(validate_english_only "$BODY" 2>&1) || \
+        deny_response "PR/issue --body rejected: $REASON"
+fi
+
+allow_response

--- a/global/settings.json
+++ b/global/settings.json
@@ -80,6 +80,11 @@
             "type": "command",
             "command": "~/.claude/hooks/pr-target-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pr-language-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -93,6 +93,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-target-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-language-guard.ps1",
+            "timeout": 5
           }
         ]
       },

--- a/hooks/lib/validate-language.sh
+++ b/hooks/lib/validate-language.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# validate-language.sh
+# Shared text language validation library.
+# Single source of truth for the "English-only" rule applied to GitHub
+# Issue and Pull Request titles and bodies created via the gh CLI.
+#
+# Sourced by:
+#   - global/hooks/pr-language-guard.sh (PreToolUse — Claude-side feedback loop)
+#
+# The rule mirrors commit-settings.md: "All GitHub Issues and Pull Requests
+# must be written in English." The terminal-side enforcement layer for git
+# commits lives in validate-commit-message.sh; this library is the analogous
+# gate for gh pr/issue commands intercepted at the Bash tool boundary.
+#
+# Usage:
+#   . /path/to/validate-language.sh
+#   if ! validate_english_only "$body"; then
+#       echo "invalid" >&2
+#   fi
+
+# validate_english_only <text>
+# Returns 0 on valid (English-only or empty), 1 on invalid.
+# On failure, prints reason to stderr.
+#
+# Definition of "English-only":
+#   - Empty strings are treated as valid (nothing to validate).
+#   - All bytes must fall within ASCII printable range (0x20-0x7E) or be
+#     ASCII whitespace (space, tab, newline, carriage return, form feed,
+#     vertical tab). LC_ALL=C forces grep to interpret character classes
+#     as 7-bit ASCII regardless of the user's locale.
+#   - Any byte outside that set — accented Latin, CJK, emoji, symbols —
+#     fails validation.
+validate_english_only() {
+    local text="$1"
+
+    if [ -z "$text" ]; then
+        return 0
+    fi
+
+    if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+        local sample
+        sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
+        echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
+        return 1
+    fi
+
+    return 0
+}


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `pr-language-guard.sh/.ps1` that intercepts `gh pr|issue create|edit|comment` Bash commands and rejects any whose `--title` or `--body` contains non-ASCII characters. Mirrors the `commit-message-guard` enforcement model that proved effective for commit messages.

This is a hard hook gate that eliminates the rule drift category where long-running batch workflows occasionally lapse into Korean PR/issue bodies. The "MANDATORY English only" rule from `commit-settings.md` becomes machine-enforced rather than advisory.

## What

- `hooks/lib/validate-language.sh` (new) — shared SSOT validator with `validate_english_only()` function
- `global/hooks/pr-language-guard.sh` (new) — bash PreToolUse hook
- `global/hooks/pr-language-guard.ps1` (new) — PowerShell equivalent using `CommonHelpers.psm1`
- `global/settings.json` — registered after `pr-target-guard.sh` in PreToolUse Bash matcher
- `global/settings.windows.json` — registered after `pr-target-guard.ps1`
- `HOOKS.md` — new section "13. PR Language Guard" plus quick-nav entry

## Why

Part of #287. Long-running batch workflows accumulate context drift, and after 20+ items the model occasionally writes non-English PR bodies despite the advisory rule. A deterministic hook gate at the Bash boundary closes this category of drift entirely, the same way `commit-message-guard` did for commit messages.

## How

1. Scope gate: regex `gh\s+(pr|issue)\s+(create|edit|comment)` — six combinations are guarded.
2. Skip command-substitution (`--body \"\$(...)\"`), heredocs, and `--body-file` references — these cannot be parsed at the shell layer, so the hook defers to other safeguards.
3. Extract `--title`/`-t` and `--body`/`-b` values supporting double-quoted, single-quoted, and `flag=value` layouts.
4. Validate via shared library: allow ASCII printable (0x20-0x7E) and ASCII whitespace (0x09-0x0D); reject anything else.
5. Deny reason includes the first non-ASCII grapheme so Claude can self-correct.
6. PowerShell variant uses `[System.Globalization.StringInfo]` to walk grapheme clusters, ensuring surrogate-pair characters (emoji, supplementary-plane CJK) are reported as a single unit.

## Test Plan

Bash hook smoke tests (19 cases verified locally, all pass):

- English title + body: ALLOW
- Korean body / Korean title: DENY with actionable reason
- Single-quoted Korean body: DENY
- \`--title=value\` form with non-ASCII: DENY
- \`-t\`/\`-b\` short flags: ALLOW (English) / DENY (Korean)
- Emoji in body: DENY
- \`--body-file\` reference: ALLOW (defer to other layers)
- Heredoc body (\`--body \"\$(cat <<EOF...)\"\`): ALLOW (defer)
- \`gh issue comment\` / \`gh pr edit\` with Korean: DENY
- \`gh repo view\` and other gh commands: ALLOW
- \`gh pr review --body\` (out of scope): ALLOW
- Multiline English body with tabs: ALLOW
- Special ASCII (punctuation, symbols, \$VAR, ~/.claude): ALLOW
- Empty stdin: ALLOW (fail-open)

PowerShell hook follows the same pattern as \`commit-message-guard.ps1\` — relies on CI for verification since pwsh is not available locally.

## Acceptance Criteria

- [x] Hook script exists for both bash and PowerShell
- [x] Shared library \`validate-language.sh\` enforces SSOT pattern
- [x] Registered in both \`settings.json\` files
- [x] Smoke test: Korean body in \`gh pr create\` is blocked
- [x] Smoke test: English-only body passes
- [x] Deny response includes actionable feedback (first non-ASCII grapheme reported)
- [x] Documented in \`HOOKS.md\`

## Notes

- The original issue described \`exit 2\` for the failure mode. The actual claude-config PreToolUse pattern uses \`exit 0\` plus a JSON \`permissionDecision: \"deny\"\` (consistent with \`commit-message-guard.sh\` and \`pr-target-guard.sh\`). The actionable feedback requirement is satisfied via the JSON \`permissionDecisionReason\` field.
- The cartesian product \`(pr|issue) x (create|edit|comment)\` guards six commands. The issue listed four (\`gh pr create\`, \`gh pr edit\`, \`gh issue create\`, \`gh issue comment\`); we additionally guard \`gh pr comment\` and \`gh issue edit\` for consistency since the same English policy applies.
- \`gh pr review --body\` is intentionally out of scope — review comments may have different policy needs and warrant a separate decision.

Closes #291
Part of #287