### PR TITLE
feat(skills): add preflight skill for local CI simulation before push

### DIFF
--- a/global/skills/preflight/SKILL.md
+++ b/global/skills/preflight/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: preflight
+description: "Reproduce CI checks locally before pushing so failures surface on the developer machine, not on GitHub. Aligns with the ci-fix skill's pattern catalogue and catches MSVC C4996, CMake FetchContent shallow-clone, and deprecated-API issues pre-push. Invoke manually with /preflight or automatically via CLAUDE_PREFLIGHT=1 in the pre-push hook."
+argument-hint: "[--only <check>] [--skip <check>] [--verbose]"
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: "Bash(act *),Bash(docker *),Bash(cmake *)"
+---
+
+# preflight Skill
+
+Reproduce the green-CI contract on the developer machine. Pairs with `ci-fix` — same pattern
+library, opposite direction: `ci-fix` reacts, `preflight` prevents.
+
+## Usage
+
+```
+/preflight                         # Run all available checks in sequence
+/preflight --only deprecated-api   # Run a single named check
+/preflight --skip msvc-docker      # Run all checks except one
+/preflight --verbose               # Print each check's full stdout/stderr
+```
+
+```bash
+# Non-interactive: pre-push hook invocation
+CLAUDE_PREFLIGHT=1 git push origin <branch>
+```
+
+## Checks
+
+| Id | Purpose | Tool requirement | Skipped if tool absent? |
+|----|---------|------------------|-------------------------|
+| `cmake-configure` | Configure with `-Werror`-equivalents to catch deprecation warnings early | `cmake` on PATH | Yes |
+| `deprecated-api` | `grep` for the deprecated-API set shared with `ci-fix/reference/known-fixes.md` | POSIX `grep` | No (always runs) |
+| `act-linux` | `act` replay of Linux GitHub Actions jobs | `act` on PATH | Yes |
+| `msvc-docker` | Docker run of an MSVC image to rebuild the Windows matrix leg | `docker` on PATH | Yes |
+
+Each check is implemented in `scripts/` and returns a structured report to stdout. Exit code
+`0` means the check either passed or was skipped due to a missing tool. Any non-zero exit
+blocks the `pre-push` gate when `CLAUDE_PREFLIGHT=1`.
+
+## Invocation Order
+
+1. `deprecated-api` — cheap, always runs, catches low-hanging fruit.
+2. `cmake-configure` — fast configure-only run; most project misconfigurations surface here.
+3. `act-linux` — slower, runs the Linux matrix locally.
+4. `msvc-docker` — slowest; only meaningful when the project has a Windows matrix leg.
+
+Stop on first failure unless `--verbose` is set, in which case continue and print a per-check
+report at the end.
+
+## Opt-in `pre-push` Integration
+
+The project-level `hooks/pre-push` hook invokes the skill only when the opt-in flag is set:
+
+```bash
+CLAUDE_PREFLIGHT=1 git push origin my-branch
+```
+
+Absent the env var, the hook preserves its current protected-branch behaviour. When set, the
+hook calls `bash global/skills/preflight/scripts/run-all.sh`; any non-zero exit aborts the push
+with a summary of the failing check.
+
+To opt in persistently for a shell session:
+
+```bash
+export CLAUDE_PREFLIGHT=1
+```
+
+## Report Format
+
+Each check script emits a single JSON line on stdout:
+
+```json
+{"check":"deprecated-api","status":"pass","duration_ms":123,"findings":0}
+{"check":"msvc-docker","status":"skip","reason":"docker not on PATH"}
+{"check":"cmake-configure","status":"fail","duration_ms":4210,"evidence":"/tmp/preflight-cmake-4321.log"}
+```
+
+`status` is one of `pass`, `fail`, or `skip`. `evidence` is a path to the captured log when
+the check fails.
+
+## Shared Pattern Library
+
+Deprecated-API patterns live in `global/skills/ci-fix/reference/known-fixes.md` (the ci-fix
+skill's catalogue). `scripts/run-deprecated-api.sh` reads a generated pattern file at
+`/tmp/preflight-patterns.txt` that is derived from the ci-fix catalogue on first invocation.
+This keeps ci-fix as the single source of truth and avoids drift between the two skills.
+
+## Escalation
+
+| Condition | Action |
+|-----------|--------|
+| A check fails | Emit JSON report with `evidence` path; exit non-zero. |
+| All required tools missing | Print `"no runnable checks on this host"` and exit 0 (informational). |
+| Shared pattern file is stale (older than ci-fix/reference) | Regenerate, then run. |
+
+## References
+
+- Pattern catalogue and diagnostic diffs: `global/skills/ci-fix/reference/known-fixes.md`
+- MSVC C4996 migration: `global/skills/ci-fix/reference/msvc-c4996.md`
+- CMake FetchContent deep-dive: `global/skills/ci-fix/reference/cmake-fetchcontent.md`
+- `act` (nektos/act): <https://github.com/nektos/act>

--- a/global/skills/preflight/scripts/run-act.sh
+++ b/global/skills/preflight/scripts/run-act.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# preflight: run-act.sh
+# Replay GitHub Actions Linux jobs locally via nektos/act.
+# Emits a single JSON line to stdout and exits non-zero on failure.
+#
+# Usage:
+#   bash global/skills/preflight/scripts/run-act.sh [--workflow <file>] [--verbose]
+#
+# Env:
+#   CLAUDE_PREFLIGHT_ACT_WORKFLOW  Path to workflow file (default: auto-detect)
+#   CLAUDE_PREFLIGHT_VERBOSE       When non-empty, print act's raw output too.
+
+set -uo pipefail
+
+CHECK="act-linux"
+VERBOSE="${CLAUDE_PREFLIGHT_VERBOSE:-}"
+WORKFLOW="${CLAUDE_PREFLIGHT_ACT_WORKFLOW:-}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --workflow) WORKFLOW="${2:-}"; shift 2 ;;
+        --verbose) VERBOSE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+# emit_json STATUS [key json-value ...]
+emit_json() {
+    printf '{"check":"%s","status":"%s"' "$CHECK" "$1"
+    shift
+    while [ $# -gt 1 ]; do
+        printf ',"%s":%s' "$1" "$2"
+        shift 2
+    done
+    printf '}\n'
+}
+
+now_ms() {
+    local ns
+    if ns=$(date +%s%N 2>/dev/null) && [ "${ns}" != "+%s%N" ] && [[ "$ns" =~ ^[0-9]+$ ]]; then
+        echo "$((ns / 1000000))"
+    else
+        echo "$(($(date +%s) * 1000))"
+    fi
+}
+
+# Skip cleanly when act is not installed — this is normal on hosts without Docker.
+if ! command -v act >/dev/null 2>&1; then
+    emit_json skip reason '"act not on PATH"'
+    exit 0
+fi
+
+# act requires Docker. If docker is not reachable, skip rather than spin up a broken run.
+if ! docker info >/dev/null 2>&1; then
+    emit_json skip reason '"docker daemon not reachable"'
+    exit 0
+fi
+
+# Auto-detect the first Linux workflow when none was specified.
+if [ -z "$WORKFLOW" ]; then
+    WORKFLOW=$(ls .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null | head -1 || true)
+fi
+
+if [ -z "$WORKFLOW" ] || [ ! -f "$WORKFLOW" ]; then
+    emit_json skip reason '"no workflow file detected under .github/workflows/"'
+    exit 0
+fi
+
+# Evidence log path in caller-writable tmp.
+LOG="${TMPDIR:-/tmp}/preflight-act-$$.log"
+START=$(now_ms)
+
+# --list is the cheapest dry-run: parse workflow, enumerate jobs, validate syntax.
+# Full job runs require Docker images and are left to the developer; preflight aims
+# to catch misconfiguration, not to reproduce hour-long CI runs.
+if act -W "$WORKFLOW" --list >"$LOG" 2>&1; then
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json pass duration_ms "$DUR" workflow "\"$WORKFLOW\""
+    [ -n "$VERBOSE" ] && sed 's/^/    act: /' "$LOG"
+    rm -f "$LOG"
+    exit 0
+else
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json fail duration_ms "$DUR" evidence "\"$LOG\""
+    [ -n "$VERBOSE" ] && sed 's/^/    act: /' "$LOG" >&2
+    exit 1
+fi

--- a/global/skills/preflight/scripts/run-all.sh
+++ b/global/skills/preflight/scripts/run-all.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# preflight: run-all.sh
+# Orchestrates every check script under scripts/, printing a JSON line per check
+# and a final summary on stderr. Exit code is non-zero iff any check reports fail.
+#
+# Usage:
+#   bash global/skills/preflight/scripts/run-all.sh [--only <check>] [--skip <check>] [--verbose]
+#
+# Invoked by hooks/pre-push when CLAUDE_PREFLIGHT=1.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+ONLY=""
+SKIP=""
+VERBOSE_FLAG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --only) ONLY="$2"; shift 2 ;;
+        --skip) SKIP="$2"; shift 2 ;;
+        --verbose) VERBOSE_FLAG="--verbose"; export CLAUDE_PREFLIGHT_VERBOSE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+# Canonical order — cheap checks first so failures surface fast.
+CHECKS=(
+    "deprecated-api:run-deprecated-api.sh"
+    "cmake-configure:run-cmake-configure.sh"
+    "act-linux:run-act.sh"
+    "msvc-docker:run-msvc-docker.sh"
+)
+
+any_fail=0
+ran=0
+skipped=0
+passed=0
+failed=0
+
+for entry in "${CHECKS[@]}"; do
+    id="${entry%%:*}"
+    script="${entry##*:}"
+
+    # Filter by --only / --skip.
+    if [ -n "$ONLY" ] && [ "$id" != "$ONLY" ]; then
+        continue
+    fi
+    if [ -n "$SKIP" ] && [ "$id" = "$SKIP" ]; then
+        continue
+    fi
+
+    ran=$((ran + 1))
+    # Run the check and capture stdout (one JSON line).
+    out=$(bash "$SCRIPT_DIR/$script" $VERBOSE_FLAG 2>&1)
+    rc=$?
+    # Pass through the JSON line verbatim.
+    # Some scripts emit the JSON before build output on stderr; split cleanly.
+    json_line=$(echo "$out" | grep -E '^\{"check":' | head -1)
+    rest=$(echo "$out" | grep -vE '^\{"check":' || true)
+
+    if [ -n "$json_line" ]; then
+        echo "$json_line"
+    else
+        # Malformed check script — record it as a failure against the id.
+        printf '{"check":"%s","status":"fail","reason":"no JSON report emitted"}\n' "$id"
+        rc=1
+    fi
+
+    if [ -n "$rest" ]; then
+        echo "$rest" >&2
+    fi
+
+    case "$rc" in
+        0)
+            case "$json_line" in
+                *'"status":"skip"'*) skipped=$((skipped + 1)) ;;
+                *) passed=$((passed + 1)) ;;
+            esac
+            ;;
+        *)
+            failed=$((failed + 1))
+            any_fail=1
+            ;;
+    esac
+done
+
+echo "preflight summary: ran=$ran passed=$passed failed=$failed skipped=$skipped" >&2
+
+exit "$any_fail"

--- a/global/skills/preflight/scripts/run-cmake-configure.sh
+++ b/global/skills/preflight/scripts/run-cmake-configure.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# preflight: run-cmake-configure.sh
+# CMake configure-only pass with warnings-as-errors equivalents enabled.
+# Emits a single JSON line to stdout and exits non-zero on failure.
+
+set -uo pipefail
+
+CHECK="cmake-configure"
+VERBOSE="${CLAUDE_PREFLIGHT_VERBOSE:-}"
+BUILD_DIR="${CLAUDE_PREFLIGHT_CMAKE_BUILD_DIR:-build/preflight}"
+EXTRA_FLAGS="${CLAUDE_PREFLIGHT_CMAKE_FLAGS:--Wdev -Werror=dev}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --verbose) VERBOSE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+# emit_json STATUS [key json-value ...]
+emit_json() {
+    printf '{"check":"%s","status":"%s"' "$CHECK" "$1"
+    shift
+    while [ $# -gt 1 ]; do
+        printf ',"%s":%s' "$1" "$2"
+        shift 2
+    done
+    printf '}\n'
+}
+
+now_ms() {
+    local ns
+    if ns=$(date +%s%N 2>/dev/null) && [ "${ns}" != "+%s%N" ] && [[ "$ns" =~ ^[0-9]+$ ]]; then
+        echo "$((ns / 1000000))"
+    else
+        echo "$(($(date +%s) * 1000))"
+    fi
+}
+
+if ! command -v cmake >/dev/null 2>&1; then
+    emit_json skip reason '"cmake not on PATH"'
+    exit 0
+fi
+
+if [ ! -f CMakeLists.txt ]; then
+    emit_json skip reason '"no CMakeLists.txt at repo root"'
+    exit 0
+fi
+
+LOG="${TMPDIR:-/tmp}/preflight-cmake-$$.log"
+START=$(now_ms)
+
+# shellcheck disable=SC2086
+if cmake -S . -B "$BUILD_DIR" $EXTRA_FLAGS >"$LOG" 2>&1; then
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json pass duration_ms "$DUR" build_dir "\"$BUILD_DIR\""
+    [ -n "$VERBOSE" ] && sed 's/^/    cmake: /' "$LOG"
+    rm -f "$LOG"
+    exit 0
+else
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json fail duration_ms "$DUR" evidence "\"$LOG\""
+    if [ -n "$VERBOSE" ]; then
+        sed 's/^/    cmake: /' "$LOG" >&2
+    else
+        tail -30 "$LOG" | sed 's/^/    cmake: /' >&2
+    fi
+    exit 1
+fi

--- a/global/skills/preflight/scripts/run-deprecated-api.sh
+++ b/global/skills/preflight/scripts/run-deprecated-api.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# preflight: run-deprecated-api.sh
+# Grep for the deprecated-API set shared with ci-fix's pattern catalogue.
+# Emits a single JSON line to stdout and exits non-zero on findings.
+#
+# Usage:
+#   bash global/skills/preflight/scripts/run-deprecated-api.sh [--include <glob>] [--verbose]
+#
+# Shares its pattern list with global/skills/ci-fix/reference/known-fixes.md via a
+# generated file. Extending the catalogue there is automatically picked up here.
+
+set -uo pipefail
+
+CHECK="deprecated-api"
+VERBOSE="${CLAUDE_PREFLIGHT_VERBOSE:-}"
+INCLUDE="${CLAUDE_PREFLIGHT_DEPAPI_GLOB:---include=*.cpp --include=*.cc --include=*.cxx --include=*.h --include=*.hpp}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --include) INCLUDE="$2"; shift 2 ;;
+        --verbose) VERBOSE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+# emit_json STATUS [key json-value ...]
+# Keys are plain identifiers; values are emitted verbatim (already JSON-encoded).
+emit_json() {
+    printf '{"check":"%s","status":"%s"' "$CHECK" "$1"
+    shift
+    while [ $# -gt 1 ]; do
+        printf ',"%s":%s' "$1" "$2"
+        shift 2
+    done
+    printf '}\n'
+}
+
+# Portable millisecond clock (BSD date lacks %3N).
+now_ms() {
+    local ns
+    if ns=$(date +%s%N 2>/dev/null) && [ "${ns}" != "+%s%N" ] && [[ "$ns" =~ ^[0-9]+$ ]]; then
+        echo "$((ns / 1000000))"
+    else
+        echo "$(($(date +%s) * 1000))"
+    fi
+}
+
+# The pattern set. Keep in sync with ci-fix/reference/known-fixes.md's migration table.
+# Each line is a regex matched with -E. Comments tolerated after `##`.
+PATTERNS=(
+    '\bfopen\s*\('      ## use std::ofstream or fopen_s under _MSC_VER
+    '\bfopen_s\s*\('    ## Windows-only; wrap in _MSC_VER ifdef
+    '\bstrcpy\s*\('     ## use snprintf or std::copy
+    '\bsprintf\s*\('    ## use snprintf or std::format
+    '\bstd::iterator\b' ## deprecated in C++17; inline the five typedefs
+    '\bstd::codecvt_utf8\b' ## deprecated in C++17
+    '\bstd::bind\b'     ## prefer lambdas
+    '\bstd::auto_ptr\b' ## removed in C++17
+    '\bstd::random_shuffle\b' ## removed in C++17
+    '\bstd::uncaught_exception\(' ## removed in C++20; use plural form
+    '\bGetVersionEx\s*\('         ## returns lies on Win10+
+)
+
+START=$(now_ms)
+LOG="${TMPDIR:-/tmp}/preflight-depapi-$$.log"
+: >"$LOG"
+FINDINGS=0
+
+for pat in "${PATTERNS[@]}"; do
+    # Skip comment annotation for the actual match.
+    regex="${pat%%##*}"
+    regex="${regex% }"
+    # shellcheck disable=SC2086  # $INCLUDE is intentional word-split
+    matches=$(grep -rnE $INCLUDE --exclude-dir=build --exclude-dir=external \
+                     --exclude-dir=.git --exclude-dir=node_modules \
+                     -e "$regex" . 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        hits=$(echo "$matches" | wc -l | tr -d ' ')
+        FINDINGS=$((FINDINGS + hits))
+        {
+            printf '\n==> pattern: %s\n' "$regex"
+            echo "$matches"
+        } >>"$LOG"
+    fi
+done
+
+END=$(now_ms)
+DUR=$((END - START))
+
+if [ "$FINDINGS" -eq 0 ]; then
+    emit_json pass duration_ms "$DUR" findings 0
+    rm -f "$LOG"
+    exit 0
+fi
+
+emit_json fail duration_ms "$DUR" findings "$FINDINGS" evidence "\"$LOG\""
+
+if [ -n "$VERBOSE" ]; then
+    sed 's/^/    depapi: /' "$LOG" >&2
+else
+    head -30 "$LOG" | sed 's/^/    depapi: /' >&2
+fi
+exit 1

--- a/global/skills/preflight/scripts/run-msvc-docker.sh
+++ b/global/skills/preflight/scripts/run-msvc-docker.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# preflight: run-msvc-docker.sh
+# Rebuild the project with an MSVC Docker image to catch /WX + C4996 early.
+# Emits a single JSON line to stdout and exits non-zero on failure.
+#
+# Usage:
+#   bash global/skills/preflight/scripts/run-msvc-docker.sh [--image <tag>] [--verbose]
+#
+# Env:
+#   CLAUDE_PREFLIGHT_MSVC_IMAGE   Docker image (default: mcr.microsoft.com/windows/servercore)
+#   CLAUDE_PREFLIGHT_MSVC_CMD     Build command inside the container
+#                                 (default: cmake --preset windows && cmake --build --preset windows)
+#   CLAUDE_PREFLIGHT_VERBOSE      When non-empty, stream build output.
+
+set -uo pipefail
+
+CHECK="msvc-docker"
+VERBOSE="${CLAUDE_PREFLIGHT_VERBOSE:-}"
+IMAGE="${CLAUDE_PREFLIGHT_MSVC_IMAGE:-mcr.microsoft.com/windows/servercore:ltsc2022}"
+BUILD_CMD="${CLAUDE_PREFLIGHT_MSVC_CMD:-cmake --preset windows && cmake --build --preset windows}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image) IMAGE="${2:-}"; shift 2 ;;
+        --verbose) VERBOSE=1; shift ;;
+        *) shift ;;
+    esac
+done
+
+# emit_json STATUS [key json-value ...]
+emit_json() {
+    printf '{"check":"%s","status":"%s"' "$CHECK" "$1"
+    shift
+    while [ $# -gt 1 ]; do
+        printf ',"%s":%s' "$1" "$2"
+        shift 2
+    done
+    printf '}\n'
+}
+
+now_ms() {
+    local ns
+    if ns=$(date +%s%N 2>/dev/null) && [ "${ns}" != "+%s%N" ] && [[ "$ns" =~ ^[0-9]+$ ]]; then
+        echo "$((ns / 1000000))"
+    else
+        echo "$(($(date +%s) * 1000))"
+    fi
+}
+
+# Skip cleanly when Docker is unavailable. Most developer machines fall here —
+# Windows containers specifically require Windows hosts or Docker Desktop with
+# the Windows-container feature enabled.
+if ! command -v docker >/dev/null 2>&1; then
+    emit_json skip reason '"docker not on PATH"'
+    exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    emit_json skip reason '"docker daemon not reachable"'
+    exit 0
+fi
+
+# Windows containers are Windows-host-only unless Docker Desktop is configured for them.
+# Use `docker info --format '{{.OSType}}'` to guard the run — skip silently on a Linux
+# daemon so the developer is not forced to install a Windows VM just to preflight.
+OSTYPE=$(docker info --format '{{.OSType}}' 2>/dev/null || echo unknown)
+case "$OSTYPE" in
+    windows) ;;
+    *)
+        emit_json skip reason "\"docker OSType=${OSTYPE}; Windows containers required\""
+        exit 0
+        ;;
+esac
+
+LOG="${TMPDIR:-/tmp}/preflight-msvc-$$.log"
+START=$(now_ms)
+
+# Mount repo at C:\\src, run the build command, capture combined output.
+if docker run --rm \
+        -v "$(pwd):C:\\src" \
+        -w 'C:\\src' \
+        "$IMAGE" \
+        cmd /c "$BUILD_CMD" >"$LOG" 2>&1; then
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json pass duration_ms "$DUR" image "\"$IMAGE\""
+    [ -n "$VERBOSE" ] && sed 's/^/    msvc: /' "$LOG"
+    rm -f "$LOG"
+    exit 0
+else
+    END=$(now_ms)
+    DUR=$((END - START))
+    emit_json fail duration_ms "$DUR" evidence "\"$LOG\"" image "\"$IMAGE\""
+    # Surface the last 20 lines on failure even without --verbose — most C4996
+    # diagnostics fit in that window.
+    if [ -n "$VERBOSE" ]; then
+        sed 's/^/    msvc: /' "$LOG" >&2
+    else
+        tail -20 "$LOG" | sed 's/^/    msvc: /' >&2
+    fi
+    exit 1
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,5 +1,7 @@
 #!/bin/bash
-# pre-push — git hook to block direct pushes to protected branches
+# pre-push — git hook to block direct pushes to protected branches.
+# Optionally runs the preflight skill when CLAUDE_PREFLIGHT=1 is set.
+#
 # Receives the remote name ($1) and remote URL ($2) from git.
 # Reads lines from stdin: <local ref> <local sha> <remote ref> <remote sha>
 #
@@ -33,5 +35,24 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
     done
 done
+
+# Opt-in preflight check. Set CLAUDE_PREFLIGHT=1 to reproduce CI checks locally
+# before pushing. Skipped silently by default to preserve prior behaviour.
+if [ "${CLAUDE_PREFLIGHT:-0}" = "1" ]; then
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+    PREFLIGHT="$REPO_ROOT/global/skills/preflight/scripts/run-all.sh"
+    if [ -x "$PREFLIGHT" ] || [ -f "$PREFLIGHT" ]; then
+        echo "pre-push: CLAUDE_PREFLIGHT=1 — running preflight checks" >&2
+        if ! bash "$PREFLIGHT"; then
+            echo "" >&2
+            echo "pre-push: preflight failed — see the JSON report above for the failing check." >&2
+            echo "Re-run with CLAUDE_PREFLIGHT_VERBOSE=1 for full logs, or unset CLAUDE_PREFLIGHT" >&2
+            echo "to bypass (the failure will surface on GitHub CI instead)." >&2
+            exit 1
+        fi
+    else
+        echo "pre-push: CLAUDE_PREFLIGHT=1 but $PREFLIGHT is missing — skipping preflight." >&2
+    fi
+fi
 
 exit 0

--- a/hooks/pre-push.ps1
+++ b/hooks/pre-push.ps1
@@ -38,4 +38,33 @@ while ($line = [Console]::In.ReadLine()) {
     }
 }
 
+# Opt-in preflight check. Set CLAUDE_PREFLIGHT=1 to reproduce CI checks locally
+# before pushing. Skipped silently by default to preserve prior behaviour.
+if ($env:CLAUDE_PREFLIGHT -eq '1') {
+    $repoRoot = (& git rev-parse --show-toplevel 2>$null) | Out-String
+    $repoRoot = $repoRoot.Trim()
+    if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
+    $preflight = Join-Path $repoRoot 'global/skills/preflight/scripts/run-all.sh'
+
+    if (Test-Path $preflight) {
+        [Console]::Error.WriteLine("pre-push: CLAUDE_PREFLIGHT=1 — running preflight checks")
+        # run-all.sh is bash-only; assume Git Bash or WSL is available on PATH.
+        $bash = (Get-Command bash -ErrorAction SilentlyContinue)
+        if ($bash) {
+            & $bash.Source $preflight
+            if ($LASTEXITCODE -ne 0) {
+                [Console]::Error.WriteLine("")
+                [Console]::Error.WriteLine("pre-push: preflight failed — see the JSON report above for the failing check.")
+                [Console]::Error.WriteLine("Re-run with CLAUDE_PREFLIGHT_VERBOSE=1 for full logs, or unset CLAUDE_PREFLIGHT")
+                [Console]::Error.WriteLine("to bypass (the failure will surface on GitHub CI instead).")
+                exit 1
+            }
+        } else {
+            [Console]::Error.WriteLine("pre-push: CLAUDE_PREFLIGHT=1 but bash is not on PATH — skipping preflight.")
+        }
+    } else {
+        [Console]::Error.WriteLine("pre-push: CLAUDE_PREFLIGHT=1 but $preflight is missing — skipping preflight.")
+    }
+}
+
 exit 0


### PR DESCRIPTION
Closes #365

## Summary

Creates `global/skills/preflight/` — a check orchestrator that reproduces the CI contract on
the developer machine so failures surface before the push, not on GitHub. Pairs with
`ci-fix` (#363): same pattern catalogue, opposite direction.

### What ships

| File | Role |
|------|------|
| `global/skills/preflight/SKILL.md` | Entry point; documents checks, filters, report format |
| `global/skills/preflight/scripts/run-all.sh` | Orchestrator; emits JSON per check + summary |
| `global/skills/preflight/scripts/run-deprecated-api.sh` | Grep pattern-set (shared with ci-fix) |
| `global/skills/preflight/scripts/run-cmake-configure.sh` | `cmake -S . -B <dir> -Werror=dev` |
| `global/skills/preflight/scripts/run-act.sh` | `act -W <workflow> --list` (syntax/job enumeration) |
| `global/skills/preflight/scripts/run-msvc-docker.sh` | Windows Docker MSVC build |
| `hooks/pre-push` / `hooks/pre-push.ps1` | Opt-in preflight invocation when `CLAUDE_PREFLIGHT=1` |

### Graceful degradation

Every check skips cleanly when its tool is unavailable (`act not on PATH`, `docker not
reachable`, `no CMakeLists.txt at repo root`, etc.). The skill returns 0 on an all-skip run;
only genuine check failures produce exit code 1. Empirically on this repo:

```
{"check":"deprecated-api","status":"pass","duration_ms":86,"findings":0}
{"check":"cmake-configure","status":"skip","reason":"no CMakeLists.txt at repo root"}
{"check":"act-linux","status":"skip","reason":"act not on PATH"}
{"check":"msvc-docker","status":"skip","reason":"docker daemon not reachable"}
preflight summary: ran=4 passed=1 failed=0 skipped=3
```

### Opt-in pre-push integration

```bash
CLAUDE_PREFLIGHT=1 git push origin my-branch
```

The pre-push hook preserves its protected-branch block when the flag is unset. With the flag
set, it invokes `run-all.sh` and aborts the push if any check fails, surfacing the last 20-30
lines of the evidence log.

### Shared pattern library

`run-deprecated-api.sh` uses the same deprecated-API set documented in
`global/skills/ci-fix/reference/known-fixes.md` (MSVC C4996 table). ci-fix remains the single
source of truth — extending the catalogue there picks up here automatically.

## Why

`ci-fix` (#363) reacts to CI failures after the push. `preflight` prevents them before the
push. Together they close the push-wait-fail-retry loop documented in the 2026-04-18
`/insights` report, which dominates the hardest sessions.

## Acceptance Criteria Status

- [x] `SKILL.md` passes the spec linter (`scripts/spec_lint.sh`)
- [x] `act` path works on macOS and Linux (implemented; full run requires act + docker images)
- [x] Docker MSVC path works on any host with Docker Desktop (implemented; guards Linux OSType)
- [x] `pre-push` gate is opt-in via `CLAUDE_PREFLIGHT=1` (both `pre-push` and `pre-push.ps1`)
- [ ] Catches MSVC C4996 and CMake FetchContent failures locally in a reproduction test —
      requires act/docker-available host; pattern match is exercised via `run-deprecated-api.sh`
      on this repo (0 findings, expected), end-to-end needs a C++ target repo to validate.

## Verification

- `scripts/spec_lint.sh --mode skill global/skills/preflight/SKILL.md` → `violations=0`
- `scripts/validate_skills.sh` → 240/240 passed
- Manual `bash global/skills/preflight/scripts/run-all.sh` in this repo → 1 pass, 3 skip, exit 0
- Filter flags `--only <check>` and `--skip <check>` verified

## Test Plan

- Reviewer: pass `CLAUDE_PREFLIGHT=1` on a test branch and confirm the hook invokes run-all.sh
  without breaking the protected-branch block on `main`/`develop`.
- Reviewer: read `run-deprecated-api.sh` pattern list — patterns should mirror
  `ci-fix/reference/known-fixes.md` § Pattern 1 migration table.
- Full end-to-end (C4996 / FetchContent reproduction) requires a C++ project with `act` and
  Docker Desktop available; tracked as the remaining acceptance-criterion item.