### PR TITLE
release(2026-04-20): fix post-release-develop-reset workflow

### DIFF
--- a/.github/workflows/post-release-develop-reset.yml
+++ b/.github/workflows/post-release-develop-reset.yml
@@ -7,16 +7,13 @@ name: Post-release develop reset
 # recreates develop at main's HEAD so the next release cut starts from a clean
 # zero-divergence state.
 #
-# Branch protection prerequisites (enforced in repository settings):
-#   - develop.allow_deletions: true
-#   - main protection unchanged (no push from this workflow to main)
-#   - admin enforcement remains on — this workflow uses REST API with
-#     administration:write permission, which the token grants scoped to this
-#     run only.
+# Prerequisites (configured in repository settings):
+#   - Default branch is `main` (GitHub refuses to delete the default branch).
+#   - develop.allow_deletions: true (server-side branch protection).
+#   - main protection unchanged — this workflow does not push to main.
 #
-# The workflow temporarily swaps the repository default branch to main while
-# develop is being deleted, because GitHub refuses to delete the default
-# branch. Default is restored to develop once the new ref exists.
+# The workflow uses only contents:write permission, which the default
+# GITHUB_TOKEN grants. No PAT or administration scope is required.
 
 on:
   push:
@@ -25,7 +22,6 @@ on:
 
 permissions:
   contents: write
-  administration: write
 
 concurrency:
   group: post-release-develop-reset
@@ -43,7 +39,7 @@ jobs:
           set -euo pipefail
           main_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
           develop_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
-          echo "main_sha=$main_sha"     >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha"       >> "$GITHUB_OUTPUT"
           echo "develop_sha=$develop_sha" >> "$GITHUB_OUTPUT"
           if [ "$main_sha" = "$develop_sha" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -52,16 +48,6 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "develop ($develop_sha) differs from main ($main_sha) — will reset."
           fi
-
-      - name: Swap default branch to main
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api -X PATCH "repos/${{ github.repository }}" \
-            -f default_branch=main \
-            --jq '.default_branch'
 
       - name: Delete develop
         if: steps.compare.outputs.skip == 'false'
@@ -83,16 +69,6 @@ jobs:
             -f "ref=refs/heads/develop" \
             -f "sha=$MAIN_SHA" \
             --jq '.object.sha'
-
-      - name: Restore develop as default branch
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api -X PATCH "repos/${{ github.repository }}" \
-            -f default_branch=develop \
-            --jq '.default_branch'
 
       - name: Summary
         if: always()

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -99,28 +99,27 @@ main ← develop ← feature/*
    ```bash
    MAIN_SHA=$(gh api repos/$ORG/$PROJECT/git/ref/heads/main --jq .object.sha)
 
-   # 1. Temporarily swap the default branch to main so GitHub allows
-   #    develop to be deleted (GitHub refuses to delete the default branch).
-   gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=main
-
-   # 2. Delete develop on the server.
+   # 1. Delete develop on the server.
    gh api -X DELETE repos/$ORG/$PROJECT/git/refs/heads/develop
 
-   # 3. Recreate develop at main's HEAD via the REST API. Using gh api
+   # 2. Recreate develop at main's HEAD via the REST API. Using gh api
    #    instead of `git push origin develop` avoids the local pre-push hook
    #    that blocks pushes to protected branches — branch protection is
    #    still applied to the new ref by GitHub.
    gh api -X POST repos/$ORG/$PROJECT/git/refs \
      -f ref=refs/heads/develop \
      -f sha="$MAIN_SHA"
-
-   # 4. Restore develop as the default branch.
-   gh api -X PATCH repos/$ORG/$PROJECT -f default_branch=develop
    ```
 
-> **Prerequisite.** The develop branch protection must have
-> `allow_deletions: true` for either path to succeed. `allow_force_pushes` can
-> remain `false` — recreation is done by creating a new ref, not force-pushing.
+> **Prerequisites.** The following repository settings are required for either
+> path to succeed:
+>
+> - `default_branch = main`. GitHub refuses to delete whichever branch is set
+>   as the repository default, so `main` must own that role. `develop` remains
+>   the working/integration branch but is not the repository default.
+> - `develop.allow_deletions = true` on branch protection. `allow_force_pushes`
+>   can remain `false` — recreation creates a fresh ref, it does not rewrite
+>   develop's history.
 >
 > **Why recreate develop?** Squash merging develop → main produces a single commit on
 > `main` with a different SHA than the original commits on `develop`. This causes the

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -42,7 +42,7 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 ## Standard Workflows
 
 - **Issue-to-PR lifecycle**: implement → local build/test → create PR → monitor CI → squash merge → close issue → close epic if all sub-issues done.
-- **Branching strategy**: `develop` is the default working branch. Create feature branches from `develop`, squash merge back via PR, then delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs. After release merge, `develop` is reset to `main`'s HEAD automatically by the `post-release-develop-reset` workflow (manual fallback: `docs/branching-strategy.md` §6).
+- **Branching strategy**: `main` is the repository default branch and holds releases. `develop` is the integration branch — create feature branches from `develop`, squash merge back via PR, delete the feature branch. Release by creating a PR from `develop` to `main` — CI runs only on main-targeting PRs. After release merge, `develop` is reset to `main`'s HEAD automatically by the `post-release-develop-reset` workflow (manual fallback: `docs/branching-strategy.md` §6).
 - **Protected branches**: Never push directly to `main` or `develop`. Always use PRs with squash merge.
 - Skip lengthy planning phases. Start implementation immediately, analyzing code as you go.
 - After merging, check if parent epic should be closed.


### PR DESCRIPTION
## What

Release cut merging the workflow fix from #388 into main.

| Source | Summary |
|---|---|
| #388 | `fix(workflow): drop administration scope from post-release-develop-reset` |

### Version impact

Workflow + docs only — no VERSION_MAP bump.

## Why

The previous release (#387) landed a workflow that requested an unsupported permission scope (`administration: write`) on GITHUB_TOKEN, causing it to fail at workflow validation on every main push. This release replaces it with a version that uses only `contents: write` — the swap step that required the elevated permission is no longer needed because `main` is now the permanent repository default branch.

## Who

- Author: single-maintainer release cut.
- Reviewers: self-review sufficient.

## When

- Urgency: Normal — the broken workflow is fail-open, so there's no bleed-through.
- Target: immediate merge on CI green. The merge commit itself will trigger the fixed workflow — first real exercise of the automation.

## Where

- `.github/workflows/post-release-develop-reset.yml`
- `docs/branching-strategy.md` §6
- `global/CLAUDE.md` branching-strategy bullet

## How

### Testing Done

- YAML validated (`yaml.safe_load`).
- Recovery already applied out-of-band: develop and main are currently both at `4c0c969b` (SHA identical).

### Test Plan for Reviewers

1. Wait for main-targeting CI to finish.
2. All checks `SUCCESS` required before merge.
3. Squash merge.
4. Observe `post-release-develop-reset` workflow run on the resulting main push. Expected: workflow completes successfully. Compare step may or may not short-circuit depending on whether main moved ahead of develop via this merge (it will — this release adds a new commit to main).

### Breaking Changes

None.

### Rollback

Revert this PR. Current develop/main state (both at `4c0c969b`) is preserved even if the revert runs through the flow.