### PR TITLE
fix(workflow): make post-release-develop-reset idempotent

### DIFF
--- a/.github/workflows/post-release-develop-reset.yml
+++ b/.github/workflows/post-release-develop-reset.yml
@@ -1,19 +1,26 @@
 name: Post-release develop reset
 
-# Automatically aligns the `develop` branch SHA with `main` after each release
-# merge. Squash-merging `develop` → `main` produces a single commit on main with
-# a different SHA than the source commits, so develop drifts ahead in graph
-# distance even though content is identical. This workflow deletes and
-# recreates develop at main's HEAD so the next release cut starts from a clean
-# zero-divergence state.
+# Aligns the `develop` branch SHA with `main` after each release merge.
+# Squash-merging `develop` → `main` produces a single commit on main with a
+# different SHA than the source commits, so develop drifts in graph distance
+# even when content is identical. In addition, the repository has
+# delete_branch_on_merge=true, so GitHub auto-deletes develop the moment the
+# release PR merges. This workflow re-creates develop at main's HEAD so the
+# next release cut starts from a clean zero-divergence state.
 #
 # Prerequisites (configured in repository settings):
-#   - Default branch is `main` (GitHub refuses to delete the default branch).
-#   - develop.allow_deletions: true (server-side branch protection).
-#   - main protection unchanged — this workflow does not push to main.
+#   - Default branch is `main` — GitHub refuses to delete whichever branch is
+#     set as the repository default.
+#   - develop.allow_deletions: true — server-side branch protection permits
+#     deletions.
 #
 # The workflow uses only contents:write permission, which the default
 # GITHUB_TOKEN grants. No PAT or administration scope is required.
+#
+# Idempotency: the workflow handles three states it can find develop in —
+#   (a) develop matches main — skip.
+#   (b) develop exists but differs from main — delete, then create fresh.
+#   (c) develop does not exist (auto-deleted by the release merge) — create.
 
 on:
   push:
@@ -31,54 +38,53 @@ jobs:
   reset-develop:
     runs-on: ubuntu-latest
     steps:
-      - name: Compare develop and main
-        id: compare
+      - name: Ensure develop matches main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          main_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
-          develop_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
-          echo "main_sha=$main_sha"       >> "$GITHUB_OUTPUT"
-          echo "develop_sha=$develop_sha" >> "$GITHUB_OUTPUT"
+
+          main_sha=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
+          develop_sha=$(gh api "repos/$REPO/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
+
+          echo "main    = $main_sha"
+          echo "develop = ${develop_sha:-<missing>}"
+
           if [ "$main_sha" = "$develop_sha" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "develop already at $main_sha — nothing to do."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "develop ($develop_sha) differs from main ($main_sha) — will reset."
+            exit 0
           fi
 
-      - name: Delete develop
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/develop"
-          echo "develop deleted."
+          if [ -n "$develop_sha" ]; then
+            echo "develop is at $develop_sha — deleting before recreation."
+            gh api -X DELETE "repos/$REPO/git/refs/heads/develop"
+          else
+            echo "develop is missing (likely auto-deleted by the release merge) — will create fresh."
+          fi
 
-      - name: Recreate develop at main's SHA
-        if: steps.compare.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAIN_SHA: ${{ steps.compare.outputs.main_sha }}
-        run: |
-          set -euo pipefail
-          gh api -X POST "repos/${{ github.repository }}/git/refs" \
+          echo "Creating develop at $main_sha."
+          new_sha=$(gh api -X POST "repos/$REPO/git/refs" \
             -f "ref=refs/heads/develop" \
-            -f "sha=$MAIN_SHA" \
-            --jq '.object.sha'
+            -f "sha=$main_sha" \
+            --jq '.object.sha')
+
+          if [ "$new_sha" != "$main_sha" ]; then
+            echo "Post-create SHA ($new_sha) does not match main ($main_sha) — aborting." >&2
+            exit 1
+          fi
+          echo "develop now at $new_sha."
 
       - name: Summary
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          main_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || echo "unknown")
-          develop_sha=$(gh api "repos/${{ github.repository }}/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "missing")
-          default=$(gh api "repos/${{ github.repository }}" --jq '.default_branch' 2>/dev/null || echo "unknown")
+          main_sha=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || echo "unknown")
+          develop_sha=$(gh api "repos/$REPO/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "missing")
+          default=$(gh api "repos/$REPO" --jq '.default_branch' 2>/dev/null || echo "unknown")
           {
             echo "## Post-release develop reset"
             echo ""
@@ -87,5 +93,5 @@ jobs:
             echo "| main SHA | \`$main_sha\` |"
             echo "| develop SHA | \`$develop_sha\` |"
             echo "| default branch | $default |"
-            echo "| skipped | ${{ steps.compare.outputs.skip }} |"
+            echo "| aligned | $([ "$main_sha" = "$develop_sha" ] && echo yes || echo no) |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -121,6 +121,14 @@ main ← develop ← feature/*
 >   can remain `false` — recreation creates a fresh ref, it does not rewrite
 >   develop's history.
 >
+> **Interaction with `delete_branch_on_merge`.** The repository setting
+> `delete_branch_on_merge = true` causes GitHub to auto-delete the head branch
+> of every merged PR, including `develop` when a release PR merges into main.
+> The automated workflow is idempotent: when it fires on the release push,
+> develop is typically already gone and the workflow simply creates it fresh
+> at main's SHA. The manual fallback behaves the same — if step 1's delete
+> returns 422 ("Reference does not exist"), proceed to step 2 directly.
+>
 > **Why recreate develop?** Squash merging develop → main produces a single commit on
 > `main` with a different SHA than the original commits on `develop`. This causes the
 > two branches to diverge in git history, making subsequent develop → main PRs show


### PR DESCRIPTION
## What

Second fix on the post-release-develop-reset workflow: rewrite the delete/create sequence as a single idempotent step and document the `delete_branch_on_merge` interaction.

**Targeting `main` directly** because this is a workflow-file fix and the workflow only runs from `main`. Shipping through develop would delay the fix by one extra release cycle while `main` still carries the broken version.

| File | Change |
|---|---|
| `.github/workflows/post-release-develop-reset.yml` | Collapse compare+delete+create into one step that handles three states: matches main (skip), exists (delete+create), missing (create). Post-create SHA verification added. |
| `docs/branching-strategy.md` §6 | Add note about `delete_branch_on_merge=true` causing develop to auto-delete at release-merge time; the automation and the fallback both handle the missing case. |

## Why

PR #389 landed the intended "no-admin-scope" version of the workflow on main. On its first real run it hit `HTTP 422 Reference does not exist` at the delete step, which broke the recreate step (skipped by `if:` guard), leaving develop absent until manually re-created.

Root cause: the repository has `delete_branch_on_merge: true`. When the release PR merges develop → main, GitHub auto-deletes the head branch immediately. The workflow then fires on the main push, tries to read develop (404 → empty sha), decides it needs to delete+create (empty ≠ main sha), and the delete fails because develop is already gone.

The idempotent rewrite handles this cleanly: a missing develop is a normal case, not an error.

## Who

- Author: single-maintainer fix-forward.
- Reviewers: self-review sufficient.

## When

- Urgency: same-session fix — next release cycle would see the same failure mode until this lands.
- Target: immediate merge on CI green.

## Where

- `.github/workflows/post-release-develop-reset.yml` — single step replaces three.
- `docs/branching-strategy.md` — §6 prerequisites expanded.

## How

### Idempotent logic

```
read main_sha
read develop_sha (or "" on 404)
if main_sha == develop_sha: skip (aligned)
if develop_sha non-empty: DELETE refs/heads/develop
POST refs with main_sha
verify created sha == main_sha
```

Handles:
- develop matches main → exit 0 (no change).
- develop drifted → delete + create.
- develop auto-deleted by merge → create only.
- develop recreated but returned wrong SHA → fail loudly.

### Recovery already applied

develop and main are currently both at `cf54bdd06c6b4dc7c7c0caaad694329287c85d84`. This PR only fixes future runs; no additional manual action needed once it merges.

### Testing Done

- YAML validated.
- Ran the equivalent API sequence manually during recovery (delete then POST refs) — each call individually verified.

### Test Plan for Reviewers

1. Wait for main-targeting CI to finish.
2. `gh pr checks` must be green.
3. Squash merge.
4. The workflow fires on the merge commit. With develop already at main's SHA, the workflow will log "develop already at … — nothing to do" and exit 0. This is the aligned-state branch of the logic; the delete-then-create branch will be exercised on the next real release.

### Breaking Changes

None.

### Rollback

Revert this PR. The old fail-open broken workflow resumes; no data loss.