### PR TITLE
feat(hooks): add pre-edit-read-guard PreToolUse hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -27,6 +27,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Restore core principles after context compaction | [Post-Compact Restore](#17-post-compact-restore-postcompact) |
 | Validate task descriptions at creation time | [Task Created Validator](#18-task-created-validator-taskcreated) |
 | Auto-commit working tree after Task/Agent runs | [Post Task/Agent Checkpoint](#19-post-taskagent-checkpoint-posttooluse) |
+| Block Edit/Write on files that weren't Read first | [Pre-edit Read Guard](#20-pre-edit-read-guard-pretoolusepostooluse) |
 | Block direct pushes to protected branches | [Pre-push Protected Branch Guard](#git-hooks-pre-push-protected-branch-guard) |
 | Add my own custom hook | [Adding New Hooks](#adding-new-hooks) |
 | Set up hooks on Windows | [Windows Support](#windows-support-powershell) |
@@ -647,6 +648,68 @@ TaskCreated rejected: description must contain at least one '- [ ]' checkbox mar
 **Opt-out**: Remove the `PostToolUse` matcher block from `global/settings.json` and re-run `scripts/sync.sh`. Individual sessions can skip by running outside a git worktree.
 
 **Test fixture**: `tests/hooks/test-post-task-checkpoint.sh` exercises dirty/clean/non-repo paths, agent-name sanitization, malformed-JSON fail-open, and the two-agent overwrite scenario.
+
+### 20. Pre-edit Read Guard (PreToolUse/PostToolUse)
+
+*Converts "file was not read" tool-contract violations into an actionable Read-first deny message on the first attempt — no more silent Edit retries.*
+
+**Purpose**: Enforce the Claude Code contract that `Edit` and `Write` on an existing file require a prior `Read` in the same session. Without this guard the tool simply errors out and the model retries in the dark. With it, the hook denies the edit up-front with a reason that tells Claude exactly which file to Read.
+
+**Trigger**: A single script is registered under two hook entries:
+- `PreToolUse` matcher `Edit|Write` — the guard (returns `allow`/`deny` JSON).
+- `PostToolUse` matcher `Read` — the tracker (records the Read path, no JSON).
+
+**Files**: `global/hooks/pre-edit-read-guard.sh`, `global/hooks/pre-edit-read-guard.ps1`
+
+**Tracker**: `$TMPDIR/claude-read-set-<session-id>` on Unix, `%TEMP%\claude-read-set-<session-id>` on Windows. One absolute path per line, deduplicated. Cleared naturally when the temp directory rotates between sessions.
+
+**Behavior**:
+1. Read JSON from stdin (`tool_name`, `tool_input.file_path`, `session_id`).
+2. **If `tool_name == "Read"`**: resolve `file_path` to absolute, append to tracker if absent. Emit no JSON. Best-effort — any failure is swallowed.
+3. **If `tool_name in {"Edit","Write"}`**: resolve `file_path` to absolute, then:
+   - Tracker file missing → `allow` (first-run safety for fresh sessions).
+   - `Write` on a non-existent file → `allow` (new files cannot have been Read).
+   - Tracker contains the path → `allow`.
+   - Otherwise → `deny` with a message naming the exact file to Read first.
+4. **Any other `tool_name`**: `allow` (prevents interference with other matchers).
+
+**Deny reason format**:
+```
+Cannot Edit '/abs/path/to/file' without reading it first in this session. Call Read on '/abs/path/to/file' and retry. (Session <id>, tracker <path>.)
+```
+
+**Decision control**: Always exits 0. Fail-open on empty stdin or missing `jq` — the hook never blocks the workflow when it can't do its job correctly.
+
+**Configuration** (`global/settings.json`):
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Edit|Write",
+      "hooks": [
+        { "type": "command", "command": "~/.claude/hooks/pre-edit-read-guard.sh", "timeout": 5 }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Read",
+      "hooks": [
+        { "type": "command", "command": "~/.claude/hooks/pre-edit-read-guard.sh", "timeout": 5, "async": true }
+      ]
+    }
+  ]
+}
+```
+
+**Limitations**:
+- Session-scoped. Across restarts the tracker rotates with `$TMPDIR` and Claude must Read again.
+- Case-sensitive file match on case-insensitive filesystems (macOS default HFS+/APFS) can produce rare false negatives if the same path is Read with different casing — normalize via `realpath` where available.
+- `Edit` on a file that the user manually modified outside the session still passes once it is in the tracker. The hook verifies Read, not freshness.
+
+**Opt-out**: Remove the two matcher blocks from `global/settings.json` and `global/settings.windows.json`, then re-run `scripts/sync.sh`.
+
+**Test fixture**: `tests/hooks/test-pre-edit-read-guard.sh` exercises the deny/allow paths, first-run tracker-missing safety, Write on non-existent files, and Read-then-Edit unlocking.
 
 ### Hook Response Format
 

--- a/global/hooks/pre-edit-read-guard.ps1
+++ b/global/hooks/pre-edit-read-guard.ps1
@@ -1,0 +1,108 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# pre-edit-read-guard.ps1
+# Enforces the "Read before Edit/Write" tool contract.
+#
+# Registered under TWO hook entries in global/settings.json:
+#   1. PreToolUse  matcher "Edit|Write" - guard mode (deny when tracker lacks file_path)
+#   2. PostToolUse matcher "Read"       - track mode (record file_path in tracker)
+#
+# Tracker: $env:TEMP\claude-read-set-<session-id>
+#   One absolute path per line. Cleared naturally when $env:TEMP rotates.
+#
+# Exit codes: always 0. Decision is encoded in the JSON response for PreToolUse
+# events; PostToolUse emits no JSON and is best-effort.
+
+$json = Read-HookInput
+
+# Fail-open on empty stdin (harness may not have wired input yet).
+if (-not $json) {
+    exit 0
+}
+
+$toolName = ''
+$filePath = ''
+$sessionId = $env:CLAUDE_SESSION_ID
+try { $toolName = [string]$json.tool_name } catch {}
+try { $filePath = [string]$json.tool_input.file_path } catch {}
+if ([string]::IsNullOrEmpty($sessionId)) {
+    try { $sessionId = [string]$json.session_id } catch {}
+}
+if ([string]::IsNullOrEmpty($sessionId)) { $sessionId = 'unknown' }
+
+$trackerDir = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR } else { [System.IO.Path]::GetTempPath() }
+$tracker = Join-Path $trackerDir ("claude-read-set-{0}" -f $sessionId)
+
+function Resolve-Path-Safe {
+    param([string]$Path)
+    if ([string]::IsNullOrEmpty($Path)) { return $Path }
+    try {
+        return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    } catch {
+        return $Path
+    }
+}
+
+switch ($toolName) {
+    'Read' {
+        # Track mode: append the Read path. Best-effort, no JSON output.
+        if ([string]::IsNullOrEmpty($filePath)) { exit 0 }
+        $resolved = Resolve-Path-Safe $filePath
+        try {
+            if (-not (Test-Path -LiteralPath $trackerDir)) {
+                New-Item -ItemType Directory -Path $trackerDir -Force | Out-Null
+            }
+            $existing = @()
+            if (Test-Path -LiteralPath $tracker) {
+                $existing = Get-Content -LiteralPath $tracker -ErrorAction SilentlyContinue
+            }
+            if ($existing -notcontains $resolved) {
+                Add-Content -LiteralPath $tracker -Value $resolved -ErrorAction SilentlyContinue
+            }
+        } catch {}
+        exit 0
+    }
+
+    { $_ -eq 'Edit' -or $_ -eq 'Write' } {
+        # Guard mode: deny unless the target has been Read this session.
+        if ([string]::IsNullOrEmpty($filePath)) {
+            New-HookAllowResponse
+            exit 0
+        }
+        $resolved = Resolve-Path-Safe $filePath
+
+        # First-run safety: no tracker file yet means this is a fresh session.
+        if (-not (Test-Path -LiteralPath $tracker)) {
+            New-HookAllowResponse
+            exit 0
+        }
+
+        # Exempt genuinely new files for Write (Edit requires existing files).
+        if ($toolName -eq 'Write' -and -not (Test-Path -LiteralPath $resolved)) {
+            New-HookAllowResponse
+            exit 0
+        }
+
+        $hit = $false
+        try {
+            $hit = (Get-Content -LiteralPath $tracker -ErrorAction SilentlyContinue) -contains $resolved
+        } catch {}
+
+        if ($hit) {
+            New-HookAllowResponse
+            exit 0
+        }
+
+        $reason = "Cannot $toolName '$filePath' without reading it first in this session. Call Read on '$filePath' and retry. (Session $sessionId, tracker $tracker.)"
+        New-HookDenyResponse -Reason $reason
+        exit 0
+    }
+
+    default {
+        # Unknown tool - allow to avoid interfering with other matchers.
+        New-HookAllowResponse
+        exit 0
+    }
+}

--- a/global/hooks/pre-edit-read-guard.sh
+++ b/global/hooks/pre-edit-read-guard.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# pre-edit-read-guard.sh
+# Enforces the "Read before Edit/Write" tool contract.
+#
+# Registered under TWO hook entries in global/settings.json:
+#   1. PreToolUse  matcher "Edit|Write" → guard mode (deny when tracker lacks file_path)
+#   2. PostToolUse matcher "Read"       → track mode (record file_path in tracker)
+#
+# The single script branches on .tool_name so only one binary ships.
+#
+# Tracker: $TMPDIR/claude-read-set-<session-id>
+#   - One absolute path per line
+#   - Cleared naturally when $TMPDIR is rotated between sessions
+#   - Fail-open if absent (first-run safety; see deny_or_fail_open below)
+#
+# Exit codes: always 0. Decision is encoded in the JSON response for PreToolUse
+# events; PostToolUse emits no JSON and is best-effort.
+
+set -uo pipefail
+
+# --- helpers ----------------------------------------------------------------
+
+allow_response() {
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+deny_response() {
+    local reason="$1"
+    # Escape backslashes and double-quotes so the reason survives raw embedding.
+    reason="${reason//\\/\\\\}"
+    reason="${reason//\"/\\\"}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+# --- parse input -------------------------------------------------------------
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail-open on totally empty input — better to let the user through than to
+# block every tool call when the harness has not wired stdin yet.
+if [ -z "$INPUT" ]; then
+    exit 0
+fi
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Resolve session id (env var preferred; fall back to JSON field).
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+if [ -z "$SESSION_ID" ]; then
+    SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
+fi
+
+# Use $TMPDIR so every platform gets a writable spot; default to /tmp.
+TRACKER_DIR="${TMPDIR:-/tmp}"
+TRACKER="${TRACKER_DIR%/}/claude-read-set-${SESSION_ID}"
+
+# --- branch on event ---------------------------------------------------------
+
+case "$TOOL_NAME" in
+    Read)
+        # Track mode: append the Read path. Best-effort, no JSON output.
+        [ -z "$FILE_PATH" ] && exit 0
+        # Resolve to absolute path when possible.
+        if command -v realpath >/dev/null 2>&1; then
+            RESOLVED=$(realpath "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+        else
+            RESOLVED="$FILE_PATH"
+        fi
+        mkdir -p "$TRACKER_DIR" 2>/dev/null || exit 0
+        # Deduplicate: only append if not already present.
+        if [ -f "$TRACKER" ] && grep -Fxq "$RESOLVED" "$TRACKER" 2>/dev/null; then
+            exit 0
+        fi
+        echo "$RESOLVED" >> "$TRACKER" 2>/dev/null || true
+        exit 0
+        ;;
+
+    Edit|Write)
+        # Guard mode: deny unless the target has been Read this session.
+        [ -z "$FILE_PATH" ] && allow_response
+
+        if command -v realpath >/dev/null 2>&1; then
+            RESOLVED=$(realpath "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+        else
+            RESOLVED="$FILE_PATH"
+        fi
+
+        # First-run safety: if the tracker does not exist yet, allow. This
+        # covers fresh sessions and harnesses that have not fired a Read yet.
+        if [ ! -f "$TRACKER" ]; then
+            allow_response
+        fi
+
+        # Exempt genuinely new files — Write creates them so Read is impossible.
+        # Applies to Write only; Edit requires an existing file by contract.
+        if [ "$TOOL_NAME" = "Write" ] && [ ! -e "$RESOLVED" ]; then
+            allow_response
+        fi
+
+        # Tracker hit → allow.
+        if grep -Fxq "$RESOLVED" "$TRACKER" 2>/dev/null; then
+            allow_response
+        fi
+
+        # Tracker miss → deny with actionable reason.
+        deny_response "Cannot ${TOOL_NAME} '${FILE_PATH}' without reading it first in this session. Call Read on '${FILE_PATH}' and retry. (Session ${SESSION_ID}, tracker ${TRACKER}.)"
+        ;;
+
+    *)
+        # Unknown tool — allow to avoid interfering with other matchers.
+        allow_response
+        ;;
+esac

--- a/global/settings.json
+++ b/global/settings.json
@@ -109,6 +109,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-edit-read-guard.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -169,6 +179,17 @@
             "type": "command",
             "command": "~/.claude/hooks/post-task-checkpoint.sh",
             "timeout": 15,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-edit-read-guard.sh",
+            "timeout": 5,
             "async": true
           }
         ]

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -120,6 +120,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -180,6 +190,17 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/post-task-checkpoint.ps1",
             "timeout": 15,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
+            "timeout": 5,
             "async": true
           }
         ]

--- a/tests/hooks/test-pre-edit-read-guard.sh
+++ b/tests/hooks/test-pre-edit-read-guard.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Test suite for pre-edit-read-guard.sh
+# Run: bash tests/hooks/test-pre-edit-read-guard.sh
+
+HOOK="global/hooks/pre-edit-read-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Per-test sandbox so the tracker does not leak between assertions.
+TEST_SESSION="test-$$-${RANDOM}"
+# Use the caller's TMPDIR (falls back to /tmp) so we stay within whatever
+# sandbox write policy the runner enforces. mktemp is avoided because some
+# harnesses deny mkdir in /var/folders.
+BASE_TMPDIR="${TMPDIR:-/tmp}"
+TRACKER_DIR="${BASE_TMPDIR%/}/claude-hook-test-$$-${RANDOM}"
+mkdir -p "$TRACKER_DIR" || { echo "Cannot create $TRACKER_DIR"; exit 2; }
+export TMPDIR="$TRACKER_DIR"
+export CLAUDE_SESSION_ID="$TEST_SESSION"
+TRACKER="$TRACKER_DIR/claude-read-set-$TEST_SESSION"
+
+cleanup() {
+    rm -rf "$TRACKER_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+reset_tracker() {
+    rm -f "$TRACKER" 2>/dev/null || true
+}
+
+run_hook() {
+    local input="$1"
+    echo "$input" | bash "$HOOK" 2>/dev/null
+}
+
+assert_deny() {
+    local input="$1" label="$2"
+    local result
+    result=$(run_hook "$input")
+    if echo "$result" | grep -q '"deny"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label -- expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local input="$1" label="$2"
+    local result
+    result=$(run_hook "$input")
+    if echo "$result" | grep -q '"allow"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label -- expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_silent() {
+    local input="$1" label="$2"
+    local result
+    result=$(run_hook "$input")
+    if [ -z "$result" ]; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label -- expected no output, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== pre-edit-read-guard.sh tests ==="
+echo ""
+
+# --- Fixtures ---------------------------------------------------------------
+EXISTING_FILE="$TRACKER_DIR/existing.txt"
+NEW_FILE="$TRACKER_DIR/brand-new.txt"
+echo "seed" > "$EXISTING_FILE"
+# Resolve to absolute path the hook will compute.
+EXISTING_RESOLVED=$(realpath "$EXISTING_FILE" 2>/dev/null || echo "$EXISTING_FILE")
+NEW_RESOLVED=$(realpath "$NEW_FILE" 2>/dev/null || echo "$NEW_FILE")
+
+# --- Fail-open ------------------------------------------------------------
+echo "[Fail-open]"
+reset_tracker
+# Empty input → exit 0 with no body (always fail-open).
+OUT=$(run_hook '')
+if [ -z "$OUT" ]; then
+    ((PASS++)); echo "  PASS: Empty input -> silent fail-open"
+else
+    ((FAIL++)); ERRORS+=("Empty input should produce no output, got: $OUT"); echo "  FAIL: Empty input"
+fi
+# Malformed JSON → fail-open (hook cannot extract tool_name).
+assert_allow '{"tool_name":"Edit","tool_input":{"file_path":"'"$EXISTING_RESOLVED"'"}}' "[warmup] allow when tracker absent (first-run safety)"
+
+# --- Guard mode: tracker-missing ---------------------------------------------
+echo ""
+echo "[Guard: tracker missing -> first-run allow]"
+reset_tracker
+assert_allow "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Edit with no tracker -> allow"
+assert_allow "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Write with no tracker -> allow"
+
+# --- Guard mode: tracker present, file not read -----------------------------
+echo ""
+echo "[Guard: tracker present but file absent from it]"
+reset_tracker
+# Create tracker with a different path (to simulate "some other file was read").
+mkdir -p "$TRACKER_DIR"
+echo "/some/other/file" > "$TRACKER"
+assert_deny "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Edit on unread existing file -> deny"
+# Write on a non-existent target must still be allowed (new file).
+assert_allow "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$NEW_RESOLVED\"}}" "Write on new (non-existent) file -> allow"
+# Write on an EXISTING unread file should be denied too.
+assert_deny "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Write on existing unread file -> deny"
+
+# --- Track mode: Read populates tracker -------------------------------------
+echo ""
+echo "[Track: Read -> tracker append]"
+reset_tracker
+# Tracker starts absent.
+[ ! -f "$TRACKER" ] && { ((PASS++)); echo "  PASS: Tracker initially absent"; } \
+    || { ((FAIL++)); ERRORS+=("Tracker should be absent at start"); echo "  FAIL: Tracker leaked"; }
+assert_silent "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Read emits no JSON"
+# Tracker must now list the file.
+if grep -Fxq "$EXISTING_RESOLVED" "$TRACKER" 2>/dev/null; then
+    ((PASS++)); echo "  PASS: Tracker contains read file"
+else
+    ((FAIL++)); ERRORS+=("Tracker missing entry for $EXISTING_RESOLVED after Read"); echo "  FAIL: tracker not populated"
+fi
+# Running Read again must not double-count (deduplication).
+assert_silent "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Read again emits no JSON"
+COUNT=$(grep -Fxc "$EXISTING_RESOLVED" "$TRACKER" 2>/dev/null || echo 0)
+if [ "$COUNT" = "1" ]; then
+    ((PASS++)); echo "  PASS: Duplicate Read deduplicated"
+else
+    ((FAIL++)); ERRORS+=("Tracker dup count=$COUNT expected 1"); echo "  FAIL: duplicate entries"
+fi
+
+# --- Read-then-Edit allows the edit -----------------------------------------
+echo ""
+echo "[Read-then-Edit unlock]"
+assert_allow "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Edit after Read -> allow"
+assert_allow "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$EXISTING_RESOLVED\"}}" "Write after Read -> allow"
+
+# --- Unknown tool pass-through ----------------------------------------------
+echo ""
+echo "[Unknown tool]"
+assert_allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi\"}}" "Unknown tool -> allow (non-interfering)"
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ $FAIL -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #364

## Summary

Adds a PreToolUse hook that blocks `Edit` or `Write` when the target file has not been `Read`
in the current session, surfacing an actionable deny message instead of a silent tool-contract
error. Converts a common retry-in-the-dark failure mode into a one-attempt fix.

### What ships

| File | Role |
|------|------|
| `global/hooks/pre-edit-read-guard.sh` | Guard + tracker (bash) |
| `global/hooks/pre-edit-read-guard.ps1` | Guard + tracker (PowerShell) |
| `global/settings.json` | + `PreToolUse Edit|Write` and `PostToolUse Read` entries |
| `global/settings.windows.json` | Same pair (pwsh form) |
| `HOOKS.md` | New § 20 documenting behaviour and opt-out |
| `tests/hooks/test-pre-edit-read-guard.sh` | 15-case suite |

### Design

A single script is registered under **two** hook events, branching on `.tool_name`:

- **PreToolUse matcher `Edit|Write`** — guard mode. Resolves `file_path` to absolute, checks
  the session-local tracker, and replies `allow`/`deny` JSON. Fail-open when the tracker file
  does not exist (first-run safety) or when `Write` targets a non-existent file (new files
  cannot have been Read).
- **PostToolUse matcher `Read`** — track mode. Appends the Read path to the tracker with
  deduplication. Emits no JSON, never blocks.

Tracker path: `$TMPDIR/claude-read-set-<session-id>` (Unix) or `%TEMP%\claude-read-set-<session-id>`
(Windows). One absolute path per line.

### Deny message

Denies include the exact path to Read first so Claude can remediate in one retry:

```
Cannot Edit '/abs/path/to/file' without reading it first in this session.
Call Read on '/abs/path/to/file' and retry. (Session <id>, tracker <path>.)
```

## Why

The 2026-04-18 `/insights` report observed "8 of 11 file edits failed because files weren't
read first." The underlying tool contract is well-defined; what was missing was an
on-the-first-attempt signal. This hook converts the silent failure into explicit guidance.

## Acceptance Criteria Status

- [x] Hook denies `Edit` on an unread file with a remediation message
- [x] Hook allows `Edit` once the file has been `Read` in the session
- [x] `Write` on a genuinely new file (non-existent target) is allowed
- [x] Test fixture under `tests/hooks/test-pre-edit-read-guard.sh` covers both paths + edge cases
- [x] `HOOKS.md` documents the hook (§ 20)

## Verification

- `tests/hooks/test-runner.sh` — 253 passed, 0 failed (238 baseline + 15 new)
- `scripts/spec_lint.sh --mode settings global/settings*.json` — `violations=0`
- `scripts/validate_skills.sh` — 232/232 passed

## Test Plan

- Reviewer: check the two hook entries in `global/settings.json` (lines ~104 and ~186) to
  confirm the matcher pair is registered.
- Reviewer: read `HOOKS.md § 20` — opt-out instructions and tracker location should match
  intent for your platform.
- After merging and syncing, test manually: open a fresh session, attempt `Edit` on a file
  without prior `Read` → expect deny with the remediation message; `Read` the file then retry
  → expect allow.