### PR TITLE
feat(settings): disable built-in git instructions to cut system prompt

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -16,4 +16,4 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.12.0
+settings-schema: 1.12.1

--- a/global/settings.json
+++ b/global/settings.json
@@ -378,8 +378,9 @@
   "effortLevel": "high",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
+  "includeGitInstructions": false,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "showTurnDuration": true,
   "teammateMode": "in-process"
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.0",
+  "version": "1.12.1",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -53,6 +53,7 @@
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "effortLevel": "high",
+  "includeGitInstructions": false,
 
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## What

Add `"includeGitInstructions": false` to both global settings files and bump `settings-schema` to 1.12.1.

| File | Change |
|---|---|
| `global/settings.json` | +1 key, version 1.12.0 -> 1.12.1 |
| `global/settings.windows.json` | +1 key, version 1.12.0 -> 1.12.1 |
| `VERSION_MAP.yml` | `settings-schema` 1.12.0 -> 1.12.1 |

Change type: settings/chore (no runtime code).

## Why

Inspired by https://www.stdy.blog/increasing-token-efficiency-by-setting-adjustment-in-claude-and-codex/ — Claude Code injects a generic git-instructions block into the system prompt on every session. In this repo that block is pure duplication: our CLAUDE.md plus `git-commit-format.md`, `branching-strategy.md`, `git-conflict-resolution.md`, and `commit-hooks.md` already cover the same surface with project-specific rules that are strictly more specific.

Disabling the built-in block is the single change from the referenced analysis that satisfies all of:

- Zero function loss (project rules strictly cover the surface).
- Zero added configuration complexity (one key; no new files, scripts, aliases, or modes).
- Zero management risk (trivial rollback: delete one line; no drift surface).

All other recommendations from the blog (env var output caps, `--tools` whitelists, `DISABLE_AUTO_MEMORY`, `DISABLE_CLAUDE_MDS`, `DISABLE_BUILTIN_AGENTS`, lean/bare profile aliases) were evaluated and rejected because they either conflict with the suite's existing design (MEMORY.md, 55 hooks, 8 agents, 9 skills) or require new wrapper scripts that would add cross-platform maintenance burden.

## Who

- Author: single-maintainer change.
- Reviewers: self-review sufficient; settings-only change gated by `check_versions.sh` and JSON validation.

## When

- Urgency: Normal. No release dependency.
- Target: next `develop` -> `main` release cut.

## Where

- `global/settings.json` — top-level behavior flags cluster.
- `global/settings.windows.json` — same flag mirrored for Windows profile.
- `VERSION_MAP.yml` — `settings-schema` field.

No hook, agent, skill, or script is touched. No breaking change to plugin/plugin-lite/suite versions.

## How

### Implementation

Added `"includeGitInstructions": false` adjacent to the other behavior flags (`alwaysThinkingEnabled`, `effortLevel`, `autoUpdatesChannel`, `skipDangerousModePermissionPrompt`). Bumped `settings-schema` patch version via `VERSION_MAP.yml` per the repo's SSOT pattern.

### Testing Done

- [x] `scripts/check_versions.sh` — OK (suite=1.10.0, plugin=2.3.0, plugin-lite=1.1.0, settings-schema=1.12.1).
- [x] JSON syntax validated on both settings files.
- [x] Diff inspection: 5 insertions, 3 deletions across 3 files. No unrelated changes.

### Test Plan for Reviewers

1. `bash scripts/check_versions.sh` — must print `check_versions: OK`.
2. `python -c "import json; json.load(open('global/settings.json')); json.load(open('global/settings.windows.json'))"` — must exit 0.
3. After merge and sync, confirm new sessions load without the built-in git instructions section in the system prompt.

### Breaking Changes

None. The built-in git instructions are a help layer that this repo already fully supersedes via project rules.

### Rollback

Delete the `"includeGitInstructions": false` line in both settings files and revert `VERSION_MAP.yml` patch bump. One-file-per-consumer; no migration required.