### PR TITLE
release(2026-04-20): merge develop to main (settings-schema 1.12.1)

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -16,4 +16,4 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.12.0
+settings-schema: 1.12.1

--- a/global/hooks/pr-target-guard.ps1
+++ b/global/hooks/pr-target-guard.ps1
@@ -69,12 +69,17 @@ if ($headMatch.Success) {
     $head = $head -replace '^["\x27]|["\x27]$', ''
 }
 
-# Allow release PRs: develop -> main
+# Allow release PRs: develop -> main or release/* -> main
+# (matches .github/workflows/validate-pr-target.yml server-side policy)
 if ($head -eq 'develop') {
     New-HookAllowResponse
     exit 0
 }
+if ($head -like 'release/*') {
+    New-HookAllowResponse
+    exit 0
+}
 
-# Deny: non-develop branch targeting main
-New-HookDenyResponse -Reason "PR targeting 'main' is blocked by branching policy. Feature/fix branches must target 'develop'. For release PRs (develop -> main), use: /release <version>"
+# Deny: non-develop/non-release branch targeting main
+New-HookDenyResponse -Reason "PR targeting 'main' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into 'main'. Feature/fix branches must target 'develop'."
 exit 0

--- a/global/hooks/pr-target-guard.sh
+++ b/global/hooks/pr-target-guard.sh
@@ -83,17 +83,23 @@ if [ "$BASE" != "main" ]; then
     allow_response
 fi
 
-# Base is 'main' — check if this is a release PR (--head develop)
+# Base is 'main' — check if this is a release PR (--head develop or release/*)
 HEAD=$(echo "$CMD" | sed -nE "s/.*(--head[= ])[\"']?([a-zA-Z0-9._/-]+).*/\2/p" | head -1)
 if [ -z "$HEAD" ]; then
     HEAD=$(echo "$CMD" | sed -nE "s/.*-H[[:space:]]*[\"']?([a-zA-Z0-9._/-]+).*/\1/p" | head -1)
 fi
 HEAD=$(echo "$HEAD" | sed -E "s/^[\"']//;s/[\"']$//")
 
-# Allow release PRs: develop → main
+# Allow release PRs: develop → main or release/* → main
+# (matches .github/workflows/validate-pr-target.yml server-side policy)
 if [ "$HEAD" = "develop" ]; then
     allow_response
 fi
+case "$HEAD" in
+    release/*)
+        allow_response
+        ;;
+esac
 
-# Deny: non-develop branch targeting main
-deny_response "PR targeting 'main' is blocked by branching policy. Feature/fix branches must target 'develop'. For release PRs (develop -> main), use: /release <version>"
+# Deny: non-develop/non-release branch targeting main
+deny_response "PR targeting 'main' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into 'main'. Feature/fix branches must target 'develop'."

--- a/global/settings.json
+++ b/global/settings.json
@@ -378,8 +378,9 @@
   "effortLevel": "high",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
+  "includeGitInstructions": false,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "showTurnDuration": true,
   "teammateMode": "in-process"
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.0",
+  "version": "1.12.1",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -53,6 +53,7 @@
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "effortLevel": "high",
+  "includeGitInstructions": false,
 
   "hooks": {
     "PreToolUse": [

--- a/tests/hooks/test-pr-target-guard.sh
+++ b/tests/hooks/test-pr-target-guard.sh
@@ -69,6 +69,15 @@ assert_allow '{"tool_input":{"command":"gh pr create --head develop --base main 
 assert_allow '{"tool_input":{"command":"gh pr create --base=main --head=develop --title \"release\""}}' "equals form → allow"
 
 echo ""
+echo "[Release exception: release/* → main allowed]"
+assert_allow '{"tool_input":{"command":"gh pr create --base main --head release/1.10.0 --title \"release: v1.10.0\""}}' "--head release/1.10.0 → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --base main --head release/2.0.0-beta.1 --title \"release: beta\""}}' "--head release/<semver> → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --base=main --head=release/v3 --title \"release\""}}' "--head=release/v3 (equals form) → allow"
+assert_allow '{"tool_input":{"command":"gh pr create --base main --head release/2026-04-18 --title \"release\""}}' "--head release/<date> → allow"
+assert_deny '{"tool_input":{"command":"gh pr create --base main --head release --title \"release\""}}' "--head release (bare, no slash) → deny"
+assert_deny '{"tool_input":{"command":"gh pr create --base main --head release-candidate --title \"release\""}}' "--head release-candidate (no slash) → deny"
+
+echo ""
 echo "[Normal workflow: allow]"
 assert_allow '{"tool_input":{"command":"gh pr create --base develop --title \"feat: new feature\""}}' "--base develop → allow"
 assert_allow '{"tool_input":{"command":"gh pr create --title \"feat: something\""}}' "no --base (defaults to develop) → allow"


### PR DESCRIPTION
## What

Release cut bundling two patches from develop into main.

| PR | Commit | Summary |
|---|---|---|
| #381 | 10c38b0 | `fix(hooks): accept release/* heads in pr-target-guard` |
| #382 | bea7af7 | `feat(settings): disable built-in git instructions to cut system prompt` |

### Version impact

| Field | Before | After |
|---|---|---|
| `settings-schema` | 1.12.0 | **1.12.1** |
| `suite` | 1.10.0 | 1.10.0 (unchanged) |
| `plugin` | 2.3.0 | 2.3.0 (unchanged) |
| `plugin-lite` | 1.1.0 | 1.1.0 (unchanged) |

## Why

- **#381**: pr-target-guard previously rejected `release/*` heads when opening develop -> main PRs. Fix accepts them to unblock regular release cuts.
- **#382**: Claude Code's built-in git instructions duplicate this repo's CLAUDE.md + workflow rules. Disabling the built-in block trims the system prompt every session with zero behavioral loss.

Selected as the minimum-risk, maximum-effect subset of recommendations from https://www.stdy.blog/increasing-token-efficiency-by-setting-adjustment-in-claude-and-codex/ — no new files, scripts, aliases, or modes introduced.

## Who

- Author: single-maintainer release cut.
- Reviewers: self-review sufficient; release-only PR, no new runtime code, settings/hooks changes already CI-gated at source PRs.

## When

- Urgency: Normal.
- Target: immediate merge on CI green.

## Where

- `global/settings.json` / `global/settings.windows.json` — `includeGitInstructions: false`, version 1.12.0 -> 1.12.1.
- `VERSION_MAP.yml` — `settings-schema` bump.
- `global/hooks/pr-target-guard.sh` + `tests/hooks/test-pr-target-guard.sh` — `release/*` head acceptance.

## How

### Testing Done

- `check_versions.sh`: OK (suite=1.10.0, plugin=2.3.0, plugin-lite=1.1.0, settings-schema=1.12.1).
- JSON validated on both settings files.
- Source PRs (#381, #382) passed their own gates before merging into develop.

### Test Plan for Reviewers

1. Wait for main-targeting CI workflows to complete.
2. Confirm `gh pr checks` shows all checks `SUCCESS`.
3. Squash merge.
4. Post-merge: delete `develop` and recreate from `main` per repo branching-strategy.

### Breaking Changes

None.

### Rollback

Revert this release PR via `gh pr revert` or a follow-up revert commit. Source PRs (#381, #382) can be individually reverted if needed.