### PR TITLE
fix(ci): remove remaining dead HAS_FIELD assignment

### DIFF
--- a/global/hooks/task-created-validator.sh
+++ b/global/hooks/task-created-validator.sh
@@ -22,7 +22,6 @@ fi
 # "field present but empty string" — both rules below should fire on the latter.
 SENTINEL=$'\x01'
 RAW=""
-HAS_FIELD=0
 
 if command -v jq >/dev/null 2>&1; then
     RAW=$(printf '%s' "$INPUT" | jq -r '


### PR DESCRIPTION
Final cleanup after #352 and #353. shellcheck found HAS_FIELD=0 at task-created-validator.sh:25 that was never read. #352 removed only the HAS_FIELD=1 at line 68; this removes the earlier declaration as well. Unblocks #351 shellcheck jobs.