### PR TITLE
fix(ci): clean remaining SC2034 and ensure bash 4+ on macOS runner

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -20,12 +20,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install jq
+      - name: Install jq and bash 4+
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             sudo apt-get update && sudo apt-get install -y jq
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install jq
+            # macOS ships with bash 3.2; install bash 4+ so hooks that need
+            # associative arrays (e.g., markdown-anchor-validator.sh) can
+            # re-exec into it via the PATH checks in the hook itself.
+            brew install jq bash
           fi
 
       - name: Run hook tests

--- a/global/hooks/task-created-validator.sh
+++ b/global/hooks/task-created-validator.sh
@@ -65,7 +65,6 @@ if [ "$RAW" = "$SENTINEL" ]; then
 fi
 
 DESC="$RAW"
-HAS_FIELD=1
 
 # Trim whitespace
 TRIMMED=$(printf '%s' "$DESC" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')

--- a/tests/batch_drift_benchmark/test-aggregate-results.sh
+++ b/tests/batch_drift_benchmark/test-aggregate-results.sh
@@ -52,10 +52,10 @@ else
     FAIL=$((FAIL + 1)); ERRORS+=("help missing script name"); echo "  FAIL: help missing script name"
 fi
 
-missing_strategy=$(bash "$SCRIPT" --started-at x --completed-at y "$CLEAN_DIR" 2>&1); rc=$?
+bash "$SCRIPT" --started-at x --completed-at y "$CLEAN_DIR" > /dev/null 2>&1; rc=$?
 if [ "$rc" -ne 0 ]; then PASS=$((PASS + 1)); echo "  PASS: missing --strategy rejected"; else FAIL=$((FAIL + 1)); echo "  FAIL: missing --strategy should fail"; fi
 
-bad_dir_out=$(bash "$SCRIPT" --strategy s --started-at x --completed-at y /no/such/path 2>&1); rc=$?
+bash "$SCRIPT" --strategy s --started-at x --completed-at y /no/such/path > /dev/null 2>&1; rc=$?
 if [ "$rc" -ne 0 ]; then PASS=$((PASS + 1)); echo "  PASS: non-existent raw dir rejected"; else FAIL=$((FAIL + 1)); echo "  FAIL: bad dir should fail"; fi
 
 echo ""


### PR DESCRIPTION
## What

Address the remaining CI failures surfaced in the #351 re-run after #352 landed:
1. macOS runner lacked bash 4+ → `markdown-anchor-validator.sh` fell back to its skip-mode, failing 1 deny-expecting test.
2. Three additional SC2034 warnings not covered in #352 (`HAS_FIELD`, `missing_strategy`, `bad_dir_out`).

## Why

After #352, #351 CI showed:
- `validate`: PASS (was FAIL — chmod fix worked)
- `test (macos-latest)`: 1/224 still failed — bash 4+ not discoverable on runner
- `shellcheck`: still FAIL — more SC2034 warnings in files not touched by #352
- `test (ubuntu-latest)`: CANCELED by matrix fail-fast, not a real failure

## Where

- `.github/workflows/validate-hooks.yml` — add `bash` to the macOS brew install step
- `global/hooks/task-created-validator.sh` — remove dead `HAS_FIELD=1` assignment
- `tests/batch_drift_benchmark/test-aggregate-results.sh` — redirect unused command output to `/dev/null` (same pattern as #352)

## How

### 1. bash 4+ on macOS runner

`brew install jq` → `brew install jq bash`. GitHub macOS runners have Homebrew pre-installed but not bash; installing puts bash 4+ at `/opt/homebrew/bin/bash` (ARM) or `/usr/local/bin/bash` (x64), which the existing re-exec candidate list in `markdown-anchor-validator.sh` (added in #352) already checks.

### 2. Remaining SC2034

- `task-created-validator.sh`: `HAS_FIELD=1` was set but never read. Removed.
- `test-aggregate-results.sh`: 2 output-capturing variables (`missing_strategy`, `bad_dir_out`) whose exit code was the only asserted property. Converted to `> /dev/null 2>&1`, mirroring the same fix applied to sibling test files in #352.

### Test Plan

- [x] Local shellcheck on modified scripts
- [ ] CI — expect all 7 checks green after merge

### Breaking Changes

None.

### Rollback Plan

Revert this PR. CI returns to the post-#352 state (validate pass, shellcheck/test still flaky on macOS).

---

Follow-up to #352. Unblocks #351.