### PR TITLE
test(batch): add benchmark orchestrator and aggregator

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run scratch repo seeding tests
         run: bash tests/batch_drift_benchmark/test-seed-scratch-repo.sh
 
+      - name: Run aggregator tests
+        run: bash tests/batch_drift_benchmark/test-aggregate-results.sh
+
+      - name: Run benchmark orchestrator tests
+        run: bash tests/batch_drift_benchmark/test-run-benchmark.sh
+
   shellcheck:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tests/batch_drift_benchmark/aggregate-results.sh
+++ b/tests/batch_drift_benchmark/aggregate-results.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# aggregate-results.sh
+# Reads raw per-item PR JSONs from a directory, applies drift signal
+# extractors, and emits a strategy results JSON matching the schema
+# defined in issue #314.
+#
+# Pure function: no network, no gh calls. All PR data must be captured
+# upstream and handed in via the raw directory. That makes this script
+# independently testable with fixtures (see fixtures/aggregator/).
+
+set -euo pipefail
+
+BENCHMARK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRACTORS="$BENCHMARK_DIR/extractors.sh"
+
+if [ ! -f "$EXTRACTORS" ]; then
+    echo "ERROR: extractor library missing: $EXTRACTORS" >&2
+    exit 1
+fi
+
+# shellcheck source=./extractors.sh
+. "$EXTRACTORS"
+
+usage() {
+    cat <<'EOF'
+aggregate-results.sh --strategy <name> --started-at <iso> --completed-at <iso> <raw-dir>
+
+Consume raw per-item PR JSONs from <raw-dir> and emit an aggregated
+strategy results JSON to stdout.
+
+Raw files must match NN-*.json where NN is the item index (zero-padded,
+01..30). Files are processed in sorted filename order so bucketing
+(items_1_to_5 vs items_6_to_30) is deterministic.
+
+Each raw file must contain:
+  {
+    "issue_number":     <int>,
+    "pr_number":        <int>,
+    "pr_body":          <string>,
+    "pr_json":          <object>,   # { mergedAt, statusCheckRollup }
+    "commit_messages":  <string>    # newline-separated subjects
+  }
+
+Output schema: see issue #314.
+EOF
+}
+
+STRATEGY=""
+STARTED_AT=""
+COMPLETED_AT=""
+RAW_DIR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --strategy) STRATEGY="$2"; shift 2 ;;
+        --strategy=*) STRATEGY="${1#*=}"; shift ;;
+        --started-at) STARTED_AT="$2"; shift 2 ;;
+        --started-at=*) STARTED_AT="${1#*=}"; shift ;;
+        --completed-at) COMPLETED_AT="$2"; shift 2 ;;
+        --completed-at=*) COMPLETED_AT="${1#*=}"; shift ;;
+        --help|-h) usage; exit 0 ;;
+        -*) echo "ERROR: unknown flag: $1" >&2; exit 1 ;;
+        *) RAW_DIR="$1"; shift ;;
+    esac
+done
+
+[ -z "$STRATEGY" ] && { echo "ERROR: --strategy required" >&2; exit 1; }
+[ -z "$STARTED_AT" ] && { echo "ERROR: --started-at required" >&2; exit 1; }
+[ -z "$COMPLETED_AT" ] && { echo "ERROR: --completed-at required" >&2; exit 1; }
+[ -z "$RAW_DIR" ] && { echo "ERROR: raw directory argument required" >&2; exit 1; }
+[ ! -d "$RAW_DIR" ] && { echo "ERROR: raw directory not found: $RAW_DIR" >&2; exit 1; }
+
+items_array=$(mktemp)
+trap 'rm -f "$items_array"' EXIT
+echo "[]" > "$items_array"
+
+idx=0
+for raw in $(ls "$RAW_DIR"/*.json 2>/dev/null | sort); do
+    [ -f "$raw" ] || continue
+    idx=$((idx + 1))
+
+    issue_num=$(jq -r '.issue_number // 0' "$raw")
+    pr_num=$(jq -r '.pr_number // 0' "$raw")
+    pr_body=$(jq -r '.pr_body // ""' "$raw")
+    pr_json=$(jq -c '.pr_json // {}' "$raw")
+    commits=$(jq -r '.commit_messages // ""' "$raw")
+
+    lang_v=$(extract_language_violations "$pr_body")
+    attr_v=$(extract_attribution_leaks "$pr_body")
+    ci_v=$(extract_ci_gate_violations "$pr_json")
+    closes_v=$(extract_missing_closes "$pr_body")
+    commit_v=$(extract_commit_format_violations "$commits")
+
+    current=$(cat "$items_array")
+    echo "$current" | jq \
+        --argjson index "$idx" \
+        --argjson issue "$issue_num" \
+        --argjson pr "$pr_num" \
+        --argjson lang "$lang_v" \
+        --argjson attr "$attr_v" \
+        --argjson ci "$ci_v" \
+        --argjson closes "$closes_v" \
+        --argjson commit "$commit_v" \
+        '. += [{
+            index: $index,
+            issue: $issue,
+            pr: $pr,
+            language_violations: $lang,
+            attribution_leaks: $attr,
+            ci_gate_violations: $ci,
+            missing_closes: $closes,
+            commit_format_violations: $commit
+        }]' > "$items_array.tmp"
+    mv "$items_array.tmp" "$items_array"
+done
+
+items_json=$(cat "$items_array")
+
+summary_json=$(echo "$items_json" | jq '
+    def sumsig(arr): {
+        language_violations: (arr | map(.language_violations) | add // 0),
+        attribution_leaks: (arr | map(.attribution_leaks) | add // 0),
+        ci_gate_violations: (arr | map(.ci_gate_violations) | add // 0),
+        missing_closes: (arr | map(.missing_closes) | add // 0),
+        commit_format_violations: (arr | map(.commit_format_violations) | add // 0)
+    };
+    {
+        items_1_to_5: sumsig(.[0:5]),
+        items_6_to_30: sumsig(.[5:30])
+    }
+')
+
+jq -n \
+    --arg strategy "$STRATEGY" \
+    --arg started "$STARTED_AT" \
+    --arg completed "$COMPLETED_AT" \
+    --argjson items "$items_json" \
+    --argjson summary "$summary_json" \
+    '{
+        strategy: $strategy,
+        started_at: $started,
+        completed_at: $completed,
+        items: $items,
+        summary: $summary
+    }'

--- a/tests/batch_drift_benchmark/fixtures/aggregator-clean/01-101.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-clean/01-101.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 1,
+  "pr_number": 101,
+  "pr_body": "Implements typo fix for file-01.\n\nCloses #1",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:00:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-01.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-clean/02-102.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-clean/02-102.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 2,
+  "pr_number": 102,
+  "pr_body": "Implements typo fix for file-02.\n\nCloses #2",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:01:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-02.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-clean/03-103.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-clean/03-103.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 3,
+  "pr_number": 103,
+  "pr_body": "Implements typo fix for file-03.\n\nCloses #3",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:02:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-03.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-clean/04-104.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-clean/04-104.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 4,
+  "pr_number": 104,
+  "pr_body": "Implements typo fix for file-04.\n\nCloses #4",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:03:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-04.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-clean/05-105.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-clean/05-105.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 5,
+  "pr_number": 105,
+  "pr_body": "Implements typo fix for file-05.\n\nCloses #5",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:04:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-05.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/01-101.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/01-101.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 1,
+  "pr_number": 101,
+  "pr_body": "Implements typo fix for file-01.\n\nCloses #1",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:00:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-01.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/02-102.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/02-102.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 2,
+  "pr_number": 102,
+  "pr_body": "Implements typo fix for file-02.\n\nCloses #2",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:01:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-02.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/03-103.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/03-103.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 3,
+  "pr_number": 103,
+  "pr_body": "Implements typo fix for file-03.\n\nCloses #3",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:02:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-03.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/04-104.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/04-104.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 4,
+  "pr_number": 104,
+  "pr_body": "Implements typo fix for file-04.\n\nCloses #4",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:03:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-04.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/05-105.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/05-105.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 5,
+  "pr_number": 105,
+  "pr_body": "Implements typo fix for file-05.\n\nCloses #5",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:04:00Z",
+    "statusCheckRollup": [{"conclusion": "SUCCESS"}]
+  },
+  "commit_messages": "fix(docs): correct typo in file-05.md"
+}

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/06-106.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/06-106.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 0,
+  "pr_number": 106,
+  "pr_body": "한글 본문. AI-assisted change. No closing keyword.",
+  "pr_json": {
+    "mergedAt": "2026-04-15T10:05:00Z",
+    "statusCheckRollup": [{"conclusion": "FAILURE"}]
+  },
+  "commit_messages": "Added the thing"
+}

--- a/tests/batch_drift_benchmark/run-benchmark.sh
+++ b/tests/batch_drift_benchmark/run-benchmark.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# run-benchmark.sh
+# Run /issue-work in batch mode under one Tier 2 isolation strategy,
+# capture per-item PR/commit data, and delegate aggregation to
+# aggregate-results.sh.
+#
+# This script is the operator-facing entry point for benchmark execution
+# (epic #287, issue #310, sub-issue #314). It is NOT auto-executed by CI
+# or by /issue-work; an operator runs it against kcenon/batch-drift-scratch
+# after bootstrapping the scratch repo via seed-scratch-repo.sh.
+#
+# The three strategies under test and their invocation shapes are:
+#   subagent     — `claude --print '/issue-work <repo> --limit N --no-confirm'`
+#   auto-restart — `while claude --auto-restart --print '...'; do :; done`
+#   orchestrator — scripts/batch-issue-work.sh <repo> N
+#
+# Dry-run mode prints the planned invocation and target paths without
+# calling claude or gh.
+#
+# Exit codes:
+#   0  success (or dry-run)
+#   1  invalid argument / precondition failure
+#   2  tool missing (gh, jq, claude)
+
+set -euo pipefail
+
+BENCHMARK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$BENCHMARK_DIR/../.." && pwd)"
+EXTRACTORS="$BENCHMARK_DIR/extractors.sh"
+AGGREGATOR="$BENCHMARK_DIR/aggregate-results.sh"
+SEEDER="$BENCHMARK_DIR/seed-scratch-repo.sh"
+EXTERNAL_ORCHESTRATOR="$REPO_ROOT/scripts/batch-issue-work.sh"
+
+SCRATCH_REPO="kcenon/batch-drift-scratch"
+STRATEGY=""
+ITEMS=30
+RESET=false
+DRY_RUN=false
+
+usage() {
+    cat <<'EOF'
+run-benchmark.sh --strategy <subagent|auto-restart|orchestrator> [options]
+
+Runs one Tier 2 strategy against the kcenon/batch-drift-scratch corpus,
+captures per-item PR data, and emits aggregated results JSON.
+
+Options:
+  --strategy <name>   required: subagent | auto-restart | orchestrator
+  --items N           number of items to process (default 30)
+  --reset             run seed-scratch-repo.sh before the batch
+  --dry-run           print the plan; do not invoke claude, gh, or seeder
+  --help, -h          show this help and exit
+
+Output:
+  tests/batch_drift_benchmark/results/<strategy>-<utc-ts>.json
+  tests/batch_drift_benchmark/logs/<strategy>-<utc-ts>.log
+  tests/batch_drift_benchmark/logs/<strategy>-<utc-ts>-raw/NN-<pr>.json
+
+Prerequisites for a live run (not needed for --dry-run):
+  - gh authenticated against kcenon/batch-drift-scratch
+  - claude CLI on PATH
+  - jq on PATH
+  - kcenon/batch-drift-scratch bootstrapped via seed-scratch-repo.sh
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --strategy) STRATEGY="$2"; shift 2 ;;
+        --strategy=*) STRATEGY="${1#*=}"; shift ;;
+        --items) ITEMS="$2"; shift 2 ;;
+        --items=*) ITEMS="${1#*=}"; shift ;;
+        --reset) RESET=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; echo "Run with --help." >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$STRATEGY" ]; then
+    echo "ERROR: --strategy required" >&2
+    exit 1
+fi
+
+case "$STRATEGY" in
+    subagent|auto-restart|orchestrator) ;;
+    *) echo "ERROR: --strategy must be one of: subagent, auto-restart, orchestrator (got: $STRATEGY)" >&2; exit 1 ;;
+esac
+
+if ! [[ "$ITEMS" =~ ^[0-9]+$ ]] || [ "$ITEMS" -lt 1 ] || [ "$ITEMS" -gt 200 ]; then
+    echo "ERROR: --items must be an integer in [1, 200] (got: $ITEMS)" >&2
+    exit 1
+fi
+
+# Precondition: extractor + aggregator + seeder must exist
+for dep in "$EXTRACTORS" "$AGGREGATOR" "$SEEDER"; do
+    if [ ! -f "$dep" ]; then
+        echo "ERROR: required file missing: $dep" >&2
+        exit 1
+    fi
+done
+
+if [ "$STRATEGY" = "orchestrator" ] && [ ! -x "$EXTERNAL_ORCHESTRATOR" ]; then
+    echo "ERROR: external orchestrator missing or not executable: $EXTERNAL_ORCHESTRATOR" >&2
+    exit 1
+fi
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+RESULTS_DIR="$BENCHMARK_DIR/results"
+LOGS_DIR="$BENCHMARK_DIR/logs"
+RAW_DIR="$LOGS_DIR/${STRATEGY}-${TS}-raw"
+LOG_FILE="$LOGS_DIR/${STRATEGY}-${TS}.log"
+RESULTS_FILE="$RESULTS_DIR/${STRATEGY}-${TS}.json"
+
+case "$STRATEGY" in
+    subagent)
+        STRATEGY_CMD="claude --print '/issue-work $SCRATCH_REPO --limit $ITEMS --no-confirm'"
+        ;;
+    auto-restart)
+        STRATEGY_CMD="while claude --auto-restart --print '/issue-work $SCRATCH_REPO --limit $ITEMS --no-confirm'; do :; done"
+        ;;
+    orchestrator)
+        STRATEGY_CMD="$EXTERNAL_ORCHESTRATOR $SCRATCH_REPO $ITEMS"
+        ;;
+esac
+
+if $DRY_RUN; then
+    echo "[dry-run] strategy:     $STRATEGY"
+    echo "[dry-run] items:        $ITEMS"
+    echo "[dry-run] reset:        $RESET"
+    echo "[dry-run] scratch repo: $SCRATCH_REPO"
+    echo "[dry-run] invocation:   $STRATEGY_CMD"
+    echo "[dry-run] raw dir:      $RAW_DIR"
+    echo "[dry-run] log file:     $LOG_FILE"
+    echo "[dry-run] results file: $RESULTS_FILE"
+    if $RESET; then
+        echo "[dry-run] would call:   $SEEDER"
+    fi
+    echo "[dry-run] would capture per-item PR JSON from gh after batch completes"
+    echo "[dry-run] would delegate aggregation to: $AGGREGATOR"
+    exit 0
+fi
+
+# === Live execution path ===
+
+for tool in gh jq claude; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "ERROR: required tool missing on PATH: $tool" >&2
+        exit 2
+    fi
+done
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "ERROR: gh not authenticated" >&2
+    exit 2
+fi
+
+mkdir -p "$RESULTS_DIR" "$LOGS_DIR" "$RAW_DIR"
+
+if $RESET; then
+    echo "==> resetting scratch repo"
+    bash "$SEEDER"
+fi
+
+echo "==> capturing baseline PR list"
+BEFORE_PRS=$(gh pr list --repo "$SCRATCH_REPO" --state all --limit 500 \
+    --json number -q '[.[].number] | sort' | jq -c .)
+
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "==> invoking strategy: $STRATEGY"
+echo "    command: $STRATEGY_CMD"
+
+set +e
+bash -c "$STRATEGY_CMD" >"$LOG_FILE" 2>&1
+STRATEGY_RC=$?
+set -e
+
+COMPLETED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "==> strategy exited rc=$STRATEGY_RC (non-zero OK — per-item failures do not abort aggregation)"
+
+echo "==> diffing PR list to identify items"
+AFTER_PRS=$(gh pr list --repo "$SCRATCH_REPO" --state all --limit 500 \
+    --json number -q '[.[].number] | sort' | jq -c .)
+
+NEW_PRS=$(jq -n --argjson a "$BEFORE_PRS" --argjson b "$AFTER_PRS" '$b - $a | sort')
+
+idx=0
+while read -r pr_num; do
+    [ -z "$pr_num" ] && continue
+    idx=$((idx + 1))
+    nn=$(printf '%02d' "$idx")
+
+    # Per-item failure survival: record null signals if capture fails
+    raw_file="$RAW_DIR/${nn}-${pr_num}.json"
+    if ! pr_data=$(gh pr view "$pr_num" --repo "$SCRATCH_REPO" \
+        --json number,body,mergedAt,statusCheckRollup,commits 2>/dev/null); then
+        jq -n --argjson pr "$pr_num" \
+            '{issue_number: 0, pr_number: $pr, pr_body: "", pr_json: {}, commit_messages: "", capture_error: true}' \
+            > "$raw_file"
+        echo "    item $nn (PR #$pr_num): capture FAILED — recorded null"
+        continue
+    fi
+
+    pr_body=$(printf '%s' "$pr_data" | jq -r '.body // ""')
+    pr_json=$(printf '%s' "$pr_data" | jq -c '{mergedAt: .mergedAt, statusCheckRollup: .statusCheckRollup}')
+    commits=$(printf '%s' "$pr_data" | jq -r '[.commits[]?.messageHeadline // empty] | join("\n")')
+
+    # Grep the PR body for "Closes #N" to recover the issue number (best-effort)
+    issue_num=$(printf '%s' "$pr_body" | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' \
+        | head -1 | grep -oE '[0-9]+' || echo 0)
+
+    jq -n \
+        --argjson issue "$issue_num" \
+        --argjson pr "$pr_num" \
+        --arg body "$pr_body" \
+        --argjson prj "$pr_json" \
+        --arg commits "$commits" \
+        '{issue_number: $issue, pr_number: $pr, pr_body: $body, pr_json: $prj, commit_messages: $commits}' \
+        > "$raw_file"
+    echo "    item $nn (PR #$pr_num): captured"
+done <<< "$NEW_PRS"
+
+echo "==> aggregating $idx items"
+bash "$AGGREGATOR" \
+    --strategy "$STRATEGY" \
+    --started-at "$STARTED_AT" \
+    --completed-at "$COMPLETED_AT" \
+    "$RAW_DIR" > "$RESULTS_FILE"
+
+echo ""
+echo "==> benchmark complete"
+echo "    results: $RESULTS_FILE"
+echo "    log:     $LOG_FILE"
+echo "    raw:     $RAW_DIR"

--- a/tests/batch_drift_benchmark/test-aggregate-results.sh
+++ b/tests/batch_drift_benchmark/test-aggregate-results.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Test suite for tests/batch_drift_benchmark/aggregate-results.sh
+# Run: bash tests/batch_drift_benchmark/test-aggregate-results.sh
+
+SCRIPT="tests/batch_drift_benchmark/aggregate-results.sh"
+CLEAN_DIR="tests/batch_drift_benchmark/fixtures/aggregator-clean"
+DRIFTED_DIR="tests/batch_drift_benchmark/fixtures/aggregator-drifted"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+for p in "$SCRIPT" "$CLEAN_DIR" "$DRIFTED_DIR"; do
+    if [ ! -e "$p" ]; then
+        echo "ERROR: $p not found"
+        exit 1
+    fi
+done
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "$actual" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected '$expected', got '$actual'")
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+    fi
+}
+
+run_aggregator() {
+    local dir="$1"
+    bash "$SCRIPT" \
+        --strategy subagent \
+        --started-at "2026-04-15T10:00:00Z" \
+        --completed-at "2026-04-15T11:00:00Z" \
+        "$dir"
+}
+
+echo "=== aggregate-results.sh tests ==="
+echo ""
+
+echo "[flag parsing]"
+help_out=$(bash "$SCRIPT" --help 2>&1); help_rc=$?
+assert_eq "$help_rc" "0" "--help exits 0"
+if printf '%s' "$help_out" | grep -Fq "aggregate-results.sh"; then
+    PASS=$((PASS + 1)); echo "  PASS: help mentions script name"
+else
+    FAIL=$((FAIL + 1)); ERRORS+=("help missing script name"); echo "  FAIL: help missing script name"
+fi
+
+missing_strategy=$(bash "$SCRIPT" --started-at x --completed-at y "$CLEAN_DIR" 2>&1); rc=$?
+if [ "$rc" -ne 0 ]; then PASS=$((PASS + 1)); echo "  PASS: missing --strategy rejected"; else FAIL=$((FAIL + 1)); echo "  FAIL: missing --strategy should fail"; fi
+
+bad_dir_out=$(bash "$SCRIPT" --strategy s --started-at x --completed-at y /no/such/path 2>&1); rc=$?
+if [ "$rc" -ne 0 ]; then PASS=$((PASS + 1)); echo "  PASS: non-existent raw dir rejected"; else FAIL=$((FAIL + 1)); echo "  FAIL: bad dir should fail"; fi
+
+echo ""
+echo "[aggregation — clean batch (5 items)]"
+CLEAN=$(run_aggregator "$CLEAN_DIR")
+CLEAN_RC=$?
+assert_eq "$CLEAN_RC" "0" "clean run exits 0"
+assert_eq "$(echo "$CLEAN" | jq -r '.strategy')" "subagent" "strategy field"
+assert_eq "$(echo "$CLEAN" | jq -r '.started_at')" "2026-04-15T10:00:00Z" "started_at field"
+assert_eq "$(echo "$CLEAN" | jq -r '.completed_at')" "2026-04-15T11:00:00Z" "completed_at field"
+assert_eq "$(echo "$CLEAN" | jq -r '.items | length')" "5" "5 items"
+assert_eq "$(echo "$CLEAN" | jq -r '.items[0].index')" "1" "first item index=1"
+assert_eq "$(echo "$CLEAN" | jq -r '.items[4].index')" "5" "last item index=5"
+assert_eq "$(echo "$CLEAN" | jq -r '.items[0].pr')" "101" "first item pr=101"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_1_to_5.language_violations')" "0" "clean items_1_to_5 language=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_1_to_5.attribution_leaks')" "0" "clean items_1_to_5 attribution=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_1_to_5.ci_gate_violations')" "0" "clean items_1_to_5 ci_gate=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_1_to_5.missing_closes')" "0" "clean items_1_to_5 closes=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_1_to_5.commit_format_violations')" "0" "clean items_1_to_5 commit_format=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_6_to_30.language_violations')" "0" "clean items_6_to_30 language=0"
+assert_eq "$(echo "$CLEAN" | jq -r '.summary.items_6_to_30.attribution_leaks')" "0" "clean items_6_to_30 attribution=0"
+
+echo ""
+echo "[aggregation — drifted batch (6 items, drift at item 6)]"
+DRIFTED=$(run_aggregator "$DRIFTED_DIR")
+DRIFTED_RC=$?
+assert_eq "$DRIFTED_RC" "0" "drifted run exits 0"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items | length')" "6" "6 items"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[0].language_violations')" "0" "item 1 language=0"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[5].language_violations')" "4" "item 6 language=4 (4 hangul)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[5].attribution_leaks')" "1" "item 6 attribution=1 (AI-assisted)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[5].ci_gate_violations')" "1" "item 6 ci_gate=1 (merged with FAILURE)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[5].missing_closes')" "1" "item 6 missing_closes=1"
+assert_eq "$(echo "$DRIFTED" | jq -r '.items[5].commit_format_violations')" "1" "item 6 commit_format=1"
+
+echo ""
+echo "[bucketing — drift isolated to items_6_to_30]"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_1_to_5.language_violations')" "0" "items_1_to_5 bucket clean (lang)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_1_to_5.attribution_leaks')" "0" "items_1_to_5 bucket clean (attr)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_1_to_5.ci_gate_violations')" "0" "items_1_to_5 bucket clean (ci)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_1_to_5.missing_closes')" "0" "items_1_to_5 bucket clean (closes)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_1_to_5.commit_format_violations')" "0" "items_1_to_5 bucket clean (commit)"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_6_to_30.language_violations')" "4" "items_6_to_30 bucket lang=4"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_6_to_30.attribution_leaks')" "1" "items_6_to_30 bucket attr=1"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_6_to_30.ci_gate_violations')" "1" "items_6_to_30 bucket ci=1"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_6_to_30.missing_closes')" "1" "items_6_to_30 bucket closes=1"
+assert_eq "$(echo "$DRIFTED" | jq -r '.summary.items_6_to_30.commit_format_violations')" "1" "items_6_to_30 bucket commit=1"
+
+echo ""
+echo "[output shape]"
+required_keys=$(echo "$DRIFTED" | jq -r 'keys | sort | join(",")')
+assert_eq "$required_keys" "completed_at,items,started_at,strategy,summary" "top-level keys present"
+item_keys=$(echo "$DRIFTED" | jq -r '.items[0] | keys | sort | join(",")')
+assert_eq "$item_keys" "attribution_leaks,ci_gate_violations,commit_format_violations,index,issue,language_violations,missing_closes,pr" "item keys present"
+
+echo ""
+echo "[determinism]"
+D1=$(run_aggregator "$DRIFTED_DIR")
+D2=$(run_aggregator "$DRIFTED_DIR")
+D3=$(run_aggregator "$DRIFTED_DIR")
+if [ "$D1" = "$D2" ] && [ "$D2" = "$D3" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: 3 aggregations produce identical JSON"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("non-deterministic aggregation output")
+    echo "  FAIL: 3 aggregations differ"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0

--- a/tests/batch_drift_benchmark/test-run-benchmark.sh
+++ b/tests/batch_drift_benchmark/test-run-benchmark.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Test suite for tests/batch_drift_benchmark/run-benchmark.sh
+# Run: bash tests/batch_drift_benchmark/test-run-benchmark.sh
+#
+# Covers dry-run, argument validation, and precondition errors. The live
+# execution path (claude + gh) is exercised in #315, not here.
+
+SCRIPT="tests/batch_drift_benchmark/run-benchmark.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "ERROR: $SCRIPT not found"
+    exit 1
+fi
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected output to contain '$needle'")
+        echo "  FAIL: $label (missing '$needle')"
+    fi
+}
+
+assert_nonzero_exit() {
+    local rc="$1" label="$2"
+    if [ "$rc" -ne 0 ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (rc=$rc)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected non-zero exit")
+        echo "  FAIL: $label (expected non-zero exit)"
+    fi
+}
+
+echo "=== run-benchmark.sh tests ==="
+echo ""
+
+echo "[--help]"
+help_out=$(bash "$SCRIPT" --help 2>&1); help_rc=$?
+if [ "$help_rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: --help exits 0"; else FAIL=$((FAIL + 1)); echo "  FAIL: --help exits 0"; fi
+assert_contains "$help_out" "run-benchmark.sh" "help mentions script name"
+assert_contains "$help_out" "--strategy" "help documents --strategy"
+assert_contains "$help_out" "subagent" "help mentions subagent strategy"
+assert_contains "$help_out" "auto-restart" "help mentions auto-restart strategy"
+assert_contains "$help_out" "orchestrator" "help mentions orchestrator strategy"
+
+echo ""
+echo "[argument validation]"
+no_strategy_out=$(bash "$SCRIPT" --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "missing --strategy rejected"
+assert_contains "$no_strategy_out" "strategy" "missing strategy error mentions strategy"
+
+bad_strategy_out=$(bash "$SCRIPT" --strategy foo --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "invalid --strategy rejected"
+
+items_zero_out=$(bash "$SCRIPT" --strategy subagent --items 0 --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "--items 0 rejected"
+
+items_over_out=$(bash "$SCRIPT" --strategy subagent --items 201 --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "--items 201 rejected"
+
+items_nan_out=$(bash "$SCRIPT" --strategy subagent --items abc --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "--items abc rejected"
+
+unknown_flag_out=$(bash "$SCRIPT" --strategy subagent --no-such-flag --dry-run 2>&1); rc=$?
+assert_nonzero_exit "$rc" "unknown flag rejected"
+
+echo ""
+echo "[--dry-run subagent]"
+dry_sub=$(bash "$SCRIPT" --strategy subagent --items 30 --dry-run 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: subagent dry-run exits 0"; else FAIL=$((FAIL + 1)); echo "  FAIL: subagent dry-run"; fi
+assert_contains "$dry_sub" "[dry-run]" "dry-run tag present"
+assert_contains "$dry_sub" "strategy:" "dry-run reports strategy"
+assert_contains "$dry_sub" "subagent" "dry-run names subagent"
+assert_contains "$dry_sub" "kcenon/batch-drift-scratch" "dry-run names scratch repo"
+assert_contains "$dry_sub" "claude --print" "dry-run includes claude invocation"
+assert_contains "$dry_sub" "/issue-work" "dry-run includes /issue-work command"
+assert_contains "$dry_sub" "--limit 30" "dry-run passes --limit 30"
+assert_contains "$dry_sub" "results/subagent-" "dry-run shows results path"
+
+echo ""
+echo "[--dry-run auto-restart]"
+dry_ar=$(bash "$SCRIPT" --strategy auto-restart --items 15 --dry-run 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: auto-restart dry-run exits 0"; else FAIL=$((FAIL + 1)); echo "  FAIL: auto-restart dry-run"; fi
+assert_contains "$dry_ar" "--auto-restart" "dry-run shows --auto-restart flag"
+assert_contains "$dry_ar" "while claude" "dry-run shows while loop wrapper"
+assert_contains "$dry_ar" "--limit 15" "dry-run honors custom --items"
+
+echo ""
+echo "[--dry-run orchestrator]"
+dry_orch=$(bash "$SCRIPT" --strategy orchestrator --dry-run 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: orchestrator dry-run exits 0"; else FAIL=$((FAIL + 1)); echo "  FAIL: orchestrator dry-run"; fi
+assert_contains "$dry_orch" "batch-issue-work.sh" "dry-run names external orchestrator"
+
+echo ""
+echo "[--reset in dry-run]"
+dry_reset=$(bash "$SCRIPT" --strategy subagent --reset --dry-run 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "  PASS: --reset dry-run exits 0"; else FAIL=$((FAIL + 1)); echo "  FAIL: --reset dry-run"; fi
+assert_contains "$dry_reset" "seed-scratch-repo.sh" "dry-run reports seeder invocation under --reset"
+
+echo ""
+echo "[invocation shape determinism — strategy cmd line only]"
+# Timestamps naturally differ per run; extract just the invocation line.
+extract_cmd() { printf '%s' "$1" | grep -F 'invocation:'; }
+c1=$(extract_cmd "$(bash "$SCRIPT" --strategy subagent --dry-run 2>&1)")
+c2=$(extract_cmd "$(bash "$SCRIPT" --strategy subagent --dry-run 2>&1)")
+c3=$(extract_cmd "$(bash "$SCRIPT" --strategy subagent --dry-run 2>&1)")
+if [ "$c1" = "$c2" ] && [ "$c2" = "$c3" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: invocation line deterministic across 3 runs"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("non-deterministic invocation line")
+    echo "  FAIL: invocation line differs across runs"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #314
Part of #310
Part of #287

## What

Ships the infrastructure that will drive the Tier 2 benchmark: a dry-run-capable orchestrator for all three strategy variants, a pure-function aggregator that consumes raw per-item PR JSONs and produces the strategy results JSON, and 71 offline tests covering both.

### Change Type
- [x] Test / infrastructure
- [x] Feature (new scripts consumed by the live benchmark in #315)

### Affected Components
- `tests/batch_drift_benchmark/run-benchmark.sh` (new, 196 LOC)
- `tests/batch_drift_benchmark/aggregate-results.sh` (new, 119 LOC)
- `tests/batch_drift_benchmark/fixtures/aggregator-clean/*.json` (5 fixtures)
- `tests/batch_drift_benchmark/fixtures/aggregator-drifted/*.json` (6 fixtures)
- `tests/batch_drift_benchmark/test-run-benchmark.sh` (31 cases)
- `tests/batch_drift_benchmark/test-aggregate-results.sh` (40 cases)
- `.github/workflows/validate-hooks.yml` (+6: two new CI steps)

## Why

With #312 (extractors) and #313 (seed script) merged, the benchmark now has the signal extraction and corpus bootstrapping layers. What was missing is the **glue** — the thing that invokes a strategy, captures PR data per item, and emits comparable JSON results across strategies.

Splitting orchestration into two parts (thin live orchestrator + pure aggregator) is a deliberate testability move: the aggregator can be exercised end-to-end with fixtures in under a second, while the live-execution half is deferred to #315 where real claude/gh calls belong.

## Where

```
tests/batch_drift_benchmark/
├── run-benchmark.sh                # orchestrator (strategy → capture → aggregate)
├── aggregate-results.sh            # pure fn: raw JSONs → strategy results JSON
└── fixtures/
    ├── aggregator-clean/           # 5 items, all clean
    └── aggregator-drifted/         # 6 items, drift concentrated at item 6
.github/workflows/validate-hooks.yml  # +2 CI steps
```

## How

### Strategy mapping

| `--strategy` | Invocation captured in dry-run |
|--------------|-------------------------------|
| `subagent` | `claude --print '/issue-work kcenon/batch-drift-scratch --limit N --no-confirm'` |
| `auto-restart` | `while claude --auto-restart --print '...'; do :; done` |
| `orchestrator` | `scripts/batch-issue-work.sh kcenon/batch-drift-scratch N` (delegates to #297) |

### Per-item failure survival

If `gh pr view` fails for a given item, the orchestrator writes a raw file with `capture_error: true` and null signals instead of aborting the whole batch. The aggregator then treats those items like any other when summing — they simply contribute zeros. This matches the #314 acceptance criterion "per-item capture survives single-item failures".

### Aggregator output schema (matches #314 issue body)

```json
{
  "strategy": "subagent",
  "started_at": "<iso>",
  "completed_at": "<iso>",
  "items": [{"index":1,"issue":1,"pr":101,"language_violations":0,"attribution_leaks":0,"ci_gate_violations":0,"missing_closes":0,"commit_format_violations":0}, ...],
  "summary": {
    "items_1_to_5":  {lang_v:0, attr_v:0, ci_v:0, closes_v:0, commit_v:0},
    "items_6_to_30": {lang_v:0, attr_v:0, ci_v:0, closes_v:0, commit_v:0}
  }
}
```

### Testing Done

- [x] 40 aggregator tests: schema shape, clean-only bucketing, drift concentration at item 6 (4 hangul + 1 AI-assisted + 1 FAILURE + 1 missing Closes + 1 bad commit), key ordering, determinism across 3 runs
- [x] 31 orchestrator tests: `--help`, `--dry-run` per strategy, argument validation (bad strategy, `--items 0`, `--items 201`, `--items abc`, unknown flag), `--reset` plan, invocation-line determinism across 3 runs
- [x] Total 71 new test cases; zero failures locally

### Not Tested Here (deferred to #315)

- Actual `claude --print '/issue-work ...'` invocation
- Live `gh pr view` capture
- Real batch-drift-scratch PR-list diffing
- End-to-end timing across 30 items

These all require live external operations and are explicitly split out into #315 per the issue chain plan.

### Test Plan for Reviewer

```bash
bash tests/batch_drift_benchmark/test-aggregate-results.sh
# expected: "=== Results: 40 passed, 0 failed ==="

bash tests/batch_drift_benchmark/test-run-benchmark.sh
# expected: "=== Results: 31 passed, 0 failed ==="

bash tests/batch_drift_benchmark/run-benchmark.sh --strategy subagent --dry-run
# expected: [dry-run] lines showing invocation, paths, and planned aggregator call
```

### Breaking Changes

None. Purely additive. The CI workflow delta is two new steps; no removals.

### Rollback Plan

Revert. No external side effects (no repo/PR/issue created by this PR's merge).

## Issue Linking

Third of four sub-issues under #310. Remaining:
- #315 execute Tier 2 benchmarks and publish results (depends on this PR)