### PR TITLE
feat(skills): add ci-fix skill codifying recurring CI failure patterns

### DIFF
--- a/global/skills/ci-fix/SKILL.md
+++ b/global/skills/ci-fix/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ci-fix
+description: "Diagnose and fix failing CI checks by classifying the failure into a known pattern and applying a codified remediation. Use when CI reports MSVC C4996 warnings-as-errors, CMake FetchContent shallow-clone failures, __cpp_lib_format probe mismatches, or when pr-work escalates a failing workflow. Cuts the push-wait-fail-retry loop to a single iteration for the three dominant patterns documented from prior sessions."
+argument-hint: "[pr-number] [--pattern msvc-c4996|cmake-fetchcontent|cpp-lib-format] [--dry-run]"
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: "Bash(gh *)"
+---
+
+# ci-fix Skill
+
+Classify a failing CI run into one of the three recurring patterns captured in `reference/known-fixes.md`
+and apply the codified remediation before re-pushing.
+
+## Usage
+
+```
+/ci-fix                                         # Auto-detect current branch's failing PR
+/ci-fix 601                                     # Target PR #601
+/ci-fix 601 --pattern msvc-c4996                # Skip classification, apply a specific fix
+/ci-fix 601 --dry-run                           # Print the diagnosis and proposed diff only
+```
+
+## Arguments
+
+| Argument | Purpose |
+|----------|---------|
+| `[pr-number]` | PR to diagnose. If omitted, resolve via the current branch's open PR. |
+| `--pattern <id>` | Skip classification. Valid ids: `msvc-c4996`, `cmake-fetchcontent`, `cpp-lib-format`. |
+| `--dry-run` | Print diagnosis, quote the failing log excerpt, and show the proposed diff. Do not write files or push. |
+
+## When to Invoke
+
+- A PR's CI has **one failing run** matching one of the three patterns.
+- `pr-work` has escalated after its built-in retry budget is exhausted.
+- The user says "fix CI", "classify this CI failure", or names a pattern explicitly.
+
+Do **not** invoke for:
+- Flaky-but-unknown failures (log, ask user, add to `known-fixes.md` if it recurs).
+- Green CI (nothing to fix).
+
+## Classification Pipeline
+
+Follow this deterministic sequence. Stop at the first match.
+
+1. **Fetch log excerpt**
+   ```bash
+   RUN_ID=$(gh run list --branch "$(git branch --show-current)" \
+     --json databaseId,conclusion --jq '.[] | select(.conclusion=="failure") | .databaseId' | head -1)
+   gh run view "$RUN_ID" --log-failed | tail -200
+   ```
+
+2. **Match against the classifier table** (`reference/known-fixes.md` § Classifier):
+
+   | Signal in log | Pattern |
+   |---------------|---------|
+   | `error C4996` OR `warning C4996` under MSVC with `/WX` | `msvc-c4996` |
+   | `FetchContent` + `fatal: could not read Username` / `object ... not found` / `remote error: upload-pack` on a commit hash | `cmake-fetchcontent` |
+   | `<format>` include + missing `__cpp_lib_format` OR link error for `std::format` | `cpp-lib-format` |
+
+3. **Apply the codified fix**
+   - `msvc-c4996` → see `reference/msvc-c4996.md`
+   - `cmake-fetchcontent` → see `reference/cmake-fetchcontent.md`
+   - `cpp-lib-format` → see `reference/known-fixes.md` § cpp-lib-format
+
+4. **Commit with conventional format**
+   ```
+   fix(ci): <pattern-id> — <short reason>
+   ```
+
+5. **Push and monitor**
+   Reuse the `pr-work` CI monitor loop. Budget: 20 minutes total (4 × 5-minute retries).
+
+## Escalation
+
+| Condition | Action |
+|-----------|--------|
+| Classifier does not match | Print the first 80 lines of the log; ask the user to either add a new pattern to `known-fixes.md` or hand off. |
+| Fix applied but CI still red | Re-classify once. On a second miss, convert the PR to draft and escalate. |
+| 20-minute budget exceeded | Report current check table; do **not** merge. |
+
+## Time Budget
+
+Per invocation: **20 minutes** wall-clock from classification to a green re-run. Break down:
+
+- Classification + diff: ~2 minutes
+- Push + workflow dispatch + queue wait: ~3 minutes
+- CI run itself: up to 10 minutes for typical matrices
+- One retry slot: ~5 minutes
+
+If total elapsed exceeds 20 minutes, stop, report status, and hand off.
+
+## References
+
+- Pattern catalogue and diffs: `reference/known-fixes.md`
+- CMake FetchContent macro expansion: `reference/cmake-fetchcontent.md`
+- MSVC C4996 migration guidance: `reference/msvc-c4996.md`
+- Invoked from: `global/skills/pr-work/SKILL.md` on failing-CI escalation

--- a/global/skills/ci-fix/reference/cmake-fetchcontent.md
+++ b/global/skills/ci-fix/reference/cmake-fetchcontent.md
@@ -1,0 +1,122 @@
+# CMake FetchContent — Shallow Clone and Macro Expansion
+
+Deep dive for the `cmake-fetchcontent` pattern in `known-fixes.md`. Read this when the
+before/after diff is not enough — typically when a helper macro sits between the caller and
+`FetchContent_Declare`.
+
+## Why `GIT_SHALLOW ON` + commit hash fails
+
+`git clone --depth 1` instructs the server to advertise only the tip of each branch. Tags are
+negotiated separately with `--branch <tag>`. A bare commit hash is not advertised under either
+path, so the resolver returns:
+
+```
+fatal: reference is not a tree: <sha>
+```
+
+or, on some servers, a less specific `upload-pack` error. CMake surfaces these as:
+
+```
+CMake Error at FetchContent_Declare: failed to clone https://.../fmt.git
+```
+
+This is not a CMake bug — it is a direct consequence of the Git transfer protocol when asked to
+materialize a commit the server is not advertising.
+
+## Resolution matrix
+
+| Pin type | `GIT_SHALLOW` safe? | Notes |
+|----------|---------------------|-------|
+| Tag (`v10.2.1`) | Yes | Most common choice for releases. |
+| Branch (`main`, `release/1.0`) | Yes | Non-deterministic; avoid for reproducible builds. |
+| Short SHA (`abcd123`) | No | Shallow fetch cannot resolve. |
+| Full SHA (`abcd123...`) | No | Same. Drop shallow or use a submodule. |
+| Tag + SHA (belt-and-braces) | Yes | Use tag for fetch, verify SHA post-fetch. |
+
+## Macro expansion mechanics
+
+CMake macros expand argument tokens textually before the surrounding command is parsed. This
+matters for `GIT_TAG` values containing characters CMake treats specially: `;`, `$`, `"`, and
+whitespace.
+
+### Failure mode A — list expansion
+
+`${list}` expands to a semicolon-joined string. If a macro receives what it thinks is a single
+tag but was actually passed a list, `FetchContent_Declare` sees multiple `GIT_TAG` values:
+
+```cmake
+set(TAG_LIST "v10.2.1" "v10.2.2")    # a CMake list
+fetch_dep(fmt "https://.../fmt.git" ${TAG_LIST})
+# Expands to:
+#   fetch_dep(fmt "https://.../fmt.git" v10.2.1;v10.2.2)
+# FetchContent then parses the tag as "v10.2.1;v10.2.2" and fails.
+```
+
+**Fix**: quote in the macro body:
+
+```cmake
+macro(fetch_dep name repo tag)
+    FetchContent_Declare(${name}
+        GIT_REPOSITORY ${repo}
+        GIT_TAG        "${tag}"
+    )
+endmacro()
+```
+
+### Failure mode B — nested variable references
+
+If the caller passes `${VAR_NAME}` and `VAR_NAME` itself holds another variable reference,
+expansion can produce an empty string:
+
+```cmake
+set(FMT_VERSION "")
+set(DEP_TAG "${FMT_VERSION}")        # intentionally empty sentinel
+fetch_dep(fmt "https://.../fmt.git" ${DEP_TAG})
+# GIT_TAG expands to an empty token; FetchContent defaults to the default branch
+# and the build is non-deterministic.
+```
+
+**Fix**: validate at the caller:
+
+```cmake
+if(NOT FMT_VERSION)
+    message(FATAL_ERROR "FMT_VERSION must be set before calling fetch_dep")
+endif()
+```
+
+## Submodule alternative
+
+When a project must pin to a commit hash that no tag points at (e.g. a patch not yet released),
+prefer `git submodule` over `FetchContent`:
+
+```bash
+git submodule add -b main https://github.com/fmtlib/fmt.git external/fmt
+git -C external/fmt checkout <sha>
+git add external/fmt
+git commit -m "deps: pin fmt to <sha> via submodule"
+```
+
+Drawback: consumers of the repo must run `git submodule update --init --recursive`. Benefit: no
+shallow-clone negotiation involved — the commit is materialized by the submodule checkout.
+
+## Verification
+
+```bash
+rm -rf build
+cmake -S . -B build -G Ninja
+```
+
+Look for:
+
+```
+-- FetchContent: populating fmt
+-- FetchContent: fmt populated
+```
+
+If you see `fatal: reference is not a tree` or `git fetch failed`, the fix was not applied
+correctly — re-check `GIT_SHALLOW` and quoting.
+
+## Cross-reference
+
+- Pattern summary: `known-fixes.md` § Pattern 2
+- CMake docs: <https://cmake.org/cmake/help/latest/module/FetchContent.html>

--- a/global/skills/ci-fix/reference/known-fixes.md
+++ b/global/skills/ci-fix/reference/known-fixes.md
@@ -1,0 +1,193 @@
+# ci-fix — Known Fix Patterns
+
+Catalogue of the three recurring CI failure patterns this skill handles. Each entry includes
+a deterministic classifier, a before/after diff template, and a verification step.
+
+## Classifier
+
+Run against the last 200 lines of `gh run view <id> --log-failed`. First match wins.
+
+| Priority | Pattern id | Signal (regex, case-insensitive) |
+|----------|-----------|----------------------------------|
+| 1 | `msvc-c4996` | `error C4996` or `warning C4996` accompanied by `/WX` or `treated as an error` under an MSVC toolchain |
+| 2 | `cmake-fetchcontent` | `FetchContent` + (`fatal: could not read Username` OR `object .* not found` OR `could not fetch`) |
+| 3 | `cpp-lib-format` | (`<format>` or `std::format`) AND (`__cpp_lib_format` or `cannot open source file` or `unresolved external symbol.*format`) |
+
+If none match, fall through to escalation (see `SKILL.md` § Escalation).
+
+---
+
+## Pattern 1: `msvc-c4996` — Deprecated API under warnings-as-errors
+
+**Root cause**: MSVC flags a deprecated API call (`strcpy`, `sprintf`, `fopen`, `std::iterator`,
+etc.) and the project enables `/WX` (warnings as errors). Common trigger: `<iterator>` and
+`<codecvt>` deprecations, or C runtime functions used in examples/adapters that were added after
+the project-wide deprecation policy was set.
+
+**Before (fails)**
+```cpp
+// example/legacy.cpp
+#include <cstdio>
+void write_log(const char* msg) {
+    FILE* f = fopen("log.txt", "a");    // C4996: 'fopen': This function or variable may be unsafe
+    fprintf(f, "%s\n", msg);
+    fclose(f);
+}
+```
+
+**After (passes)**
+```cpp
+// example/legacy.cpp
+#include <cstdio>
+#include <fstream>
+void write_log(const char* msg) {
+    std::ofstream f("log.txt", std::ios::app);
+    f << msg << '\n';
+}
+```
+
+Alternative when `fopen` is strictly required (e.g. third-party signature):
+```cpp
+FILE* f = nullptr;
+#ifdef _MSC_VER
+    fopen_s(&f, "log.txt", "a");
+#else
+    f = std::fopen("log.txt", "a");
+#endif
+```
+
+**Do not** apply `#pragma warning(disable: 4996)` or add `_CRT_SECURE_NO_WARNINGS` project-wide
+to silence the message — that hides the next deprecation too. Fix the call site.
+
+**Verify**: build the affected target locally with `cmake --build build --target <target>` on a
+Windows runner, or push and monitor the matrix leg only.
+
+See also `msvc-c4996.md` for the full migration table.
+
+---
+
+## Pattern 2: `cmake-fetchcontent` — Shallow clone with a commit hash
+
+**Root cause**: `FetchContent_Declare` is given `GIT_SHALLOW ON` together with `GIT_TAG <sha>`.
+Shallow clones only resolve branch tips and tags; an arbitrary commit hash is not advertised by
+the server and the fetch fails with `fatal: reference is not a tree`. The failure is
+amplified when the `GIT_TAG` value arrives via macro expansion — quoting becomes non-obvious.
+
+**Before (fails)**
+```cmake
+FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG        9a2138a8ec4ecef4e8c2ef3d1c8c1f3c4c0f2f3e   # commit sha
+    GIT_SHALLOW    ON
+)
+```
+
+**After (passes)** — pick one:
+
+1. **Drop shallow clone** for commit-hash pins (preferred when determinism matters):
+   ```cmake
+   FetchContent_Declare(
+       fmt
+       GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+       GIT_TAG        9a2138a8ec4ecef4e8c2ef3d1c8c1f3c4c0f2f3e
+       # GIT_SHALLOW removed; a full fetch is required to resolve a non-tip commit
+   )
+   ```
+
+2. **Pin to a tag or branch** and keep `GIT_SHALLOW ON`:
+   ```cmake
+   FetchContent_Declare(
+       fmt
+       GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+       GIT_TAG        10.2.1
+       GIT_SHALLOW    ON
+   )
+   ```
+
+**Macro expansion caveat** — when `GIT_TAG` flows through a helper macro, quote the value at
+the macro boundary:
+```cmake
+# fetch_dep expects: fetch_dep(<name> <repo> <tag>)
+macro(fetch_dep name repo tag)
+    FetchContent_Declare(${name}
+        GIT_REPOSITORY ${repo}
+        GIT_TAG        ${tag}            # unquoted OK only when tag is a single token
+    )
+endmacro()
+```
+Passing a tag with characters that require escaping (rare, but possible with Git refs) demands
+`"${tag}"`. See `cmake-fetchcontent.md` for the full analysis.
+
+**Verify**: `cmake -S . -B build -G <generator>` on a clean checkout. The configure step is
+where `FetchContent_MakeAvailable` resolves the fetch.
+
+---
+
+## Pattern 3: `cpp-lib-format` — `__cpp_lib_format` probe vs link-time availability
+
+**Root cause**: `<format>` is partially implemented across toolchains. `__cpp_lib_format` tells
+the compiler the header parses; it does **not** guarantee the linker can resolve `std::format`
+symbols. Projects that gate `<format>` purely on the feature macro hit link errors on Clang +
+libstdc++ 14 and on older Apple Clang.
+
+**Before (fails at link time on mixed toolchains)**
+```cpp
+// format_adapter.hpp
+#include <version>
+#if __cpp_lib_format >= 201907L
+  #include <format>
+  inline std::string render(int n) { return std::format("{}", n); }
+#else
+  #include <sstream>
+  inline std::string render(int n) { std::ostringstream os; os << n; return os.str(); }
+#endif
+```
+
+**After (passes)** — add a CMake-level probe that compiles *and* links:
+
+```cmake
+# cmake/checks.cmake
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+    #include <format>
+    int main() { return std::format(\"{}\", 42).size(); }
+" CLAUDE_HAS_STD_FORMAT)
+
+if(CLAUDE_HAS_STD_FORMAT)
+    target_compile_definitions(adapter PRIVATE CLAUDE_HAS_STD_FORMAT=1)
+endif()
+```
+
+```cpp
+// format_adapter.hpp
+#if defined(CLAUDE_HAS_STD_FORMAT)
+  #include <format>
+  inline std::string render(int n) { return std::format("{}", n); }
+#else
+  #include <sstream>
+  inline std::string render(int n) { std::ostringstream os; os << n; return os.str(); }
+#endif
+```
+
+The project-controlled `CLAUDE_HAS_STD_FORMAT` replaces a hopeful `__cpp_lib_format` check and
+is driven by a probe that actually links.
+
+**Do not** rely on `__has_include(<format>)` either — the header may exist while `std::format`
+remains unlinked (libc++ before 17, libstdc++ before 13).
+
+**Verify**: the CMake configure log must show
+`Performing Test CLAUDE_HAS_STD_FORMAT - Success` on supported matrices.
+
+---
+
+## Extending the Catalogue
+
+To add a new pattern:
+
+1. Append a row to the Classifier table with a precise regex.
+2. Add a section following the same structure: Root cause → Before → After → Verify.
+3. If the pattern needs more than ~200 lines of exposition, promote it to its own file under
+   `reference/` and link it from this catalogue (as done for `msvc-c4996` and
+   `cmake-fetchcontent`).
+4. Cover the new pattern with a reproduction in `tests/` if the project has a skill-test harness.

--- a/global/skills/ci-fix/reference/msvc-c4996.md
+++ b/global/skills/ci-fix/reference/msvc-c4996.md
@@ -1,0 +1,120 @@
+# MSVC C4996 — Deprecated API Migration
+
+Deep dive for the `msvc-c4996` pattern in `known-fixes.md`. Read this when the simple "swap
+`fopen` for `ofstream`" recipe is not enough — typically when the deprecated symbol is a
+standard-library type (`std::iterator`, `std::codecvt`) or a Win32 API that does not have an
+obvious cross-platform replacement.
+
+## Why MSVC flags C4996 as an error
+
+The project's CI enables `/WX` (treat warnings as errors). C4996 is the warning MSVC emits for
+any symbol marked with `[[deprecated]]` or `_CRT_DEPRECATE_TEXT`. The warning exists on every
+toolchain; `/WX` is what makes it a CI blocker.
+
+The fix belongs at the call site. Neither `#pragma warning(disable: 4996)` nor
+`_CRT_SECURE_NO_WARNINGS` scales — they hide future deprecations and are symptomatic of not
+having a migration plan.
+
+## Migration table
+
+| Deprecated symbol | Preferred replacement | Notes |
+|-------------------|------------------------|-------|
+| `strcpy`, `strcat`, `sprintf`, `vsprintf` | `snprintf` + bounds, or `std::format` / `std::string` | Bounds-checked. |
+| `fopen`, `freopen` | `std::ofstream` / `std::ifstream` | RAII; no need for `fclose`. |
+| `fopen_s` (non-portable) | Platform shim, see Pattern 1 snippet | Keep `fopen_s` inside `#ifdef _MSC_VER`. |
+| `std::iterator` (deprecated in C++17) | Define the five typedefs inline | `using iterator_category = …` etc. |
+| `std::codecvt_utf8` (deprecated in C++17) | `MultiByteToWideChar` + `WideCharToMultiByte` on Windows; `iconv` or ICU elsewhere | `<codecvt>` is slated for removal. |
+| `std::bind` | Lambda | Lambdas inline better and avoid surprising binding semantics. |
+| `std::random_shuffle` | `std::shuffle` with an RNG | Removed in C++17; C4996 warns on compatibility shims. |
+| `std::auto_ptr` | `std::unique_ptr` | Removed in C++17. |
+| `std::uncaught_exception()` | `std::uncaught_exceptions()` (plural) | Removed in C++20. |
+| Win32 `GetVersionEx` | `VerifyVersionInfo` or version helpers in `<VersionHelpers.h>` | `GetVersionEx` returns lies on Win10+. |
+
+## `std::iterator` migration
+
+Before:
+```cpp
+class MyIter : public std::iterator<std::forward_iterator_tag, int> {
+    // …
+};
+```
+
+After:
+```cpp
+class MyIter {
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = int;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = int*;
+    using reference         = int&;
+    // …
+};
+```
+
+The base class was never load-bearing — iterator traits look up the typedefs directly on the
+iterator type. Removing the base is a pure rename.
+
+## `std::codecvt_utf8` migration on Windows
+
+Before:
+```cpp
+#include <codecvt>
+#include <locale>
+std::wstring to_wide(const std::string& s) {
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> cv;
+    return cv.from_bytes(s);
+}
+```
+
+After (Windows):
+```cpp
+#include <Windows.h>
+std::wstring to_wide(const std::string& s) {
+    if (s.empty()) return {};
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), (int)s.size(), nullptr, 0);
+    std::wstring out(n, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), (int)s.size(), out.data(), n);
+    return out;
+}
+```
+
+Cross-platform projects should gate on `_WIN32` and keep a `<codecvt>` implementation for other
+platforms, pending a move to `{fmt}` or ICU for real i18n.
+
+## When you cannot migrate — scoped suppression
+
+If the call site is third-party code you cannot edit, scope the suppression tightly:
+
+```cpp
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4996)
+#endif
+
+    third_party_call_that_uses_deprecated_api();
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+```
+
+Do **not** scope the suppression wider than the offending statement. Any future C4996 in the
+suppressed region becomes silent.
+
+## Verification
+
+Rebuild the Windows matrix leg only:
+
+```bash
+cmake --preset windows
+cmake --build --preset windows --target <target> -- /verbosity:normal | \
+    grep -E "(C4996|/WX)" || echo "No C4996 under /WX"
+```
+
+A successful fix prints `No C4996 under /WX` and produces a green CI leg on the next push.
+
+## Cross-reference
+
+- Pattern summary: `known-fixes.md` § Pattern 1
+- MSVC C4996 docs: <https://learn.microsoft.com/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996>

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -327,6 +327,12 @@ Based on workflow analysis, fix the identified issues:
 | **Missing header** | Add required #include statements |
 | **Link error** | Fix undefined references, library linking |
 
+**Known-pattern shortcut**: before hand-authoring a fix, check the `ci-fix` skill
+(`global/skills/ci-fix/SKILL.md`). It classifies the failure log against three recurring
+patterns (MSVC C4996, CMake FetchContent shallow clone, `__cpp_lib_format` probe) and applies
+a codified remediation. Invoke with `/ci-fix <pr-number>` — falls through to this manual
+workflow when no pattern matches.
+
 ### 6. Verify Fix Locally
 
 Select inline (< 30s) or background + log polling (30s+) strategy based on build duration. Diagnose before retrying — do NOT re-run the same build without changes.


### PR DESCRIPTION
Closes #363

## Summary

Creates `global/skills/ci-fix/` — a classifier-plus-known-fixes pipeline for three CI failure
patterns that have recurred across multiple sessions. Cross-references from `pr-work` so the
skill is the first stop when a failing run is detected.

### What ships

| File | Role |
|------|------|
| `global/skills/ci-fix/SKILL.md` | Diagnose → classify → apply known fix → monitor (20-min budget) |
| `global/skills/ci-fix/reference/known-fixes.md` | Classifier table + per-pattern before/after diffs |
| `global/skills/ci-fix/reference/cmake-fetchcontent.md` | Macro-expansion + shallow-clone deep dive |
| `global/skills/ci-fix/reference/msvc-c4996.md` | Deprecated-API migration table |
| `global/skills/pr-work/SKILL.md` | Cross-reference callout to invoke ci-fix first |

### Classifier patterns

1. **msvc-c4996** — MSVC deprecated API under `/WX` warnings-as-errors
2. **cmake-fetchcontent** — `GIT_SHALLOW ON` with a commit-hash `GIT_TAG`
3. **cpp-lib-format** — `__cpp_lib_format` probe that does not match link-time availability

Each pattern has a deterministic regex classifier, a before/after code diff, and a verification
step. When no pattern matches the skill prints the log excerpt and hands off rather than
hand-authoring a fix.

## Why

The 2026-04-18 `/insights` report documents 2–3 trial-and-error push cycles per CI failure
when a classifier-plus-known-fixes skill would cut this to one attempt. This eliminates the
dominant friction in CI/CD debugging workflows.

## Acceptance Criteria Status

- [x] `ci-fix/SKILL.md` passes the spec linter (`scripts/spec_lint.sh`)
- [x] Three reference documents cover each pattern with verified diffs
- [x] `pr-work` invokes `ci-fix` on failing CI (cross-reference added in § 5 Fix Issues)
- [ ] Manual test against a PR reproducing each pattern — will be validated against the next
      organic occurrence (cannot synthesize representative PRs in this change)

## Verification

- `scripts/spec_lint.sh --mode skill global/skills/ci-fix/SKILL.md global/skills/pr-work/SKILL.md` → `violations=0`
- `scripts/validate_skills.sh` → `232/232 passed` (2 pre-existing warnings)

## Test Plan

- Reviewer: skim the classifier table in `known-fixes.md` — regexes should be specific enough
  to avoid false matches on unrelated failures.
- Reviewer: confirm the `pr-work` cross-reference in section 5 does not disrupt the existing
  failure-type table.
- On the next real CI failure matching one of the three patterns, invoke `/ci-fix <pr>` and
  compare against hand-authored fix time.