### PR TITLE
fix(workflow): drop administration scope from post-release-develop-reset

### DIFF
--- a/.github/workflows/post-release-develop-reset.yml
+++ b/.github/workflows/post-release-develop-reset.yml
@@ -7,16 +7,13 @@ name: Post-release develop reset
 # recreates develop at main's HEAD so the next release cut starts from a clean
 # zero-divergence state.
 #
-# Branch protection prerequisites (enforced in repository settings):
-#   - develop.allow_deletions: true
-#   - main protection unchanged (no push from this workflow to main)
-#   - admin enforcement remains on — this workflow uses REST API with
-#     administration:write permission, which the token grants scoped to this
-#     run only.
+# Prerequisites (configured in repository settings):
+#   - Default branch is `main` (GitHub refuses to delete the default branch).
+#   - develop.allow_deletions: true (server-side branch protection).
+#   - main protection unchanged — this workflow does not push to main.
 #
-# The workflow temporarily swaps the repository default branch to main while
-# develop is being deleted, because GitHub refuses to delete the default
-# branch. Default is restored to develop once the new ref exists.
+# The workflow uses only contents:write permission, which the default
+# GITHUB_TOKEN grants. No PAT or administration scope is required.
 
 on:
   push:
@@ -25,7 +22,6 @@ on:
 
 permissions:
   contents: write
-  administration: write
 
 concurrency:
   group: post-release-develop-reset
@@ -43,7 +39,7 @@ jobs:
           set -euo pipefail
           main_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
           develop_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
-          echo "main_sha=$main_sha"     >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha"       >> "$GITHUB_OUTPUT"
           echo "develop_sha=$develop_sha" >> "$GITHUB_OUTPUT"
           if [ "$main_sha" = "$develop_sha" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -52,16 +48,6 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "develop ($develop_sha) differs from main ($main_sha) — will reset."
           fi
-
-      - name: Swap default branch to main
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api -X PATCH "repos/${{ github.repository }}" \
-            -f default_branch=main \
-            --jq '.default_branch'
 
       - name: Delete develop
         if: steps.compare.outputs.skip == 'false'
@@ -83,16 +69,6 @@ jobs:
             -f "ref=refs/heads/develop" \
             -f "sha=$MAIN_SHA" \
             --jq '.object.sha'
-
-      - name: Restore develop as default branch
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api -X PATCH "repos/${{ github.repository }}" \
-            -f default_branch=develop \
-            --jq '.default_branch'
 
       - name: Summary
         if: always()

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -99,28 +99,27 @@ main ← develop ← feature/*
    ```bash
    MAIN_SHA=$(gh api repos/$ORG/$PROJECT/git/ref/heads/main --jq .object.sha)
 
-   # 1. Temporarily swap the default branch to main so GitHub allows
-   #    develop to be deleted (GitHub refuses to delete the default branch).
-   gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=main
-
-   # 2. Delete develop on the server.
+   # 1. Delete develop on the server.
    gh api -X DELETE repos/$ORG/$PROJECT/git/refs/heads/develop
 
-   # 3. Recreate develop at main's HEAD via the REST API. Using gh api
+   # 2. Recreate develop at main's HEAD via the REST API. Using gh api
    #    instead of `git push origin develop` avoids the local pre-push hook
    #    that blocks pushes to protected branches — branch protection is
    #    still applied to the new ref by GitHub.
    gh api -X POST repos/$ORG/$PROJECT/git/refs \
      -f ref=refs/heads/develop \
      -f sha="$MAIN_SHA"
-
-   # 4. Restore develop as the default branch.
-   gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=develop
    ```
 
-> **Prerequisite.** The develop branch protection must have
-> `allow_deletions: true` for either path to succeed. `allow_force_pushes` can
-> remain `false` — recreation is done by creating a new ref, not force-pushing.
+> **Prerequisites.** The following repository settings are required for either
+> path to succeed:
+>
+> - `default_branch = main`. GitHub refuses to delete whichever branch is set
+>   as the repository default, so `main` must own that role. `develop` remains
+>   the working/integration branch but is not the repository default.
+> - `develop.allow_deletions = true` on branch protection. `allow_force_pushes`
+>   can remain `false` — recreation creates a fresh ref, it does not rewrite
+>   develop's history.
 >
 > **Why recreate develop?** Squash merging develop → main produces a single commit on
 > `main` with a different SHA than the original commits on `develop`. This causes the

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -42,7 +42,7 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 ## Standard Workflows
 
 - **Issue-to-PR lifecycle**: implement → local build/test → create PR → monitor CI → squash merge → close issue → close epic if all sub-issues done.
-- **Branching strategy**: `develop` is the default working branch. Create feature branches from `develop`, squash merge back via PR, then delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs. After release merge, `develop` is reset to `main`'s HEAD automatically by the `post-release-develop-reset` workflow (manual fallback: `docs/branching-strategy.md` §6).
+- **Branching strategy**: `main` is the repository default branch and holds releases. `develop` is the integration branch — create feature branches from `develop`, squash merge back via PR, delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs. After release merge, `develop` is reset to `main`'s HEAD automatically by the `post-release-develop-reset` workflow (manual fallback: `docs/branching-strategy.md` §6).
 - **Protected branches**: Never push directly to `main` or `develop`. Always use PRs with squash merge.
 - Skip lengthy planning phases. Start implementation immediately, analyzing code as you go.
 - After merging, check if parent epic should be closed.


### PR DESCRIPTION
## What

Fix a broken workflow introduced in #386 and clean up the surrounding docs.

| File | Change |
|---|---|
| `.github/workflows/post-release-develop-reset.yml` | Remove `administration: write` permission and the two `default_branch` swap steps. Workflow now needs only `contents: write`. |
| `docs/branching-strategy.md` §6 | Drop the swap from the manual fallback; document `main`-as-default as a prerequisite instead. |
| `global/CLAUDE.md` | Update the branching-strategy bullet to state that `main` is the default branch and `develop` is the integration branch. |

### Out-of-band repository setting change (already applied)

`default_branch` was changed from `develop` to `main` via `gh api PATCH`. This is a one-time setting change that underpins the workflow simplification and does not require code.

## Why

#386 requested `administration: write` in the workflow so the job could temporarily swap the default branch to `main` before deleting `develop` (GitHub refuses to delete whichever branch is the repository default). GITHUB_TOKEN does not accept `administration` as a scope — the valid scopes are listed in GitHub's permissions docs and `administration` is not one of them. As a result the workflow failed with "likely a workflow file issue" on every push to main, including the release merge of #386/#387 itself.

Two ways forward:
1. Use a stored PAT with `administration` scope to perform the swap at runtime.
2. Make `main` the permanent default branch and drop the swap.

Option 2 is simpler, more conventional (most GitHub repos default to `main`), and removes a moving part from the automation. `develop` remains the integration branch — no team workflow changes. Only the repository default pointer changed.

## Who

- Author: single-maintainer fix-forward for #386.
- Reviewers: self-review sufficient; workflow and docs only, no runtime code.

## When

- Urgency: Normal — the broken workflow is fail-open (it doesn't block anything), so there's no bleed-through. The next main push after this merges will exercise the fixed workflow end-to-end.
- Target: immediate.

## Where

- `.github/workflows/post-release-develop-reset.yml` — net -42 lines.
- `docs/branching-strategy.md` — §6 simplified.
- `global/CLAUDE.md` — 1-line bullet edit.

## How

### Workflow now does

1. `Compare develop and main` — skip if already equal.
2. `Delete develop` via REST API.
3. `Recreate develop at main's SHA` via REST API.
4. `Summary` — write a markdown summary to the job page.

Permissions: `contents: write` (built-in). Concurrency group unchanged.

### Recovery already applied

After #387 merged, I ran the delete-recreate sequence manually via `gh api` to bring develop back in line with main. Current state:

- `main` = `develop` = `4c0c969b26bd230e0a1c8c223bad93da610a0ec8`
- default branch = `main`
- `develop.allow_deletions` = `true` (unchanged)
- `develop.allow_force_pushes` = `false` (unchanged)

So this PR is purely the docs + workflow correction; no additional manual action is needed after merge.

### Testing Done

- `python -c 'import yaml; yaml.safe_load(open(...))'` — YAML parses.
- Workflow logic is idempotent: the initial compare step short-circuits when develop already matches main (which it does right now, so the first post-merge run will log "nothing to do").

### Test Plan for Reviewers

1. Merge to develop. The workflow file does not run on develop pushes (`on: push: branches: [main]`).
2. Next release PR (develop -> main) triggers the workflow on its main push.
3. Because develop and main are already aligned at that point, the workflow's compare step will skip and log a no-op. Real exercise happens on the release *after* that, when the squash merge puts main one commit ahead.

### Breaking Changes

None at the repo workflow level. The default-branch change is visible to contributors (cloning now defaults to `main`) but does not change any CLI workflows.

### Rollback

Revert this PR and manually PATCH `default_branch` back to `develop`. The old workflow would still fail, so rollback implies disabling the automation entirely; pair a revert with removing the workflow file if that is the intent.