### PR TITLE
test(hooks): use jq as primary JSON validator with python fallback

### DIFF
--- a/tests/hooks/test-instructions-loaded-reinforcer.sh
+++ b/tests/hooks/test-instructions-loaded-reinforcer.sh
@@ -27,10 +27,13 @@ assert_valid_json() {
     local label="$1"
     local result
     result=$(echo '{}' | bash "$HOOK" 2>/dev/null)
-    if echo "$result" | python -m json.tool >/dev/null 2>&1; then
+    if echo "$result" | jq empty >/dev/null 2>&1; then
         PASS=$((PASS + 1))
         echo "  PASS: $label"
     elif echo "$result" | python3 -m json.tool >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    elif echo "$result" | python -m json.tool >/dev/null 2>&1; then
         PASS=$((PASS + 1))
         echo "  PASS: $label"
     else

--- a/tests/hooks/test-post-compact-restore.sh
+++ b/tests/hooks/test-post-compact-restore.sh
@@ -27,10 +27,13 @@ assert_valid_json() {
     local label="$1"
     local result
     result=$(echo '{}' | bash "$HOOK" 2>/dev/null)
-    if echo "$result" | python -m json.tool >/dev/null 2>&1; then
+    if echo "$result" | jq empty >/dev/null 2>&1; then
         PASS=$((PASS + 1))
         echo "  PASS: $label"
     elif echo "$result" | python3 -m json.tool >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    elif echo "$result" | python -m json.tool >/dev/null 2>&1; then
         PASS=$((PASS + 1))
         echo "  PASS: $label"
     else


### PR DESCRIPTION
## What

Make the `assert_valid_json` helpers in `tests/hooks/test-instructions-loaded-reinforcer.sh` and `tests/hooks/test-post-compact-restore.sh` try `jq` before falling back to `python3` / `python`.

## Why

On runners where neither `python` nor `python3` is installed (minimal WSL / slim Docker images), both existing branches exit 127 and the harness incorrectly reports valid hook output as invalid JSON. The two suites above were the only ones affected.

Verified locally: the emitted JSON parses cleanly with \`jq empty\`; only the python invocation was failing.

## How

- Prepend a \`jq empty\` branch to the existing if/elif chain in both tests
- Keep \`python3\` and \`python\` as fallbacks so environments without jq but with python continue to work

\`jq\` is already a runtime dependency of every hook these tests cover, so it is guaranteed present whenever the hooks themselves run.

## Test plan

- [x] \`bash tests/hooks/test-instructions-loaded-reinforcer.sh\` — 8/8 passing
- [x] \`bash tests/hooks/test-post-compact-restore.sh\` — 8/8 passing
- [ ] Reviewer: confirm \`validate-hooks.yml\` passes on ubuntu-latest + macos-latest