### PR TITLE
release(2026-04-20): exit-code-based develop existence check

### DIFF
--- a/.github/workflows/post-release-develop-reset.yml
+++ b/.github/workflows/post-release-develop-reset.yml
@@ -46,7 +46,16 @@ jobs:
           set -euo pipefail
 
           main_sha=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
-          develop_sha=$(gh api "repos/$REPO/git/ref/heads/develop" --jq '.object.sha' 2>/dev/null || echo "")
+
+          # Detect develop existence by gh api's exit code. `gh api` prints
+          # the error body to stdout on 404, so the previous `|| echo ""`
+          # pattern captured the error JSON as a non-empty string and tricked
+          # the branch below into attempting to delete a missing ref.
+          if develop_json=$(gh api "repos/$REPO/git/ref/heads/develop" 2>/dev/null); then
+            develop_sha=$(echo "$develop_json" | jq -r '.object.sha')
+          else
+            develop_sha=""
+          fi
 
           echo "main    = $main_sha"
           echo "develop = ${develop_sha:-<missing>}"


### PR DESCRIPTION
## What

Third and intended-final iteration on the post-release-develop-reset workflow. Merges #393 into main.

## Why

See #393. The prior idempotent version still failed because `gh api ... || echo ""` captured the 404 error body as `develop_sha` rather than empty string. Exit-code pattern fixes it.

## When

- Immediate merge on CI green. This merge will exercise the create-only branch of the idempotent logic (delete_branch_on_merge removes develop, workflow recreates it).

## How

### Test Plan

1. CI green.
2. Squash merge.
3. Observe workflow run. Expected flow:
   - `main = <new-merge-sha>`
   - `develop = <missing>` (auto-deleted by merge)
   - Enters create-only branch
   - POST refs creates develop at main's SHA
   - Summary reports aligned=yes

### Rollback

Revert PR #393 and this release. Manual fallback remains documented.