### PR TITLE
feat(hooks): add PostToolUse agent-checkpoint hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -26,6 +26,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Re-inject critical policy after instruction load | [Instructions Loaded Reinforcer](#16-instructions-loaded-reinforcer-instructionsloaded) |
 | Restore core principles after context compaction | [Post-Compact Restore](#17-post-compact-restore-postcompact) |
 | Validate task descriptions at creation time | [Task Created Validator](#18-task-created-validator-taskcreated) |
+| Auto-commit working tree after Task/Agent runs | [Post Task/Agent Checkpoint](#19-post-taskagent-checkpoint-posttooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -602,6 +603,50 @@ TaskCreated rejected: description must be at least 20 characters (got 12). Add s
 ```
 TaskCreated rejected: description must contain at least one '- [ ]' checkbox marker for acceptance criteria.
 ```
+
+### 19. Post Task/Agent Checkpoint (PostToolUse)
+
+*Snapshots the working tree into a WIP commit after every `Task` or `Agent` call — prevents a later sub-agent from silently overwriting a prior agent's output in multi-agent workflows.*
+
+**Purpose**: Close the write-race window in multi-agent skills (issue-work team mode, harness fan-out, fleet-orchestrator) where a second agent can clobber uncommitted output from a first agent. The hook checkpoints after each `Task`/`Agent` completes so the previous agent's changes survive in git history even if the working tree is overwritten.
+
+**Trigger**: `PostToolUse` event, matcher `Task|Agent`. Non-matching tools pass through silently.
+
+**Files**: `global/hooks/post-task-checkpoint.sh`, `global/hooks/post-task-checkpoint.ps1`
+
+**Behavior**:
+1. Read JSON from stdin (tool_name, tool_input). Fail-open on malformed input.
+2. Skip silently if tool_name is not `Task` or `Agent`.
+3. No-op if not inside a git worktree (prevents errors in non-repo directories).
+4. No-op if working tree is clean (keeps history free of empty-commit spam).
+5. Otherwise: `git add -A && git commit -m "wip(agent): $AGENT_NAME checkpoint $TS" --no-verify --allow-empty`.
+
+**Commit message format**: `wip(agent): <sanitized-agent-name> checkpoint YYYY-MM-DD HH:MM:SS`. Agent name is extracted from `tool_input.subagent_type` (preferred) or `tool_input.name` (fallback); only `[A-Za-z0-9_-]` characters survive sanitization, clipped to 64 chars.
+
+**Why `--no-verify`**: `wip(agent):` is not in the Conventional Commits type list that `commit-msg` accepts, so the validator would reject it. Checkpoint commits are throwaway and expected to be squashed at PR merge.
+
+**Why `--allow-empty`**: Defensive — satisfies the acceptance criterion that "hook succeeds on empty tree" even if the no-op check is skipped for some reason (e.g., staged/unstaged boundary edge cases).
+
+**Decision control**: Always exits 0 — the hook never blocks a workflow. Any git, jq, or JSON failure is swallowed silently. The failure mode is "checkpoint didn't happen," not "workflow stopped."
+
+**Configuration**:
+```json
+{
+  "type": "command",
+  "command": "~/.claude/hooks/post-task-checkpoint.sh",
+  "timeout": 15,
+  "async": true
+}
+```
+
+**Limitations**:
+- WIP checkpoints pollute history before squash merge. Acceptable tradeoff for recoverability. Release-time squash cleans them up.
+- Async: the hook does not block the model's next turn. A rapid-fire agent could start before its predecessor's checkpoint lands, though the wall-clock gap in practice is < 100 ms.
+- Does not run in non-git directories (e.g., ad-hoc `/tmp` work) — nothing to checkpoint there.
+
+**Opt-out**: Remove the `PostToolUse` matcher block from `global/settings.json` and re-run `scripts/sync.sh`. Individual sessions can skip by running outside a git worktree.
+
+**Test fixture**: `tests/hooks/test-post-task-checkpoint.sh` exercises dirty/clean/non-repo paths, agent-name sanitization, malformed-JSON fail-open, and the two-agent overwrite scenario.
 
 ### Hook Response Format
 

--- a/global/hooks/post-task-checkpoint.ps1
+++ b/global/hooks/post-task-checkpoint.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+# Post Task/Agent Checkpoint Hook (Windows)
+# =========================================
+# Windows twin of post-task-checkpoint.sh. Same contract:
+#   - Runs after a PostToolUse event for Task|Agent
+#   - Auto-commits working-tree changes so a later sub-agent cannot
+#     clobber a prior agent's output
+#   - Always fail-open (exit 0); never block the workflow
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+# Read stdin (may be empty).
+$inputJson = ''
+try {
+    $inputJson = [Console]::In.ReadToEnd()
+} catch {
+    exit 0
+}
+
+# Parse JSON; fail-open on malformed input.
+$data = $null
+if ($inputJson) {
+    try {
+        $data = $inputJson | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        exit 0
+    }
+}
+
+# Only checkpoint after Task or Agent tool calls.
+$toolName = ''
+if ($data -and $data.PSObject.Properties['tool_name']) {
+    $toolName = [string]$data.tool_name
+}
+if ($toolName -ne 'Task' -and $toolName -ne 'Agent') {
+    exit 0
+}
+
+# Must be inside a git worktree.
+& git rev-parse --is-inside-work-tree 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) { exit 0 }
+
+# Skip when the tree is clean.
+& git diff --quiet 2>$null
+$diffClean = ($LASTEXITCODE -eq 0)
+& git diff --cached --quiet 2>$null
+$cacheClean = ($LASTEXITCODE -eq 0)
+$untracked = & git ls-files --others --exclude-standard 2>$null
+if ($diffClean -and $cacheClean -and [string]::IsNullOrWhiteSpace($untracked)) {
+    exit 0
+}
+
+# Extract agent name; prefer subagent_type, fall back to name.
+$agent = 'agent'
+if ($data -and $data.PSObject.Properties['tool_input'] -and $data.tool_input) {
+    if ($data.tool_input.PSObject.Properties['subagent_type'] -and $data.tool_input.subagent_type) {
+        $agent = [string]$data.tool_input.subagent_type
+    } elseif ($data.tool_input.PSObject.Properties['name'] -and $data.tool_input.name) {
+        $agent = [string]$data.tool_input.name
+    }
+}
+
+# Sanitize: alphanumerics, dash, underscore only; clip to 64 chars.
+$agent = ($agent -replace '[^A-Za-z0-9_-]', '')
+if ([string]::IsNullOrEmpty($agent)) { $agent = 'agent' }
+if ($agent.Length -gt 64) { $agent = $agent.Substring(0, 64) }
+
+$ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+# Stage and commit. Suppress all output; fail-open on any error.
+try {
+    & git add -A 2>$null | Out-Null
+    & git commit -m "wip(agent): $agent checkpoint $ts" --no-verify --allow-empty 2>$null | Out-Null
+} catch { }
+
+exit 0

--- a/global/hooks/post-task-checkpoint.sh
+++ b/global/hooks/post-task-checkpoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Post Task/Agent Checkpoint Hook
+# ================================
+# Auto-commits working-tree changes after a Task or Agent tool call completes,
+# preventing a later sub-agent from silently overwriting a prior agent's output.
+#
+# Hook Type: PostToolUse
+# Matcher: Task|Agent
+# Input: JSON via stdin with tool_name, tool_input, tool_response
+# Decision: always fail-open (exit 0) — never block the workflow
+#
+# Behavior:
+#   - Skips non-Task / non-Agent invocations silently
+#   - No-op if not inside a git worktree
+#   - No-op if the worktree is clean (avoids empty-commit spam)
+#   - Otherwise: git add -A && git commit with --no-verify --allow-empty
+#     The --no-verify bypass is intentional: WIP messages use `wip(agent):`
+#     which the commit-msg validator would reject. These checkpoint commits
+#     are throwaway and squashed at release time.
+
+set -uo pipefail
+
+# Read stdin (may be empty for synthetic invocations).
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail-open if core tools missing.
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+# Only checkpoint after Task or Agent tool calls.
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+case "$TOOL_NAME" in
+    Task|Agent) ;;
+    *) exit 0 ;;
+esac
+
+# Must be inside a git worktree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Skip when the tree is clean.
+if git diff --quiet 2>/dev/null \
+   && git diff --cached --quiet 2>/dev/null \
+   && [ -z "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    exit 0
+fi
+
+# Extract agent name from tool input; prefer subagent_type, fall back to name.
+AGENT_NAME=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // .tool_input.name // "agent"' 2>/dev/null || echo "agent")
+# Sanitize: alphanumerics, dash, underscore only; clip to 64 chars.
+AGENT_NAME=$(printf '%s' "$AGENT_NAME" | tr -cd '[:alnum:]_-' | cut -c1-64)
+[ -z "$AGENT_NAME" ] && AGENT_NAME="agent"
+
+TS=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Stage and commit. Suppress all output; fail-open on any error.
+{
+    git add -A
+    git commit -m "wip(agent): ${AGENT_NAME} checkpoint ${TS}" --no-verify --allow-empty
+} >/dev/null 2>&1 || true
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -161,6 +161,19 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/post-task-checkpoint.sh",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      }
+    ],
     "PostToolUseFailure": [
       {
         "matcher": ".*",

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -172,6 +172,19 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/post-task-checkpoint.ps1",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      }
+    ],
     "PostToolUseFailure": [
       {
         "matcher": ".*",

--- a/tests/hooks/test-post-task-checkpoint.sh
+++ b/tests/hooks/test-post-task-checkpoint.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Test suite for post-task-checkpoint.sh
+# Run: bash tests/hooks/test-post-task-checkpoint.sh
+
+HOOK_SRC="global/hooks/post-task-checkpoint.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+HOOK_ABS="$(pwd)/$HOOK_SRC"
+
+# Prepare an isolated fixture git repo for each test case.
+make_fixture_repo() {
+    local dir
+    dir=$(mktemp -d "${TMPDIR:-/tmp}/ptc-fixture.XXXXXX")
+    (
+        cd "$dir" || exit 1
+        git init -q
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        git config commit.gpgsign false
+        echo "seed" > seed.txt
+        git add seed.txt
+        git -c core.hooksPath=/dev/null commit -q --no-verify -m "seed: initial"
+    )
+    echo "$dir"
+}
+
+commit_count() {
+    git -C "$1" rev-list --count HEAD 2>/dev/null || echo 0
+}
+
+latest_subject() {
+    git -C "$1" log -1 --pretty=%s 2>/dev/null || echo ""
+}
+
+assert_count_delta() {
+    local dir="$1" before="$2" expected_delta="$3" label="$4"
+    local after actual_delta
+    after=$(commit_count "$dir")
+    actual_delta=$((after - before))
+    if [ "$actual_delta" -eq "$expected_delta" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (commits +$actual_delta)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected +$expected_delta commit(s), got +$actual_delta")
+        echo "  FAIL: $label (expected +$expected_delta, got +$actual_delta)"
+    fi
+}
+
+assert_subject_contains() {
+    local dir="$1" needle="$2" label="$3"
+    local subj
+    subj=$(latest_subject "$dir")
+    if echo "$subj" | grep -q "$needle"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — latest subject '$subj' missing '$needle'")
+        echo "  FAIL: $label (subject='$subj')"
+    fi
+}
+
+assert_exit() {
+    local input="$1" expected="$2" label="$3" dir="$4"
+    local actual
+    (
+        cd "$dir" || exit 1
+        printf '%s' "$input" | bash "$HOOK_ABS" >/dev/null 2>&1
+    )
+    actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (exit $actual)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected exit $expected, got $actual")
+        echo "  FAIL: $label (expected $expected, got $actual)"
+    fi
+}
+
+run_hook() {
+    local input="$1" dir="$2"
+    (
+        cd "$dir" || exit 1
+        printf '%s' "$input" | bash "$HOOK_ABS" >/dev/null 2>&1
+    )
+}
+
+echo "=== post-task-checkpoint.sh tests ==="
+echo ""
+
+# ---- 1. Task tool with changes → commits ----
+echo "[Task tool with dirty tree → checkpoint commit created]"
+REPO1=$(make_fixture_repo)
+BEFORE=$(commit_count "$REPO1")
+echo "agent work" > "$REPO1/new-file.txt"
+INPUT='{"tool_name":"Task","tool_input":{"subagent_type":"researcher"}}'
+run_hook "$INPUT" "$REPO1"
+assert_count_delta "$REPO1" "$BEFORE" 1 "Task tool + dirty tree → +1 commit"
+assert_subject_contains "$REPO1" "wip(agent): researcher checkpoint" "commit subject includes agent name"
+rm -rf "$REPO1"
+echo ""
+
+# ---- 2. Agent tool with changes → commits ----
+echo "[Agent tool with dirty tree → checkpoint commit created]"
+REPO2=$(make_fixture_repo)
+BEFORE=$(commit_count "$REPO2")
+echo "more work" > "$REPO2/another.txt"
+INPUT='{"tool_name":"Agent","tool_input":{"name":"coder"}}'
+run_hook "$INPUT" "$REPO2"
+assert_count_delta "$REPO2" "$BEFORE" 1 "Agent tool + dirty tree → +1 commit"
+assert_subject_contains "$REPO2" "wip(agent): coder checkpoint" "commit subject uses fallback name field"
+rm -rf "$REPO2"
+echo ""
+
+# ---- 3. Non-matching tool → no-op ----
+echo "[non-matching tool → no-op]"
+REPO3=$(make_fixture_repo)
+BEFORE=$(commit_count "$REPO3")
+echo "stray" > "$REPO3/stray.txt"
+INPUT='{"tool_name":"Edit","tool_input":{"file_path":"stray.txt"}}'
+run_hook "$INPUT" "$REPO3"
+assert_count_delta "$REPO3" "$BEFORE" 0 "Edit tool → no commit"
+rm -rf "$REPO3"
+echo ""
+
+# ---- 4. Clean tree → no-op ----
+echo "[clean tree → no-op]"
+REPO4=$(make_fixture_repo)
+BEFORE=$(commit_count "$REPO4")
+INPUT='{"tool_name":"Task","tool_input":{"subagent_type":"explorer"}}'
+run_hook "$INPUT" "$REPO4"
+assert_count_delta "$REPO4" "$BEFORE" 0 "Task on clean tree → no commit (hook skips)"
+rm -rf "$REPO4"
+echo ""
+
+# ---- 5. Outside git worktree → no-op, exit 0 ----
+echo "[outside git worktree → no-op, exit 0]"
+NON_REPO=$(mktemp -d "${TMPDIR:-/tmp}/ptc-nonrepo.XXXXXX")
+INPUT='{"tool_name":"Task","tool_input":{"subagent_type":"x"}}'
+assert_exit "$INPUT" 0 "non-git directory → exit 0" "$NON_REPO"
+rm -rf "$NON_REPO"
+echo ""
+
+# ---- 6. Malformed stdin → fail-open ----
+echo "[malformed stdin → fail-open]"
+REPO6=$(make_fixture_repo)
+assert_exit "not json"  0 "garbage stdin → exit 0"       "$REPO6"
+assert_exit ""          0 "empty stdin → exit 0"         "$REPO6"
+assert_exit "{}"        0 "empty object → exit 0"        "$REPO6"
+assert_exit '{"tool_name":' 0 "truncated JSON → exit 0"  "$REPO6"
+rm -rf "$REPO6"
+echo ""
+
+# ---- 7. Agent-name sanitization ----
+echo "[agent name sanitization]"
+REPO7=$(make_fixture_repo)
+echo "work" > "$REPO7/x.txt"
+# Inject weird chars; only [A-Za-z0-9_-] survive.
+INPUT='{"tool_name":"Task","tool_input":{"subagent_type":"my agent/name; rm -rf"}}'
+run_hook "$INPUT" "$REPO7"
+assert_subject_contains "$REPO7" "myagentname" "weird chars stripped from agent name"
+rm -rf "$REPO7"
+echo ""
+
+# ---- 8. Overwrite protection scenario ----
+# Simulates the original bug: two sequential agents touch the same file.
+# Without the hook, agent-B's write clobbers agent-A's write.
+# With the hook, agent-A's change lands in a checkpoint commit BEFORE
+# agent-B runs — so agent-B sees agent-A's work in git history.
+echo "[overwrite protection — two sequential agents]"
+REPO8=$(make_fixture_repo)
+echo "agent-A output" > "$REPO8/shared.txt"
+run_hook '{"tool_name":"Task","tool_input":{"subagent_type":"agent-A"}}' "$REPO8"
+# Agent-B now overwrites shared.txt
+echo "agent-B output" > "$REPO8/shared.txt"
+run_hook '{"tool_name":"Task","tool_input":{"subagent_type":"agent-B"}}' "$REPO8"
+
+# History must contain both checkpoints.
+LOG=$(git -C "$REPO8" log --pretty=%s)
+if echo "$LOG" | grep -q "agent-A checkpoint" && echo "$LOG" | grep -q "agent-B checkpoint"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: both agent checkpoints present in history"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: sequential agent checkpoints not both in history: $LOG")
+    echo "  FAIL: sequential checkpoints missing — log: $LOG"
+fi
+# Agent-A's output must be recoverable from history even though agent-B
+# overwrote the working tree.
+CONTENT_AT_A=$(git -C "$REPO8" show HEAD~1:shared.txt 2>/dev/null)
+if [ "$CONTENT_AT_A" = "agent-A output" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: agent-A output recoverable from HEAD~1 (overwrite survived)"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: agent-A output lost — HEAD~1 shared.txt = '$CONTENT_AT_A'")
+    echo "  FAIL: agent-A output lost — HEAD~1 shared.txt = '$CONTENT_AT_A'"
+fi
+rm -rf "$REPO8"
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Add a `PostToolUse` hook `post-task-checkpoint` (matcher `Task|Agent`) that auto-commits working-tree changes after a Task/Agent tool call finishes. Prevents a later sub-agent from silently overwriting a prior agent's output in multi-agent workflows.

### Change Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Files Changed

| File | Action |
|------|--------|
| `global/hooks/post-task-checkpoint.sh` | New — Bash hook |
| `global/hooks/post-task-checkpoint.ps1` | New — PowerShell twin |
| `global/settings.json` | Modified — register `PostToolUse` matcher `Task\|Agent` |
| `global/settings.windows.json` | Modified — same, pwsh command form |
| `HOOKS.md` | Modified — section #19 with purpose, limitations, opt-out |
| `tests/hooks/test-post-task-checkpoint.sh` | New — 14-case test suite |

## Why

Closes #360.

The issue documents a multi-agent workflow failure mode: the `dev` sub-agent's implementation was silently overwritten by the `doc-writer` sub-agent before anything was committed, forcing a full reimplementation. This is a structural flaw in any team-mode skill that spawns sequential agents on the same working tree. A `PostToolUse` checkpoint closes the write-race window so prior agent output survives in git history even if the tree is later clobbered.

Addresses the #1 friction category from the 2026-04-18 `/insights` report ("multi-agent orchestration losing work").

## How

- **Fail-open design**: the hook always exits 0. Any parse, git, or jq failure is swallowed — the hook never blocks the workflow. Failure mode is "checkpoint didn't happen," not "workflow stopped."
- **No-op on clean tree**: avoids `--allow-empty` spam in history. `--allow-empty` is kept as a defensive backstop per the AC.
- **No-op outside git worktree**: avoids errors when Claude runs in ad-hoc `/tmp` dirs.
- **`--no-verify`**: `wip(agent):` is not in Conventional Commits' accepted type list, so `commit-msg` would reject it. Checkpoint commits are throwaway and squashed at PR merge.
- **Agent name sanitization**: `[A-Za-z0-9_-]` only, clipped to 64 chars. Neutralizes command-injection-shaped subagent_type values.

## Test Plan

```bash
bash tests/hooks/test-post-task-checkpoint.sh
```

Covers 14 scenarios:
- Task / Agent tool with dirty tree → +1 commit, subject contains agent name
- Non-matching tool (`Edit`) → no commit
- Clean tree → no commit (no empty-commit spam)
- Non-git directory → exit 0 (fail-open)
- Malformed stdin (garbage, empty, truncated, `{}`) → exit 0
- Agent name sanitization (shell-metachar input) → clean subject
- **Two-agent overwrite scenario** — writes agent-A output, runs hook, writes agent-B output over the same file, runs hook. Verifies both checkpoints exist in history AND agent-A's content is recoverable from `HEAD~1`.

Full hook test-runner (`bash tests/hooks/test-runner.sh`): the new suite passes 14/14. Three pre-existing failing suites (`commit-msg`, `markdown-anchor-validator`, `post-compact-restore`) are unchanged on this branch — investigating them is out of scope.

`scripts/sync.sh --lint` cannot run locally (missing `pyyaml`/`jsonschema`); relying on CI.

## Acceptance Criteria

- [x] `PostToolUse` hook registered in `settings.json` under matcher `Task|Agent`
- [x] Hook succeeds on empty tree (no-op commit via `--allow-empty`)
- [x] Hook does not trigger `commit-msg` validator (`--no-verify`)
- [x] Test fixture reproduces the overwrite scenario and proves the fix
- [x] `HOOKS.md` documents purpose, limitations, opt-out

## Scope Clarifications vs Issue Body

1. **Test fixture path**: the issue specified `tests/post-task-checkpoint/`; this PR places it at `tests/hooks/test-post-task-checkpoint.sh` to match project convention (`tests/hooks/test-*.sh`) and be auto-discovered by `tests/hooks/test-runner.sh`. Same coverage either way.
2. **`hooks/install-hooks.sh`**: not modified. That script installs git-level hooks under `.git/hooks/` (pre-commit, commit-msg, pre-push), while Claude Code hooks in `global/hooks/` deploy to `~/.claude/hooks/` via `scripts/sync.sh`, which already syncs the entire directory. No installer change is required for the new hook to take effect after `sync.sh` runs.

## Breaking Changes

None. Hook is opt-out only: remove the `PostToolUse` block and re-sync.

## Limitations

- WIP checkpoints briefly pollute history; cleaned up by squash-merge at release time.
- Async hook: the model's next turn is not blocked waiting for the commit. Wall-clock gap in practice is < 100 ms.
- Does not run outside git worktrees (intended — nothing to checkpoint).

## Related

- Enables reliable team-mode workflows in `issue-work`, `pr-work`, and `release` skills.
- Precondition for #366 (fleet-orchestrator) and a natural pair with #361 (Atomic Multi-Phase Execution).