### PR TITLE
fix(workflow): detect develop existence by exit code not stdout

### DIFF
--- a/.github/workflows/post-release-develop-reset.yml
+++ b/.github/workflows/post-release-develop-reset.yml
@@ -46,7 +46,16 @@ jobs:
           set -euo pipefail
 
           main_sha=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
-          develop_sha=$(gh api "repos/$REPO/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
+
+          # Detect develop existence by gh api's exit code. `gh api` prints
+          # the error body to stdout on 404, so the previous `|| echo ""`
+          # pattern captured the error JSON as a non-empty string and tricked
+          # the branch below into attempting to delete a missing ref.
+          if develop_json=$(gh api "repos/$REPO/git/ref/heads/develop" 2>/dev/null); then
+            develop_sha=$(echo "$develop_json" | jq -r '.object.sha')
+          else
+            develop_sha=""
+          fi
 
           echo "main    = $main_sha"
           echo "develop = ${develop_sha:-<missing>}"


### PR DESCRIPTION
## What

Third and (intended to be) final fix on the post-release-develop-reset workflow. Replace the output-based existence check with the standard exit-code pattern so a missing develop is recognised as missing rather than as an error-body string.

| File | Change |
|---|---|
| `.github/workflows/post-release-develop-reset.yml` | Use `if gh api ...; then ... else develop_sha=""; fi` instead of `develop_sha=$(gh api ... \|\| echo "")`. |

## Why

The #391 idempotent rewrite relied on `gh api ... \|\| echo ""` to set `develop_sha` to empty on 404. `gh api` actually prints the JSON error body to stdout on 404, so the fallback `echo ""` never ran. `develop_sha` became the string `{"message":"Not Found",…}` — non-empty — and the logic walked the "develop exists, delete first" branch, which then hit HTTP 422 because the ref was already auto-deleted by `delete_branch_on_merge`.

Exit code is the authoritative signal for this kind of check. The rewrite uses it.

## Who

- Author: single-maintainer fix-forward.
- Reviewers: self-review sufficient.

## When

- Urgency: same-session — every failed release cycle leaves develop missing until manual recovery.
- Target: immediate merge on CI green, then release cut to main.

## Where

- `.github/workflows/post-release-develop-reset.yml` only.

## How

### Tested locally

```bash
REPO=kcenon/claude-config
if develop_json=$(gh api "repos/$REPO/git/ref/heads/develop" 2>/dev/null); then
  echo "develop exists"
else
  echo "develop missing"
fi

if bogus=$(gh api "repos/$REPO/git/ref/heads/definitely-not-a-branch-xyz" 2>/dev/null); then
  echo "would wrongly claim bogus exists"
else
  echo "bogus correctly detected as missing"
fi
```

Output confirmed: develop recognised as existing, bogus branch recognised as missing. Exit-code pattern works as intended.

### Recovery already applied

develop and main are currently both at `d77fa8539733499d096da3ee5fcb81b2f0e5cf86`. This PR fixes future runs.

### Test Plan for Reviewers

1. Merge to develop.
2. Release PR develop → main.
3. On merge: `delete_branch_on_merge` removes develop. Workflow fires. With the exit-code pattern, develop_sha is empty, the "will create fresh" branch runs, develop ends at main's SHA.

### Breaking Changes

None.

### Rollback

Revert this PR. Prior behaviour resumes; manual fallback remains documented.