### PR TITLE
feat(scripts): add external batch orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ vi ~/.claude/git-identity.md
 | Backup settings | `./scripts/backup.sh` | `.\scripts\backup.ps1` |
 | Sync settings | `./scripts/sync.sh` | `.\scripts\sync.ps1` |
 | Verify backup | `./scripts/verify.sh` | `.\scripts\verify.ps1` |
+| Batch open issues | `./scripts/batch-issue-work.sh <org/repo>` | `.\scripts\batch-issue-work.ps1 -OrgProject <org/repo>` |
+| Batch failing PRs | `./scripts/batch-pr-work.sh <org/repo>` | `.\scripts\batch-pr-work.ps1 -OrgProject <org/repo>` |
 
 For detailed scenarios, see [Use Cases](#use-cases).
 
@@ -721,6 +723,54 @@ cd ~/claude_config_backup
 # Modify Git identity
 vi ~/.claude/git-identity.md
 ```
+
+---
+
+### Use Case D: Batch-Process Open Issues or Failing PRs
+
+External orchestrators that spawn one fresh `claude` process per item.
+Each process handles exactly one issue (or PR), so context state cannot
+leak between items — item N+1 starts with the same CLAUDE.md / skill
+attention pool as item 1. Complements the in-session batch mode of
+`/issue-work` and `/pr-work` by pushing isolation to the OS process
+boundary.
+
+Use these wrappers when:
+
+- You expect the batch to exceed the in-session safe cap (default 5, hard
+  cap 10 without `--force-large`) and want stricter per-item isolation.
+- You are running unattended (cron, CI, overnight) and want each item to
+  start from a clean slate regardless of how long the batch runs.
+- You need per-item logs on disk for post-run analysis rather than a
+  single scrollback in a live terminal.
+
+```bash
+# Process up to 5 open issues in a repo (default limit)
+./scripts/batch-issue-work.sh kcenon/claude-config
+
+# Process up to 3 open issues
+./scripts/batch-issue-work.sh kcenon/claude-config 3
+
+# Process failing PRs instead
+./scripts/batch-pr-work.sh kcenon/claude-config
+```
+
+```powershell
+# PowerShell equivalents
+.\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config
+.\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config -Limit 3
+.\scripts\batch-pr-work.ps1    -OrgProject kcenon/claude-config
+```
+
+Per-item logs are written to `~/.claude/batch-logs/<timestamp>/`:
+
+- `issue-<number>.log` for each issue handled by `batch-issue-work`
+- `pr-<number>.log` for each PR handled by `batch-pr-work`
+
+On any item failure, the batch **pauses and exits non-zero**. Successful
+items are not rolled back. Inspect the log for the failed item, fix the
+underlying cause, and re-run the orchestrator — items already merged will
+be skipped because they are no longer in the open list.
 
 ---
 

--- a/scripts/batch-issue-work.ps1
+++ b/scripts/batch-issue-work.ps1
@@ -1,0 +1,102 @@
+#Requires -Version 7.0
+
+# Batch issue-work orchestrator (PowerShell)
+# ===========================================
+# Spawns one fresh `claude` CLI process per open issue. Each process handles
+# exactly one item, so context state cannot leak between items -- item N+1
+# starts with the same CLAUDE.md / skill attention pool as item 1.
+#
+# Usage:
+#   .\scripts\batch-issue-work.ps1 -OrgProject <org/repo> [-Limit <n>]
+#
+# Example:
+#   .\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config
+#   .\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config -Limit 3
+#
+# Per-item logs are written to:
+#   $HOME/.claude/batch-logs/<timestamp>/issue-<number>.log
+#
+# On any item failure, the batch pauses and exits with a non-zero code so
+# the operator can inspect the log before deciding to continue.
+
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$OrgProject,
+
+    [Parameter(Position = 1)]
+    [ValidateRange(1, 100)]
+    [int]$Limit = 5
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Write-Info      { param([string]$Message) Write-Host "[info] $Message" -ForegroundColor Blue }
+function Write-Ok        { param([string]$Message) Write-Host "[ok]   $Message" -ForegroundColor Green }
+function Write-Warn      { param([string]$Message) Write-Host "[warn] $Message" -ForegroundColor Yellow }
+function Write-Err       { param([string]$Message) Write-Host "[err]  $Message" -ForegroundColor Red }
+function Write-Highlight { param([string]$Message) Write-Host $Message -ForegroundColor Cyan }
+
+if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+    Write-Err 'claude CLI not found on PATH. Install Claude Code and re-run.'
+    exit 2
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Err 'gh CLI not found on PATH. Install GitHub CLI and re-run.'
+    exit 2
+}
+
+$Timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$LogDir    = Join-Path $HOME ".claude/batch-logs/$Timestamp"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+Write-Highlight 'Batch issue-work orchestrator'
+Write-Info "Repository : $OrgProject"
+Write-Info "Limit      : $Limit"
+Write-Info "Log dir    : $LogDir"
+Write-Host ''
+
+$IssuesJson = gh issue list --repo $OrgProject --state open --limit $Limit `
+    --json number,title | ConvertFrom-Json
+
+if (-not $IssuesJson -or $IssuesJson.Count -eq 0) {
+    Write-Warn "No open issues found in $OrgProject"
+    exit 0
+}
+
+$Total      = $IssuesJson.Count
+$Processed  = 0
+$FailedItem = $null
+
+foreach ($Issue in $IssuesJson) {
+    $Processed++
+    $LogFile = Join-Path $LogDir "issue-$($Issue.number).log"
+
+    Write-Highlight "[$Processed/$Total] Processing #$($Issue.number) -- $($Issue.title)"
+    Write-Info "Log: $LogFile"
+
+    # Each item runs in a fresh claude process so its context state is
+    # discarded on exit. --print exits after the turn completes.
+    $Prompt = "/issue-work $OrgProject $($Issue.number) --solo"
+    & claude --print $Prompt *>$LogFile
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "#$($Issue.number) failed (exit $LASTEXITCODE). Pausing batch."
+        Write-Err "Inspect the log before continuing: $LogFile"
+        $FailedItem = "#$($Issue.number)"
+        break
+    }
+
+    Write-Ok "#$($Issue.number) completed"
+}
+
+Write-Host ''
+if ($FailedItem) {
+    Write-Err "Batch paused on $FailedItem ($Processed/$Total processed)"
+    Write-Err "Logs: $LogDir"
+    exit 1
+}
+
+Write-Ok "Batch complete: $Processed/$Total items processed"
+Write-Info "Logs: $LogDir"

--- a/scripts/batch-issue-work.sh
+++ b/scripts/batch-issue-work.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Batch issue-work orchestrator
+# ==============================
+# Spawns one fresh `claude` CLI process per open issue. Each process handles
+# exactly one item, so context state cannot leak between items — item N+1
+# starts with the same CLAUDE.md / skill attention pool as item 1.
+#
+# Usage:
+#   ./scripts/batch-issue-work.sh <org/repo> [limit]
+#
+# Example:
+#   ./scripts/batch-issue-work.sh kcenon/claude-config
+#   ./scripts/batch-issue-work.sh kcenon/claude-config 3
+#
+# Per-item logs are written to:
+#   ~/.claude/batch-logs/<timestamp>/issue-<number>.log
+#
+# On any item failure, the batch pauses and exits non-zero so the operator
+# can inspect the log before deciding to continue. Successful items are NOT
+# rolled back — reruns should skip already-merged issues by inspecting state.
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()      { echo -e "${BLUE}[info]${NC} $1"; }
+success()   { echo -e "${GREEN}[ok]${NC}   $1"; }
+warning()   { echo -e "${YELLOW}[warn]${NC} $1"; }
+error()     { echo -e "${RED}[err]${NC}  $1"; }
+highlight() { echo -e "${CYAN}$1${NC}"; }
+
+if [[ $# -lt 1 ]]; then
+    error "Missing required argument: <org/repo>"
+    echo "Usage: $0 <org/repo> [limit]"
+    exit 2
+fi
+
+ORG_PROJECT="$1"
+LIMIT="${2:-5}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    error "Limit must be a positive integer (got: $LIMIT)"
+    exit 2
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+    error "claude CLI not found on PATH. Install Claude Code and re-run."
+    exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    error "gh CLI not found on PATH. Install GitHub CLI and re-run."
+    exit 2
+fi
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+LOG_DIR="$HOME/.claude/batch-logs/${TIMESTAMP}"
+mkdir -p "$LOG_DIR"
+
+highlight "Batch issue-work orchestrator"
+info "Repository : $ORG_PROJECT"
+info "Limit      : $LIMIT"
+info "Log dir    : $LOG_DIR"
+echo
+
+# Collect open issues, oldest first, with configurable limit.
+ISSUES=$(gh issue list --repo "$ORG_PROJECT" --state open --limit "$LIMIT" \
+    --json number,title -q '.[] | "\(.number)\t\(.title)"')
+
+if [[ -z "$ISSUES" ]]; then
+    warning "No open issues found in $ORG_PROJECT"
+    exit 0
+fi
+
+TOTAL=$(echo "$ISSUES" | wc -l | tr -d ' ')
+PROCESSED=0
+FAILED_ITEM=""
+
+# IFS=newline so titles with spaces stay intact.
+while IFS=$'\t' read -r ISSUE_NUMBER ISSUE_TITLE; do
+    PROCESSED=$((PROCESSED + 1))
+    LOG_FILE="${LOG_DIR}/issue-${ISSUE_NUMBER}.log"
+
+    highlight "[${PROCESSED}/${TOTAL}] Processing #${ISSUE_NUMBER} — ${ISSUE_TITLE}"
+    info "Log: ${LOG_FILE}"
+
+    # Each item runs in a fresh claude process so its context state is
+    # discarded on exit. --print exits after the turn completes.
+    if claude --print "/issue-work ${ORG_PROJECT} ${ISSUE_NUMBER} --solo" \
+        >"$LOG_FILE" 2>&1; then
+        success "#${ISSUE_NUMBER} completed"
+    else
+        EXIT_CODE=$?
+        error "#${ISSUE_NUMBER} failed (exit ${EXIT_CODE}). Pausing batch."
+        error "Inspect the log before continuing: ${LOG_FILE}"
+        FAILED_ITEM="#${ISSUE_NUMBER}"
+        break
+    fi
+done <<< "$ISSUES"
+
+echo
+if [[ -n "$FAILED_ITEM" ]]; then
+    error "Batch paused on ${FAILED_ITEM} (${PROCESSED}/${TOTAL} processed)"
+    error "Logs: ${LOG_DIR}"
+    exit 1
+fi
+
+success "Batch complete: ${PROCESSED}/${TOTAL} items processed"
+info "Logs: ${LOG_DIR}"

--- a/scripts/batch-pr-work.ps1
+++ b/scripts/batch-pr-work.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.0
+
+# Batch pr-work orchestrator (PowerShell)
+# ========================================
+# Spawns one fresh `claude` CLI process per failing PR. Each process handles
+# exactly one PR, so CI log accumulation and diff-read state cannot leak
+# between items -- PR N+1 starts with the same CLAUDE.md / skill attention
+# pool as PR 1.
+#
+# Usage:
+#   .\scripts\batch-pr-work.ps1 -OrgProject <org/repo> [-Limit <n>]
+#
+# Example:
+#   .\scripts\batch-pr-work.ps1 -OrgProject kcenon/claude-config
+#   .\scripts\batch-pr-work.ps1 -OrgProject kcenon/claude-config -Limit 3
+#
+# Per-item logs are written to:
+#   $HOME/.claude/batch-logs/<timestamp>/pr-<number>.log
+#
+# A PR is considered "failing" if at least one check has conclusion
+# FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, or STARTUP_FAILURE.
+# Passing and in-progress PRs are skipped.
+
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$OrgProject,
+
+    [Parameter(Position = 1)]
+    [ValidateRange(1, 100)]
+    [int]$Limit = 5
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Write-Info      { param([string]$Message) Write-Host "[info] $Message" -ForegroundColor Blue }
+function Write-Ok        { param([string]$Message) Write-Host "[ok]   $Message" -ForegroundColor Green }
+function Write-Warn      { param([string]$Message) Write-Host "[warn] $Message" -ForegroundColor Yellow }
+function Write-Err       { param([string]$Message) Write-Host "[err]  $Message" -ForegroundColor Red }
+function Write-Highlight { param([string]$Message) Write-Host $Message -ForegroundColor Cyan }
+
+if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+    Write-Err 'claude CLI not found on PATH. Install Claude Code and re-run.'
+    exit 2
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Err 'gh CLI not found on PATH. Install GitHub CLI and re-run.'
+    exit 2
+}
+
+$Timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$LogDir    = Join-Path $HOME ".claude/batch-logs/$Timestamp"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+Write-Highlight 'Batch pr-work orchestrator'
+Write-Info "Repository : $OrgProject"
+Write-Info "Limit      : $Limit"
+Write-Info "Log dir    : $LogDir"
+Write-Host ''
+
+$FailingConclusions = @('FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE')
+
+$AllPrs = gh pr list --repo $OrgProject --state open --limit 100 `
+    --json number,title,statusCheckRollup | ConvertFrom-Json
+
+$FailingPrs = @($AllPrs | Where-Object {
+    $_.statusCheckRollup -and (
+        $_.statusCheckRollup | Where-Object {
+            $FailingConclusions -contains $_.conclusion
+        }
+    )
+} | Select-Object -First $Limit)
+
+if ($FailingPrs.Count -eq 0) {
+    Write-Warn "No open PRs with failing checks found in $OrgProject"
+    exit 0
+}
+
+$Total      = $FailingPrs.Count
+$Processed  = 0
+$FailedItem = $null
+
+foreach ($Pr in $FailingPrs) {
+    $Processed++
+    $LogFile = Join-Path $LogDir "pr-$($Pr.number).log"
+
+    Write-Highlight "[$Processed/$Total] Processing PR #$($Pr.number) -- $($Pr.title)"
+    Write-Info "Log: $LogFile"
+
+    $Prompt = "/pr-work $OrgProject $($Pr.number) --solo"
+    & claude --print $Prompt *>$LogFile
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "PR #$($Pr.number) failed (exit $LASTEXITCODE). Pausing batch."
+        Write-Err "Inspect the log before continuing: $LogFile"
+        $FailedItem = "PR #$($Pr.number)"
+        break
+    }
+
+    Write-Ok "PR #$($Pr.number) completed"
+}
+
+Write-Host ''
+if ($FailedItem) {
+    Write-Err "Batch paused on $FailedItem ($Processed/$Total processed)"
+    Write-Err "Logs: $LogDir"
+    exit 1
+}
+
+Write-Ok "Batch complete: $Processed/$Total items processed"
+Write-Info "Logs: $LogDir"

--- a/scripts/batch-pr-work.sh
+++ b/scripts/batch-pr-work.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Batch pr-work orchestrator
+# ===========================
+# Spawns one fresh `claude` CLI process per failing PR. Each process handles
+# exactly one PR, so CI log accumulation and diff-read state cannot leak
+# between items — PR N+1 starts with the same CLAUDE.md / skill attention
+# pool as PR 1.
+#
+# Usage:
+#   ./scripts/batch-pr-work.sh <org/repo> [limit]
+#
+# Example:
+#   ./scripts/batch-pr-work.sh kcenon/claude-config
+#   ./scripts/batch-pr-work.sh kcenon/claude-config 3
+#
+# Per-item logs are written to:
+#   ~/.claude/batch-logs/<timestamp>/pr-<number>.log
+#
+# A PR is considered "failing" if at least one check has conclusion
+# FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, or STARTUP_FAILURE.
+# Passing and in-progress PRs are skipped.
+#
+# On any item failure, the batch pauses and exits non-zero so the operator
+# can inspect the log before deciding to continue.
+
+set -u
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()      { echo -e "${BLUE}[info]${NC} $1"; }
+success()   { echo -e "${GREEN}[ok]${NC}   $1"; }
+warning()   { echo -e "${YELLOW}[warn]${NC} $1"; }
+error()     { echo -e "${RED}[err]${NC}  $1"; }
+highlight() { echo -e "${CYAN}$1${NC}"; }
+
+if [[ $# -lt 1 ]]; then
+    error "Missing required argument: <org/repo>"
+    echo "Usage: $0 <org/repo> [limit]"
+    exit 2
+fi
+
+ORG_PROJECT="$1"
+LIMIT="${2:-5}"
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+    error "Limit must be a positive integer (got: $LIMIT)"
+    exit 2
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+    error "claude CLI not found on PATH. Install Claude Code and re-run."
+    exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    error "gh CLI not found on PATH. Install GitHub CLI and re-run."
+    exit 2
+fi
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+LOG_DIR="$HOME/.claude/batch-logs/${TIMESTAMP}"
+mkdir -p "$LOG_DIR"
+
+highlight "Batch pr-work orchestrator"
+info "Repository : $ORG_PROJECT"
+info "Limit      : $LIMIT"
+info "Log dir    : $LOG_DIR"
+echo
+
+# Collect open PRs that have at least one failing check. jq selects PRs
+# where any statusCheckRollup entry has a terminal failure conclusion.
+FAILING_PRS=$(gh pr list --repo "$ORG_PROJECT" --state open --limit 100 \
+    --json number,title,statusCheckRollup \
+    -q '.[] | select(
+            [.statusCheckRollup[]?.conclusion] |
+            any(
+                . == "FAILURE" or . == "TIMED_OUT" or . == "CANCELLED" or
+                . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE"
+            )
+        ) | "\(.number)\t\(.title)"' | head -n "$LIMIT")
+
+if [[ -z "$FAILING_PRS" ]]; then
+    warning "No open PRs with failing checks found in $ORG_PROJECT"
+    exit 0
+fi
+
+TOTAL=$(echo "$FAILING_PRS" | wc -l | tr -d ' ')
+PROCESSED=0
+FAILED_ITEM=""
+
+while IFS=$'\t' read -r PR_NUMBER PR_TITLE; do
+    PROCESSED=$((PROCESSED + 1))
+    LOG_FILE="${LOG_DIR}/pr-${PR_NUMBER}.log"
+
+    highlight "[${PROCESSED}/${TOTAL}] Processing PR #${PR_NUMBER} — ${PR_TITLE}"
+    info "Log: ${LOG_FILE}"
+
+    if claude --print "/pr-work ${ORG_PROJECT} ${PR_NUMBER} --solo" \
+        >"$LOG_FILE" 2>&1; then
+        success "PR #${PR_NUMBER} completed"
+    else
+        EXIT_CODE=$?
+        error "PR #${PR_NUMBER} failed (exit ${EXIT_CODE}). Pausing batch."
+        error "Inspect the log before continuing: ${LOG_FILE}"
+        FAILED_ITEM="PR #${PR_NUMBER}"
+        break
+    fi
+done <<< "$FAILING_PRS"
+
+echo
+if [[ -n "$FAILED_ITEM" ]]; then
+    error "Batch paused on ${FAILED_ITEM} (${PROCESSED}/${TOTAL} processed)"
+    error "Logs: ${LOG_DIR}"
+    exit 1
+fi
+
+success "Batch complete: ${PROCESSED}/${TOTAL} items processed"
+info "Logs: ${LOG_DIR}"


### PR DESCRIPTION
## What

### Summary
Adds four wrapper scripts under `scripts/` that spawn one fresh `claude` CLI process per batch item, pushing per-item isolation to the OS process boundary. Each invocation handles exactly one issue (or PR), so no state — conversation-level, tool-result-level, or host-process-level — can leak between items.

Complements `/issue-work` and `/pr-work`'s in-session batch mode (subagent delegation + `--auto-restart`) with a local-only alternative for long unattended runs where the user wants each item to start from a clean slate regardless of batch size.

### Change Type
- [x] Feature (new functionality)
- [x] Documentation (README Use Case D + Common Tasks table)
- [ ] Bugfix

### Affected Components
- `scripts/batch-issue-work.sh` (new, 115 lines)
- `scripts/batch-issue-work.ps1` (new, 102 lines)
- `scripts/batch-pr-work.sh` (new, 124 lines)
- `scripts/batch-pr-work.ps1` (new, 112 lines)
- `README.md` (+50 lines): Use Case D section + 2 rows in the Common Tasks table

## Why

### Problem Solved
Even with subagent delegation and `--auto-restart` shipped, there is a class of long unattended batches where the user wants to cap per-item state at zero and avoid any shared parent process. The external orchestrator pattern answers that: each item gets its own `claude` invocation with its own CLAUDE.md load, its own skill catalogue, and its own empty tool-result pool.

This is strictly the strongest per-item isolation available short of remote agent dispatch — and remote dispatch was evaluated and deferred in #298 / PR #308 because its unique value proposition (parallel execution across accounts or machines) is not a current batch-mode requirement.

### Related Issues
- Closes #297 (feat(scripts): add external batch orchestrator script)
- Part of #287 (epic: prevent rule drift in long-running batch workflows) — Tier 3 strategy A
- Complements #294 / PR #306 (subagent delegation) and #296 / PR #307 (`--auto-restart`)
- Referenced by #298 / PR #308 (research doc) as the "local-only alternative" in the cost comparison table

### Alternative Approaches Considered
1. **Single unified script that auto-detects issue-work vs pr-work**: rejected — the selection logic is different enough (open issues vs PRs with failing checks) that splitting into two scripts is clearer than a mode flag.
2. **No PowerShell variants**: rejected — existing repo convention is `.sh` + `.ps1` paired for every user-facing script (`install`, `backup`, `sync`, `verify`).
3. **Parallel item dispatch with `xargs -P`**: rejected as scope creep. Issue #297 says "loop", not "parallelize", and the batch-size cap is bounded by rule drift, not throughput.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `scripts/batch-issue-work.sh` | New bash orchestrator |
| `scripts/batch-issue-work.ps1` | New PowerShell orchestrator (parallel) |
| `scripts/batch-pr-work.sh` | New bash orchestrator for failing PRs |
| `scripts/batch-pr-work.ps1` | New PowerShell equivalent |
| `README.md` | Use Case D section + 2 rows in Common Tasks table |

No skills, rules, or hooks touched. Pure additive change under `scripts/`.

## How

### Execution Model
Each script is a thin orchestrator:
1. Parse `<org/repo>` and optional `[limit]` (default 5, bounded to 100 in PS via `ValidateRange`)
2. Preflight check that `claude` and `gh` are on PATH
3. Create per-run log directory at `~/.claude/batch-logs/<timestamp>/`
4. Enumerate candidate items via `gh` (open issues, or PRs with failing checks for pr-work)
5. Loop: for each item, spawn `claude --print "/issue-work <org/repo> <n> --solo"` with stdout+stderr redirected to a per-item log file
6. On failure: pause the batch, print the failed item and log path, exit non-zero
7. On success: log summary, exit zero

Each inner `claude` invocation runs the single-item Solo workflow (the skill resolves `/issue-work` with a numeric argument as single-item mode), so no per-item code path changes are needed in the skill files.

### pr-work failure selection

`batch-pr-work.sh` and `batch-pr-work.ps1` pick PRs whose `statusCheckRollup` contains at least one of:
- `FAILURE`
- `TIMED_OUT`
- `CANCELLED`
- `ACTION_REQUIRED`
- `STARTUP_FAILURE`

Passing and in-progress PRs are skipped, so the batch only processes PRs that actually need fixing. This matches `pr-work`'s single-item semantics.

### Failure handling
Item failures always pause the batch with a non-zero exit. Successful items are not rolled back — if the operator re-runs after fixing the failed item, it naturally resumes because merged issues and passing PRs drop out of the candidate list.

### Testing Done
- [x] Bash syntax validated via `bash -n` on both `.sh` files (pass)
- [x] Both `.sh` files chmod +x
- [x] Logic walkthrough for both orchestrators: argument parsing, preflight checks, empty-list handling, single-item happy path, single-item failure path, EOL handling in log writes
- [x] README Use Case D renders as a valid section in the existing Use Cases structure and matches the header conventions (H3, trailing `---` separator)
- [x] Common Tasks table extended with 2 rows, columns aligned with the existing rows
- [ ] **PowerShell syntax**: `pwsh` is not available in the current sandbox, so PS scripts are validated by reading against existing `verify.ps1` / `install.ps1` conventions. Will rely on reviewer verification if the user has PS 7 locally.
- [ ] **Smoke test (3-item batch → 3 logs → 3 PRs)**: deferred. Running the smoke test from this session would be recursive (the current session is itself inside `claude`), and would create real PRs against real repos. Recommended to run manually in a regular shell against a non-critical test repository before promoting the scripts to main.

### Test Plan for Reviewers
1. Read `scripts/batch-issue-work.sh` and confirm the `while read ... do ... done <<< "$ISSUES"` loop handles the tab-separated `number \t title` records correctly (titles with spaces preserved).
2. Confirm `batch-pr-work.sh`'s jq `select(...)` expression filters on at least one failing conclusion, and that `.statusCheckRollup[]?.conclusion` handles PRs without any checks (`?` avoids jq errors on null).
3. Confirm the PS variants use `ValidateRange(1, 100)` for `-Limit` and `ConvertFrom-Json` for the `gh` output.
4. Confirm both bash scripts are `chmod +x` and both PS scripts do NOT need execute bits (they are invoked via `.\`).
5. Optional smoke test against a test repo: create 3 throwaway issues, run `./scripts/batch-issue-work.sh <test-repo> 3`, confirm 3 log files appear under `~/.claude/batch-logs/<ts>/`.

### Breaking Changes
None. Pure additive change.

### Rollback Plan
Revert this PR. No runtime state, no configuration changes, no external dependencies affected.

## Acceptance Criteria Status

From issue #297:
- [x] Bash + PowerShell variants exist (4 files total)
- [x] Per-item logs written to `~/.claude/batch-logs/<timestamp>/`
- [x] Failure pauses batch, does not silently continue (non-zero exit + per-item failure message)
- [x] Documented in `README.md` Use Cases section (new Use Case D + 2 rows in Common Tasks table)
- [ ] **Smoke test: 3-item batch produces 3 logs and 3 PRs** — deferred (see Testing Done note above). The smoke test requires an external shell context to avoid recursive `claude` invocation and non-trivial side effects (real PR creation). Recommended to run against a scratch repo before promoting to main.

## Checklist
- [x] Code follows project style guidelines (bash style matches `sync.sh`, PS style matches `verify.ps1`)
- [x] Self-review completed
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked with closing keyword
- [x] Related issue will receive an Implementation Update comment after PR creation