### PR TITLE
feat(skills): add fleet-orchestrator skill for parallel multi-repo operations

### DIFF
--- a/docs/fleet-orchestrator.md
+++ b/docs/fleet-orchestrator.md
@@ -1,0 +1,138 @@
+# Fleet Orchestrator — Parallel Multi-Repo Directive Execution
+
+> **Type**: Skill documentation
+> **Skill location**: `global/skills/fleet-orchestrator/`
+> **Related issues**: #366 (this skill), #360 (post-task-checkpoint hook, closed), #361 (atomic multi-phase rule, closed)
+> **Related skills**: [`harness`](../global/skills/harness/SKILL.md), [`issue-work`](../global/skills/issue-work/SKILL.md), [`pr-work`](../global/skills/pr-work/SKILL.md)
+> **Purpose**: Fan out a single directive across N repositories as parallel worker Agents, with a supervisor that polls a shared manifest and aggregates results.
+
+## Background
+
+The 2026-04-18 `/insights` report documented the "8-system sequential sweep"
+pattern appearing in 4+ sessions (vcpkg readiness, 160+ deprecated item removal,
+7-project build fixes). Each ran for hours serially. The fleet-orchestrator
+compresses wall-clock time by running workers in parallel and isolates failures
+so one flaky repo does not block the rest of the sweep.
+
+Tier progression toward this skill:
+
+- **Tier 0** (shipped): lower batch limits, chunked confirmation, inline rule reminders.
+- **Tier 1** (shipped): PreToolUse guards for language, merge gate, attribution.
+- **Tier 2** (shipped): subagent delegation as the default batch dispatch; `--auto-restart` for process-level resets.
+- **Tier 3** (this skill): parallel worker fan-out across repos with shared-state coordination.
+
+This is the "On the Horizon #1" item from the 2026-04-18 report:
+**Parallel Multi-Repo Autonomous PR Fleet**.
+
+## Architecture
+
+The skill instantiates the Fan-out/Fan-in + Supervisor pattern from
+`harness/reference/agent-design-patterns.md`.
+
+```
+                    [Supervisor (main session)]
+                     | dispatch      ^ poll every POLL_INTERVAL seconds
+                     v               |
+       +-------------+---------------+-------------+
+       |             |               |             |
+   [Worker 1]    [Worker 2]      [Worker 3]    [Worker N]
+   repo A        repo B          repo C         repo N
+       \             \               /             /
+        \            flock-guarded   /            /
+         \           writes to       /           /
+          \------> fleet-status.json <----------/
+```
+
+| Component | Role |
+|-----------|------|
+| Supervisor | Main session. Input validation, worker fan-out, manifest polling, aggregation, final report. Never edits code itself. |
+| Worker (N×) | Fresh `general-purpose` Agent per repo, launched with `run_in_background=true`. Runs issue-work/pr-work on its assigned repo and writes terminal status to the manifest. |
+| Manifest | `_workspace/fleet/fleet-status.json`. Single source of truth for fleet state. Guarded by `flock`. Schema: `global/skills/fleet-orchestrator/reference/manifest-schema.json`. |
+
+## Relationship to Existing Skills
+
+| Skill | Role in a fleet run |
+|-------|---------------------|
+| `harness` | Meta-skill that produced the Fan-out + Supervisor pattern this skill follows. |
+| `issue-work` | Each worker delegates its per-repo workflow (branch → PR → CI → merge) to `issue-work --solo`. The worker adds manifest updates around that call. |
+| `pr-work` | The retry path when a worker's initial PR fails CI. Invoked by the worker, not directly by the supervisor. |
+| `issue-create` | Used by workers when the directive requires a new issue per repo (most audit/cleanup directives do). |
+
+The fleet orchestrator is deliberately a thin supervisor. Each worker reuses
+the per-repo workflows that already enforce language, attribution, and CI-gate
+rules — the fleet layer only adds the manifest integration and the retry
+classifier.
+
+## When to Reach For This Skill
+
+| Situation | Use fleet-orchestrator? |
+|-----------|-------------------------|
+| Apply the same audit/cleanup/fix across 3+ repos | Yes |
+| Sequential sweep currently taking hours | Yes |
+| Version bump for a shared internal package across repos | Yes |
+| Single repo, single issue | No — use `/issue-work` |
+| Schema change that must merge in strict cross-repo order | No — coordinate manually |
+| Repos with incompatible toolchains that share nothing but the directive | Marginal — evaluate per case |
+
+## Example Invocations
+
+```
+/fleet-orchestrator repo-a repo-b repo-c "Remove all uses of the deprecated foo_bar API"
+
+/fleet-orchestrator @repos.txt "Bump vcpkg baseline to 2026.04"
+
+/fleet-orchestrator --org kcenon "Audit for secrets in CI logs; redact and open an issue"
+
+/fleet-orchestrator repo-a repo-b repo-c "Migrate tests to Catch2 v3" --max-parallel 4 --retry 2 --poll-interval 60
+
+/fleet-orchestrator --org kcenon "Dry run only" --dry-run
+```
+
+See `global/skills/fleet-orchestrator/SKILL.md` for the full argument list and
+workflow phases.
+
+## Output Artifacts
+
+Every fleet run produces:
+
+| Path | Purpose | Retained after run? |
+|------|---------|---------------------|
+| `_workspace/fleet/fleet-status.json` | Terminal manifest with per-repo outcomes | Yes (audit trail) |
+| `_workspace/fleet/fleet-status.json.lock` | Flock file (empty) | Yes |
+| `_workspace/fleet/<repo-slug>/worker.log` | Per-worker phase log | Yes |
+| Per-repo PR on GitHub | The actual deliverable | Yes |
+
+The final supervisor report includes per-repo PR URL, CI outcome, and merge
+status, and explicitly flags any repo that landed in `draft` state for user
+review.
+
+## Failure Isolation
+
+A worker failure never halts peer workers. Each worker writes its terminal
+state into its own manifest slot under `flock`; the supervisor treats the
+manifest as the single source of truth and reconciles any worker that exited
+without writing terminal state by filling in `{status:"failed", error:{class:"worker-crash"}}`.
+
+Three failure classes to know:
+
+| Class | Meaning | Supervisor action |
+|-------|---------|-------------------|
+| `code-review-needed` | Real code bug exposed by CI; PR left as draft. | Flagged in the final report for user action. |
+| `retry-exhausted` | Transient CI failures consumed the retry budget without the worker identifying a root cause. | Flagged in the final report, log path included. |
+| `preflight-failed` | Repo-level issue (no push permission, archived). | Repo is moved to `pre_excluded` in the manifest; never counted against fleet success. |
+
+## Dependencies
+
+This skill assumes the following infrastructure is in place:
+
+- **`hooks/post-task-checkpoint.sh`** (issue #360 — closed): prevents worker-side checkpoint clobbers when multiple workers run in parallel.
+- **Atomic Multi-Phase Execution rule** in `_policy.md` (issue #361 — closed): keeps workers from pausing mid-PR for confirmation. Without this rule, parallel workers would deadlock on per-phase prompts.
+- **`flock` and `jq`**: the manifest update protocol uses both. They are allowlisted in the skill's `allowed-tools` frontmatter.
+
+## References
+
+- Skill entry point: `global/skills/fleet-orchestrator/SKILL.md`
+- Worker prompt template: `global/skills/fleet-orchestrator/reference/worker-template.md`
+- Manifest schema: `global/skills/fleet-orchestrator/reference/manifest-schema.json`
+- Architecture pattern origin: `global/skills/harness/reference/agent-design-patterns.md` (Fan-out/Fan-in, Supervisor sections)
+- Motivating report: 2026-04-18 `/insights` "On the Horizon #1" — Parallel Multi-Repo Autonomous PR Fleet

--- a/global/skills/fleet-orchestrator/SKILL.md
+++ b/global/skills/fleet-orchestrator/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: fleet-orchestrator
+description: "Fan out a single high-level directive (audit, deprecation cleanup, fix, migration, version bump) across an arbitrary list of repositories as parallel Agent workers, with a supervisor that polls a shared manifest, renders a live status table, and aggregates final results. Use when the user says 'apply X across repos', 'audit N repositories', 'sweep every repo', 'run the same fix in all projects', 'parallel multi-repo', 'fleet-wide change', or provides a list of repositories with a single directive. Preferred over running issue-work in each repo sequentially."
+argument-hint: "<repos-spec> <directive-spec> [--max-parallel N] [--retry N] [--poll-interval SEC] [--dry-run]"
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: "Bash(gh *), Bash(flock *), Bash(jq *)"
+---
+
+# Fleet Orchestrator -- Parallel Multi-Repo Directive Executor
+
+A supervisor skill that applies one directive across many repositories concurrently.
+Each repository is handled by an independent worker Agent; progress and outcomes
+flow through a single JSON manifest (`fleet-status.json`) updated with `flock` for
+atomic, race-free writes.
+
+## When to Use This Skill
+
+- Applying the same change (audit, cleanup, migration, dependency bump, policy update) to N repos.
+- The user wants wall-clock compression — eight repos serialized take hours, fanned out take the length of the slowest one.
+- Failure isolation matters — one flaky repo must not block the other seven.
+- The directive is uniform enough that per-repo customization is minor (each worker still adapts to its repo's code style and issue landscape).
+
+Do NOT use this skill when:
+
+- There is only one repo — use `/issue-work` directly.
+- The directive requires tight cross-repo coordination (e.g., a schema change that must merge in strict order) — sequence it manually.
+- Repos have incompatible toolchains and the supervisor cannot meaningfully aggregate their outcomes.
+
+## Execution Mode: Sub-agent (Parallel) with Supervisor
+
+Agent teams are capped at one active team per session. Fleet work needs N independent
+workers running concurrently with run-to-completion semantics, so we use the sub-agent
+mode (`Agent(..., run_in_background=true)`) plus a file-based manifest for coordination.
+
+Data passing strategy:
+
+| Layer | Mechanism | Why |
+|-------|-----------|-----|
+| Shared state | `_workspace/fleet/fleet-status.json` | One JSON blob, race-free via `flock`, readable by every worker and the supervisor |
+| Per-worker artifacts | `_workspace/fleet/{repo-slug}/` | Per-worker scratch, logs, diff snapshots — preserved for audit |
+| Supervisor → worker | `Agent` prompt (one-shot) | Each worker gets the spec and its `repo` slot at launch; no runtime re-parameterization |
+| Worker → supervisor | Manifest writes | Supervisor polls; workers never call back |
+
+## Agent Configuration
+
+| Role | `subagent_type` | `model` | `run_in_background` | Purpose |
+|------|----------------|---------|----------------------|---------|
+| supervisor | (main session) | n/a | n/a | Input validation, worker fan-out, manifest polling, aggregation |
+| worker (one per repo) | `general-purpose` | `opus` | `true` | Executes the directive on its assigned repo, updates manifest |
+
+All workers use the same worker prompt template (`reference/worker-template.md`).
+The supervisor never edits code itself — it only dispatches, monitors, and reports.
+
+## Architecture
+
+```
+                    [Supervisor (main session)]
+                     | dispatch      ^ poll every POLL_INTERVAL seconds
+                     v               |
+       +-------------+---------------+-------------+
+       |             |               |             |
+   [Worker 1]    [Worker 2]      [Worker 3]    [Worker N]
+   repo A        repo B          repo C         repo N
+       \             \               /             /
+        \            flock-guarded   /            /
+         \           writes to       /           /
+          \------> fleet-status.json <----------/
+```
+
+## Workflow
+
+### Phase 1: Input Resolution and Validation
+
+The skill accepts inputs in three forms; pick the first that matches:
+
+| Input form | Example | How to parse |
+|------------|---------|--------------|
+| Inline list | `repo-a repo-b repo-c "fix all TODOs"` | Positional args: repos until a non-repo-like token, then the directive |
+| File list | `@repos.txt "fix all TODOs"` | Read `repos.txt`, one `owner/repo` per line |
+| Org-wide | `--org kcenon "fix all TODOs"` | `gh repo list <org> --json nameWithOwner,isArchived --jq '[.[] \| select(.isArchived == false)] \| .[].nameWithOwner'` |
+
+Validation rules:
+
+1. Every repo must resolve to `owner/repo` form. Reject entries without a `/`.
+2. Deduplicate repos.
+3. Verify each repo exists and the current user has write access: `gh api "repos/{owner}/{repo}" --jq .permissions.push`.
+4. Repos failing step 3 are moved to a `pre-excluded` list in the manifest with a reason, not dispatched.
+5. The directive must be non-empty. If empty, prompt the user for it (one-shot).
+6. If `N > --max-parallel`, workers are launched in waves of `--max-parallel`. Default: 8 (conservative; most Macs handle this comfortably).
+
+### Phase 2: Manifest Initialization
+
+Create `_workspace/fleet/` and write the initial manifest:
+
+```bash
+FLEET_ID="fleet-$(date '+%Y%m%d-%H%M%S')"
+mkdir -p "_workspace/fleet"
+MANIFEST="_workspace/fleet/fleet-status.json"
+
+# Seed the manifest. Use jq to build the structure to guarantee valid JSON.
+jq -n \
+  --arg fleet_id "$FLEET_ID" \
+  --arg started_at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+  --arg directive "$DIRECTIVE" \
+  --argjson repos "$REPOS_JSON" \
+  '{
+     schema_version: "1.0.0",
+     fleet_id: $fleet_id,
+     started_at: $started_at,
+     directive: $directive,
+     max_parallel: '$MAX_PARALLEL',
+     max_retries: '$MAX_RETRIES',
+     workers: ($repos | map({
+       repo: .,
+       status: "queued",
+       started_at: null,
+       updated_at: null,
+       pr_url: null,
+       ci_conclusion: null,
+       merge_status: null,
+       retry_count: 0,
+       error: null,
+       phase: "queued"
+     })),
+     summary: null
+   }' > "$MANIFEST"
+```
+
+> Full schema: `reference/manifest-schema.json` (JSON Schema Draft 2020-12).
+> Changes to the manifest shape must bump `schema_version` in both the seed
+> above and the schema file.
+
+### Phase 3: Fan-out Worker Dispatch
+
+Launch workers up to `--max-parallel` at a time. The `Agent` tool with
+`run_in_background=true` returns immediately, so all N calls go out in a
+single message:
+
+```
+For each repo in the first wave (size min(N, MAX_PARALLEL)):
+    Agent(
+        subagent_type: "general-purpose",
+        model: "opus",
+        run_in_background: true,
+        description: "Fleet worker: <repo>",
+        prompt: <render reference/worker-template.md with substitutions>
+    )
+```
+
+Template substitutions for each worker (load `reference/worker-template.md` and
+replace these tokens before passing as `prompt`):
+
+| Token | Value |
+|-------|-------|
+| `{{REPO}}` | `owner/repo` |
+| `{{DIRECTIVE}}` | The full directive text |
+| `{{MANIFEST_PATH}}` | Absolute path to `fleet-status.json` |
+| `{{MAX_RETRIES}}` | Retry cap for transient CI failures |
+| `{{FLEET_ID}}` | For log correlation |
+
+Record each dispatched worker's task ID in a local map so the supervisor can
+call `TaskOutput(block=false)` on it when polling.
+
+When a worker finishes and `workers[i].status` becomes `completed` or `failed`,
+the supervisor picks the next queued repo and dispatches a new worker (maintains
+`--max-parallel` throughput).
+
+### Phase 4: Supervisor Polling Loop
+
+Every `--poll-interval` seconds (default 120):
+
+1. Read the manifest atomically:
+   ```bash
+   flock -s "$MANIFEST.lock" -c "cat $MANIFEST" | jq .
+   ```
+2. Render a status table to the user (see the template in **Status Table Rendering** below).
+3. For each worker task ID, call `TaskOutput(block=false, timeout=2000)`. If the
+   task has exited, reconcile its status in the manifest (belt-and-suspenders:
+   the worker should have already written its terminal status).
+4. Dispatch a new worker if there is a queued repo and capacity.
+5. Terminate the loop when every worker is in `completed` or `failed`.
+
+**Do NOT** use blocking `TaskOutput(block=true)` — it would freeze the supervisor
+and prevent monitoring peer workers.
+
+**Stuck-worker detection**: if `updated_at` for any running worker is older than
+`10 × poll_interval`, flag it as `stuck` in the rendered table but do not kill
+it — the worker may be legitimately running a long build. Escalate to the user
+only after `20 × poll_interval` of silence.
+
+### Phase 5: Aggregation and Reporting
+
+Once all workers have terminated:
+
+1. Read the final manifest.
+2. Compute the `summary` block:
+   ```jsonc
+   {
+     "total": N,
+     "merged": <count status=completed AND merge_status=merged>,
+     "draft": <count merge_status=draft>,
+     "failed": <count status=failed>,
+     "skipped": <count status=skipped>,
+     "duration_seconds": <ended_at - started_at>
+   }
+   ```
+3. Write `summary` back to the manifest (flock-guarded).
+4. Render the final aggregated report (see **Final Report** below).
+5. Do NOT delete `_workspace/fleet/` — keep it for the audit trail.
+
+### Phase 6: Cleanup
+
+- Cancel any still-running background tasks (should be none, but defensive).
+- Print the absolute path to `_workspace/fleet/fleet-status.json` so the user
+  can inspect it later.
+- If any worker ended in `failed` with `error.class == "code-review-needed"`,
+  list those repos explicitly for user attention.
+
+## Status Table Rendering
+
+Each poll cycle renders this table (omit workers still in `queued` if the
+fleet is large, or cap at 20 rows):
+
+```markdown
+## Fleet Status — fleet-20260420-071500
+
+Elapsed: 00:12:34 | Active: 5 / 8 | Queued: 2 | Completed: 6 | Failed: 0
+
+| # | Repo | Phase | PR | CI | Merge | Retries | Last update |
+|---|------|-------|-----|-----|-------|---------|-------------|
+| 1 | kcenon/repo-a | merged | #89 | success | merged | 0 | 00:11:20 ago |
+| 2 | kcenon/repo-b | ci-monitoring | #90 | in_progress | — | 1 | 00:00:42 ago |
+| 3 | kcenon/repo-c | implementing | — | — | — | 0 | 00:00:18 ago |
+| 4 | kcenon/repo-d | failed | #91 (draft) | failure | — | 3 | 00:03:55 ago |
+| 5 | kcenon/repo-e | queued | — | — | — | 0 | — |
+```
+
+`Phase` values mirror the worker's state machine (see worker template).
+
+## Final Report
+
+```markdown
+## Fleet Execution Report — fleet-20260420-071500
+
+Directive: <short form of the directive>
+
+| Metric | Value |
+|--------|-------|
+| Repos dispatched | 8 |
+| Merged | 6 |
+| Draft (awaiting manual review) | 1 |
+| Failed | 1 |
+| Duration | 00:27:14 |
+
+### Per-Repo Outcomes
+
+| Repo | Result | PR | CI | Notes |
+|------|--------|----|-----|-------|
+| kcenon/repo-a | merged | https://github.com/kcenon/repo-a/pull/89 | success | — |
+| kcenon/repo-b | merged | https://github.com/kcenon/repo-b/pull/90 | success | Retried once (flaky lint) |
+| kcenon/repo-c | merged | https://github.com/kcenon/repo-c/pull/41 | success | — |
+| kcenon/repo-d | draft | https://github.com/kcenon/repo-d/pull/91 | failure | 3 retries exhausted; user review needed |
+| kcenon/repo-e | failed | — | — | Pre-excluded: no push permission |
+| ... | ... | ... | ... | ... |
+
+### Action Required
+
+- `kcenon/repo-d` — CI failure after 3 retries. Log: `_workspace/fleet/repo-d/retry-3.log`.
+
+Manifest: `_workspace/fleet/fleet-status.json`
+```
+
+## Error Handling
+
+| Situation | Strategy |
+|-----------|----------|
+| One worker crashes without writing terminal status | Supervisor detects exit via `TaskOutput`, writes `{status:"failed", error:{class:"worker-crash"}}` on its behalf |
+| Manifest write races | `flock` around every write; readers use `-s` (shared) lock for consistency |
+| Transient CI failure (test flake, runner timeout) | Worker retries up to `--max-retries` with exponential backoff (30s, 120s, 300s) |
+| Genuine code failure | Worker converts PR to draft, writes `error.class="code-review-needed"`, exits cleanly; supervisor flags in the final report |
+| Manifest file corrupted | Fatal error — supervisor halts, prints the last good backup (worker should snapshot to `fleet-status.json.N` after every N writes) |
+| Repo pre-flight fails (no push, archived) | Added to `pre-excluded` list in the manifest, never dispatched |
+| Supervisor run interrupted mid-fleet | Resume is manual: re-invoke the skill with `--resume <fleet-id>`; it re-reads the manifest and re-launches workers in non-terminal states |
+
+## Test Scenarios
+
+### Normal Flow
+
+1. User invokes with 8 repos and a directive.
+2. Phase 1 validates all 8; none are pre-excluded.
+3. Phase 2 writes an 8-entry manifest, all queued.
+4. Phase 3 dispatches 8 workers in parallel.
+5. Phase 4 polls every 120s; workers transition queued → running → completed.
+6. One worker retries a flaky CI run, succeeds on retry.
+7. Phase 5 aggregates: 8 merged, 0 failed.
+8. Final report printed; `_workspace/fleet/` retained.
+
+Expected outcome: manifest shows all 8 with `status="completed"` and `merge_status="merged"`.
+
+### Failure Isolation Flow
+
+1. User invokes with 8 repos.
+2. Worker 3 hits a genuine compile error on retry 3.
+3. Worker 3 converts its PR to draft, writes `error.class="code-review-needed"`, exits with status `failed`.
+4. Workers 1, 2, 4-8 continue unaffected.
+5. Phase 5 reports 7 merged, 1 draft-awaiting-review.
+
+Expected outcome: worker 3's failure does not stop peer workers; final report explicitly flags worker 3 for user action.
+
+### Pre-flight Exclusion Flow
+
+1. User invokes with 10 repos; 2 are archived.
+2. Phase 1 excludes the 2 archived repos, lists them in the manifest with `pre-excluded: "archived"`.
+3. Phase 2-5 operate on the 8 live repos.
+
+Expected outcome: final report lists the 2 pre-excluded repos separately from the 8 dispatched.
+
+## Dependencies and Related Skills
+
+- **`hooks/post-task-checkpoint.sh`** (issue #360 — closed): ensures worker-side
+  checkpoints don't overwrite each other. The fleet orchestrator leans on this
+  for cross-worker file safety inside `_workspace/`.
+- **Atomic Multi-Phase Execution rule** (issue #361 — closed, in `_policy.md`):
+  keeps workers from stopping mid-PR for confirmation.
+- **`harness`**: the meta-skill that produced this pattern. Fleet orchestrator
+  is an instance of Fan-out/Fan-in + Supervisor from `harness/reference/agent-design-patterns.md`.
+- **`issue-work`**: the per-repo workflow each worker executes. The worker template
+  is a thin wrapper that adds manifest updates around `issue-work`'s Solo mode.
+- **`pr-work`**: the retry path when a worker's initial PR fails CI.
+
+## References
+
+- **Worker prompt template**: `reference/worker-template.md` — what each per-repo worker does step-by-step.
+- **Manifest schema**: `reference/manifest-schema.json` — the authoritative JSON Schema for `fleet-status.json`.
+- **Documentation**: `docs/fleet-orchestrator.md` — user-facing overview, examples, and the "On the Horizon" context that motivated this skill.
+
+## Output Checklist
+
+After a fleet run, confirm:
+
+- [ ] `_workspace/fleet/fleet-status.json` exists and validates against the schema.
+- [ ] Every repo has a terminal status (`completed`, `failed`, or `skipped`).
+- [ ] `summary` block is populated.
+- [ ] Final report matches the manifest counts.
+- [ ] Failed repos are called out explicitly for user action.
+- [ ] `_workspace/fleet/` is preserved for audit.

--- a/global/skills/fleet-orchestrator/reference/manifest-schema.json
+++ b/global/skills/fleet-orchestrator/reference/manifest-schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kcenon.github.io/claude-config/schemas/fleet-status-1.0.0.json",
+  "title": "Fleet Status Manifest",
+  "description": "Shared state file written by fleet-orchestrator workers and read by the supervisor. All writers MUST hold an exclusive flock on <manifest>.lock. Readers SHOULD hold a shared lock.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "fleet_id",
+    "started_at",
+    "directive",
+    "max_parallel",
+    "max_retries",
+    "workers"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Semantic version of this schema. Bump on any breaking change."
+    },
+    "fleet_id": {
+      "type": "string",
+      "pattern": "^fleet-[0-9]{8}-[0-9]{6}$",
+      "description": "Unique fleet identifier; timestamp-based for human readability."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp when the supervisor initialized the fleet."
+    },
+    "ended_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp when the last worker terminated. Null while the fleet is active."
+    },
+    "directive": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Verbatim directive text the supervisor fanned out. Workers receive this as their spec."
+    },
+    "max_parallel": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 32,
+      "description": "Supervisor's concurrency cap. Workers beyond this wait in queued state."
+    },
+    "max_retries": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10,
+      "description": "Maximum retry attempts for transient CI failures per worker."
+    },
+    "pre_excluded": {
+      "type": "array",
+      "description": "Repos that failed pre-flight checks and were never dispatched.",
+      "items": {
+        "type": "object",
+        "required": ["repo", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "repo": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
+          "reason": {
+            "type": "string",
+            "enum": ["archived", "no-push-permission", "not-found", "malformed", "duplicate"]
+          }
+        }
+      }
+    },
+    "workers": {
+      "type": "array",
+      "description": "One entry per dispatched repo. Order matches the supervisor's dispatch order.",
+      "items": { "$ref": "#/$defs/worker" }
+    },
+    "summary": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/summary" }
+      ],
+      "description": "Computed by the supervisor after all workers terminate. Null while the fleet is active."
+    }
+  },
+  "$defs": {
+    "worker": {
+      "type": "object",
+      "required": ["repo", "status", "phase", "retry_count"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$",
+          "description": "GitHub nameWithOwner form, e.g. 'kcenon/claude-config'."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["queued", "running", "completed", "failed", "skipped"],
+          "description": "Terminal states: completed, failed, skipped. Non-terminal: queued, running."
+        },
+        "phase": {
+          "type": "string",
+          "enum": [
+            "queued",
+            "preflight",
+            "issue-creation",
+            "branching",
+            "implementing",
+            "building",
+            "pr-creation",
+            "ci-monitoring",
+            "ci-retry",
+            "merging",
+            "cleanup",
+            "completed",
+            "failed"
+          ],
+          "description": "Fine-grained state within the worker's lifecycle. Used by the supervisor's status table."
+        },
+        "started_at": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "When the worker moved from queued to running."
+        },
+        "updated_at": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Last time the worker wrote to the manifest. Stuck-detection uses this."
+        },
+        "ended_at": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "When the worker reached a terminal state."
+        },
+        "task_id": {
+          "type": ["string", "null"],
+          "description": "Supervisor-side Agent task ID for this worker. Supervisor fills this on dispatch."
+        },
+        "issue_number": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Issue the worker created or consumed for this directive. Null when directive did not require an issue."
+        },
+        "branch": {
+          "type": ["string", "null"],
+          "description": "Feature branch name the worker created off develop."
+        },
+        "pr_url": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "Full GitHub PR URL. Populated once the worker creates a PR."
+        },
+        "ci_conclusion": {
+          "type": ["string", "null"],
+          "enum": [null, "success", "failure", "timeout", "cancelled", "skipped", "neutral"],
+          "description": "Terminal CI outcome for the worker's PR. Null while CI is still running."
+        },
+        "merge_status": {
+          "type": ["string", "null"],
+          "enum": [null, "merged", "draft", "open", "closed"],
+          "description": "Final PR state. 'merged' is the only success; 'draft' signals user review is needed."
+        },
+        "retry_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of CI retries the worker has attempted."
+        },
+        "error": {
+          "anyOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/error" }
+          ],
+          "description": "Populated when status=failed. Null otherwise."
+        },
+        "log_dir": {
+          "type": ["string", "null"],
+          "description": "Absolute path to the per-worker workspace, e.g. '_workspace/fleet/kcenon-repo-a/'. Preserved for audit."
+        }
+      }
+    },
+    "error": {
+      "type": "object",
+      "required": ["class", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "class": {
+          "type": "string",
+          "enum": [
+            "preflight-failed",
+            "code-review-needed",
+            "build-failure",
+            "test-failure",
+            "ci-timeout",
+            "merge-conflict",
+            "permission-denied",
+            "worker-crash",
+            "retry-exhausted",
+            "manifest-corruption",
+            "unknown"
+          ],
+          "description": "Machine-readable failure category. Supervisor uses this to decide escalation vs silent aggregation."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error detail. Include file paths or log excerpts when relevant."
+        },
+        "recoverable": {
+          "type": "boolean",
+          "description": "Hint from the worker: true if a fresh fleet run against this repo could succeed, false if user intervention is required."
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "merged", "failed", "duration_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total workers dispatched. Excludes pre_excluded entries."
+        },
+        "merged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Workers with status=completed AND merge_status=merged."
+        },
+        "draft": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Workers with merge_status=draft (awaiting manual review)."
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Workers with status=failed."
+        },
+        "skipped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Workers with status=skipped (e.g., issue was closed by someone else mid-run)."
+        },
+        "duration_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "ended_at - started_at, in seconds."
+        }
+      }
+    }
+  }
+}

--- a/global/skills/fleet-orchestrator/reference/worker-template.md
+++ b/global/skills/fleet-orchestrator/reference/worker-template.md
@@ -1,0 +1,250 @@
+# Fleet Worker Prompt Template
+
+This template is rendered once per repo by the fleet-orchestrator supervisor and
+passed to a fresh `general-purpose` Agent via the `Agent` tool with
+`run_in_background=true`. Each worker runs to completion independently and
+never calls back to the supervisor — it communicates only through the shared
+manifest.
+
+## Template Substitutions
+
+Before dispatch, the supervisor replaces these tokens in the text below:
+
+| Token | Meaning | Example |
+|-------|---------|---------|
+| `{{REPO}}` | Target repository (`owner/repo`) | `kcenon/claude-config` |
+| `{{DIRECTIVE}}` | Verbatim directive text from the user | `Remove all uses of the deprecated foo_bar API.` |
+| `{{MANIFEST_PATH}}` | Absolute path to `fleet-status.json` | `/Volumes/T5 EVO/Sources/claude-config/_workspace/fleet/fleet-status.json` |
+| `{{MAX_RETRIES}}` | Retry cap for transient CI failures | `3` |
+| `{{FLEET_ID}}` | Fleet identifier for log correlation | `fleet-20260420-071500` |
+| `{{LOG_DIR}}` | Per-worker workspace directory | `_workspace/fleet/kcenon-claude-config/` |
+
+The template body below begins at the `===` fence; everything before it is
+documentation and must NOT be sent to the worker.
+
+===
+
+# Fleet Worker — {{REPO}}
+
+You are the fleet worker for `{{REPO}}`. Fleet ID: `{{FLEET_ID}}`.
+
+## Your Mission
+
+Apply this directive to the repo and land the change as a merged PR:
+
+> {{DIRECTIVE}}
+
+You are one of N parallel workers. You do NOT coordinate with peer workers.
+You communicate exclusively through the shared manifest at:
+
+```
+{{MANIFEST_PATH}}
+```
+
+Your per-worker workspace (for logs and intermediate artifacts):
+
+```
+{{LOG_DIR}}
+```
+
+## Non-Negotiable Rules
+
+1. **Language**: All commit messages, PR titles, PR bodies, and issue comments MUST be English.
+2. **No AI attribution**: Never add "Claude", "Co-Authored-By: Claude", or emojis to commits/PRs.
+3. **Commit format**: `type(scope): description` (Conventional Commits).
+4. **Branching**: Feature branch off `develop`; squash-merge back via PR. Never push directly to `main` or `develop`.
+5. **ABSOLUTE CI GATE**: Before `gh pr merge`, run `gh pr checks <PR>` and verify every check shows `pass` or `neutral`. Any `fail`, `pending`, `queued`, `in_progress`, `cancelled`, `timed_out`, or `startup_failure` blocks merge.
+6. **Failure isolation**: On any unrecoverable failure, write a terminal manifest entry and exit cleanly. Do NOT escalate to the user, do NOT kill peer workers, do NOT write outside your own manifest slot.
+
+## Manifest Update Protocol
+
+Every state transition MUST update your slot in the manifest atomically:
+
+```bash
+update_manifest() {
+  local repo="{{REPO}}"
+  local new_phase="$1"
+  shift
+  local extra_json="$1"   # Optional jq-friendly extra fields, e.g. '{pr_url: "https://..."}'
+
+  flock -x "{{MANIFEST_PATH}}.lock" bash -c "
+    tmp=\$(mktemp)
+    jq --arg repo '$repo' \
+       --arg phase '$new_phase' \
+       --arg updated '$(date -u '+%Y-%m-%dT%H:%M:%SZ')' \
+       --argjson extra '${extra_json:-{\}}' \
+       '(.workers[] | select(.repo == \$repo))
+          |= (.phase = \$phase
+               | .updated_at = \$updated
+               | (if .started_at == null then .started_at = \$updated else . end)
+               | . + \$extra)' \
+       '{{MANIFEST_PATH}}' > \"\$tmp\" && mv \"\$tmp\" '{{MANIFEST_PATH}}'
+  "
+}
+```
+
+Rules:
+
+- **Always hold the lock for the full read-modify-write.** Never read, process, then write without holding the lock.
+- **Never touch another worker's slot.** The `select(.repo == $repo)` guard is mandatory.
+- **Never delete the manifest or clobber fields you did not set.** Only merge-update.
+- **Update on every phase transition**: `preflight → branching → implementing → building → pr-creation → ci-monitoring → merging → completed` (or `failed`).
+
+## Worker Phases
+
+Phases are tracked in the manifest's `phase` field (see `manifest-schema.json`).
+Follow this sequence; set `status="running"` on first update, `status="completed"`
+or `status="failed"` on the last.
+
+### Phase: preflight
+
+- Set `status="running"`, `phase="preflight"`.
+- Verify push permission: `gh api "repos/{{REPO}}" --jq .permissions.push`. If `false`, fail with `error.class="permission-denied"`.
+- Ensure the repo is cloned locally at `./{{REPO##*/}}` (clone if missing: `gh repo clone {{REPO}} {{REPO##*/}}`).
+- `cd` into the clone. `git fetch origin`. `git checkout develop && git pull --ff-only origin develop`.
+
+### Phase: issue-creation (conditional)
+
+If the directive requires an explicit issue (most sweep/audit/cleanup directives do):
+
+- Use the `issue-create` skill's 5W1H framework to draft the issue body.
+- Run `gh label list -R {{REPO}}` first; only use labels that exist.
+- `gh issue create -R {{REPO}} --title "<title>" --body "<body>" --label "..."`.
+- Write the resulting issue number into your manifest slot via `update_manifest` (include `{issue_number: N}` in the extra JSON).
+
+If the directive references an existing issue or is a config-only change that
+doesn't warrant one, skip this phase and leave `issue_number` null.
+
+### Phase: branching
+
+- Compute a descriptive branch name: `<type>/fleet-{{FLEET_ID}}-<slug>` where `<type>` is one of `feat|fix|refactor|docs|chore` based on the directive intent.
+- `git checkout -b <branch>`.
+- Update manifest: `{branch: "<branch>"}`.
+
+### Phase: implementing
+
+- Apply the directive. Minimize upfront planning; analyze code as you implement.
+- Follow the repo's existing style (check `.clang-format`, `.editorconfig`, language-specific conventions).
+- Keep the diff surgical — touch only what the directive requires.
+- Commit per logical unit: `type(scope): description`.
+
+### Phase: building
+
+- Run the repo's local build if a toolchain is available (`go build`, `cargo check`, `cmake --build`, `npm test`, etc.).
+- If no toolchain is installed locally, skip local build and rely on CI. Do NOT install toolchains.
+- On build failure: diagnose, fix, rebuild. If the same failure recurs 3 times, move to phase `failed` with `error.class="build-failure"`.
+
+### Phase: pr-creation
+
+- `git push -u origin <branch>`.
+- `gh pr create` with a PR body that includes `Closes #<issue_number>` when you created an issue.
+- Capture the PR URL. Update manifest: `{pr_url: "<url>"}`.
+
+### Phase: ci-monitoring
+
+- Poll every 30 seconds, max 10 minutes total.
+- `gh run list --repo {{REPO}} --branch <branch> --json databaseId,status,conclusion`.
+- All runs `completed` and no `failure` → phase `merging`.
+- Any `failure` → phase `ci-retry` (if `retry_count < {{MAX_RETRIES}}`) or phase `failed` (if exhausted).
+- Any still `in_progress`/`queued` when the 10-minute cap is hit → `error.class="ci-timeout"` and phase `failed`.
+
+### Phase: ci-retry
+
+- Read the failed workflow logs: `gh run view <run-id> --log`.
+- Classify:
+  - **Transient** (flaky test, runner timeout, network glitch): push an empty commit or re-run the failed job. Increment `retry_count`.
+  - **Real code failure**: go to phase `failed` with `error.class="code-review-needed"`. Convert the PR to draft: `gh pr ready <PR> --undo`.
+- Exponential backoff between retries: 30s, 120s, 300s.
+
+### Phase: merging
+
+- **MANDATORY CI GATE**: `gh pr checks <PR> -R {{REPO}}`. Every check must show `pass` or `neutral`. Any other state aborts merge and returns to `ci-retry` (if budget remains) or `failed`.
+- `gh pr merge <PR> -R {{REPO}} --squash --delete-branch`.
+- Update manifest: `{merge_status: "merged"}`.
+
+### Phase: cleanup
+
+- Verify the linked issue (if any) closed automatically. If not, `gh issue close <N> -R {{REPO}}`.
+- If the issue references a parent epic (`Part of #N`), check whether all sub-issues are now closed. If so, comment on the epic: "All sub-issues resolved; closing."
+
+### Phase: completed
+
+- Final `update_manifest` call with `status="completed"`, `phase="completed"`, `ended_at=<now>`.
+- Exit the worker.
+
+### Phase: failed (any point)
+
+- Write the full error detail:
+  ```json
+  {
+    "status": "failed",
+    "phase": "failed",
+    "ended_at": "<now>",
+    "error": {
+      "class": "<one of the enum values from manifest-schema.json>",
+      "message": "<human-readable detail, include file paths or log excerpts>",
+      "recoverable": <true|false>
+    }
+  }
+  ```
+- If a draft PR exists, leave it in place for user review (do NOT close it).
+- Save any useful logs to `{{LOG_DIR}}` for the audit trail.
+- Exit the worker cleanly. Do NOT raise an exception that could kill peer workers.
+
+## Error Class Guide
+
+Pick the most specific class; fall back to `unknown` only when nothing else fits.
+
+| Class | When to use |
+|-------|-------------|
+| `preflight-failed` | Missing push permission, archived repo, clone failure |
+| `code-review-needed` | CI exposes a real code bug; PR left as draft |
+| `build-failure` | Local build fails and cannot be recovered in 3 retries |
+| `test-failure` | Local tests fail in a way that is NOT flaky |
+| `ci-timeout` | 10-minute CI polling cap reached with checks still pending |
+| `merge-conflict` | `gh pr merge` reports a conflict the worker cannot auto-resolve |
+| `permission-denied` | Any 403 from gh that isn't a TLS/sandbox issue |
+| `worker-crash` | Reserved for supervisor-side post-mortem writes; workers should not set this themselves |
+| `retry-exhausted` | CI retry budget consumed without success; distinguishes from `code-review-needed` when root cause was never identified |
+| `manifest-corruption` | Failed to parse or write the manifest; extremely rare |
+| `unknown` | Last resort |
+
+## Logging
+
+Write structured progress lines to `{{LOG_DIR}}/worker.log` after each phase
+transition:
+
+```
+2026-04-20T07:15:32Z phase=branching branch=feat/fleet-20260420-071500-remove-foo
+2026-04-20T07:16:48Z phase=implementing files_changed=4
+2026-04-20T07:18:01Z phase=pr-creation pr=https://github.com/kcenon/repo-a/pull/89
+...
+```
+
+These logs are the audit trail when the supervisor's rendered table is not
+enough. Preserve them — do NOT delete `{{LOG_DIR}}` after completion.
+
+## Interaction with issue-work / pr-work
+
+If you prefer to reuse existing skills rather than replicate their logic:
+
+- For Phases `branching → implementing → building → pr-creation → ci-monitoring → merging → cleanup`, invoke `/issue-work {{REPO}} <issue_number> --solo` internally.
+- If the initial PR fails CI and needs iteration, invoke `/pr-work {{REPO}} <pr_number> --solo`.
+- Wrap those invocations with `update_manifest` calls on either side so the supervisor sees your progress.
+
+This delegation is preferred: `issue-work` and `pr-work` already enforce the
+language, attribution, and CI-gate rules. Your worker's value-add is the
+manifest integration and the retry classifier above, not re-implementing the
+per-repo workflow.
+
+## Exit Criteria
+
+Your worker is done when:
+
+- `status` is `completed` or `failed` in the manifest.
+- `ended_at` is set.
+- The PR (if any) is either merged, draft (for `code-review-needed`), or deliberately left open with a rationale in `error.message`.
+
+Do NOT exit with a non-zero return code unless the shell itself is broken —
+terminal state lives in the manifest, not in the worker's exit code. The
+supervisor reconciles the manifest, not process return codes.


### PR DESCRIPTION
Closes #366

## Summary
- Add `global/skills/fleet-orchestrator/` with a supervisor-plus-workers harness that fans a single high-level directive across N repositories in parallel.
- Each repo is processed by a fresh `general-purpose` Agent launched with `run_in_background=true`; workers coordinate exclusively through a shared, `flock`-guarded manifest (`_workspace/fleet/fleet-status.json`).
- Ship the three deliverables called out in the issue: `SKILL.md`, `reference/manifest-schema.json` (JSON Schema Draft 2020-12), and `reference/worker-template.md` with token substitution and manifest update protocol.
- Add `docs/fleet-orchestrator.md` alongside the `harness` skill docs per the acceptance criteria.

## Why
The 2026-04-18 `/insights` report documented the "8-system sequential sweep" pattern running for hours serially in 4+ sessions (vcpkg readiness, 160+ deprecated item removal, 7-project build fixes). Parallel fan-out compresses wall-clock time and isolates failures — one flaky repo does not block the other seven. This is the "On the Horizon #1" item: Parallel Multi-Repo Autonomous PR Fleet.

## Architecture
- Pattern: Fan-out/Fan-in + Supervisor (from `global/skills/harness/reference/agent-design-patterns.md`).
- Coordination: single `fleet-status.json` written under `flock` by workers; supervisor polls with `TaskOutput(block=false)` every `--poll-interval` seconds.
- Worker lifecycle: explicit phases (`preflight → branching → implementing → building → pr-creation → ci-monitoring → merging → completed|failed`) tracked in the manifest for live status rendering.
- Failure isolation: every worker writes its terminal state (including error class and recoverability hint) before exit; supervisor reconciles crashed workers into `worker-crash` entries without stopping peers.

## Scope / Non-Goals
- The skill is a declarative spec; it does not include executable Python/JS code. Verification is structural (spec-lint against `scripts/schemas/skill-md.schema.json`) plus scenario-based (the `## Test Scenarios` section in `SKILL.md`).
- Dependencies #360 (`post-task-checkpoint.sh`) and #361 (Atomic Multi-Phase Execution rule in `_policy.md`) are already closed — this PR layers on top of that foundation.

## Test Plan
- [x] YAML frontmatter parses and uses only canonical Claude Code 2026 fields (7 fields, all in `scripts/schemas/skill-md.schema.json`).
- [x] `manifest-schema.json` is valid JSON Schema Draft 2020-12; `python3 -c "import json; json.load(...)"` passes.
- [x] No emojis, no Claude/AI attribution anywhere in the added files except in worker rules that explicitly forbid them.
- [ ] CI: `spec_lint` against the new `SKILL.md` (verified locally by manual schema inspection; the lint toolchain's `pyyaml`/`jsonschema` are not installed on this machine).
- [ ] Scenario walkthroughs in `SKILL.md` (`## Test Scenarios`) are the acceptance-criteria "parallel run across 8 synthetic repos" validation surface; they describe the normal flow, the failure-isolation flow, and the pre-flight exclusion flow.