### PR TITLE
feat(skills): add Atomic Multi-Phase Execution rule to _policy.md

### DIFF
--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -1,5 +1,19 @@
 # Global Command Policies
 
+## Atomic Multi-Phase Execution
+
+When a user specifies multiple phases — "Phase 1/2/3", "up to Phase N", "until all are created", or similar multi-step directives — treat the full plan as a single atomic unit.
+
+- Complete ALL phases before returning control to the user
+- Do NOT pause between phases for mid-plan confirmation
+- Do NOT ask "shall I continue?" between phases — the user already said yes by specifying the plan
+- Only stop early if a real blocker is encountered: missing file, auth error, destructive-action confirmation, or genuinely ambiguous requirement. State the blocker explicitly and wait for resolution
+- Progress updates between phases are fine; confirmation prompts are not
+
+This rule exists because long multi-phase requests otherwise incur repeated "continue" prompts as the model pauses mid-plan for phantom confirmation. The user's original plan specification is the only confirmation needed.
+
+## Common Rules
+
 - Git/GitHub output (commits, PRs, issues, release notes): English
 - No emojis in commits, PR titles, issue titles
 - Commit format: Conventional Commits (`type(scope): description`)

--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -511,7 +511,7 @@ See `reference/team-mode.md` for the complete team mode workflow with 3-team arc
 
 ## Policies
 
-See [_policy.md](../_policy.md) for common rules.
+See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-Phase Execution** rule — when the user specifies multiple phases (e.g., "Phase 1/2/3"), complete all phases without pausing between them for confirmation.
 
 ### Command-Specific Rules
 

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -424,7 +424,7 @@ See `reference/team-mode.md` for the complete team mode workflow including archi
 
 ## Policies
 
-See [_policy.md](../_policy.md) for common rules.
+See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-Phase Execution** rule — when the user specifies multiple phases (e.g., "Phase 1/2/3"), complete all phases without pausing between them for confirmation.
 
 ### Command-Specific Rules
 

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -448,7 +448,7 @@ See `reference/team-mode.md` for the complete team mode workflow with changelog 
 
 ## Policies
 
-See [_policy.md](../_policy.md) for common rules.
+See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-Phase Execution** rule — when the user specifies multiple phases (e.g., "Phase 1/2/3"), complete all phases without pausing between them for confirmation.
 
 ### Command-Specific Rules
 


### PR DESCRIPTION
## What

Add a top-level **Atomic Multi-Phase Execution** section to `global/skills/_policy.md` and cross-reference it from `issue-work/SKILL.md`, `pr-work/SKILL.md`, and `release/SKILL.md`.

### Change Type
- [x] Feature (policy rule)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation

### Files Changed

| File | Action |
|------|--------|
| `global/skills/_policy.md` | Added new top section; preserved existing bullets under `## Common Rules` |
| `global/skills/issue-work/SKILL.md` | Cross-reference added in `## Policies` section |
| `global/skills/pr-work/SKILL.md` | Same cross-reference |
| `global/skills/release/SKILL.md` | Same cross-reference |

## Why

Closes #361.

The 2026-04-18 `/insights` report shows repeated friction where the user had to say "Phase 3까지 모두 생성하라" twice and "continue" multiple times because the model stopped mid-plan for phantom confirmation. This is default-behavior drift, not a per-task problem — codifying the rule in `_policy.md` (loaded every session) eliminates the repetition. Complements #360 (agent-checkpoint) in stabilizing multi-phase workflows.

## How

- New section added near the top of `_policy.md`, before the existing flat bullet list (which is preserved verbatim under a new `## Common Rules` header so existing cross-references remain valid).
- Rule text expanded slightly beyond the issue's proposed wording to (a) rule out the specific drift pattern "shall I continue?" between phases, (b) make explicit that progress updates are still welcome, and (c) state the motivation inline so future readers understand *why*.
- Cross-references use bold `**Atomic Multi-Phase Execution**` so the rule is immediately scannable from the three skill files most affected by the friction.

## Acceptance Criteria

- [x] `_policy.md` contains the new `## Atomic Multi-Phase Execution` section
- [x] Three referenced skills link back to the policy
- [ ] `scripts/sync.sh --lint` passes — cannot run locally (missing pyyaml/jsonschema); relying on CI
- [ ] Manual test: prompt a 3-phase request and verify all phases complete in one turn — deferred to next user session (behavioral change verification)

## Scope Clarification vs Issue Body

- `project/.claude/skills/_policy.md` does not exist in the current tree; `scripts/sync.sh` does not mirror `_policy.md` into the project-side skills directory (which hosts a different skill set — coding-guidelines, documentation, etc.). No mirror update required.

## Breaking Changes

None. Policy addition only. Existing common-rules bullets preserved verbatim.

## Related

- Complements #360 (agent-checkpoint hook)
- Enables reliable completion of #363/#364/#365 when those skills launch multi-phase workflows