### PR TITLE
chore(versions): unify version numbering via VERSION_MAP.yml

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -11,6 +11,15 @@ on:
       - 'scripts/validate_skills.sh'
       - 'scripts/check_references.sh'
       - 'scripts/sync_references.sh'
+      - 'VERSION_MAP.yml'
+      - 'scripts/check_versions.sh'
+      - 'scripts/sync_versions.sh'
+      - 'plugin/.claude-plugin/plugin.json'
+      - 'plugin-lite/.claude-plugin/plugin.json'
+      - 'global/settings.json'
+      - 'global/settings.windows.json'
+      - 'README.md'
+      - 'README.ko.md'
 
 jobs:
   validate:
@@ -32,3 +41,6 @@ jobs:
 
       - name: Check workflow reference mirrors match canonical
         run: ./scripts/check_references.sh
+
+      - name: Check VERSION_MAP consumers match declared values
+        run: ./scripts/check_versions.sh

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -1,0 +1,19 @@
+# VERSION_MAP: Single Source of Truth for claude-config version declarations.
+#
+# Each field tracks an INDEPENDENT SemVer — values are NOT synchronized.
+# scripts/check_versions.sh verifies each consumer matches its declared field.
+# The /release skill bumps one field at a time via `--target <field>`.
+#
+# Consumers (checked by scripts/check_versions.sh):
+#   suite           -> README.md, README.ko.md (shields.io badge URL)
+#   plugin          -> plugin/.claude-plugin/plugin.json (version)
+#   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json (version)
+#   settings-schema -> global/settings.json, global/settings.windows.json (version)
+#
+# To bump a version: edit the field here, then run scripts/sync_versions.sh
+# (or /release <field> <new-version>) to propagate to consumers.
+
+suite: 1.9.0
+plugin: 2.3.0
+plugin-lite: 1.1.0
+settings-schema: 1.12.0

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -206,6 +206,34 @@ pwsh scripts/sync_references.ps1   # Windows
 
 **Why this pattern**: Symlinks do not round-trip reliably through `git clone` on default Windows configurations. Build-time sync keeps all three files byte-identical without requiring platform-specific filesystem features.
 
+### Version Declarations (VERSION_MAP SSOT)
+
+**Type**: Repository-internal convention
+
+Four independent version fields are declared across the suite. `VERSION_MAP.yml` at the repo root is the single source of truth; each field moves on its own SemVer track.
+
+| Field             | Consumers                                                  |
+|-------------------|------------------------------------------------------------|
+| `suite`           | `README.md`, `README.ko.md` (shields.io badge URL)         |
+| `plugin`          | `plugin/.claude-plugin/plugin.json` (`version`)            |
+| `plugin-lite`     | `plugin-lite/.claude-plugin/plugin.json` (`version`)       |
+| `settings-schema` | `global/settings.json`, `global/settings.windows.json`     |
+
+**Bumping a version**: edit the target field in `VERSION_MAP.yml`, then propagate:
+
+```bash
+scripts/sync_versions.sh      # macOS / Linux / WSL
+pwsh scripts/sync_versions.ps1   # Windows
+# or, via sync.sh fast path:
+scripts/sync.sh --versions-only
+```
+
+The `/release` skill wraps this flow — pass `--target <field>` to bump one track.
+
+**CI enforcement**: `.github/workflows/validate-skills.yml` runs `scripts/check_versions.sh` on every PR. The job fails (exit 2) if any consumer drifts from its declared field in `VERSION_MAP.yml`.
+
+**Why independent tracks**: `plugin` and `plugin-lite` release on their own cadence (different users install different variants), and `settings-schema` rev-locks to schema-breaking changes in `global/settings.json`. A single monorepo version would force lockstep releases where none is semantically required.
+
 ## Using This Configuration Elsewhere
 
 ### What Works Out of the Box

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Create a release with automated changelog generation from commits since last release using semantic versioning.
-argument-hint: "<version> [--draft] [--prerelease] [--solo|--team]"
+argument-hint: "<version> [--target <field>] [--draft] [--prerelease] [--solo|--team]"
 user-invocable: true
 context: fork
 allowed-tools:
@@ -34,12 +34,37 @@ Create a release with automated changelog generation from commits since last rel
 `$ARGUMENTS` format: `<version> [options]` or `<organization>/<project-name> <version> [options]`
 
 - **version**: Semantic version (e.g., 1.2.0, 2.0.0-beta.1)
+- **--target**: Which version track to bump. One of: `suite` (default), `plugin`, `plugin-lite`, `settings-schema`. See "Version Source" below.
 - **--draft**: Create as draft release (not published)
 - **--prerelease**: Mark as pre-release
 - **--solo**: Force solo mode — single agent handles all steps sequentially
 - **--team**: Force team mode — dev + reviewer + doc-writer in parallel
 - If neither provided: auto-recommend based on commit count since last release
 - **--org**: GitHub organization or user (optional, auto-detected if not provided)
+
+## Version Source
+
+When this skill runs in the claude-config repository (or any repo that declares a
+`VERSION_MAP.yml` at the root), versions are tracked as **independent SemVer fields**:
+
+| Field             | Consumers                                                  |
+|-------------------|------------------------------------------------------------|
+| `suite`           | `README.md`, `README.ko.md` (shields.io badge)             |
+| `plugin`          | `plugin/.claude-plugin/plugin.json`                        |
+| `plugin-lite`     | `plugin-lite/.claude-plugin/plugin.json`                   |
+| `settings-schema` | `global/settings.json`, `global/settings.windows.json`     |
+
+Each field moves on its own SemVer track — bumping `plugin` does NOT bump the others.
+`--target <field>` selects which field to update; default is `suite`.
+
+Propagation rule:
+1. The skill edits `VERSION_MAP.yml` — set `<target>: <new-version>`.
+2. The skill runs `scripts/sync_versions.sh` (or `.ps1` on Windows) to copy values
+   from the map into each consumer file.
+3. `scripts/check_versions.sh` runs in CI to catch any future drift.
+
+If no `VERSION_MAP.yml` exists at the repo root, the skill falls back to its legacy
+single-version behavior (version passed as the sole argument, no multi-track bumping).
 
 ## Organization Detection
 
@@ -166,6 +191,47 @@ if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
 fi
 ```
 
+### 1.5. Update VERSION_MAP and Sync Consumers (when VERSION_MAP.yml exists)
+
+If `VERSION_MAP.yml` exists at the repo root, parse `--target` (default `suite`),
+update the map, and propagate to consumers before cutting the release PR:
+
+```bash
+if [ -f VERSION_MAP.yml ]; then
+    # Parse --target flag (default: suite)
+    TARGET="suite"
+    if [[ "$ARGUMENTS" =~ --target[[:space:]]+(suite|plugin|plugin-lite|settings-schema) ]]; then
+        TARGET="${BASH_REMATCH[1]}"
+    fi
+
+    # Update VERSION_MAP.yml: set <target>: <new-version>
+    sed -E -i.bak "s/^(${TARGET}:)[[:space:]]*[^[:space:]#]+/\1 ${VERSION}/" VERSION_MAP.yml
+    rm -f VERSION_MAP.yml.bak
+
+    # Propagate to consumer files
+    if [ -x scripts/sync_versions.sh ]; then
+        bash scripts/sync_versions.sh
+    fi
+
+    # Verify no drift before proceeding
+    if [ -x scripts/check_versions.sh ]; then
+        bash scripts/check_versions.sh
+    fi
+
+    # Stage the changes so they land in the release PR
+    git add VERSION_MAP.yml
+    git add plugin/.claude-plugin/plugin.json plugin-lite/.claude-plugin/plugin.json 2>/dev/null || true
+    git add global/settings.json global/settings.windows.json 2>/dev/null || true
+    git add README.md README.ko.md 2>/dev/null || true
+    git commit -m "chore(release): bump ${TARGET} to ${VERSION}"
+    git push origin develop
+fi
+```
+
+**Tag format**: for `--target suite` (or when VERSION_MAP.yml is absent), use `v$VERSION`.
+For other targets, use `<target>-v$VERSION` (e.g., `plugin-v2.3.1`) to keep SemVer tracks
+separate in the git tag history.
+
 ### 2. Get Previous Release Tag
 
 ```bash
@@ -290,11 +356,17 @@ If CI fails, diagnose and fix on `develop`, push, and re-poll. Max 3 attempts.
 git checkout main
 git pull origin main
 
+# Determine tag name based on --target (default: suite -> v$VERSION)
+TAG_NAME="v$VERSION"
+if [ -f VERSION_MAP.yml ] && [ "${TARGET:-suite}" != "suite" ]; then
+    TAG_NAME="${TARGET}-v$VERSION"
+fi
+
 # Create annotated tag on main
-git tag -a "v$VERSION" -m "Release v$VERSION"
+git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
 
 # Push tag to remote
-git push origin "v$VERSION"
+git push origin "$TAG_NAME"
 ```
 
 ### 7.5. Recreate develop from main

--- a/scripts/check_versions.ps1
+++ b/scripts/check_versions.ps1
@@ -1,0 +1,102 @@
+# Verify each consumer file's declared version matches VERSION_MAP.yml.
+# Exits non-zero on drift. Each field tracks an independent SemVer.
+#
+# Consumers:
+#   suite           -> README.md, README.ko.md (shields.io badge)
+#   plugin          -> plugin/.claude-plugin/plugin.json
+#   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json
+#   settings-schema -> global/settings.json, global/settings.windows.json
+#
+# Usage: pwsh scripts/check_versions.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Split-Path -Parent $ScriptDir
+$MapFile = Join-Path $RootDir 'VERSION_MAP.yml'
+
+if (-not (Test-Path -LiteralPath $MapFile -PathType Leaf)) {
+    Write-Error "VERSION_MAP.yml not found at $MapFile"
+    exit 1
+}
+
+function Read-MapField {
+    param([string]$Key)
+    $line = Get-Content -LiteralPath $MapFile | Where-Object { $_ -match "^${Key}:" } | Select-Object -First 1
+    if (-not $line) {
+        Write-Error "field '$Key' not found in VERSION_MAP.yml"
+        exit 1
+    }
+    if ($line -match "^${Key}:\s*([^\s#]+)") {
+        return $Matches[1]
+    }
+    Write-Error "failed to parse field '$Key'"
+    exit 1
+}
+
+$Suite          = Read-MapField 'suite'
+$Plugin         = Read-MapField 'plugin'
+$PluginLite     = Read-MapField 'plugin-lite'
+$SettingsSchema = Read-MapField 'settings-schema'
+
+$drift = 0
+
+function Test-JsonVersion {
+    param([string]$File, [string]$Expected, [string]$Label)
+    $path = Join-Path $RootDir $File
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Write-Host "FAIL: consumer missing: $File" -ForegroundColor Red
+        $script:drift = 1
+        return
+    }
+    $line = Get-Content -LiteralPath $path | Where-Object { $_ -match '"version"\s*:' } | Select-Object -First 1
+    if ($line -match '"version"\s*:\s*"([^"]+)"') {
+        $actual = $Matches[1]
+        if ($actual -ne $Expected) {
+            Write-Host "FAIL: $File version=$actual, VERSION_MAP[$Label]=$Expected" -ForegroundColor Red
+            $script:drift = 1
+        }
+    } else {
+        Write-Host "FAIL: $File has no version field" -ForegroundColor Red
+        $script:drift = 1
+    }
+}
+
+function Test-ReadmeBadge {
+    param([string]$File, [string]$Expected)
+    $path = Join-Path $RootDir $File
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Write-Host "FAIL: consumer missing: $File" -ForegroundColor Red
+        $script:drift = 1
+        return
+    }
+    $content = Get-Content -LiteralPath $path -Raw
+    if ($content -match 'shields\.io/badge/version-(\d+\.\d+\.\d+)') {
+        $actual = $Matches[1]
+        if ($actual -ne $Expected) {
+            Write-Host "FAIL: $File badge=$actual, VERSION_MAP[suite]=$Expected" -ForegroundColor Red
+            $script:drift = 1
+        }
+    } else {
+        Write-Host "FAIL: $File has no shields.io version badge" -ForegroundColor Red
+        $script:drift = 1
+    }
+}
+
+Test-JsonVersion 'plugin/.claude-plugin/plugin.json'      $Plugin         'plugin'
+Test-JsonVersion 'plugin-lite/.claude-plugin/plugin.json' $PluginLite     'plugin-lite'
+Test-JsonVersion 'global/settings.json'                   $SettingsSchema 'settings-schema'
+Test-JsonVersion 'global/settings.windows.json'           $SettingsSchema 'settings-schema'
+Test-ReadmeBadge 'README.md'    $Suite
+Test-ReadmeBadge 'README.ko.md' $Suite
+
+if ($drift -eq 0) {
+    Write-Host "check_versions: OK"
+    Write-Host "  suite=$Suite  plugin=$Plugin  plugin-lite=$PluginLite  settings-schema=$SettingsSchema"
+    exit 0
+}
+
+Write-Host ""
+Write-Host "check_versions: drift detected. Update consumers to match VERSION_MAP.yml," -ForegroundColor Red
+Write-Host "or run scripts/sync_versions.ps1 to auto-propagate map values to consumers." -ForegroundColor Red
+exit 2

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verify each consumer file's declared version matches VERSION_MAP.yml.
+# Exits non-zero on drift. Each field tracks an independent SemVer.
+#
+# Consumers:
+#   suite           -> README.md, README.ko.md (shields.io badge)
+#   plugin          -> plugin/.claude-plugin/plugin.json
+#   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json
+#   settings-schema -> global/settings.json, global/settings.windows.json
+#
+# Usage: scripts/check_versions.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MAP_FILE="$ROOT_DIR/VERSION_MAP.yml"
+
+if [ ! -f "$MAP_FILE" ]; then
+    echo "ERROR: VERSION_MAP.yml not found at $MAP_FILE" >&2
+    exit 1
+fi
+
+# Extract a top-level scalar from a simple YAML file (no dependency on yq).
+# Only supports `key: value` at column 0 with optional inline comment.
+read_map_field() {
+    local key="$1"
+    local value
+    value=$(grep -E "^${key}:" "$MAP_FILE" | head -1 | sed -E "s/^${key}:[[:space:]]*([^[:space:]#]+).*/\1/")
+    if [ -z "$value" ]; then
+        echo "ERROR: field '${key}' not found in VERSION_MAP.yml" >&2
+        exit 1
+    fi
+    printf '%s' "$value"
+}
+
+SUITE=$(read_map_field "suite")
+PLUGIN=$(read_map_field "plugin")
+PLUGIN_LITE=$(read_map_field "plugin-lite")
+SETTINGS_SCHEMA=$(read_map_field "settings-schema")
+
+drift=0
+
+check_json_version() {
+    local file="$1"
+    local expected="$2"
+    local label="$3"
+    local path="$ROOT_DIR/$file"
+    if [ ! -f "$path" ]; then
+        echo "FAIL: consumer missing: $file" >&2
+        drift=1
+        return
+    fi
+    local actual
+    actual=$(grep -E '"version"[[:space:]]*:' "$path" | head -1 | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: $file version=$actual, VERSION_MAP[$label]=$expected" >&2
+        drift=1
+    fi
+}
+
+check_readme_badge() {
+    local file="$1"
+    local expected="$2"
+    local path="$ROOT_DIR/$file"
+    if [ ! -f "$path" ]; then
+        echo "FAIL: consumer missing: $file" >&2
+        drift=1
+        return
+    fi
+    local actual
+    actual=$(grep -oE 'shields\.io/badge/version-[0-9]+\.[0-9]+\.[0-9]+' "$path" | head -1 | sed -E 's|.*badge/version-||')
+    if [ -z "$actual" ]; then
+        echo "FAIL: $file has no shields.io version badge" >&2
+        drift=1
+        return
+    fi
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: $file badge=$actual, VERSION_MAP[suite]=$expected" >&2
+        drift=1
+    fi
+}
+
+check_json_version "plugin/.claude-plugin/plugin.json"       "$PLUGIN"          "plugin"
+check_json_version "plugin-lite/.claude-plugin/plugin.json"  "$PLUGIN_LITE"     "plugin-lite"
+check_json_version "global/settings.json"                    "$SETTINGS_SCHEMA" "settings-schema"
+check_json_version "global/settings.windows.json"            "$SETTINGS_SCHEMA" "settings-schema"
+check_readme_badge "README.md"    "$SUITE"
+check_readme_badge "README.ko.md" "$SUITE"
+
+if [ "$drift" -eq 0 ]; then
+    echo "check_versions: OK"
+    echo "  suite=$SUITE  plugin=$PLUGIN  plugin-lite=$PLUGIN_LITE  settings-schema=$SETTINGS_SCHEMA"
+    exit 0
+fi
+
+echo "" >&2
+echo "check_versions: drift detected. Update consumers to match VERSION_MAP.yml," >&2
+echo "or run scripts/sync_versions.sh to auto-propagate map values to consumers." >&2
+exit 2

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -24,6 +24,12 @@ if [[ "${1:-}" == "--references-only" ]]; then
     exec "$SCRIPT_DIR/sync_references.sh"
 fi
 
+# Fast path: propagate VERSION_MAP.yml values into consumer files.
+# See docs/CUSTOM_EXTENSIONS.md for version track layout.
+if [[ "${1:-}" == "--versions-only" ]]; then
+    exec "$SCRIPT_DIR/sync_versions.sh"
+fi
+
 echo -e "${BLUE}"
 cat << 'EOF'
 ╔═══════════════════════════════════════════════════════════════╗

--- a/scripts/sync_versions.ps1
+++ b/scripts/sync_versions.ps1
@@ -1,0 +1,78 @@
+# Propagate VERSION_MAP.yml values into consumer files.
+# Use after editing VERSION_MAP.yml (typically invoked by the /release skill).
+#
+# Consumers:
+#   suite           -> README.md, README.ko.md (shields.io badge)
+#   plugin          -> plugin/.claude-plugin/plugin.json
+#   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json
+#   settings-schema -> global/settings.json, global/settings.windows.json
+#
+# Usage: pwsh scripts/sync_versions.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Split-Path -Parent $ScriptDir
+$MapFile = Join-Path $RootDir 'VERSION_MAP.yml'
+
+if (-not (Test-Path -LiteralPath $MapFile -PathType Leaf)) {
+    Write-Error "VERSION_MAP.yml not found at $MapFile"
+    exit 1
+}
+
+function Read-MapField {
+    param([string]$Key)
+    $line = Get-Content -LiteralPath $MapFile | Where-Object { $_ -match "^${Key}:" } | Select-Object -First 1
+    if (-not $line) {
+        Write-Error "field '$Key' not found in VERSION_MAP.yml"
+        exit 1
+    }
+    if ($line -match "^${Key}:\s*([^\s#]+)") { return $Matches[1] }
+    Write-Error "failed to parse field '$Key'"
+    exit 1
+}
+
+$Suite          = Read-MapField 'suite'
+$Plugin         = Read-MapField 'plugin'
+$PluginLite     = Read-MapField 'plugin-lite'
+$SettingsSchema = Read-MapField 'settings-schema'
+
+function Set-JsonVersion {
+    param([string]$File, [string]$NewVersion)
+    $path = Join-Path $RootDir $File
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Write-Host "SKIP: $File (not found)"
+        return
+    }
+    $content = Get-Content -LiteralPath $path -Raw
+    $pattern = '("version"\s*:\s*")[^"]+(")'
+    $replacement = '${1}' + $NewVersion + '${2}'
+    $updated = [regex]::Replace($content, $pattern, $replacement, 'None', [System.TimeSpan]::FromSeconds(2))
+    Set-Content -LiteralPath $path -Value $updated -NoNewline
+    Write-Host "synced: $File -> version=$NewVersion"
+}
+
+function Set-ReadmeBadge {
+    param([string]$File, [string]$NewVersion)
+    $path = Join-Path $RootDir $File
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Write-Host "SKIP: $File (not found)"
+        return
+    }
+    $content = Get-Content -LiteralPath $path -Raw
+    $pattern = '(shields\.io/badge/version-)\d+\.\d+\.\d+'
+    $replacement = '${1}' + $NewVersion
+    $updated = [regex]::Replace($content, $pattern, $replacement)
+    Set-Content -LiteralPath $path -Value $updated -NoNewline
+    Write-Host "synced: $File -> badge=$NewVersion"
+}
+
+Set-JsonVersion 'plugin/.claude-plugin/plugin.json'      $Plugin
+Set-JsonVersion 'plugin-lite/.claude-plugin/plugin.json' $PluginLite
+Set-JsonVersion 'global/settings.json'                   $SettingsSchema
+Set-JsonVersion 'global/settings.windows.json'           $SettingsSchema
+Set-ReadmeBadge 'README.md'    $Suite
+Set-ReadmeBadge 'README.ko.md' $Suite
+
+Write-Host ""
+Write-Host "sync_versions: done. Run scripts/check_versions.ps1 to verify."

--- a/scripts/sync_versions.sh
+++ b/scripts/sync_versions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Propagate VERSION_MAP.yml values into consumer files.
+# Use after editing VERSION_MAP.yml (typically invoked by the /release skill).
+#
+# Consumers:
+#   suite           -> README.md, README.ko.md (shields.io badge)
+#   plugin          -> plugin/.claude-plugin/plugin.json
+#   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json
+#   settings-schema -> global/settings.json, global/settings.windows.json
+#
+# Usage: scripts/sync_versions.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MAP_FILE="$ROOT_DIR/VERSION_MAP.yml"
+
+if [ ! -f "$MAP_FILE" ]; then
+    echo "ERROR: VERSION_MAP.yml not found at $MAP_FILE" >&2
+    exit 1
+fi
+
+read_map_field() {
+    local key="$1"
+    local value
+    value=$(grep -E "^${key}:" "$MAP_FILE" | head -1 | sed -E "s/^${key}:[[:space:]]*([^[:space:]#]+).*/\1/")
+    if [ -z "$value" ]; then
+        echo "ERROR: field '${key}' not found in VERSION_MAP.yml" >&2
+        exit 1
+    fi
+    printf '%s' "$value"
+}
+
+SUITE=$(read_map_field "suite")
+PLUGIN=$(read_map_field "plugin")
+PLUGIN_LITE=$(read_map_field "plugin-lite")
+SETTINGS_SCHEMA=$(read_map_field "settings-schema")
+
+# Portable in-place replacement: sed -i differs between GNU and BSD.
+sed_inplace() {
+    local expr="$1"
+    local file="$2"
+    local tmp="${file}.tmp.$$"
+    sed -E "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+set_json_version() {
+    local file="$1"
+    local new="$2"
+    local path="$ROOT_DIR/$file"
+    if [ ! -f "$path" ]; then
+        echo "SKIP: $file (not found)" >&2
+        return
+    fi
+    sed_inplace 's/("version"[[:space:]]*:[[:space:]]*")[^"]+(")/\1'"${new}"'\2/' "$path"
+    echo "synced: $file -> version=$new"
+}
+
+set_readme_badge() {
+    local file="$1"
+    local new="$2"
+    local path="$ROOT_DIR/$file"
+    if [ ! -f "$path" ]; then
+        echo "SKIP: $file (not found)" >&2
+        return
+    fi
+    sed_inplace 's|(shields\.io/badge/version-)[0-9]+\.[0-9]+\.[0-9]+|\1'"${new}"'|' "$path"
+    echo "synced: $file -> badge=$new"
+}
+
+set_json_version "plugin/.claude-plugin/plugin.json"       "$PLUGIN"
+set_json_version "plugin-lite/.claude-plugin/plugin.json"  "$PLUGIN_LITE"
+set_json_version "global/settings.json"                    "$SETTINGS_SCHEMA"
+set_json_version "global/settings.windows.json"            "$SETTINGS_SCHEMA"
+set_readme_badge "README.md"    "$SUITE"
+set_readme_badge "README.ko.md" "$SUITE"
+
+echo ""
+echo "sync_versions: done. Run scripts/check_versions.sh to verify."


### PR DESCRIPTION
Closes #330

## What

Introduces `VERSION_MAP.yml` at the repo root as the single source of truth for four independent SemVer tracks, plus tooling to propagate and verify.

| Field | Consumers |
|-------|-----------|
| `suite` (1.9.0) | `README.md`, `README.ko.md` (shields.io badge) |
| `plugin` (2.3.0) | `plugin/.claude-plugin/plugin.json` |
| `plugin-lite` (1.1.0) | `plugin-lite/.claude-plugin/plugin.json` |
| `settings-schema` (1.12.0) | `global/settings.json`, `global/settings.windows.json` |

## Why

Before this PR, four files declared versions independently with no cross-check. `/release` could not determine what "current version" meant because the four values disagreed. The README badge (1.9.0) pointed to a suite version that was never codified anywhere.

This PR does NOT synchronize the four values into one — each track has a legitimate independent cadence (plugin and plugin-lite ship to different users; settings-schema rev-locks to schema breaks). Instead it declares each field's value explicitly, propagates to consumers, and gates drift in CI.

## Where

New:
- `VERSION_MAP.yml` — declared values for each track
- `scripts/check_versions.{sh,ps1}` — drift detector (exit 2 on mismatch)
- `scripts/sync_versions.{sh,ps1}` — map -> consumers propagation

Modified:
- `.github/workflows/validate-skills.yml` — runs `check_versions.sh` on every PR targeting main
- `global/skills/release/SKILL.md` — accepts `--target <field>`, updates map, runs sync before cutting release PR. Tag format becomes `<target>-v<version>` for non-suite targets; `v<version>` preserved for suite
- `scripts/sync.sh` — adds `--versions-only` fast path
- `docs/CUSTOM_EXTENSIONS.md` — documents VERSION_MAP SSOT layout

## How

1. `VERSION_MAP.yml` stores each field's current value.
2. `sync_versions.sh` reads the map and writes each consumer (JSON `version` field, shields.io badge URL).
3. `check_versions.sh` reads the map and verifies each consumer's declared value matches. Runs portable bash (grep/sed only — no `yq`/`jq` dependency).
4. CI wires `check_versions.sh` into `validate-skills.yml`, so any future drift fails the release PR.
5. The release skill accepts `--target <field>` (default `suite`), edits `VERSION_MAP.yml`, runs `sync_versions.sh`, commits the bump, and continues with its existing PR/tag flow. Legacy single-version behavior is preserved when no `VERSION_MAP.yml` is present.

### Acceptance Criteria

- [x] `VERSION_MAP.yml` created at repo root with 4 independent tracks
- [x] `scripts/check_versions.sh` validates all references and exits non-zero on drift
- [x] CI job runs `check_versions.sh` on every PR (via `validate-skills.yml`)
- [x] `global/skills/release/SKILL.md` updated to use `VERSION_MAP.yml` as source
- [x] README badge URL points to the canonical `suite` version
- [x] All declared values match consumer files initially

## Test Plan

Round-trip verified locally:
```
bash scripts/sync_versions.sh  # propagates map -> consumers (idempotent)
bash scripts/check_versions.sh # exits 0 when in sync
```

Drift detection verified by running `check_versions` with an intentional README mismatch — exited 2 and printed the drifted consumer.

Discovered during implementation: `global/settings.windows.json` was a **5th consumer** not listed in the original issue; it also declares `version: "1.12.0"` for `settings-schema`. Added to the map's consumer list.

## Related

Parent: #328
Part of the phase-1 improvement batch (after #329).