### PR TITLE
test(batch): add drift regression harness and nightly CI workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ settings.local.json
 
 # Session logs
 session.log
+
+# Benchmark runtime outputs (committed results go in results/)
+tests/batch_drift_benchmark/logs/
+tests/batch_drift_regression/last-run-summary.json

--- a/docs/batch-drift-regression.md
+++ b/docs/batch-drift-regression.md
@@ -1,0 +1,179 @@
+# Batch Drift Regression Test
+
+Automated regression test that verifies batch workflows retain rule compliance
+at scale. Ensures a 30-item batch does not drift measurably from a 5-item baseline.
+
+Part of epic [#287](https://github.com/kcenon/claude-config/issues/287).
+
+## Overview
+
+Long-running batch sessions (>15 items) suffer attention dilution: the model
+progressively ignores rules as context accumulates. The Tier 0-2 mitigations
+(hooks, chunked gates, subagent delegation) defend against this drift. The
+regression test measures whether those defenses hold.
+
+## Architecture
+
+```
+┌────────────────────────┐
+│  GitHub Actions         │  Nightly + manual dispatch
+│  batch-drift-regression │
+└─────────┬──────────────┘
+          │
+          ▼
+┌────────────────────────┐
+│  run-regression.sh      │  Orchestrates: seed → benchmark → assert
+└─────────┬──────────────┘
+          │
+    ┌─────┼──────────────────┐
+    ▼     ▼                  ▼
+  seed  run-benchmark.sh   thresholds.json
+         │
+         ▼
+  aggregate-results.sh
+         │
+         ▼
+  extractors.sh  ← SSOT: hooks/lib/validate-commit-message.sh
+```
+
+### Components
+
+| Component | Path | Role |
+|-----------|------|------|
+| Regression runner | `tests/batch_drift_regression/run-regression.sh` | Top-level orchestrator |
+| Thresholds | `tests/batch_drift_regression/thresholds.json` | Max allowed drift counts |
+| CI workflow | `.github/workflows/batch-drift-regression.yml` | Nightly schedule + dispatch |
+| Benchmark runner | `tests/batch_drift_benchmark/run-benchmark.sh` | Executes strategy under test |
+| Seed script | `tests/batch_drift_benchmark/seed-scratch-repo.sh` | Bootstraps scratch repo |
+| Extractors | `tests/batch_drift_benchmark/extractors.sh` | Signal measurement functions |
+| Aggregator | `tests/batch_drift_benchmark/aggregate-results.sh` | Per-item → bucket summary |
+| Documentation | `docs/batch-drift-regression.md` | This file |
+
+## Drift Signals
+
+Five signals are measured on every PR produced during the batch:
+
+| Signal | What it measures | Extractor |
+|--------|-----------------|-----------|
+| `language_violations` | CJK characters in PR body (non-English leak) | `extract_language_violations` |
+| `attribution_leaks` | Claude/Anthropic/AI-assisted references | `extract_attribution_leaks` |
+| `ci_gate_violations` | PR merged while checks not all passing | `extract_ci_gate_violations` |
+| `missing_closes` | PR body missing `Closes #N` keyword | `extract_missing_closes` |
+| `commit_format_violations` | Commits failing Conventional Commits format | `extract_commit_format_violations` |
+
+Attribution detection uses `CMV_ATTRIBUTION_REGEX` from
+`hooks/lib/validate-commit-message.sh` (SSOT) — the same regex enforced by the
+`commit-message-guard` and `attribution-guard` hooks.
+
+## Thresholds
+
+Default thresholds apply to the `items_6_to_30` bucket (items beyond the
+safe-zone baseline). They are defined in `tests/batch_drift_regression/thresholds.json`:
+
+| Signal | Max Allowed | Rationale |
+|--------|-------------|-----------|
+| `language_violations` | 0 | Mandatory English — zero tolerance |
+| `attribution_leaks` | 0 | Enforced by hooks — zero tolerance |
+| `ci_gate_violations` | 0 | Absolute CI gate — zero tolerance |
+| `missing_closes` | 1 | Allow 1 transient miss (edge case in auto-close) |
+| `commit_format_violations` | 0 | Enforced by commit-msg hook — zero tolerance |
+
+### Tuning Thresholds
+
+Edit `thresholds.json` or pass `--threshold-file` with a custom file.
+Thresholds should be tuned after the first live benchmark run (#315) provides
+baseline data. A threshold of 0 means "as strict as the 5-item baseline."
+
+## Running the Test
+
+### Locally
+
+```bash
+# Dry-run (no network, no cost)
+bash tests/batch_drift_regression/run-regression.sh --dry-run
+
+# Live run (requires gh + claude CLI, creates real PRs)
+bash tests/batch_drift_regression/run-regression.sh \
+    --strategy subagent \
+    --items 30
+
+# Custom thresholds
+bash tests/batch_drift_regression/run-regression.sh \
+    --threshold-file path/to/custom-thresholds.json
+
+# Skip seeding (reuse existing scratch repo state)
+bash tests/batch_drift_regression/run-regression.sh --skip-seed
+```
+
+### Via GitHub Actions
+
+- **Nightly**: Runs automatically at 03:17 UTC (12:17 KST) daily
+- **Manual**: Go to Actions → "Batch Drift Regression" → Run workflow
+  - Select strategy (default: subagent)
+  - Set item count (default: 30)
+  - Optionally skip seeding
+
+### CI Requirements
+
+The workflow requires two repository secrets:
+
+| Secret | Purpose |
+|--------|---------|
+| `SCRATCH_REPO_TOKEN` | GitHub PAT with write access to `kcenon/batch-drift-scratch` |
+| `ANTHROPIC_API_KEY` | API key for Claude CLI invocations |
+
+## Triage Guide
+
+### When the regression test fails
+
+1. **Check the summary artifact** — download `regression-summary` from the Actions run
+2. **Identify which signal(s) failed** — the `last-run-summary.json` file lists each signal with actual vs threshold
+3. **Check if the failure is in items 6-30** — early items (1-5) are always the baseline
+4. **Review the raw PR data** — download `benchmark-logs` artifact for per-item JSON
+
+### Common failure causes
+
+| Signal | Likely Cause | Fix |
+|--------|-------------|-----|
+| `language_violations` | `pr-language-guard` hook disabled or bypassed | Verify hook in `global/hooks/` |
+| `attribution_leaks` | `attribution-guard` hook regex drift | Check SSOT regex in `hooks/lib/validate-commit-message.sh` |
+| `ci_gate_violations` | `merge-gate-guard` hook weakened | Verify hook logic and test |
+| `missing_closes` | Skill template changed | Check `Closes #N` pattern in skill files |
+| `commit_format_violations` | `commit-msg` hook broken | Run `hooks/lib/validate-commit-message.sh` tests |
+
+### Intentional regression testing
+
+To verify the test catches real drift, temporarily disable a hook and run:
+
+```bash
+# 1. Disable pr-language-guard (backup first)
+mv global/hooks/pr-language-guard.sh global/hooks/pr-language-guard.sh.bak
+
+# 2. Run regression — should FAIL on language_violations
+bash tests/batch_drift_regression/run-regression.sh --strategy subagent
+
+# 3. Restore hook
+mv global/hooks/pr-language-guard.sh.bak global/hooks/pr-language-guard.sh
+```
+
+## Outputs
+
+| Output | Path | Retention |
+|--------|------|-----------|
+| Run summary | `tests/batch_drift_regression/last-run-summary.json` | Until next run |
+| Strategy results | `tests/batch_drift_benchmark/results/<strategy>-<ts>.json` | Permanent (committed) |
+| Benchmark logs | `tests/batch_drift_benchmark/logs/<strategy>-<ts>.log` | 14 days (CI artifact) |
+| Raw PR data | `tests/batch_drift_benchmark/logs/<strategy>-<ts>-raw/` | 14 days (CI artifact) |
+
+## Cost
+
+Each regression run processes N items through a full `/issue-work` cycle:
+- 30 items × ~1 Claude session each = significant token usage
+- Creates ~30 PRs in the scratch repo
+- Typical runtime: 1-3 hours
+
+The nightly schedule limits cost to one run per day. Use `workflow_dispatch`
+for ad-hoc runs after skill or hook changes.
+
+---
+*Part of epic #287. Version 1.0.0*

--- a/tests/batch_drift_regression/run-regression.sh
+++ b/tests/batch_drift_regression/run-regression.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# run-regression.sh
+# Behavioral regression test for batch drift (epic #287, issue #311).
+#
+# Runs a full batch under a Tier 2 isolation strategy against the scratch
+# repo, then asserts that drift signal counts stay within configurable
+# thresholds. Returns non-zero if any threshold is exceeded.
+#
+# This script is the CI-facing entry point. The nightly GitHub Actions
+# workflow calls it; operators can also run it locally.
+#
+# Prerequisites (live mode only):
+#   - gh CLI authenticated with write access to scratch repo
+#   - claude CLI on PATH
+#   - jq on PATH
+#   - Scratch repo accessible (created by seed script if missing)
+#
+# Exit codes:
+#   0  all thresholds passed (or dry-run)
+#   1  one or more thresholds exceeded
+#   2  precondition failure / missing tool
+#   3  benchmark execution failed
+
+set -euo pipefail
+
+REGRESSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_DIR="$REGRESSION_DIR/../batch_drift_benchmark"
+SEEDER="$BENCHMARK_DIR/seed-scratch-repo.sh"
+RUNNER="$BENCHMARK_DIR/run-benchmark.sh"
+
+STRATEGY="subagent"
+ITEMS=30
+THRESHOLD_FILE="$REGRESSION_DIR/thresholds.json"
+DRY_RUN=false
+SKIP_SEED=false
+
+usage() {
+    cat <<'EOF'
+run-regression.sh [options]
+
+Run a batch drift regression test: seed scratch repo, execute a Tier 2
+strategy, aggregate results, and assert thresholds.
+
+Options:
+  --strategy <name>        Tier 2 strategy (default: subagent)
+                           Values: subagent | auto-restart | orchestrator
+  --items N                Number of batch items (default: 30)
+  --threshold-file <path>  JSON threshold file (default: thresholds.json)
+  --skip-seed              Skip scratch repo seeding (use existing state)
+  --dry-run                Validate inputs and print plan without execution
+  --help, -h               Show this help and exit
+
+Thresholds file format (all fields are max allowed counts for items 6-30):
+  {
+    "language_violations": 0,
+    "attribution_leaks": 0,
+    "ci_gate_violations": 0,
+    "missing_closes": 1,
+    "commit_format_violations": 0
+  }
+
+Exit codes:
+  0  pass (or dry-run)
+  1  threshold exceeded
+  2  precondition failure
+  3  benchmark execution failed
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --strategy) STRATEGY="$2"; shift 2 ;;
+        --strategy=*) STRATEGY="${1#*=}"; shift ;;
+        --items) ITEMS="$2"; shift 2 ;;
+        --items=*) ITEMS="${1#*=}"; shift ;;
+        --threshold-file) THRESHOLD_FILE="$2"; shift 2 ;;
+        --threshold-file=*) THRESHOLD_FILE="${1#*=}"; shift ;;
+        --skip-seed) SKIP_SEED=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+case "$STRATEGY" in
+    subagent|auto-restart|orchestrator) ;;
+    *) echo "ERROR: --strategy must be one of: subagent, auto-restart, orchestrator (got: $STRATEGY)" >&2; exit 2 ;;
+esac
+
+if ! [[ "$ITEMS" =~ ^[0-9]+$ ]] || [ "$ITEMS" -lt 1 ] || [ "$ITEMS" -gt 200 ]; then
+    echo "ERROR: --items must be an integer in [1, 200] (got: $ITEMS)" >&2
+    exit 2
+fi
+
+if [ ! -f "$THRESHOLD_FILE" ]; then
+    echo "ERROR: threshold file not found: $THRESHOLD_FILE" >&2
+    exit 2
+fi
+
+if ! jq empty "$THRESHOLD_FILE" 2>/dev/null; then
+    echo "ERROR: threshold file is not valid JSON: $THRESHOLD_FILE" >&2
+    exit 2
+fi
+
+for dep in "$SEEDER" "$RUNNER"; do
+    if [ ! -f "$dep" ]; then
+        echo "ERROR: required script missing: $dep" >&2
+        exit 2
+    fi
+done
+
+T_LANG=$(jq -r '.language_violations // 0' "$THRESHOLD_FILE")
+T_ATTR=$(jq -r '.attribution_leaks // 0' "$THRESHOLD_FILE")
+T_CI=$(jq -r '.ci_gate_violations // 0' "$THRESHOLD_FILE")
+T_CLOSES=$(jq -r '.missing_closes // 1' "$THRESHOLD_FILE")
+T_COMMIT=$(jq -r '.commit_format_violations // 0' "$THRESHOLD_FILE")
+
+if $DRY_RUN; then
+    echo "[dry-run] strategy:       $STRATEGY"
+    echo "[dry-run] items:          $ITEMS"
+    echo "[dry-run] skip-seed:      $SKIP_SEED"
+    echo "[dry-run] threshold file: $THRESHOLD_FILE"
+    echo "[dry-run] thresholds:"
+    echo "[dry-run]   language_violations:      <= $T_LANG"
+    echo "[dry-run]   attribution_leaks:        <= $T_ATTR"
+    echo "[dry-run]   ci_gate_violations:       <= $T_CI"
+    echo "[dry-run]   missing_closes:           <= $T_CLOSES"
+    echo "[dry-run]   commit_format_violations: <= $T_COMMIT"
+    echo "[dry-run] would call: $SEEDER"
+    echo "[dry-run] would call: $RUNNER --strategy $STRATEGY --items $ITEMS --reset"
+    echo "[dry-run] would assert thresholds against items_6_to_30 bucket"
+    exit 0
+fi
+
+# === Live execution ===
+
+for tool in gh jq claude; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "ERROR: required tool not on PATH: $tool" >&2
+        exit 2
+    fi
+done
+
+echo "=== Batch Drift Regression Test ==="
+echo "    strategy: $STRATEGY"
+echo "    items:    $ITEMS"
+echo "    date:     $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+if ! $SKIP_SEED; then
+    echo "==> Phase 1: Seeding scratch repo"
+    if ! bash "$SEEDER"; then
+        echo "ERROR: scratch repo seeding failed" >&2
+        exit 3
+    fi
+else
+    echo "==> Phase 1: Seeding SKIPPED (--skip-seed)"
+fi
+
+echo ""
+echo "==> Phase 2: Running benchmark (strategy=$STRATEGY, items=$ITEMS)"
+
+RESET_FLAG=""
+if ! $SKIP_SEED; then
+    RESET_FLAG="--reset"
+fi
+
+if ! bash "$RUNNER" --strategy "$STRATEGY" --items "$ITEMS" $RESET_FLAG; then
+    echo "WARNING: benchmark runner exited non-zero (per-item failures may exist)" >&2
+fi
+
+echo ""
+echo "==> Phase 3: Locating results"
+
+RESULTS_DIR="$BENCHMARK_DIR/results"
+LATEST_RESULT=$(ls -t "$RESULTS_DIR"/${STRATEGY}-*.json 2>/dev/null | head -1)
+
+if [ -z "$LATEST_RESULT" ] || [ ! -f "$LATEST_RESULT" ]; then
+    echo "ERROR: no result file found for strategy '$STRATEGY' in $RESULTS_DIR" >&2
+    exit 3
+fi
+
+echo "    result file: $LATEST_RESULT"
+
+echo ""
+echo "==> Phase 4: Asserting thresholds"
+
+BUCKET="items_6_to_30"
+if [ "$ITEMS" -le 5 ]; then
+    BUCKET="items_1_to_5"
+fi
+
+A_LANG=$(jq -r ".summary.${BUCKET}.language_violations // 0" "$LATEST_RESULT")
+A_ATTR=$(jq -r ".summary.${BUCKET}.attribution_leaks // 0" "$LATEST_RESULT")
+A_CI=$(jq -r ".summary.${BUCKET}.ci_gate_violations // 0" "$LATEST_RESULT")
+A_CLOSES=$(jq -r ".summary.${BUCKET}.missing_closes // 0" "$LATEST_RESULT")
+A_COMMIT=$(jq -r ".summary.${BUCKET}.commit_format_violations // 0" "$LATEST_RESULT")
+
+FAILED=0
+check_threshold() {
+    local name="$1" actual="$2" max="$3"
+    if [ "$actual" -gt "$max" ]; then
+        echo "    FAIL: $name = $actual (threshold: <= $max)"
+        FAILED=1
+    else
+        echo "    PASS: $name = $actual (threshold: <= $max)"
+    fi
+}
+
+check_threshold "language_violations" "$A_LANG" "$T_LANG"
+check_threshold "attribution_leaks" "$A_ATTR" "$T_ATTR"
+check_threshold "ci_gate_violations" "$A_CI" "$T_CI"
+check_threshold "missing_closes" "$A_CLOSES" "$T_CLOSES"
+check_threshold "commit_format_violations" "$A_COMMIT" "$T_COMMIT"
+
+echo ""
+
+# Emit machine-readable summary (consumed by CI artifact upload)
+SUMMARY_FILE="$REGRESSION_DIR/last-run-summary.json"
+jq -n \
+    --arg strategy "$STRATEGY" \
+    --argjson items "$ITEMS" \
+    --arg bucket "$BUCKET" \
+    --arg result_file "$LATEST_RESULT" \
+    --argjson a_lang "$A_LANG" --argjson t_lang "$T_LANG" \
+    --argjson a_attr "$A_ATTR" --argjson t_attr "$T_ATTR" \
+    --argjson a_ci "$A_CI" --argjson t_ci "$T_CI" \
+    --argjson a_closes "$A_CLOSES" --argjson t_closes "$T_CLOSES" \
+    --argjson a_commit "$A_COMMIT" --argjson t_commit "$T_COMMIT" \
+    --argjson passed "$([ $FAILED -eq 0 ] && echo true || echo false)" \
+    '{
+        strategy: $strategy,
+        items: $items,
+        bucket: $bucket,
+        result_file: $result_file,
+        passed: $passed,
+        signals: {
+            language_violations:      { actual: $a_lang, threshold: $t_lang, passed: ($a_lang <= $t_lang) },
+            attribution_leaks:        { actual: $a_attr, threshold: $t_attr, passed: ($a_attr <= $t_attr) },
+            ci_gate_violations:       { actual: $a_ci,   threshold: $t_ci,   passed: ($a_ci   <= $t_ci)   },
+            missing_closes:           { actual: $a_closes, threshold: $t_closes, passed: ($a_closes <= $t_closes) },
+            commit_format_violations: { actual: $a_commit, threshold: $t_commit, passed: ($a_commit <= $t_commit) }
+        }
+    }' > "$SUMMARY_FILE"
+
+if [ $FAILED -eq 0 ]; then
+    echo "=== REGRESSION TEST PASSED ==="
+    exit 0
+else
+    echo "=== REGRESSION TEST FAILED ==="
+    echo "    See $SUMMARY_FILE for details."
+    exit 1
+fi

--- a/tests/batch_drift_regression/test-run-regression.sh
+++ b/tests/batch_drift_regression/test-run-regression.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# test-run-regression.sh
+# Unit tests for run-regression.sh — validates argument parsing, dry-run
+# output, threshold file loading, and assertion logic.
+#
+# All tests are offline: no gh, claude, or network calls.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGRESSION="$SCRIPT_DIR/run-regression.sh"
+FIXTURE_DIR=$(mktemp -d)
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+passed=0
+failed=0
+
+pass() { passed=$((passed + 1)); echo "  PASS: $1"; }
+fail() { failed=$((failed + 1)); echo "  FAIL: $1"; }
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}
+
+assert_contains() {
+    if echo "$1" | grep -qF -- "$2"; then pass "$3"; else fail "$3 (missing '$2')"; fi
+}
+
+assert_exit() {
+    local expected="$1"; shift
+    set +e
+    "$@" >/dev/null 2>&1
+    local rc=$?
+    set -e
+    if [ "$rc" -eq "$expected" ]; then
+        pass "exit code $expected: ${*: -1}"
+    else
+        fail "expected exit $expected, got $rc: ${*: -1}"
+    fi
+}
+
+# --- Create fixtures ---
+
+# Valid threshold file
+cat > "$FIXTURE_DIR/thresholds.json" <<'EOF'
+{
+  "language_violations": 0,
+  "attribution_leaks": 0,
+  "ci_gate_violations": 0,
+  "missing_closes": 1,
+  "commit_format_violations": 0
+}
+EOF
+
+# Relaxed threshold file (for testing pass scenarios)
+cat > "$FIXTURE_DIR/relaxed.json" <<'EOF'
+{
+  "language_violations": 10,
+  "attribution_leaks": 5,
+  "ci_gate_violations": 3,
+  "missing_closes": 5,
+  "commit_format_violations": 5
+}
+EOF
+
+# Invalid JSON threshold file
+echo "not json" > "$FIXTURE_DIR/bad.json"
+
+echo "=== run-regression.sh tests ==="
+echo ""
+
+# --- Help tests ---
+echo "[--help]"
+
+out=$(bash "$REGRESSION" --help 2>&1)
+assert_eq "$?" "0" "--help exits 0"
+assert_contains "$out" "run-regression.sh" "help mentions script name"
+assert_contains "$out" "--strategy" "help documents --strategy"
+assert_contains "$out" "--threshold-file" "help documents --threshold-file"
+assert_contains "$out" "--dry-run" "help documents --dry-run"
+assert_contains "$out" "--skip-seed" "help documents --skip-seed"
+
+out=$(bash "$REGRESSION" -h 2>&1)
+assert_eq "$?" "0" "-h exits 0"
+
+echo ""
+
+# --- Argument validation ---
+echo "[argument validation]"
+
+assert_exit 2 bash "$REGRESSION" --strategy invalid --dry-run
+assert_exit 2 bash "$REGRESSION" --items 0 --dry-run
+assert_exit 2 bash "$REGRESSION" --items 201 --dry-run
+assert_exit 2 bash "$REGRESSION" --items abc --dry-run
+assert_exit 2 bash "$REGRESSION" --unknown-flag
+
+out=$(bash "$REGRESSION" --strategy invalid --dry-run 2>&1 || true)
+assert_contains "$out" "ERROR" "invalid strategy reports error"
+
+echo ""
+
+# --- Threshold file validation ---
+echo "[threshold file validation]"
+
+assert_exit 2 bash "$REGRESSION" --threshold-file /nonexistent/path --dry-run
+assert_exit 2 bash "$REGRESSION" --threshold-file "$FIXTURE_DIR/bad.json" --dry-run
+
+echo ""
+
+# --- Dry-run output ---
+echo "[dry-run]"
+
+out=$(bash "$REGRESSION" --dry-run --threshold-file "$FIXTURE_DIR/thresholds.json" 2>&1)
+assert_eq "$?" "0" "dry-run exits 0"
+assert_contains "$out" "[dry-run]" "dry-run tag present"
+assert_contains "$out" "subagent" "dry-run shows default strategy"
+assert_contains "$out" "30" "dry-run shows default items"
+assert_contains "$out" "language_violations" "dry-run shows language threshold"
+assert_contains "$out" "attribution_leaks" "dry-run shows attribution threshold"
+assert_contains "$out" "ci_gate_violations" "dry-run shows ci threshold"
+assert_contains "$out" "missing_closes" "dry-run shows closes threshold"
+assert_contains "$out" "commit_format_violations" "dry-run shows commit threshold"
+
+echo ""
+
+# --- Dry-run with custom parameters ---
+echo "[dry-run custom params]"
+
+out=$(bash "$REGRESSION" --dry-run --strategy auto-restart --items 15 \
+    --threshold-file "$FIXTURE_DIR/relaxed.json" --skip-seed 2>&1)
+assert_eq "$?" "0" "custom dry-run exits 0"
+assert_contains "$out" "auto-restart" "dry-run shows custom strategy"
+assert_contains "$out" "15" "dry-run shows custom items"
+assert_contains "$out" "true" "dry-run shows skip-seed"
+
+echo ""
+
+# --- Dry-run all strategies ---
+echo "[dry-run all strategies]"
+
+for strat in subagent auto-restart orchestrator; do
+    out=$(bash "$REGRESSION" --dry-run --strategy "$strat" \
+        --threshold-file "$FIXTURE_DIR/thresholds.json" 2>&1)
+    assert_eq "$?" "0" "$strat dry-run exits 0"
+    assert_contains "$out" "$strat" "$strat dry-run names strategy"
+done
+
+echo ""
+
+# --- Determinism ---
+echo "[determinism]"
+
+run1=$(bash "$REGRESSION" --dry-run --threshold-file "$FIXTURE_DIR/thresholds.json" 2>&1)
+run2=$(bash "$REGRESSION" --dry-run --threshold-file "$FIXTURE_DIR/thresholds.json" 2>&1)
+run3=$(bash "$REGRESSION" --dry-run --threshold-file "$FIXTURE_DIR/thresholds.json" 2>&1)
+if [ "$run1" = "$run2" ] && [ "$run2" = "$run3" ]; then
+    pass "3 dry-runs produce identical output"
+else
+    fail "dry-run output not deterministic"
+fi
+
+echo ""
+echo "=== Results: $passed passed, $failed failed ==="
+[ "$failed" -eq 0 ]

--- a/tests/batch_drift_regression/thresholds.json
+++ b/tests/batch_drift_regression/thresholds.json
@@ -1,0 +1,7 @@
+{
+  "language_violations": 0,
+  "attribution_leaks": 0,
+  "ci_gate_violations": 0,
+  "missing_closes": 1,
+  "commit_format_violations": 0
+}


### PR DESCRIPTION
Closes #311

## What

### Summary
Adds an automated behavioral regression test that verifies 30-item batch workflows
retain rule compliance within configurable drift thresholds. Reuses the benchmark
infrastructure from #312-#314 (extractors, seed script, aggregator) and adds a
threshold assertion layer + nightly CI workflow + documentation.

### Change Type
- [x] Test
- [x] Documentation
- [x] CI/CD (workflow file pending — see note below)

### Affected Components
- `tests/batch_drift_regression/` — New regression harness
- `.github/workflows/batch-drift-regression.yml` — New nightly CI workflow (not yet pushed)
- `docs/batch-drift-regression.md` — Methodology and triage documentation
- `.gitignore` — Exclude benchmark runtime outputs

## Why

### Problem Solved
Epic #287 acceptance criterion: "Behavioral regression test exists: 30-item batch
retains rule compliance equal to 5-item batch" is unsatisfied. Without an automated
check, every future change to skills, hooks, or batch-mode logic can silently
re-introduce rule drift.

### Related Issues
- Closes #311 (regression test for 30-item rule compliance)
- Part of #287 (epic: prevent rule drift in long-running batch workflows)
- Depends on #312, #313, #314 (benchmark infrastructure — all merged)

## How

### Implementation Details

**Regression runner** (`run-regression.sh`):
1. Seeds `kcenon/batch-drift-scratch` with 30 trivial issues
2. Runs `/issue-work` under a configurable Tier 2 strategy (default: subagent)
3. Aggregates per-item PR data using existing extractors
4. Asserts 5 drift signals against configurable thresholds
5. Emits machine-readable `last-run-summary.json` for CI artifacts

**Thresholds** (`thresholds.json`):
| Signal | Max Allowed |
|--------|-------------|
| `language_violations` | 0 |
| `attribution_leaks` | 0 |
| `ci_gate_violations` | 0 |
| `missing_closes` | 1 |
| `commit_format_violations` | 0 |

**CI workflow** (`batch-drift-regression.yml`):
- Nightly at 03:17 UTC (12:17 KST) + manual `workflow_dispatch`
- Configurable strategy, item count, and skip-seed options
- Uploads regression summary and benchmark logs as artifacts
- 3-hour timeout, concurrency-gated

### Testing Done
- [x] 35 unit tests for run-regression.sh (all passing)
- [x] 34 existing extractor tests (unchanged, all passing)
- [x] Dry-run validation for all 3 strategies
- [ ] Live execution (deferred to #315 benchmark run)

### Important Note: Workflow File
The `.github/workflows/batch-drift-regression.yml` file is included in the branch
locally but could not be pushed due to OAuth token scope limitations (`workflow`
scope required). This file must be:
1. Pushed separately with a PAT that has the `workflow` scope, OR
2. Created via the GitHub web UI

The workflow file is available in the local branch at:
`.github/workflows/batch-drift-regression.yml`

### CI Secrets Required
| Secret | Purpose |
|--------|---------|
| `SCRATCH_REPO_TOKEN` | GitHub PAT with write access to scratch repo |
| `ANTHROPIC_API_KEY` | API key for Claude CLI invocations |

## Checklist

- [x] Self-review completed
- [x] Tests added (35 new tests, all passing)
- [x] Documentation added (docs/batch-drift-regression.md)
- [x] No sensitive data exposed
- [x] Commits follow Conventional Commits format
- [x] Related issue linked with closing keyword