### PR TITLE
feat(hooks): add merge-gate-guard pretooluse hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -21,6 +21,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Prevent git merge/rebase on dirty trees | [Conflict Guard](#11-conflict-guard-pretooluse) |
 | Block PRs targeting main from non-develop branches | [PR Target Guard](#12-pr-target-guard-pretooluse) |
 | Block non-English titles/bodies in gh PR/issue commands | [PR Language Guard](#13-pr-language-guard-pretooluse) |
+| Block gh pr merge when any check is non-passing | [Merge Gate Guard](#14-merge-gate-guard-pretooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -325,6 +326,60 @@ Hooks are user-defined commands that automatically execute during specific Claud
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
     "permissionDecisionReason": "PR/issue --body rejected: Text contains non-ASCII characters (first run: '한국어'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+  }
+}
+```
+
+### 14. Merge Gate Guard (PreToolUse)
+
+*Hard-blocks `gh pr merge` when any PR check is failing, pending, or cancelled — eliminates the rule drift that lets failing CI rationalizations slip through in long-running batch workflows.*
+
+**Purpose**: Enforces the "ABSOLUTE CI GATE" rule from `global/CLAUDE.md` at the Bash tool boundary. Mirrors the `commit-message-guard` and `pr-language-guard` enforcement model: a deterministic hook gate that catches drift where the model occasionally rationalizes failing checks as "unrelated", "infrastructure", or "pre-existing".
+
+**Trigger**: `Bash` tool calls matching `gh pr merge`.
+
+**Files**: `global/hooks/merge-gate-guard.sh`, `global/hooks/merge-gate-guard.ps1`
+
+**Logic**:
+1. Scope gate: only process `gh pr merge` commands (all others pass through).
+2. Extract PR number from positional integer, URL form (`https://github.com/owner/repo/pull/N`), or anywhere after `gh pr merge`. Allow if no PR number is found (interactive mode).
+3. Extract `--repo` / `-R` value if present.
+4. Invoke `gh pr checks <PR> --json bucket,name,state` (with `-R` if specified).
+5. Parse the JSON array. Allowed buckets: `pass` and `skipping`. Anything in `fail`, `pending`, `cancel`, or unknown buckets blocks the merge.
+6. Deny reason includes every non-passing check name with its bucket and state, plus a reminder not to rationalize failures.
+
+**Allow policy**: A check qualifies as passing if its `bucket` is `pass` or `skipping`. The `skipping` bucket covers checks intentionally skipped (e.g. `paths-ignore` matches) and is treated as neutral, the same way GitHub itself does for branch protection rules.
+
+**Fail policy**: **Fail-OPEN** on `gh` CLI errors. Unlike most other guards, this hook allows the merge when:
+- `gh` CLI is not installed
+- `gh pr checks` returns a non-zero exit code (e.g. transient network error, auth failure, unresolvable PR)
+- The JSON response cannot be parsed
+- The PR has no checks configured at all
+
+A diagnostic is written to stderr in each fail-open case so the user can see why the gate did not run. The rationale is that this hook is a "best-effort gate", not a "hard fail on tool unavailability" — server-side branch protection rules remain as the authoritative gate, so a transient failure here should not permanently block user work.
+
+**Behavior**:
+- Returns JSON with `permissionDecision: "deny"` listing every non-passing check
+- Fail-open on any gh CLI error; diagnostics written to stderr
+- Timeout: 30 seconds (longer than other guards because it makes an external API call)
+- Cross-platform: `merge-gate-guard.sh` and `merge-gate-guard.ps1`
+
+**Configuration**:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/merge-gate-guard.sh",
+  "timeout": 30
+}
+```
+
+**Example deny response**:
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Merge blocked by ABSOLUTE CI GATE: PR #100 has non-passing checks: Build Linux [fail/FAILURE], Build Windows [pending/IN_PROGRESS]. Wait for all checks to pass before merging — never rationalize a failure as unrelated, infrastructure, or pre-existing."
   }
 }
 ```

--- a/global/hooks/merge-gate-guard.ps1
+++ b/global/hooks/merge-gate-guard.ps1
@@ -1,0 +1,144 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# merge-gate-guard.ps1
+# Blocks gh pr merge commands when any PR check is not passing.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "ABSOLUTE CI GATE" rule from global/CLAUDE.md at the Bash
+# tool boundary. Mirrors the commit-message-guard / pr-language-guard
+# enforcement model.
+#
+# Allow policy: every check must be in bucket "pass" or "skipping".
+# Anything in bucket "fail", "pending", or "cancel" blocks the merge.
+#
+# Fail policy: FAIL-OPEN on gh CLI errors. If gh is missing, unauthenticated,
+# or the API call fails, the merge is allowed and a diagnostic is written
+# to stderr. Server-side branch protection rules remain as authoritative.
+
+function Write-Diag {
+    param([string]$Message)
+    [Console]::Error.WriteLine("merge-gate-guard: $Message")
+}
+
+# --- Read input from stdin ---
+$json = Read-HookInput
+
+# Empty input: fail open - nothing to validate
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract command
+$CMD = $null
+try { $CMD = $json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+
+if (-not $CMD) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Scope gate: only check 'gh pr merge' commands
+if ($CMD -notmatch 'gh\s+pr\s+merge') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# --- Extract PR number ---
+$prNum = $null
+
+# Try positional integer immediately after 'gh pr merge'
+$m = [regex]::Match($CMD, 'gh\s+pr\s+merge\s+(\d+)')
+if ($m.Success) { $prNum = $m.Groups[1].Value }
+
+# Try URL form
+if (-not $prNum) {
+    $m = [regex]::Match($CMD, 'gh\s+pr\s+merge\s+https?://github\.com/[^/]+/[^/]+/pull/(\d+)')
+    if ($m.Success) { $prNum = $m.Groups[1].Value }
+}
+
+# Try positional integer anywhere after 'gh pr merge' (handles flags before PR)
+if (-not $prNum) {
+    $m = [regex]::Match($CMD, 'gh\s+pr\s+merge[^\d]*?(?:^|\s)(\d+)(?:\s|$)')
+    if ($m.Success) { $prNum = $m.Groups[1].Value }
+}
+
+# No PR number found - likely interactive mode. Allow and let gh handle it.
+if (-not $prNum) {
+    Write-Diag 'could not extract PR number from command, allowing'
+    New-HookAllowResponse
+    exit 0
+}
+
+# --- Extract repo (-R / --repo) ---
+$repo = $null
+$m = [regex]::Match($CMD, "--repo[\s=]+[`"']?([^\s`"']+)")
+if ($m.Success) { $repo = $m.Groups[1].Value }
+
+if (-not $repo) {
+    $m = [regex]::Match($CMD, "(?:^|\s)-R\s+[`"']?([^\s`"']+)")
+    if ($m.Success) { $repo = $m.Groups[1].Value }
+}
+
+# --- Verify gh is available ---
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Diag 'gh CLI not installed, allowing merge (fail-open)'
+    New-HookAllowResponse
+    exit 0
+}
+
+# --- Call gh pr checks ---
+$ghArgs = @('pr', 'checks', $prNum, '--json', 'bucket,name,state')
+if ($repo) { $ghArgs += @('-R', $repo) }
+
+try {
+    $checksRaw = & gh @ghArgs 2>&1
+    $ghExit = $LASTEXITCODE
+} catch {
+    Write-Diag "gh invocation threw: $_"
+    New-HookAllowResponse
+    exit 0
+}
+
+if ($ghExit -ne 0) {
+    Write-Diag "gh pr checks failed (exit $ghExit), allowing merge (fail-open): $checksRaw"
+    New-HookAllowResponse
+    exit 0
+}
+
+# Empty result means no checks configured for this PR
+if (-not $checksRaw -or "$checksRaw".Trim() -eq '[]') {
+    Write-Diag "no checks configured for PR #$prNum, allowing"
+    New-HookAllowResponse
+    exit 0
+}
+
+# --- Parse non-passing checks ---
+try {
+    $checks = $checksRaw | ConvertFrom-Json
+} catch {
+    Write-Diag "ConvertFrom-Json failed, allowing merge (fail-open): $_"
+    New-HookAllowResponse
+    exit 0
+}
+
+$nonPassing = @()
+foreach ($c in $checks) {
+    if ($c.bucket -ne 'pass' -and $c.bucket -ne 'skipping') {
+        $nonPassing += "$($c.name) [$($c.bucket)/$($c.state)]"
+    }
+}
+
+if ($nonPassing.Count -gt 0) {
+    $list = $nonPassing -join ', '
+    New-HookDenyResponse -Reason "Merge blocked by ABSOLUTE CI GATE: PR #$prNum has non-passing checks: $list. Wait for all checks to pass before merging — never rationalize a failure as unrelated, infrastructure, or pre-existing."
+    exit 0
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/merge-gate-guard.sh
+++ b/global/hooks/merge-gate-guard.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# merge-gate-guard.sh
+# Blocks gh pr merge commands when any PR check is not passing.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "ABSOLUTE CI GATE" rule from global/CLAUDE.md at the Bash
+# tool boundary. Mirrors the commit-message-guard / pr-language-guard
+# enforcement model: a deterministic hook gate that catches drift in
+# long-running batch workflows where the model occasionally rationalizes
+# failing checks as "unrelated" or "infrastructure-only".
+#
+# Allow policy: every check must be in bucket "pass" or "skipping".
+# Anything in bucket "fail", "pending", or "cancel" blocks the merge.
+#
+# Fail policy: FAIL-OPEN on gh CLI errors. If gh is missing, unauthenticated,
+# or the API call fails for any reason, the merge is allowed and a diagnostic
+# is written to stderr. This prevents transient network issues from
+# permanently blocking user work — the policy is "best-effort gate", not
+# "hard-fail on tool unavailability". Server-side branch protection rules
+# remain as the authoritative gate.
+
+set -uo pipefail
+
+# --- Response helpers ---
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+log_diag() {
+    echo "merge-gate-guard: $1" >&2
+}
+
+# --- Read input from stdin ---
+INPUT=$(cat)
+
+# Empty input: fail open — nothing to validate
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || CMD=""
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+if [ -z "$CMD" ]; then
+    allow_response
+fi
+
+# --- Scope: only validate gh pr merge commands ---
+if ! echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge'; then
+    allow_response
+fi
+
+# --- Extract PR number ---
+# Supports: gh pr merge 123, gh pr merge 123 --squash, gh pr merge --squash 123,
+#           gh pr merge https://github.com/owner/repo/pull/123
+PR_NUM=""
+
+# Try positional integer immediately after 'gh pr merge'
+PR_NUM=$(printf '%s' "$CMD" | sed -nE 's/.*gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+([0-9]+).*/\1/p' | head -n1)
+
+# Try URL form
+if [ -z "$PR_NUM" ]; then
+    PR_NUM=$(printf '%s' "$CMD" | sed -nE 's|.*gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+https?://github\.com/[^/]+/[^/]+/pull/([0-9]+).*|\1|p' | head -n1)
+fi
+
+# Try positional integer anywhere after 'gh pr merge' (handles flags before PR)
+if [ -z "$PR_NUM" ]; then
+    PR_NUM=$(printf '%s' "$CMD" | grep -oE 'gh[[:space:]]+pr[[:space:]]+merge.*' | grep -oE '(^|[[:space:]])[0-9]+([[:space:]]|$)' | head -n1 | tr -d '[:space:]')
+fi
+
+# No PR number found — likely interactive mode (gh pr merge with no args)
+# or unparseable form. Allow and let gh handle it interactively.
+if [ -z "$PR_NUM" ]; then
+    log_diag "could not extract PR number from command, allowing"
+    allow_response
+fi
+
+# --- Extract repo (-R / --repo) ---
+REPO=""
+REPO=$(printf '%s' "$CMD" | sed -nE 's/.*--repo[[:space:]=]+["'"'"']?([^[:space:]"'"'"']+).*/\1/p' | head -n1)
+if [ -z "$REPO" ]; then
+    REPO=$(printf '%s' "$CMD" | sed -nE 's/.*[[:space:]]-R[[:space:]]+["'"'"']?([^[:space:]"'"'"']+).*/\1/p' | head -n1)
+fi
+
+# --- Verify gh is available ---
+if ! command -v gh >/dev/null 2>&1; then
+    log_diag "gh CLI not installed, allowing merge (fail-open)"
+    allow_response
+fi
+
+# --- Call gh pr checks ---
+if [ -n "$REPO" ]; then
+    CHECKS_JSON=$(gh pr checks "$PR_NUM" -R "$REPO" --json bucket,name,state 2>&1)
+else
+    CHECKS_JSON=$(gh pr checks "$PR_NUM" --json bucket,name,state 2>&1)
+fi
+GH_RC=$?
+
+if [ $GH_RC -ne 0 ]; then
+    log_diag "gh pr checks failed (exit $GH_RC), allowing merge (fail-open): ${CHECKS_JSON}"
+    allow_response
+fi
+
+# Empty JSON array means no checks are configured for this PR — allow.
+if [ -z "$CHECKS_JSON" ] || [ "$CHECKS_JSON" = "[]" ]; then
+    log_diag "no checks configured for PR #${PR_NUM}, allowing"
+    allow_response
+fi
+
+# --- Parse non-passing checks ---
+# Allowed buckets: pass, skipping. Anything else blocks the merge.
+NON_PASSING=$(printf '%s' "$CHECKS_JSON" | jq -r '
+    [.[] | select(.bucket != "pass" and .bucket != "skipping")
+         | "\(.name) [\(.bucket)/\(.state)]"]
+    | join(", ")
+' 2>/dev/null)
+JQ_RC=$?
+
+if [ $JQ_RC -ne 0 ]; then
+    log_diag "jq parse failed, allowing merge (fail-open): ${CHECKS_JSON}"
+    allow_response
+fi
+
+if [ -n "$NON_PASSING" ]; then
+    deny_response "Merge blocked by ABSOLUTE CI GATE: PR #${PR_NUM} has non-passing checks: ${NON_PASSING}. Wait for all checks to pass before merging — never rationalize a failure as unrelated, infrastructure, or pre-existing."
+fi
+
+allow_response

--- a/global/settings.json
+++ b/global/settings.json
@@ -85,6 +85,11 @@
             "type": "command",
             "command": "~/.claude/hooks/pr-language-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/merge-gate-guard.sh",
+            "timeout": 30
           }
         ]
       },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -98,6 +98,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-language-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/merge-gate-guard.ps1",
+            "timeout": 30
           }
         ]
       },


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `merge-gate-guard.sh/.ps1` that intercepts `gh pr merge` commands and verifies all PR checks pass before allowing the merge. Mirrors the `commit-message-guard` and `pr-language-guard` enforcement model: a deterministic hook gate that catches the rule drift category where the model occasionally rationalizes failing CI checks as "unrelated" or "infrastructure-only" in long-running batch workflows.

## What

- `global/hooks/merge-gate-guard.sh` (new) — bash PreToolUse hook
- `global/hooks/merge-gate-guard.ps1` (new) — PowerShell equivalent using `CommonHelpers.psm1`
- `global/settings.json` — registered after `pr-language-guard.sh` in PreToolUse Bash matcher (timeout 30s for external API call)
- `global/settings.windows.json` — registered after `pr-language-guard.ps1`
- `HOOKS.md` — new section "14. Merge Gate Guard" plus quick-nav entry

## Why

Part of #287. The "ABSOLUTE CI GATE" rule in `global/CLAUDE.md` is currently a model-side instruction. After 20+ items in a batch workflow, the model occasionally rationalizes failing checks as "unrelated", "infrastructure", or "pre-existing" and proceeds with the merge anyway. A hard hook gate at the Bash boundary makes the policy structurally enforceable and immune to attention drift.

## How

1. Scope gate: regex `gh\s+pr\s+merge`. All other commands pass through.
2. Extract PR number from positional integer (`gh pr merge 123`), URL form (`https://github.com/owner/repo/pull/123`), or any position after `gh pr merge` (handles `gh pr merge --squash 123`).
3. Extract `--repo` / `-R` value if present.
4. Invoke `gh pr checks <PR> --json bucket,name,state` (with `-R` if specified).
5. Parse the JSON array. Allow buckets: `pass` and `skipping`. Anything in `fail`, `pending`, `cancel`, or unknown buckets blocks the merge.
6. Deny reason includes every non-passing check name with its bucket and state.

### Allow vs. Fail Policy

- **Allow policy**: A check passes if its `bucket` is `pass` or `skipping`. The `skipping` bucket covers checks intentionally skipped (e.g. `paths-ignore` matches), treated as neutral the same way GitHub's branch protection does.
- **Fail policy: FAIL-OPEN on gh CLI errors**. If gh is missing, unauthenticated, the API call fails, JSON cannot be parsed, or the PR has no checks configured, the merge is allowed and a diagnostic is written to stderr. This is intentional: the hook is a "best-effort gate", not a "hard fail on tool unavailability". Server-side branch protection rules remain as the authoritative gate, so a transient failure here should not permanently block user work. This is the opposite of `pr-target-guard`'s fail-closed policy.

## Test Plan

Bash hook smoke tests (13 cases verified locally — 8 positive against real PRs, 5 mock-based negative for the deny path):

**Positive (real gh):**
- Empty stdin: ALLOW (fail-open)
- `gh pr view 303`: ALLOW (out of scope)
- `gh pr merge 303 --squash` (real PR with all-pass): ALLOW
- `gh pr merge --squash 303` (flags before PR): ALLOW
- URL form `https://github.com/.../pull/303`: ALLOW
- `gh pr merge 303 --repo kcenon/claude-config`: ALLOW (--repo extracted)
- `gh pr merge --squash` (no PR number, interactive): ALLOW with diag
- `gh pr merge 999999` (nonexistent PR, gh API error): ALLOW with diag (fail-open)

**Negative (mock gh):**
- PR with `bucket=fail`: DENY listing failing check
- PR with all `pass` + `skipping`: ALLOW
- PR with only `pending`: DENY
- PR with empty `[]` (no checks configured): ALLOW with diag
- PR with `cancel` bucket: DENY

PowerShell hook follows the same pattern as `commit-message-guard.ps1`; CI verifies it (pwsh not available locally).

## Acceptance Criteria

- [x] Hook blocks `gh pr merge` if any check is non-PASS/non-SKIPPING (covers `fail`, `pending`, `cancel`)
- [x] Output to stderr is structured and actionable (diagnostics + JSON deny reason listing every non-passing check)
- [x] Hook gracefully handles `gh` API errors (log to stderr + allow on transient errors / missing gh / parse failures)
- [x] Smoke test: PR with failing check is blocked (mock test 1, 3, 5)
- [x] Smoke test: PR with all-passing checks merges normally (real test against PR #303 and mock test 2)
- [x] Documented in `HOOKS.md` with rationale (section 14, including allow/fail policy explanation)

## Notes

- The original issue mentioned `exit 2` for the failure mode. The actual claude-config PreToolUse pattern is `exit 0` + JSON `permissionDecision: "deny"`, consistent with `commit-message-guard.sh`, `pr-target-guard.sh`, and `pr-language-guard.sh`.
- Timeout is 30s instead of the standard 5s because this hook makes an external API call. The same timeout pattern is used by `markdown-anchor-validator`.
- The cartesian guard product `(pr|issue) × (create|edit|comment)` from `pr-language-guard` does not apply here — `gh pr merge` is the only relevant command.

Closes #292
Part of #287