### PR TITLE
chore(plugin): remove redundant path fields from manifests

### DIFF
--- a/plugin-lite/.claude-plugin/plugin.json
+++ b/plugin-lite/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
     "coding-standards",
     "best-practices",
     "llm-coding"
-  ],
-  "skills": "./skills/"
+  ]
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -19,9 +19,5 @@
     "workflow",
     "code-quality",
     "best-practices"
-  ],
-  "agents": "./agents/",
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  ]
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -68,11 +68,14 @@ plugin/
 
 ## Plugin Manifest Compatibility
 
-Verified against Claude Code plugin system (March 2026). The `plugin.json` manifest
-uses the standard schema with `skills` and `hooks` component paths.
+Verified against Claude Code plugin system (April 2026). The `plugin.json` manifest
+contains only the official schema fields (`name`, `version`, `description`, `author`,
+`homepage`, `repository`, `license`, `compatibility`, `keywords`).
 
-Additional manifest fields (`agents`, `mcpServers`, `lspServers`) are supported by the
-plugin system but not used by this plugin as it does not bundle those components.
+Component directories (`agents/`, `skills/`, `hooks/hooks.json`, `.mcp.json`, `.lsp.json`)
+are auto-discovered by Claude Code at the plugin root — no explicit path fields are
+declared in the manifest. Explicit path fields are only needed when overriding the
+default discovery layout.
 
 ## Requirements
 

--- a/tests/plugin/smoke-test.ps1
+++ b/tests/plugin/smoke-test.ps1
@@ -72,32 +72,21 @@ function Test-Plugin {
     $manifest = Join-Path $PluginDir '.claude-plugin' 'plugin.json'
     Test-JsonFile -FilePath $manifest
 
-    # Check referenced directories from manifest
-    if (Test-Path -LiteralPath $manifest) {
-        try {
-            $manifestData = Get-Content -Raw -LiteralPath $manifest | ConvertFrom-Json
+    # Validate components at their default locations. Claude Code auto-discovers
+    # agents/, skills/, hooks/hooks.json at the plugin root - no manifest path
+    # fields are required (see issue #331).
+    $agentsDir = Join-Path $PluginDir 'agents'
+    $skillsDir = Join-Path $PluginDir 'skills'
+    $hooksJson = Join-Path $PluginDir 'hooks' 'hooks.json'
 
-            $agentsRef = $manifestData.agents
-            $skillsRef = $manifestData.skills
-            $hooksRef  = $manifestData.hooks
-
-            if ($agentsRef) {
-                Test-DirectoryExists -Dir (Join-Path $PluginDir $agentsRef) -Label "$name/agents"
-            }
-            if ($skillsRef) {
-                Test-DirectoryExists -Dir (Join-Path $PluginDir $skillsRef) -Label "$name/skills"
-            }
-            if ($hooksRef) {
-                $hooksPath = Join-Path $PluginDir $hooksRef
-                if (Test-Path -LiteralPath $hooksPath) {
-                    Pass "$name hooks file exists"
-                } else {
-                    Fail "$name hooks file missing: $hooksPath"
-                }
-            }
-        } catch {
-            # Manifest parse failed, already reported above
-        }
+    if (Test-Path -LiteralPath $agentsDir -PathType Container) {
+        Test-DirectoryExists -Dir $agentsDir -Label "$name/agents"
+    }
+    if (Test-Path -LiteralPath $skillsDir -PathType Container) {
+        Test-DirectoryExists -Dir $skillsDir -Label "$name/skills"
+    }
+    if (Test-Path -LiteralPath $hooksJson -PathType Leaf) {
+        Test-JsonFile -FilePath $hooksJson
     }
 
     # Validate SKILL.md frontmatter

--- a/tests/plugin/smoke-test.sh
+++ b/tests/plugin/smoke-test.sh
@@ -54,28 +54,21 @@ validate_plugin() {
   local manifest="$plugin_dir/.claude-plugin/plugin.json"
   check_json "$manifest"
 
-  # Check referenced directories from manifest
-  if [ -f "$manifest" ]; then
-    local agents_ref skills_ref hooks_ref
+  # Validate components at their default locations. Claude Code auto-discovers
+  # agents/, skills/, hooks/hooks.json at the plugin root — no manifest path
+  # fields are required (see issue #331).
+  local agents_dir="$plugin_dir/agents"
+  local skills_dir="$plugin_dir/skills"
+  local hooks_json="$plugin_dir/hooks/hooks.json"
 
-    agents_ref="$(jq -r '.agents // empty' "$manifest")"
-    skills_ref="$(jq -r '.skills // empty' "$manifest")"
-    hooks_ref="$(jq -r '.hooks // empty' "$manifest")"
-
-    if [ -n "$agents_ref" ]; then
-      check_dir "$plugin_dir/$agents_ref" "$name/agents"
-    fi
-    if [ -n "$skills_ref" ]; then
-      check_dir "$plugin_dir/$skills_ref" "$name/skills"
-    fi
-    if [ -n "$hooks_ref" ]; then
-      local hooks_path="$plugin_dir/$hooks_ref"
-      if [ -f "$hooks_path" ]; then
-        pass "$name hooks file exists"
-      else
-        fail "$name hooks file missing: $hooks_path"
-      fi
-    fi
+  if [ -d "$agents_dir" ]; then
+    check_dir "$agents_dir" "$name/agents"
+  fi
+  if [ -d "$skills_dir" ]; then
+    check_dir "$skills_dir" "$name/skills"
+  fi
+  if [ -f "$hooks_json" ]; then
+    check_json "$hooks_json"
   fi
 
   # Validate SKILL.md frontmatter


### PR DESCRIPTION
Closes #331

## Summary
- Remove `agents`, `skills`, `hooks`, `lspServers` from `plugin/.claude-plugin/plugin.json`
- Remove `skills` from `plugin-lite/.claude-plugin/plugin.json`
- Refactor `tests/plugin/smoke-test.sh` and `.ps1` to validate default component locations instead of manifest-declared paths
- Update `plugin/README.md` to describe auto-discovery behavior

## Why

Per the official Claude Code plugin spec, agents/, skills/, hooks/hooks.json, .mcp.json, and .lsp.json are auto-discovered at the plugin root. Explicit path fields are only needed when overriding the defaults — declaring them here was redundant and risked masking future spec changes if the auto-discovery convention were updated.

The only consumers of the removed fields were the two smoke tests (`smoke-test.sh` / `smoke-test.ps1`). Both were refactored to inspect the default locations directly. Bootstrap and install scripts do not reference the fields.

## Test Plan

- [x] Both manifests parse as valid JSON (python json.load)
- [x] `pwsh tests/plugin/smoke-test.ps1` → 38 passed, 0 failed locally
- [ ] `bash tests/plugin/smoke-test.sh` on CI (requires jq, not installed on local Windows dev)
- [ ] `validate-skills.yml` drift check passes (runs only on main-targeting PRs)

## Acceptance Criteria

- [x] `plugin/.claude-plugin/plugin.json` contains only official schema fields
- [x] `plugin-lite/.claude-plugin/plugin.json` contains only official schema fields
- [x] Smoke tests pass against the simplified manifests
- [x] No regression in bootstrap/install scripts (no consumers found)

## Related

Parent: #328