### PR TITLE
fix(hooks): make markdown anchor validator mawk-compatible

### DIFF
--- a/global/hooks/markdown-anchor-validator.sh
+++ b/global/hooks/markdown-anchor-validator.sh
@@ -78,11 +78,15 @@ FNR == 1 { f = FILENAME; c = 0 }
 /^[[:space:]]*(```|~~~)/ { c = !c; next }
 c { next }
 # Headings: CommonMark/GitHub accept 1-6 hashes only; 7+ is regular text.
-/^#{1,6}[[:space:]]/ {
-    h = $0
-    sub(/^#{1,6}[[:space:]]+/, "", h)
-    sub(/[[:space:]#]*$/, "", h)
-    if (h != "") printf "H\t%s\t%s\n", f, h
+# Use match() + RLENGTH for mawk compatibility (mawk does not support {1,6} ERE quantifier).
+match($0, /^#+[[:space:]]/) {
+    h_count = RLENGTH - 1
+    if (h_count >= 1 && h_count <= 6) {
+        h = $0
+        sub(/^#+[[:space:]]+/, "", h)
+        sub(/[[:space:]#]*$/, "", h)
+        if (h != "") printf "H\t%s\t%s\n", f, h
+    }
 }
 {
     # Strip inline-code spans so that example syntax inside backticks


### PR DESCRIPTION
## What

Replace the ERE quantifier `/^#{1,6}/` in `global/hooks/markdown-anchor-validator.sh` with `match()` + `RLENGTH`-based logic to detect 1–6 leading hashes. Heading extraction and output behavior are preserved.

### Change Type
- [x] Bugfix (compatibility)

### Affected Components
- `global/hooks/markdown-anchor-validator.sh`

## Why

`mawk` does not support the `{1,6}` ERE quantifier, so the validator silently failed or misparsed headings on systems where `awk` resolves to `mawk` (common on minimal Debian/Ubuntu containers and CI images).

## Where

- `global/hooks/markdown-anchor-validator.sh` (9 insertions, 5 deletions)

## How

- Use `match($0, /^#+[[:space:]]/)` and compute `h_count = RLENGTH - 1`.
- Proceed only when `1 <= h_count <= 6`, preserving previous semantics.
- No changes to output format or other hook logic.

### Testing Done
- Existing heading-extraction logic unchanged; behavior verified against current fixtures via manual spot-check.

### Breaking Changes
- None.