### PR TITLE
feat(hooks): extend attribution guard to gh pr and issue commands

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -22,6 +22,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Block PRs targeting main from non-develop branches | [PR Target Guard](#12-pr-target-guard-pretooluse) |
 | Block non-English titles/bodies in gh PR/issue commands | [PR Language Guard](#13-pr-language-guard-pretooluse) |
 | Block gh pr merge when any check is non-passing | [Merge Gate Guard](#14-merge-gate-guard-pretooluse) |
+| Block AI/Claude attribution in gh PR/issue commands | [Attribution Guard](#15-attribution-guard-pretooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -380,6 +381,59 @@ A diagnostic is written to stderr in each fail-open case so the user can see why
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
     "permissionDecisionReason": "Merge blocked by ABSOLUTE CI GATE: PR #100 has non-passing checks: Build Linux [fail/FAILURE], Build Windows [pending/IN_PROGRESS]. Wait for all checks to pass before merging — never rationalize a failure as unrelated, infrastructure, or pre-existing."
+  }
+}
+```
+
+### 15. Attribution Guard (PreToolUse)
+
+*Hard-blocks AI/Claude attribution markers (Co-Authored-By: Claude, "Generated with Claude", Anthropic, etc.) in `gh pr` and `gh issue` titles and bodies — extends the existing commit-message attribution check to PR/issue text.*
+
+**Purpose**: Enforces the "No AI/Claude attribution in commits, issues, or PRs" rule from `commit-settings.md`. The existing `commit-message-guard` only inspects `git commit -m` messages; PR and issue bodies created via `gh` previously bypassed it. This hook closes that gap by gating the same Bash boundary that `pr-language-guard` uses.
+
+**Trigger**: `Bash` tool calls matching `gh (pr|issue) (create|edit|comment)`.
+
+**Files**: `global/hooks/attribution-guard.sh`, `global/hooks/attribution-guard.ps1`
+
+**Shared validation library**: `hooks/lib/validate-commit-message.sh` exposes `CMV_ATTRIBUTION_REGEX` and `validate_no_attribution()` — the same regex used by `commit-message-guard` for git commit messages. Both bash hooks source this single source of truth so attribution rules stay in lockstep across enforcement layers. The PowerShell variant inlines the equivalent regex (since the bash library cannot be sourced from PowerShell); update both when changing the pattern.
+
+**Patterns blocked** (case-insensitive):
+- `claude` (any standalone occurrence)
+- `anthropic`
+- `ai-assisted`
+- `co-authored-by: claude` (with optional whitespace)
+- `generated with` (matches "Generated with Claude Code" etc.)
+
+**Logic**:
+1. Scope gate: only process `gh (pr|issue) (create|edit|comment)` commands. Six combinations are guarded: `gh pr create|edit|comment`, `gh issue create|edit|comment`.
+2. Skip command-substitution / heredoc bodies (`--body "$(...)"`) and `--body-file` references — these cannot be parsed at the shell layer.
+3. Extract `--title` / `-t` and `--body` / `-b` values supporting double-quoted, single-quoted, and `--flag value` / `--flag=value` layouts.
+4. Pass each value through `validate_no_attribution()`. Reject if the regex matches.
+
+**Fail policy**: Fail-open. If stdin parsing fails or the command is unrecognized, the hook returns `allow`. The `commit-msg` git hook and `commit-message-guard` PreToolUse hook remain as additional layers for committed content.
+
+**Behavior**:
+- Returns JSON with `permissionDecision: "deny"` when attribution is detected
+- Defers to other layers for command-substitution and `--body-file` cases
+- Timeout: 5 seconds
+- Cross-platform: `attribution-guard.sh` and `attribution-guard.ps1`
+
+**Configuration**:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/attribution-guard.sh",
+  "timeout": 5
+}
+```
+
+**Example deny response**:
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "PR/issue --body rejected: Text contains AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude). Remove attribution before submitting."
   }
 }
 ```

--- a/global/hooks/attribution-guard.ps1
+++ b/global/hooks/attribution-guard.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# attribution-guard.ps1
+# Blocks gh pr/issue create|edit|comment commands whose --title or --body
+# contains AI/Claude attribution markers.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "No AI/Claude attribution in commits, issues, or PRs" rule
+# from commit-settings.md. Mirrors commit-message-guard / pr-language-guard /
+# merge-gate-guard enforcement model.
+#
+# Regex must match hooks/lib/validate-commit-message.sh (CMV_ATTRIBUTION_REGEX).
+# When updating one, update the other to keep enforcement consistent across
+# bash and PowerShell hosts.
+
+# Same pattern as CMV_ATTRIBUTION_REGEX in validate-commit-message.sh
+$AttributionRegex = '(?i)(claude|anthropic|ai-assisted|co-authored-by:\s*claude|generated\s+with)'
+
+# Extracts the value for a given long/short flag from a shell command string.
+function Get-FlagValue {
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][string]$LongFlag,
+        [string]$ShortFlag
+    )
+
+    # Long flag, double-quoted
+    $m = [regex]::Match($Command, "$LongFlag[\s=]+`"([^`"]*)`"")
+    if ($m.Success) { return $m.Groups[1].Value }
+
+    # Long flag, single-quoted
+    $m = [regex]::Match($Command, "$LongFlag[\s=]+'([^']*)'")
+    if ($m.Success) { return $m.Groups[1].Value }
+
+    if ($ShortFlag) {
+        $m = [regex]::Match($Command, "(?:^|\s)$ShortFlag\s+`"([^`"]*)`"")
+        if ($m.Success) { return $m.Groups[1].Value }
+
+        $m = [regex]::Match($Command, "(?:^|\s)$ShortFlag\s+'([^']*)'")
+        if ($m.Success) { return $m.Groups[1].Value }
+    }
+
+    return $null
+}
+
+# --- Read input from stdin ---
+$json = Read-HookInput
+
+# Empty input: fail open
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract command
+$CMD = $null
+try { $CMD = $json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+
+if (-not $CMD) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Scope gate: only check 'gh (pr|issue) (create|edit|comment)' commands
+if ($CMD -notmatch 'gh\s+(pr|issue)\s+(create|edit|comment)') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Skip command-substitution / heredoc bodies
+if ($CMD -match '(?:--body|-b|--title|-t)[\s=]+"\$\(') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Skip --body-file references
+if ($CMD -match '--body-file[\s=]+') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract title and body
+$title = Get-FlagValue -Command $CMD -LongFlag '--title' -ShortFlag '-t'
+$body  = Get-FlagValue -Command $CMD -LongFlag '--body'  -ShortFlag '-b'
+
+$denyReason = "Text contains AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude). Remove attribution before submitting."
+
+# Validate title
+if ($title -and ($title -match $AttributionRegex)) {
+    New-HookDenyResponse -Reason "PR/issue --title rejected: $denyReason"
+    exit 0
+}
+
+# Validate body
+if ($body -and ($body -match $AttributionRegex)) {
+    New-HookDenyResponse -Reason "PR/issue --body rejected: $denyReason"
+    exit 0
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/attribution-guard.sh
+++ b/global/hooks/attribution-guard.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# attribution-guard.sh
+# Blocks gh pr/issue create|edit|comment commands whose --title or --body
+# contains AI/Claude attribution markers.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Enforces the "No AI/Claude attribution in commits, issues, or PRs" rule
+# from commit-settings.md at the Bash tool boundary. Mirrors the
+# commit-message-guard / pr-language-guard / merge-gate-guard enforcement
+# model: a deterministic hook gate that catches drift in long-running batch
+# workflows where Co-Authored-By or "Generated with Claude" markers
+# occasionally leak into PR/issue text via the gh CLI.
+#
+# Sources shared validation rules from hooks/lib/validate-commit-message.sh,
+# specifically the validate_no_attribution() helper. Both this hook and
+# the commit-message validator use the same CMV_ATTRIBUTION_REGEX so a
+# leak cannot slip through one channel while being blocked in another.
+#
+# NOTE on parsing limits: --body using $(...) command substitution, heredocs,
+# and --body-file references cannot be parsed at the shell layer; the hook
+# returns "allow" and defers to other safeguards in those cases.
+
+set -uo pipefail
+
+# --- Response helpers ---
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+# --- Source shared validation library ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR=""
+
+# Try 1: repo-relative path (development / CI testing)
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
+if [ -f "$REPO_ROOT/hooks/lib/validate-commit-message.sh" ]; then
+    VALIDATOR="$REPO_ROOT/hooks/lib/validate-commit-message.sh"
+# Try 2: sibling lib/ directory (deployed to ~/.claude/hooks/)
+elif [ -f "$SCRIPT_DIR/lib/validate-commit-message.sh" ]; then
+    VALIDATOR="$SCRIPT_DIR/lib/validate-commit-message.sh"
+fi
+
+if [ -n "$VALIDATOR" ]; then
+    # shellcheck source=../../hooks/lib/validate-commit-message.sh
+    . "$VALIDATOR"
+fi
+
+# Inline fallback so the hook still works when the shared library is missing.
+# Keep regex in sync with hooks/lib/validate-commit-message.sh.
+if ! command -v validate_no_attribution >/dev/null 2>&1; then
+    validate_no_attribution() {
+        local text="$1"
+        if [ -z "$text" ]; then
+            return 0
+        fi
+        if printf '%s' "$text" | grep -iqE '(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'; then
+            echo "Text contains AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude). Remove attribution before submitting." >&2
+            return 1
+        fi
+        return 0
+    }
+fi
+
+# --- Read input from stdin ---
+INPUT=$(cat)
+
+# Empty input: fail open
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || CMD=""
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+# --- Scope: only validate gh pr|issue create|edit|comment commands ---
+if ! echo "$CMD" | grep -qE 'gh[[:space:]]+(pr|issue)[[:space:]]+(create|edit|comment)'; then
+    allow_response
+fi
+
+# --- Skip command-substitution / heredoc / file-based bodies ---
+if echo "$CMD" | grep -qE -- '(--body|-b|--title|-t)[[:space:]=]+"\$\('; then
+    allow_response
+fi
+if echo "$CMD" | grep -qE -- '--body-file[[:space:]=]+'; then
+    allow_response
+fi
+
+# --- Extract a quoted argument value ---
+# Tries double quotes first, then single quotes. Returns the first match
+# on stdout, empty string if not found.
+extract_quoted_value() {
+    local cmd="$1"
+    local long_flag="$2"
+    local short_flag="$3"
+    local val=""
+
+    # Long flag, double-quoted: --title "value" or --title="value"
+    val=$(printf '%s' "$cmd" | sed -nE "s/.*${long_flag}[[:space:]=]+\"([^\"]*)\".*/\1/p" | head -n1)
+    if [ -n "$val" ]; then
+        printf '%s' "$val"
+        return
+    fi
+
+    # Long flag, single-quoted
+    if [[ "$cmd" =~ ${long_flag}[[:space:]=]+\'([^\']*)\' ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    # Short flag (must be preceded by whitespace)
+    if [ -n "$short_flag" ]; then
+        val=$(printf '%s' "$cmd" | sed -nE "s/.*[[:space:]]${short_flag}[[:space:]]+\"([^\"]*)\".*/\1/p" | head -n1)
+        if [ -n "$val" ]; then
+            printf '%s' "$val"
+            return
+        fi
+        if [[ "$cmd" =~ [[:space:]]${short_flag}[[:space:]]+\'([^\']*)\' ]]; then
+            printf '%s' "${BASH_REMATCH[1]}"
+            return
+        fi
+    fi
+}
+
+TITLE=$(extract_quoted_value "$CMD" "--title" "-t")
+BODY=$(extract_quoted_value "$CMD" "--body"  "-b")
+
+# --- Validate ---
+if [ -n "$TITLE" ]; then
+    REASON=$(validate_no_attribution "$TITLE" 2>&1) || \
+        deny_response "PR/issue --title rejected: $REASON"
+fi
+
+if [ -n "$BODY" ]; then
+    REASON=$(validate_no_attribution "$BODY" 2>&1) || \
+        deny_response "PR/issue --body rejected: $REASON"
+fi
+
+allow_response

--- a/global/settings.json
+++ b/global/settings.json
@@ -90,6 +90,11 @@
             "type": "command",
             "command": "~/.claude/hooks/merge-gate-guard.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/attribution-guard.sh",
+            "timeout": 5
           }
         ]
       },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -103,6 +103,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/merge-gate-guard.ps1",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/attribution-guard.ps1",
+            "timeout": 5
           }
         ]
       },

--- a/hooks/lib/validate-commit-message.sh
+++ b/hooks/lib/validate-commit-message.sh
@@ -16,6 +16,33 @@
 # Allowed commit types (Conventional Commits)
 readonly CMV_TYPES="feat|fix|docs|style|refactor|perf|test|build|ci|chore|security"
 
+# AI attribution regex — single source of truth shared with attribution-guard
+# (PR/issue body checks). Same pattern enforced across commit messages, PR
+# titles/bodies, and issue titles/bodies so an attribution leak cannot slip
+# through one channel while being blocked in another.
+readonly CMV_ATTRIBUTION_REGEX='(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'
+
+# validate_no_attribution <text>
+# Returns 0 if text contains no AI/Claude attribution, 1 if attribution is found.
+# On failure, prints reason to stderr.
+#
+# Used by both validate_commit_message (this file) and attribution-guard.sh
+# (the PR/issue body PreToolUse hook) so the regex stays in one place.
+validate_no_attribution() {
+    local text="$1"
+
+    if [ -z "$text" ]; then
+        return 0
+    fi
+
+    if printf '%s' "$text" | grep -iqE "$CMV_ATTRIBUTION_REGEX"; then
+        echo "Text contains AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude). Remove attribution before submitting." >&2
+        return 1
+    fi
+
+    return 0
+}
+
 # validate_commit_message <message>
 # Returns 0 on valid, 1 on invalid.
 # On failure, prints reason to stderr.
@@ -51,8 +78,8 @@ validate_commit_message() {
             ;;
     esac
 
-    # Rule 4: No AI/Claude attribution
-    if printf '%s' "$msg" | grep -iqE '(claude|anthropic|ai-assisted|co-authored-by:[[:space:]]*claude|generated[[:space:]]+with)'; then
+    # Rule 4: No AI/Claude attribution (delegates to shared helper for SSOT)
+    if ! validate_no_attribution "$msg" 2>/dev/null; then
         echo "Commit message must not contain AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude)." >&2
         return 1
     fi


### PR DESCRIPTION
## Summary

Adds a new PreToolUse hook `attribution-guard.sh/.ps1` that scans `gh pr|issue create|edit|comment` commands for AI authoring markers in `--title` and `--body` arguments. Closes the gap left by `commit-message-guard`, which only inspects `git commit -m` messages — PR and issue text created via the gh CLI previously bypassed the attribution check entirely.

The bash hook reuses the existing SSOT regex via the new `validate_no_attribution()` helper added to `hooks/lib/validate-commit-message.sh`. Both this hook and the commit message validator now share a single regex constant (`CMV_ATTRIBUTION_REGEX`), so any future tweak applies everywhere.

## What

- `hooks/lib/validate-commit-message.sh` — refactored to expose `CMV_ATTRIBUTION_REGEX` (readonly) and `validate_no_attribution()` helper. `validate_commit_message()` now delegates Rule 4 to the helper. Behavior unchanged (verified by 10 regression + helper tests).
- `global/hooks/attribution-guard.sh` (new) — bash PreToolUse hook
- `global/hooks/attribution-guard.ps1` (new) — PowerShell equivalent, inlines the equivalent regex (since the bash library cannot be sourced from PowerShell)
- `global/settings.json` — registered after `merge-gate-guard.sh` in PreToolUse Bash matcher
- `global/settings.windows.json` — registered after `merge-gate-guard.ps1`
- `HOOKS.md` — new section "15. Attribution Guard" plus quick-nav entry

## Why

Part of #287. The attribution rule from `commit-settings.md` is enforced for git commits via two layers (PreToolUse hook + commit-msg git hook), but the gh CLI path was unguarded. In long-running batch workflows, the model occasionally drops AI authoring markers into PR/issue bodies — that text then lives in shared GitHub state where the attribution rule is most visible. A hard hook gate at the Bash boundary closes the gap structurally.

## How

1. Scope gate: regex `gh\s+(pr|issue)\s+(create|edit|comment)` — six combinations are guarded (same surface as pr-language-guard).
2. Skip command-substitution / heredoc bodies and `--body-file` references — these cannot be parsed at the shell layer.
3. Extract `--title`/`-t` and `--body`/`-b` values supporting double-quoted, single-quoted, and `flag=value` layouts.
4. Pass each value through `validate_no_attribution()`. The regex is case-insensitive and matches the standard set of authoring markers used by commit-message-guard. See `CMV_ATTRIBUTION_REGEX` in `hooks/lib/validate-commit-message.sh` for the exact pattern.
5. The bash hook sources the SSOT library via the same two-path resolution as commit-message-guard (repo-relative for development/CI, sibling lib/ for deployed `~/.claude/hooks/`). An inline fallback definition is provided so the hook still works if the library is missing.
6. The PowerShell hook inlines the equivalent regex pattern (with `(?i)` for case-insensitive matching). When updating either pattern, update the other to keep enforcement in lockstep.

## Test Plan

Bash hook smoke tests (13 cases verified locally, all pass):

- Clean PR body: ALLOW
- Co-author trailer with vendor name: DENY
- Vendor name in body: DENY
- "Generation with" marker: DENY
- AI-authoring hyphenated marker in body: DENY
- Title containing the model name: DENY
- Single-quoted body with co-author trailer: DENY
- Out-of-scope command (`gh repo view`): ALLOW
- Case variation (uppercase model name): DENY (case-insensitive)
- Empty stdin: ALLOW (fail-open)
- `--body-file` reference: ALLOW (defer to other layers)
- `gh issue comment` with vendor name: DENY
- False-positive guard: a word containing the substring "lavier" (e.g. "clavier") does NOT match the model name pattern — verified with a body containing "Updated clavier driver". ALLOW.

SSOT refactor regression tests (10 cases pass):

- 7 tests of the new `validate_no_attribution()` helper
- 3 regression tests of `validate_commit_message()` (valid format, attribution rejection still works, uppercase description still rejected)

PowerShell hook follows the same pattern as commit-message-guard.ps1; CI verifies it (pwsh not available locally).

## Acceptance Criteria

- [x] Hook matches all attribution-bearing `gh` commands (six command combinations)
- [x] Reuses existing `validate-commit-message.sh` SSOT (no regex duplication in bash; PowerShell inlines an equivalent because it cannot source bash)
- [x] Smoke test: PR body containing the standard co-author trailer is blocked (test 2)
- [x] Smoke test: clean PR body passes (test 1)
- [x] Documented in `HOOKS.md` (section 15, including SSOT cross-reference)

## Notes

- Original issue mentioned `exit 2`. Actual claude-config PreToolUse pattern is `exit 0` + JSON `permissionDecision: "deny"`, consistent with `commit-message-guard.sh`, `pr-target-guard.sh`, `pr-language-guard.sh`, `merge-gate-guard.sh`.
- The PR body of this very PR deliberately avoids the literal trigger words (vendor name, model name, etc.) so that, if the hook becomes self-active during merge, this PR can still be processed. Source files and test outputs include the literal words because bash strings inside script files are not subject to the hook.
- Six guarded combinations are the same as pr-language-guard: `(pr|issue) × (create|edit|comment)`.
- The cartesian product also covers `gh pr comment` and `gh issue edit` (in addition to the four commands listed in the issue) for policy consistency, mirroring pr-language-guard.

Closes #293
Part of #287