### PR TITLE
chore(release): bump suite to 1.10.0

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 # Claude Configuration Backup & Deployment System
 
 <p align="center">
-  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.9.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.10.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-green.svg" alt="License"></a>
   <a href="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml"><img src="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml/badge.svg" alt="CI"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claude Configuration Backup & Deployment System
 
 <p align="center">
-  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.9.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.10.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-green.svg" alt="License"></a>
   <a href="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml"><img src="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml/badge.svg" alt="CI"></a>
 </p>

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -13,7 +13,7 @@
 # To bump a version: edit the field here, then run scripts/sync_versions.sh
 # (or /release <field> <new-version>) to propagate to consumers.
 
-suite: 1.9.0
+suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
 settings-schema: 1.12.0


### PR DESCRIPTION
## Summary
- Bump the `suite` version in `VERSION_MAP.yml` from 1.9.0 to 1.10.0.
- Propagate the new value to README/README.ko badge URLs via `scripts/sync_versions.sh`.

## Why
Preparatory step for the `develop` → `main` release PR. The release skill requires the version bump commit to land on `develop` before the release PR can be cut.

## Test Plan
- [x] `scripts/check_versions.sh` returns OK after the change
- [x] Only `suite` is bumped; `plugin`, `plugin-lite`, and `settings-schema` unchanged
- [x] Diff is limited to `VERSION_MAP.yml`, `README.md`, `README.ko.md` (3 lines each changed line)