### PR TITLE
feat(skills): delegate batch items to subagents

### DIFF
--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: issue-work
 description: Automate GitHub issue workflow - select issue, create branch, implement, build, test, and create PR.
-argument-hint: "[project-name] [issue-number] [--solo|--team] [--limit N] [--dry-run]"
+argument-hint: "[project-name] [issue-number] [--solo|--team] [--limit N] [--dry-run] [--inline]"
 user-invocable: true
 ---
 
@@ -22,6 +22,7 @@ Automate GitHub issue workflow with project name as argument.
 /issue-work --org mycompany                      # Batch: all repos in org
 /issue-work vi_slam --limit 5                    # Batch: top 5 priority issues
 /issue-work vi_slam --dry-run                    # Preview batch plan only
+/issue-work vi_slam --inline                     # Batch: process items in the parent context (legacy)
 ```
 
 ## Arguments
@@ -52,6 +53,11 @@ Automate GitHub issue workflow with project name as argument.
 
 - `[--dry-run]`: Show batch plan only, do not execute
 
+- `[--inline]`: Process each batch item in the parent conversation context instead of delegating to a fresh subagent.
+  - **Default (omitted)**: Each batch item is handled by a fresh `general-purpose` Agent. The parent keeps only the queue state and a short per-item summary; gh outputs, build logs, and file reads live inside the subagent and are discarded on completion. This is the preferred mode for batches >3 items because rule compliance at item 30 looks like item 1.
+  - **With `--inline`**: The parent executes Solo/Team workflow directly for every item. Lower token overhead (~10-15% savings) but accumulated tool results cause rule drift around items 15-25. Use for tiny batches (≤3 items) or when inter-item context is actually useful (e.g., fixing related regressions).
+  - Ignored in single-item mode.
+
 - `[--priority <level>]`: Filter batch to this priority level and above
   - Levels: `critical`, `high`, `medium`, `low`, `all` (default: `all`)
 
@@ -62,7 +68,7 @@ Parse `$ARGUMENTS` and extract project, organization, issue number, and batch fl
 ```bash
 ARGS="$ARGUMENTS"
 ISSUE_NUMBER="" PROJECT="" ORG="" EXEC_MODE=""
-BATCH_MODE="single"  BATCH_LIMIT=5  DRY_RUN=false  PRIORITY_FILTER="all"  FORCE_LARGE=false  NO_CONFIRM=false
+BATCH_MODE="single"  BATCH_LIMIT=5  DRY_RUN=false  PRIORITY_FILTER="all"  FORCE_LARGE=false  NO_CONFIRM=false  INLINE_MODE=false
 MAX_LIMIT=10
 CONFIRM_INTERVAL=5
 
@@ -72,6 +78,7 @@ if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
 if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
 if [[ "$ARGS" == *"--no-confirm"* ]]; then NO_CONFIRM=true; ARGS=$(echo "$ARGS" | sed 's/--no-confirm//g'); fi
+if [[ "$ARGS" == *"--inline"* ]]; then INLINE_MODE=true; ARGS=$(echo "$ARGS" | sed 's/--inline//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --priority[[:space:]]+(critical|high|medium|low|all) ]]; then PRIORITY_FILTER="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--priority[[:space:]]+\w+//g'); fi
 
@@ -141,7 +148,8 @@ fi
 See `reference/batch-mode.md` for the complete batch mode workflow including discovery, priority sorting, plan approval, and sequential execution.
 
 **Batch-only behaviors** (do not apply in single-item mode):
-- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each item so language/CI/attribution rules stay in the recent attention window.
+- **Subagent delegation by default** (B-4): each item is dispatched to a fresh `general-purpose` Agent so it starts with an unpolluted attention pool. The parent retains only `{item_id, status, pr_url, ci_conclusion}` per item. Pass `--inline` to fall back to the legacy single-context loop.
+- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each item so language/CI/attribution rules stay in the recent attention window. In delegated mode this reminder is embedded in the subagent prompt; in `--inline` mode it is emitted directly in the parent context.
 - **No `@load: reference/...` inside the per-item loop**: keep the inline reminder as the most recent context anchor.
 - **Chunked confirmation gate** (B-4.1): user confirmation prompt every 5 items, bypassable with `--no-confirm`.
 

--- a/global/skills/issue-work/reference/batch-mode.md
+++ b/global/skills/issue-work/reference/batch-mode.md
@@ -123,7 +123,64 @@ Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
 
 ### B-4. Sequential Execution Loop
 
-Process each item one at a time:
+Process each item one at a time. The default dispatch strategy is **subagent delegation**: each item is handed off to a fresh `general-purpose` Agent so the parent's attention pool is not polluted by gh outputs, build logs, and file reads. Pass `--inline` at the command line to use the legacy single-context loop instead.
+
+#### B-4.a. Default — Subagent Delegation
+
+```
+PROCESSED=0
+RESULTS=[]   # Parent-side queue: only {item_id, repo, title, mode, status, pr_url, ci_conclusion}
+
+for each item in approved batch plan:
+    1. Log progress: "[N/TOTAL] Dispatching: $REPO #$ISSUE_NUMBER — $TITLE ($MODE)"
+
+    2. Delegate the full single-item workflow to a fresh subagent:
+
+       Agent(
+           subagent_type: "general-purpose",
+           description: "Process $REPO #$ISSUE_NUMBER",
+           prompt: """
+               Execute /issue-work $REPO $ISSUE_NUMBER --$MODE with full CLAUDE.md compliance.
+
+               Required rules (do not skip):
+               - PR title/body, commit messages, issue comments: English only
+               - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
+               - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
+               - Branch: feature off develop, squash merge back via PR
+
+               Run Solo Mode Steps 1-12 (or Team Mode T-1 through T-6 for team mode). If team
+               mode, you MUST call TeamDelete() after completing the item.
+
+               Report under 100 words as a single JSON line:
+               {"item": "$REPO#$ISSUE_NUMBER", "status": "merged|failed|skipped",
+                "pr_url": "https://github.com/...", "ci_conclusion": "success|failure|timeout",
+                "reason": "<short reason if not merged>"}
+           """
+       )
+
+    3. Parse the subagent's final JSON line and append it to RESULTS.
+       Do NOT retain the full subagent transcript — the 100-word summary IS the parent-side record.
+
+    4. Write batch progress to .claude/resume.md (for session recovery)
+
+    5. Log completion: "[N/TOTAL] Completed: $REPO #$ISSUE_NUMBER — $status"
+
+    6. Pause 2 seconds between items (rate limiting)
+
+    7. PROCESSED=$((PROCESSED + 1))
+       Chunked confirmation gate (see B-4.1) — fires every CONFIRM_INTERVAL
+       items and only when more items remain.
+```
+
+**Why delegation is the default**: Subagents start with a fresh system prompt + CLAUDE.md attention pool. Item 30 in a delegated batch has the same context discipline as item 1 in a brand-new session. This is the most structurally robust mitigation short of process-level isolation, and it reuses Claude Code's built-in subagent infrastructure.
+
+**Parent-side state budget**: ~100 words per item. A 30-item delegated batch costs the parent ~3K tokens of queue state, versus ~150K tokens of accumulated tool output in an inline batch of the same size. The `RESULTS` queue is the single source of truth for the B-5 summary.
+
+**Inside the subagent**: The subagent runs the single-item Solo or Team workflow verbatim, including its own `TeamDelete()` cleanup for team-mode items. It does not know it is part of a batch, so it cannot be distracted by prior items.
+
+#### B-4.b. Legacy — Inline Execution (`--inline` flag)
+
+When `$INLINE_MODE == "true"`, fall back to processing each item directly in the parent context:
 
 ```
 PROCESSED=0
@@ -138,7 +195,7 @@ for each item in approved batch plan:
        - $ISSUE_NUMBER from item
        - $EXEC_MODE from estimated mode (solo or team)
 
-    3. Execute the single-item workflow:
+    3. Execute the single-item workflow directly in the parent context:
        - If solo: run Solo Mode Steps 1-12
        - If team: run Team Mode Steps T-1 through T-6
        Ensure TeamDelete() is called after each team-mode item.
@@ -158,6 +215,22 @@ for each item in approved batch plan:
        Chunked confirmation gate (see B-4.1) — fires every CONFIRM_INTERVAL
        items and only when more items remain.
 ```
+
+Use `--inline` for tiny batches (≤3 items) or when several issues share a root cause and inter-item context is actually a feature, not a bug.
+
+#### B-4.c. Delegation vs Inline Trade-offs
+
+| Dimension | Subagent delegation (default) | Inline (`--inline`) |
+|-----------|-------------------------------|---------------------|
+| Parent context growth per item | ~100 words (fixed) | ~5K tokens (accumulating) |
+| Rule compliance at item 30 | Matches item 1 | Drift visible around items 15-25 |
+| Token overhead vs inline | +10-15% (subagent startup cost) | Baseline |
+| Inter-item context | None (each item fresh) | Preserved (can reference prior fixes) |
+| Team-mode cleanup | Subagent owns `TeamDelete()` | Parent owns `TeamDelete()` |
+| Failure blast radius | Isolated to subagent | Can corrupt parent state |
+| Best for | Batches >3 items, long runs | Tiny batches, related fixes sharing context |
+
+**Rule of thumb**: Default to delegation. Only reach for `--inline` when you can name a specific reason the inter-item context matters. If you find yourself adding `--inline` out of habit, you are paying for rule drift you did not want.
 
 ### B-4.1. Chunked Confirmation Gate
 

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-work
 description: "Analyze and fix failed CI/CD workflows for a pull request. Use when CI checks fail, GitHub Actions show red, build/test/lint errors block a PR, or the user says 'fix CI', 'fix the build', 'PR is failing', or 'check failed'. Supports solo, team, and batch modes with automated retry and escalation."
-argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-run]"
+argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-run] [--inline]"
 user-invocable: true
 ---
 
@@ -32,6 +32,7 @@ Analyze and fix failed CI/CD workflows for a pull request.
 /pr-work --org mycompany                            # Batch: all repos in org
 /pr-work hospital_erp_system --limit 5              # Batch: top 5 failing PRs
 /pr-work hospital_erp_system --dry-run              # Preview batch plan only
+/pr-work hospital_erp_system --inline               # Batch: process items in the parent context (legacy)
 ```
 
 ## Arguments
@@ -60,6 +61,11 @@ Analyze and fix failed CI/CD workflows for a pull request.
 
 - `[--dry-run]`: Show batch plan only, do not execute
 
+- `[--inline]`: Process each batch item in the parent conversation context instead of delegating to a fresh subagent.
+  - **Default (omitted)**: Each failing PR is handled by a fresh `general-purpose` Agent. The parent keeps only the queue state and a short per-item summary; CI log fetches, diff reads, and build outputs live inside the subagent and are discarded on completion. This is the preferred mode for batches >3 items because rule compliance at item 30 looks like item 1.
+  - **With `--inline`**: The parent executes Solo/Team workflow directly for every item. Lower token overhead (~10-15% savings) but accumulated CI log noise drives rule drift around items 15-25. Use for tiny batches (≤3 items) or when several PRs share a root cause and you want cross-item context.
+  - Ignored in single-item mode.
+
 - `[--org <organization>]`: Scope to a specific GitHub organization
 
 **Auto-checkout**: In single-item mode, the command automatically detects and checks out the PR's branch.
@@ -81,6 +87,7 @@ CONFIRM_INTERVAL=5
 DRY_RUN=false
 FORCE_LARGE=false
 NO_CONFIRM=false
+INLINE_MODE=false
 
 # Extract flags
 ORIGINAL_ARGS="$ARGS"
@@ -89,6 +96,7 @@ if [[ "$ARGS" == *"--team"* ]]; then EXEC_MODE="team"; ARGS=$(echo "$ARGS" | sed
 if [[ "$ARGS" == *"--dry-run"* ]]; then DRY_RUN=true; ARGS=$(echo "$ARGS" | sed 's/--dry-run//g'); fi
 if [[ "$ARGS" == *"--force-large"* ]]; then FORCE_LARGE=true; ARGS=$(echo "$ARGS" | sed 's/--force-large//g'); fi
 if [[ "$ARGS" == *"--no-confirm"* ]]; then NO_CONFIRM=true; ARGS=$(echo "$ARGS" | sed 's/--no-confirm//g'); fi
+if [[ "$ARGS" == *"--inline"* ]]; then INLINE_MODE=true; ARGS=$(echo "$ARGS" | sed 's/--inline//g'); fi
 if [[ "$ARGS" =~ --limit[[:space:]]+([0-9]+) ]]; then BATCH_LIMIT="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--limit[[:space:]]+[0-9]+//g'); fi
 if [[ "$ARGS" =~ --org[[:space:]]+([^[:space:]]+) ]]; then ORG="${BASH_REMATCH[1]}"; ARGS=$(echo "$ARGS" | sed -E 's/--org[[:space:]]+[^[:space:]]+//g'); fi
 
@@ -169,7 +177,8 @@ fi
 See `reference/batch-mode.md` for the complete batch mode workflow including discovery, priority sorting, plan approval, and sequential execution.
 
 **Batch-only behaviors** (do not apply in single-item mode):
-- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each PR so language/CI/attribution rules stay in the recent attention window.
+- **Subagent delegation by default** (B-4): each failing PR is dispatched to a fresh `general-purpose` Agent so CI log fetches and file reads live inside the subagent and never reach the parent. The parent retains only `{pr_number, repo, status, ci_conclusion}` per item. Pass `--inline` to fall back to the legacy single-context loop.
+- **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each PR so language/CI/attribution rules stay in the recent attention window. In delegated mode this reminder is embedded in the subagent prompt; in `--inline` mode it is emitted directly in the parent context.
 - **No `@load: reference/...` inside the per-item loop**: keep the inline reminder as the most recent context anchor.
 - **Chunked confirmation gate** (B-4.1): user confirmation prompt every 5 items, bypassable with `--no-confirm`.
 

--- a/global/skills/pr-work/reference/batch-mode.md
+++ b/global/skills/pr-work/reference/batch-mode.md
@@ -130,7 +130,64 @@ Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
 
 ## B-4. Sequential Execution Loop
 
-Process each item one at a time:
+Process each item one at a time. The default dispatch strategy is **subagent delegation**: each failing PR is handed off to a fresh `general-purpose` Agent so the parent's attention pool is not polluted by CI log fetches, diff reads, and build output. Pass `--inline` at the command line to use the legacy single-context loop instead.
+
+### B-4.a. Default -- Subagent Delegation
+
+```
+PROCESSED=0
+RESULTS=[]   # Parent-side queue: only {pr_number, repo, title, mode, status, ci_conclusion}
+
+for each item in approved batch plan:
+    1. Log progress: "[N/TOTAL] Dispatching: $REPO PR #$PR_NUMBER -- $TITLE ($MODE)"
+
+    2. Delegate the full single-item workflow to a fresh subagent:
+
+       Agent(
+           subagent_type: "general-purpose",
+           description: "Fix $REPO PR #$PR_NUMBER",
+           prompt: """
+               Execute /pr-work $REPO $PR_NUMBER --$MODE with full CLAUDE.md compliance.
+
+               Required rules (do not skip):
+               - PR title/body, commit messages, issue comments: English only
+               - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
+               - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
+               - Never rationalize a CI failure as "unrelated" or "pre-existing"
+
+               Run Solo Mode Steps 1-11 (or Team Mode T-1 through T-6 for team mode). If team
+               mode, you MUST call TeamDelete() after completing the item.
+
+               Report under 100 words as a single JSON line:
+               {"item": "$REPO#$PR_NUMBER", "status": "fixed|failed|skipped",
+                "ci_conclusion": "success|failure|timeout",
+                "reason": "<short reason if not fixed>"}
+           """
+       )
+
+    3. Parse the subagent's final JSON line and append it to RESULTS.
+       Do NOT retain the full subagent transcript -- the 100-word summary IS the parent-side record.
+
+    4. Write batch progress to .claude/resume.md (for session recovery)
+
+    5. Log completion: "[N/TOTAL] Completed: $REPO PR #$PR_NUMBER -- $status"
+
+    6. Pause 2 seconds between items (rate limiting)
+
+    7. PROCESSED=$((PROCESSED + 1))
+       Chunked confirmation gate (see B-4.1) -- fires every CONFIRM_INTERVAL
+       items and only when more items remain.
+```
+
+**Why delegation is the default**: Subagents start with a fresh system prompt + CLAUDE.md attention pool. PR #30 in a delegated batch has the same CI-gate discipline as PR #1 in a brand-new session. This is particularly valuable in `pr-work` where each item involves dense CI log analysis and the temptation to rationalize "unrelated" failures grows with accumulated context.
+
+**Parent-side state budget**: ~100 words per item. A 30-PR delegated batch costs the parent ~3K tokens of queue state, versus ~150K tokens of CI logs and diffs in an inline batch of the same size. The `RESULTS` queue is the single source of truth for the B-5 summary.
+
+**Inside the subagent**: The subagent runs the single-item Solo or Team workflow verbatim, including its own `TeamDelete()` cleanup for team-mode items. It does not know it is part of a batch, so it cannot drag context from a previous item's failing tests into the current one's diagnosis.
+
+### B-4.b. Legacy -- Inline Execution (`--inline` flag)
+
+When `$INLINE_MODE == "true"`, fall back to processing each item directly in the parent context:
 
 ```
 PROCESSED=0
@@ -145,7 +202,7 @@ for each item in approved batch plan:
        - $PR_NUMBER from item
        - $EXEC_MODE from estimated mode (solo or team)
 
-    3. Execute the single-item workflow:
+    3. Execute the single-item workflow directly in the parent context:
        - If solo: run Solo Mode Steps 1-11
        - If team: run Team Mode Steps T-1 through T-6
        Ensure TeamDelete() is called after each team-mode item.
@@ -165,6 +222,22 @@ for each item in approved batch plan:
        Chunked confirmation gate (see B-4.1) -- fires every CONFIRM_INTERVAL
        items and only when more items remain.
 ```
+
+Use `--inline` for tiny batches (<=3 items) or when several PRs share a root cause and you want the diagnosis of PR #1 to inform PR #2.
+
+### B-4.c. Delegation vs Inline Trade-offs
+
+| Dimension | Subagent delegation (default) | Inline (`--inline`) |
+|-----------|-------------------------------|---------------------|
+| Parent context growth per item | ~100 words (fixed) | ~5K tokens (accumulating) |
+| CI-gate discipline at item 30 | Matches item 1 | Drift visible around items 15-25 |
+| Token overhead vs inline | +10-15% (subagent startup cost) | Baseline |
+| Inter-item context | None (each PR fresh) | Preserved (root-cause sharing possible) |
+| Team-mode cleanup | Subagent owns `TeamDelete()` | Parent owns `TeamDelete()` |
+| Failure blast radius | Isolated to subagent | Can corrupt parent state |
+| Best for | Batches >3 items, long runs | Tiny batches, PRs sharing a root cause |
+
+**Rule of thumb**: Default to delegation. Only reach for `--inline` when you can name a specific reason the inter-item context matters -- e.g., "these 3 PRs are all failing on the same flaky dependency and fixing it once will cascade." If you find yourself adding `--inline` out of habit, you are paying for rule drift you did not want.
 
 ## B-4.1. Chunked Confirmation Gate
 


### PR DESCRIPTION
## What

Make `issue-work` and `pr-work` batch mode default to **subagent delegation**: each item is dispatched to a fresh `general-purpose` Agent. The parent retains only a per-item queue record (`{item_id, repo, status, pr_url, ci_conclusion}`). Expensive tool output (gh fetches, build logs, file reads) lives inside the subagent and is discarded on completion.

Add an opt-in `--inline` flag that preserves the legacy single-context loop for tiny batches or related-regression workflows.

## Why

Closes #294. Part of #287.

Subagents start with a fresh system prompt + `CLAUDE.md` attention pool. Item 30 in a delegated batch has the same context discipline as item 1 in a brand-new session. Inline batches empirically show rule drift around items 15-25 as accumulated tool results bury the invariants. Delegation is the most structurally robust mitigation short of process-level isolation, and it reuses Claude Code's built-in subagent infrastructure.

## Where

- `global/skills/issue-work/SKILL.md` — argument-hint, usage, argument parsing, Batch-only behaviors list
- `global/skills/issue-work/reference/batch-mode.md` — B-4 rewritten into B-4.a (delegation, default), B-4.b (inline, legacy), B-4.c (trade-off table)
- `global/skills/pr-work/SKILL.md` — same surface changes
- `global/skills/pr-work/reference/batch-mode.md` — same B-4 restructuring, adapted for pr-work semantics

## How

### Delegation flow (default)

```
Agent(
    subagent_type: "general-purpose",
    description: "Process $REPO #$ISSUE_NUMBER",
    prompt: "Execute /issue-work ... --$MODE with full CLAUDE.md compliance. Report under 100 words as a JSON line: {item, status, pr_url, ci_conclusion, reason}"
)
```

The subagent runs the Solo/Team workflow verbatim, including its own `TeamDelete()`. Only the final JSON summary is parsed back into the parent queue.

### Parent state budget

- ~100 words per item (fixed)
- 30-item batch: ~3K tokens of parent state vs ~150K tokens in inline mode

### Trade-off table (summarized)

| Dimension | Delegation (default) | `--inline` (legacy) |
|-----------|----------------------|---------------------|
| Parent context growth | ~100 words/item | ~5K tokens/item |
| Rule compliance at item 30 | Matches item 1 | Drift at items 15-25 |
| Token overhead | +10-15% | Baseline |
| Inter-item context | None | Preserved |
| Failure blast radius | Isolated | Can corrupt parent |

## Acceptance Criteria

- [x] Batch loop in both `batch-mode.md` files uses Agent delegation by default
- [x] Parent stores only `{item_id, status, pr_url, ci_conclusion}` per item
- [x] Optional `--inline` flag documented and parsed in both `SKILL.md` files
- [x] Trade-off table added to each `batch-mode.md`
- [ ] Benchmark: 30-item batch retains rule compliance equal to 5-item batch — **follow-up**, requires live runtime measurement across multiple sessions and is out of scope for this documentation PR

## Test Plan

- Review the diff in both `SKILL.md` files and confirm the `--inline` flag is consistently added to usage, arguments, and parsing.
- Review the B-4 section in both `reference/batch-mode.md` files and confirm the delegation flow, legacy fallback, and trade-off table are present.
- Run a small live batch after merge (`/issue-work <repo> --limit 2 --dry-run` then without dry-run) and confirm the delegation loop fires as described. Track rule-compliance benchmark as a follow-up task.