### PR TITLE
test(batch): add scratch repo seeding script

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run drift benchmark extractor tests
         run: bash tests/batch_drift_benchmark/test-extractors.sh
 
+      - name: Run scratch repo seeding tests
+        run: bash tests/batch_drift_benchmark/test-seed-scratch-repo.sh
+
   shellcheck:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tests/batch_drift_benchmark/seed-scratch-repo.sh
+++ b/tests/batch_drift_benchmark/seed-scratch-repo.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# seed-scratch-repo.sh
+# Idempotently bootstraps kcenon/batch-drift-scratch with 30 trivial typo-fix
+# issues for the Tier 2 benchmark (epic #287, issue #310, sub-issue #313).
+#
+# SCRATCH SPACE NOTICE
+# --------------------
+# kcenon/batch-drift-scratch is throwaway infrastructure owned by the benchmark.
+# It may be force-pushed, issue-wiped, or deleted between benchmark runs.
+# Do not commit anything there that you want to keep.
+#
+# Usage:
+#   tests/batch_drift_benchmark/seed-scratch-repo.sh            # live run
+#   tests/batch_drift_benchmark/seed-scratch-repo.sh --dry-run  # preview only
+#   tests/batch_drift_benchmark/seed-scratch-repo.sh --help     # usage
+#
+# Exit codes:
+#   0  success (or dry-run)
+#   1  invalid argument / precondition failure
+#   2  gh CLI missing or unauthenticated
+
+set -euo pipefail
+
+SCRATCH_REPO="kcenon/batch-drift-scratch"
+TARGET_COUNT=30
+DRY_RUN=false
+
+print_help() {
+    cat <<'EOF'
+seed-scratch-repo.sh — idempotently seed the Tier 2 benchmark scratch repo.
+
+Actions (in order):
+  1. Verify kcenon/batch-drift-scratch exists; create it if absent.
+  2. Upsert docs/file-01.md through docs/file-30.md (single-line "teh" typo).
+  3. Enumerate open issues with title prefix "fix typo in docs/file-".
+  4. For each file number 1..30 without a matching open issue, create one.
+
+Options:
+  --dry-run    Print the planned actions without calling `gh`. Network-free.
+  --help, -h   Show this help text and exit.
+
+Idempotence guarantees:
+  - Re-run on a fully seeded repo: zero create calls (files match via SHA, all
+    issues already present).
+  - Re-run on a partially seeded repo: only missing files and missing issues
+    are created.
+  - Safe to interrupt and resume.
+
+Post-conditions after a successful live run:
+  - Repo kcenon/batch-drift-scratch exists and is public.
+  - docs/file-01.md through docs/file-30.md all contain the same one-line typo.
+  - Exactly 30 open issues with titles "fix typo in docs/file-01.md" through
+    "fix typo in docs/file-30.md" exist.
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --help|-h) print_help; exit 0 ;;
+        *) echo "ERROR: unknown argument: $arg" >&2; echo "Run with --help for usage." >&2; exit 1 ;;
+    esac
+done
+
+format_nn() {
+    printf '%02d' "$1"
+}
+
+file_path_for() {
+    echo "docs/file-$(format_nn "$1").md"
+}
+
+issue_title_for() {
+    echo "fix typo in $(file_path_for "$1")"
+}
+
+file_content_for() {
+    local n="$1"
+    printf '# file %s\n\nteh quick brown fox jumps over the lazy dog.\n' "$(format_nn "$n")"
+}
+
+issue_body_for() {
+    local n="$1"
+    local path
+    path="$(file_path_for "$n")"
+    cat <<EOF
+## What
+Fix typo \`teh\` → \`the\` in ${path} line 3.
+
+## Why
+Typo blocks downstream readers; trivial single-character fix.
+
+## How
+1. Open ${path}
+2. Replace \`teh\` with \`the\`
+3. Commit with message \`fix(docs): correct typo in $(basename "$path")\`
+
+## Acceptance Criteria
+- [ ] ${path} contains "the" (not "teh") on line 3
+- [ ] Commit follows Conventional Commits
+EOF
+}
+
+if $DRY_RUN; then
+    echo "[dry-run] would verify repo: $SCRATCH_REPO (create if missing)"
+    echo "[dry-run] would upsert ${TARGET_COUNT} files:"
+    for n in $(seq 1 "$TARGET_COUNT"); do
+        echo "[dry-run]   PUT $(file_path_for "$n")"
+    done
+    echo "[dry-run] would enumerate open issues with prefix 'fix typo in docs/file-'"
+    echo "[dry-run] would create up to ${TARGET_COUNT} issues (one per missing file number)"
+    for n in $(seq 1 "$TARGET_COUNT"); do
+        echo "[dry-run]   issue: $(issue_title_for "$n")"
+    done
+    exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not installed" >&2
+    exit 2
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not authenticated (run: gh auth login)" >&2
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq not installed" >&2
+    exit 2
+fi
+
+echo "==> verifying $SCRATCH_REPO"
+if ! gh repo view "$SCRATCH_REPO" >/dev/null 2>&1; then
+    echo "    repo missing — creating"
+    gh repo create "$SCRATCH_REPO" --public --add-readme \
+        --description "Throwaway scratch repo for claude-config Tier 2 benchmark (#287)"
+else
+    echo "    repo exists"
+fi
+
+echo "==> upserting ${TARGET_COUNT} typo files"
+for n in $(seq 1 "$TARGET_COUNT"); do
+    path="$(file_path_for "$n")"
+    content="$(file_content_for "$n")"
+    b64="$(printf '%s' "$content" | base64 | tr -d '\n')"
+
+    sha=""
+    if existing=$(gh api "repos/$SCRATCH_REPO/contents/$path" 2>/dev/null); then
+        sha="$(printf '%s' "$existing" | jq -r '.sha // empty')"
+        existing_content_b64="$(printf '%s' "$existing" | jq -r '.content // empty' | tr -d '\n')"
+        if [ "$existing_content_b64" = "$b64" ]; then
+            continue
+        fi
+    fi
+
+    put_args=(--method PUT "repos/$SCRATCH_REPO/contents/$path"
+              -f "message=chore: seed $path for benchmark"
+              -f "content=$b64")
+    if [ -n "$sha" ]; then
+        put_args+=(-f "sha=$sha")
+    fi
+    gh api "${put_args[@]}" >/dev/null
+    echo "    upserted $path"
+done
+
+echo "==> enumerating existing typo issues"
+existing_titles=$(gh issue list --repo "$SCRATCH_REPO" --state open --limit 200 \
+    --json title -q '.[] | select(.title | startswith("fix typo in docs/file-")) | .title')
+
+created=0
+skipped=0
+for n in $(seq 1 "$TARGET_COUNT"); do
+    title="$(issue_title_for "$n")"
+    if printf '%s\n' "$existing_titles" | grep -Fxq "$title"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    body="$(issue_body_for "$n")"
+    gh issue create --repo "$SCRATCH_REPO" --title "$title" --body "$body" >/dev/null
+    created=$((created + 1))
+    echo "    created issue: $title"
+done
+
+echo ""
+echo "==> seed complete: created=${created}, skipped=${skipped}, target=${TARGET_COUNT}"

--- a/tests/batch_drift_benchmark/test-seed-scratch-repo.sh
+++ b/tests/batch_drift_benchmark/test-seed-scratch-repo.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Test suite for tests/batch_drift_benchmark/seed-scratch-repo.sh
+# Run: bash tests/batch_drift_benchmark/test-seed-scratch-repo.sh
+#
+# Offline: only exercises --dry-run and --help paths; never calls gh.
+
+SCRIPT="tests/batch_drift_benchmark/seed-scratch-repo.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "ERROR: $SCRIPT not found"
+    exit 1
+fi
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected output to contain '$needle'")
+        echo "  FAIL: $label (missing '$needle')"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — unexpected '$needle' in output")
+        echo "  FAIL: $label (unexpected '$needle')"
+    else
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    fi
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected '$expected', got '$actual'")
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+    fi
+}
+
+echo "=== seed-scratch-repo.sh tests ==="
+echo ""
+
+echo "[--help]"
+help_out=$(bash "$SCRIPT" --help 2>&1); help_rc=$?
+assert_eq "$help_rc" "0" "--help exits 0"
+assert_contains "$help_out" "seed-scratch-repo.sh" "help mentions script name"
+assert_contains "$help_out" "--dry-run" "help documents --dry-run"
+assert_contains "$help_out" "Idempotence" "help explains idempotence"
+help_out_short=$(bash "$SCRIPT" -h 2>&1); help_short_rc=$?
+assert_eq "$help_short_rc" "0" "-h exits 0"
+
+echo ""
+echo "[--dry-run]"
+dry_out=$(bash "$SCRIPT" --dry-run 2>&1); dry_rc=$?
+assert_eq "$dry_rc" "0" "--dry-run exits 0"
+assert_contains "$dry_out" "[dry-run]" "dry-run tag present"
+assert_contains "$dry_out" "kcenon/batch-drift-scratch" "dry-run names scratch repo"
+assert_contains "$dry_out" "docs/file-01.md" "dry-run lists file-01"
+assert_contains "$dry_out" "docs/file-30.md" "dry-run lists file-30"
+assert_contains "$dry_out" "fix typo in docs/file-01.md" "dry-run lists issue-01 title"
+assert_contains "$dry_out" "fix typo in docs/file-30.md" "dry-run lists issue-30 title"
+
+put_count=$(printf '%s\n' "$dry_out" | grep -c 'PUT docs/file-')
+assert_eq "$put_count" "30" "dry-run plans 30 PUT actions"
+
+issue_count=$(printf '%s\n' "$dry_out" | grep -c 'issue: fix typo in docs/file-')
+assert_eq "$issue_count" "30" "dry-run plans 30 issue creations"
+
+echo ""
+echo "[--dry-run is network-free]"
+# Ensure dry-run doesn't invoke `gh` by verifying no API output patterns leak in
+assert_not_contains "$dry_out" "HTTP/" "dry-run produces no HTTP output"
+assert_not_contains "$dry_out" "X-GitHub" "dry-run produces no GitHub response headers"
+
+echo ""
+echo "[argument validation]"
+bad_out=$(bash "$SCRIPT" --unknown-flag 2>&1); bad_rc=$?
+if [ "$bad_rc" -eq 0 ]; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: unknown flag should exit non-zero")
+    echo "  FAIL: unknown flag should exit non-zero"
+else
+    PASS=$((PASS + 1))
+    echo "  PASS: unknown flag exits non-zero (rc=$bad_rc)"
+fi
+assert_contains "$bad_out" "unknown argument" "unknown flag reports error"
+
+echo ""
+echo "[determinism]"
+d1=$(bash "$SCRIPT" --dry-run 2>&1)
+d2=$(bash "$SCRIPT" --dry-run 2>&1)
+d3=$(bash "$SCRIPT" --dry-run 2>&1)
+if [ "$d1" = "$d2" ] && [ "$d2" = "$d3" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: 3 dry-runs produce identical output"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: dry-run output non-deterministic")
+    echo "  FAIL: 3 dry-runs differ"
+fi
+
+echo ""
+echo "[file numbering]"
+# Sample a middle number to verify zero-padding
+assert_contains "$dry_out" "docs/file-15.md" "file-15 with zero pad"
+# 30 should not have an extra leading zero
+assert_contains "$dry_out" "docs/file-30.md" "file-30 two-digit"
+# Should not produce file-31
+assert_not_contains "$dry_out" "docs/file-31.md" "no file-31"
+# Should not produce file-00
+assert_not_contains "$dry_out" "docs/file-00.md" "no file-00"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #313
Part of #310
Part of #287

## What

Adds `tests/batch_drift_benchmark/seed-scratch-repo.sh` — an idempotent script that bootstraps `kcenon/batch-drift-scratch` with 30 trivial typo-fix issues — plus its offline test suite.

### Change Type
- [x] Test/infrastructure (script checked in; not auto-executed)

### Affected Components
- `tests/batch_drift_benchmark/seed-scratch-repo.sh` (new, 145 LOC)
- `tests/batch_drift_benchmark/test-seed-scratch-repo.sh` (new, 23 test cases)
- `.github/workflows/validate-hooks.yml` (+3 lines: new CI step)

## Why

The Tier 2 benchmark needs a stable 30-issue corpus that all three strategy variants can be measured against. Hand-creating the corpus invalidates the comparison; a scripted, idempotent, version-controlled seed makes the benchmark reproducible by any operator at any time.

Idempotence matters because partial failures (rate limits, network blips) are common during live benchmark setup. Re-running the script must converge — not duplicate — the repo state.

## Where

```
tests/batch_drift_benchmark/
├── seed-scratch-repo.sh           # NEW: idempotent bootstrapper (--dry-run, --help)
└── test-seed-scratch-repo.sh      # NEW: 23 offline cases
.github/workflows/validate-hooks.yml  # +3: sibling test step
```

Target scratch repo: `kcenon/batch-drift-scratch` (created by script on first live run; deferred to #315).

## How

### Idempotence strategy

| Action | Idempotent mechanism |
|--------|---------------------|
| Repo exists check | `gh repo view` — skip create on success |
| File upsert (30 files) | GET existing content+SHA → compare base64 → PUT only on mismatch |
| Issue enumeration | `gh issue list --json title` filtered by prefix `fix typo in docs/file-` |
| Issue creation | create only for file numbers whose title is absent from existing set |

### Testing Done

- [x] 23 local test cases pass — see `bash tests/batch_drift_benchmark/test-seed-scratch-repo.sh`
- [x] `--help` and `-h` exit 0 and cover all documented behaviors
- [x] `--dry-run` plans exactly 30 PUT actions and 30 issue creations
- [x] Dry-run is fully network-free (no HTTP / GitHub response markers in output)
- [x] Unknown flags exit non-zero with a clear error message
- [x] File numbers are strict 01..30 zero-padded (no 00, no 31)
- [x] Dry-run is deterministic across 3 identical runs

### Not Tested Here (deferred to #315)

- Actual repo creation against GitHub
- Live issue seeding
- Partial-resume scenarios (14-of-30 → 30)

These will be exercised when #315 runs the first live benchmark. The dry-run harness gives us cheap, fast feedback on the planning layer in the meantime.

### Test Plan for Reviewer

```bash
bash tests/batch_drift_benchmark/test-seed-scratch-repo.sh
# expected: "=== Results: 23 passed, 0 failed ==="

bash tests/batch_drift_benchmark/seed-scratch-repo.sh --dry-run | head -5
# expected: [dry-run] lines describing the plan
```

### Breaking Changes

None. New files only; workflow change is additive (one new step).

### Rollback Plan

Revert this PR. The scratch repo is not created until an operator explicitly runs the script without `--dry-run`; deferring that to #315 means this merge has zero external side effects.

## Issue Linking

Second of four sub-issues under #310. Remaining chain:
- #314 benchmark orchestrator (depends on #312 ✓ + #313 ← this)
- #315 execute benchmarks + publish results (depends on #314)