### PR TITLE
feat(hooks): log dangerous-command-guard decisions

### DIFF
--- a/global/hooks/dangerous-command-guard.ps1
+++ b/global/hooks/dangerous-command-guard.ps1
@@ -3,50 +3,91 @@ $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 
 # dangerous-command-guard.ps1
-# Blocks dangerous bash commands
+# Blocks dangerous bash commands and records every decision.
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always - decision is in JSON)
 # Response format: hookSpecificOutput with hookEventName
+#
+# Side effects:
+#   Writes one JSON line per invocation to
+#   ${env:CLAUDE_LOG_DIR}/dangerous-command-guard.log (defaults to
+#   ~/.claude/logs) so an operator can verify whether the hook returned
+#   allow/deny for a specific command.
 
-# Read input from stdin (Claude Code passes JSON via stdin)
-$json = Read-HookInput
+$logDir = if ($env:CLAUDE_LOG_DIR) { $env:CLAUDE_LOG_DIR } else { Join-Path $HOME '.claude/logs' }
+$logFile = Join-Path $logDir 'dangerous-command-guard.log'
 
-# Fail-closed: deny if stdin is empty or missing
-if (-not $json) {
-    New-HookDenyResponse -Reason 'Failed to parse hook input — denying for safety (fail-closed)'
+function Write-Decision {
+    param(
+        [string]$Decision,
+        [string]$Reason,
+        [string]$Command
+    )
+    try {
+        if (-not (Test-Path $logDir)) {
+            New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        }
+        $entry = [ordered]@{
+            ts       = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+            decision = $Decision
+            reason   = $Reason
+            command  = $Command
+        }
+        ($entry | ConvertTo-Json -Compress -Depth 3) | Out-File -FilePath $logFile -Append -Encoding utf8
+    } catch {
+        # Best-effort; never fail the decision on a logging failure.
+    }
+}
+
+function Respond-Deny {
+    param([string]$Reason)
+    Write-Decision -Decision 'deny' -Reason $Reason -Command $CMD
+    New-HookDenyResponse -Reason $Reason
     exit 0
 }
 
-# Extract command from tool_input
+function Respond-Allow {
+    param([string]$Reason = 'dangerous-command-guard: no dangerous pattern matched')
+    Write-Decision -Decision 'allow' -Reason $Reason -Command $CMD
+    New-HookAllowResponse -AdditionalContext $Reason
+    exit 0
+}
+
+$json = Read-HookInput
 $CMD = $null
+
+if (-not $json) {
+    Respond-Deny 'Failed to parse hook input - denying for safety (fail-closed)'
+}
+
 try {
     $CMD = $json.tool_input.command
 } catch {}
 
-# Fail-closed: deny if jq parsing failed
 if (-not $CMD) {
-    # Fallback to environment variable for backward compatibility
     $CMD = $env:CLAUDE_TOOL_INPUT
 }
 
-# Block recursive delete at root
 if ($CMD -match 'rm\s+(-[rRf]*[rR][rRf]*|--recursive)\s+/') {
-    New-HookDenyResponse -Reason 'Dangerous recursive delete at root directory blocked for safety'
-    exit 0
+    Respond-Deny 'Dangerous recursive delete at root directory blocked for safety'
 }
 
-# Block dangerous chmod
 if ($CMD -match 'chmod\s+(0?777|a\+rwx)') {
-    New-HookDenyResponse -Reason 'Dangerous permission change (777/a+rwx) blocked for security'
-    exit 0
+    Respond-Deny 'Dangerous permission change (777/a+rwx) blocked for security'
 }
 
-# Block remote script execution
 if ($CMD -match '(curl|wget)\s.*\|\s*(sh|bash|zsh|dash|python[23]?|perl|ruby|node)\b') {
-    New-HookDenyResponse -Reason 'Remote script execution via pipe blocked for security'
-    exit 0
+    Respond-Deny 'Remote script execution via pipe blocked for security'
 }
 
-# Allow the command
-New-HookAllowResponse
-exit 0
+# Tag safe read-only compound patterns (pipe/redirect + git/gh read verb)
+# so the audit trail explains why they were auto-allowed even when
+# Claude Code's allowlist cannot match a compound command.
+$safeHead = '^(git\s+(status|log|diff|show|branch|tag|remote|ls-files|rev-parse|describe|for-each-ref|worktree|fetch)|gh\s+(pr|issue|run|workflow|repo|release|auth)\s+(view|list|status|diff|checks))\b'
+if (($CMD -match '\|') -or ($CMD -match '2>&1') -or ($CMD -match '>\s*/dev/null')) {
+    if ($CMD -match $safeHead) {
+        Respond-Allow 'Safe read-only compound command (pipe/redirect with git/gh read verb)'
+    }
+}
+
+Respond-Allow

--- a/global/hooks/dangerous-command-guard.sh
+++ b/global/hooks/dangerous-command-guard.sh
@@ -1,13 +1,56 @@
 #!/bin/bash
 # dangerous-command-guard.sh
-# Blocks dangerous bash commands
+# Blocks dangerous bash commands and records every decision.
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always — decision is in JSON)
 # Response format: hookSpecificOutput with hookEventName
+#
+# Side effects:
+#   Writes one JSON line per invocation to
+#   ${CLAUDE_LOG_DIR:-$HOME/.claude/logs}/dangerous-command-guard.log
+#   so an operator can verify whether the hook returned allow/deny for a
+#   specific command. Compound commands (pipes, redirects) that Claude
+#   Code's allowlist cannot match should still show up here as "allow".
+#   If a prompt was presented despite an "allow" log entry, the root
+#   cause is upstream of this hook (e.g. unsandboxed path, multi-hook
+#   merge, permission mode), not the guard.
 
-# Helper function for deny response
+LOG_DIR="${CLAUDE_LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/dangerous-command-guard.log"
+
+# Best-effort log writer. Never blocks the decision on logging failure.
+log_decision() {
+    local decision="$1"
+    local reason="$2"
+    local cmd="$3"
+    mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    # Use jq to produce a safely escaped JSON line when available;
+    # fall back to a minimal manual escape if jq is missing.
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg ts "$ts" \
+            --arg d "$decision" \
+            --arg r "$reason" \
+            --arg c "$cmd" \
+            '{ts:$ts, decision:$d, reason:$r, command:$c}' \
+            >>"$LOG_FILE" 2>/dev/null || true
+    else
+        local esc_cmd esc_reason
+        esc_cmd=${cmd//\\/\\\\}
+        esc_cmd=${esc_cmd//\"/\\\"}
+        esc_reason=${reason//\\/\\\\}
+        esc_reason=${esc_reason//\"/\\\"}
+        printf '{"ts":"%s","decision":"%s","reason":"%s","command":"%s"}\n' \
+            "$ts" "$decision" "$esc_reason" "$esc_cmd" \
+            >>"$LOG_FILE" 2>/dev/null || true
+    fi
+}
+
 deny_response() {
     local reason="$1"
+    log_decision "deny" "$reason" "${CMD:-}"
     cat <<EOF
 {
   "hookSpecificOutput": {
@@ -20,53 +63,61 @@ EOF
     exit 0
 }
 
-# Helper function for allow response
 allow_response() {
+    local reason="${1:-dangerous-command-guard: no dangerous pattern matched}"
+    log_decision "allow" "$reason" "${CMD:-}"
+    # Escape double quotes for JSON safety.
+    local esc_reason=${reason//\"/\\\"}
     cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow"
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "$esc_reason"
   }
 }
 EOF
     exit 0
 }
 
-# Read input from stdin (Claude Code passes JSON via stdin)
 INPUT=$(cat)
 
-# Fail-closed: deny if stdin is empty or missing
 if [ -z "$INPUT" ]; then
+    CMD=""
     deny_response "Failed to parse hook input — denying for safety (fail-closed)"
 fi
 
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
-# Fail-closed: deny if jq parsing failed
 if [ $? -ne 0 ]; then
     deny_response "Failed to parse hook input JSON — denying for safety (fail-closed)"
 fi
 
-# Fallback to environment variable for backward compatibility
 if [ -z "$CMD" ]; then
     CMD="${CLAUDE_TOOL_INPUT:-}"
 fi
 
-# Block recursive delete at root
 if echo "$CMD" | grep -qE 'rm\s+(-[rRf]*[rR][rRf]*|--recursive)\s+/'; then
     deny_response "Dangerous recursive delete at root directory blocked for safety"
 fi
 
-# Block dangerous chmod
 if echo "$CMD" | grep -qE 'chmod\s+(0?777|a\+rwx)'; then
     deny_response "Dangerous permission change (777/a+rwx) blocked for security"
 fi
 
-# Block remote script execution
 if echo "$CMD" | grep -qE '(curl|wget)\s.*\|\s*(sh|bash|zsh|dash|python[23]?|perl|ruby|node)\b'; then
     deny_response "Remote script execution via pipe blocked for security"
 fi
 
-# Allow the command
+# Tag well-known safe read-only compound patterns so the reason line
+# explains why a pipe-bearing command was auto-allowed. This does not
+# widen what is allowed (all non-dangerous commands already fall through
+# to allow); it just produces a clearer audit trail.
+SAFE_READ_ONLY_HEAD='^(git\s+(status|log|diff|show|branch|tag|remote|ls-files|rev-parse|describe|for-each-ref|worktree|fetch)|gh\s+(pr|issue|run|workflow|repo|release|auth)\s+(view|list|status|diff|checks))\b'
+if echo "$CMD" | grep -qE '[|]|2>&1|>/dev/null|>\s*/dev/null'; then
+    if echo "$CMD" | grep -qE "$SAFE_READ_ONLY_HEAD"; then
+        allow_response "Safe read-only compound command (pipe/redirect with git/gh read verb)"
+    fi
+fi
+
 allow_response

--- a/tests/hooks/test-dangerous-command-guard.sh
+++ b/tests/hooks/test-dangerous-command-guard.sh
@@ -9,6 +9,16 @@ ERRORS=()
 
 cd "$(dirname "$0")/../.." || exit 1
 
+# Use a scratch log dir so assertions don't touch ~/.claude/logs.
+# Prefer $TMPDIR (sandbox-writable) before falling back to /tmp.
+SCRATCH_ROOT="${TMPDIR:-/tmp}"
+TEST_LOG_DIR=$(mktemp -d "$SCRATCH_ROOT/dcg-test.XXXXXX" 2>/dev/null) \
+    || TEST_LOG_DIR="$SCRATCH_ROOT/dcg-test.$$"
+mkdir -p "$TEST_LOG_DIR"
+export CLAUDE_LOG_DIR="$TEST_LOG_DIR"
+LOG_FILE="$TEST_LOG_DIR/dangerous-command-guard.log"
+trap 'rm -rf "$TEST_LOG_DIR"' EXIT
+
 assert_deny() {
     local input="$1" label="$2"
     local result
@@ -78,6 +88,49 @@ echo "[normal commands]"
 assert_allow '{"tool_input":{"command":"ls -la"}}' "ls -la → allow"
 assert_allow '{"tool_input":{"command":"git status"}}' "git status → allow"
 assert_allow '{"tool_input":{"command":"npm install"}}' "npm install → allow"
+
+echo ""
+echo "[safe compound commands — the original prompt-producing case]"
+assert_allow '{"tool_input":{"command":"git status 2>&1 | head -20"}}' "git status 2>&1 | head -20 → allow"
+assert_allow '{"tool_input":{"command":"git log --oneline | head"}}' "git log | head → allow"
+assert_allow '{"tool_input":{"command":"gh pr checks 123 | cat"}}' "gh pr checks | cat → allow"
+assert_allow '{"tool_input":{"command":"git diff >/dev/null 2>&1"}}' "git diff >/dev/null → allow"
+
+echo ""
+echo "[allow response shape]"
+allow_sample=$(echo '{"tool_input":{"command":"git status 2>&1 | head -20"}}' | bash "$HOOK" 2>/dev/null)
+if echo "$allow_sample" | grep -q '"permissionDecisionReason"'; then
+    ((PASS++)); echo "  PASS: allow response includes permissionDecisionReason"
+else
+    ((FAIL++)); ERRORS+=("FAIL: allow response missing permissionDecisionReason — got: $allow_sample"); echo "  FAIL: allow response missing permissionDecisionReason"
+fi
+if echo "$allow_sample" | grep -q 'Safe read-only compound command'; then
+    ((PASS++)); echo "  PASS: compound pattern emits dedicated reason"
+else
+    ((FAIL++)); ERRORS+=("FAIL: compound pattern reason missing — got: $allow_sample"); echo "  FAIL: compound pattern reason missing"
+fi
+
+echo ""
+echo "[decision log]"
+# Reset log for clean assertion.
+: >"$LOG_FILE"
+echo '{"tool_input":{"command":"git status 2>&1 | head -20"}}' | bash "$HOOK" >/dev/null
+echo '{"tool_input":{"command":"rm -rf /"}}' | bash "$HOOK" >/dev/null
+if [ -s "$LOG_FILE" ]; then
+    ((PASS++)); echo "  PASS: log file written"
+else
+    ((FAIL++)); ERRORS+=("FAIL: log file empty at $LOG_FILE"); echo "  FAIL: log file empty"
+fi
+if grep -q '"decision":"allow"' "$LOG_FILE" && grep -q '"decision":"deny"' "$LOG_FILE"; then
+    ((PASS++)); echo "  PASS: log contains both allow and deny entries"
+else
+    ((FAIL++)); ERRORS+=("FAIL: log missing allow/deny entries: $(cat "$LOG_FILE")"); echo "  FAIL: log missing allow/deny entries"
+fi
+if grep -q '"command":"git status 2>&1 | head -20"' "$LOG_FILE"; then
+    ((PASS++)); echo "  PASS: log preserves exact command string"
+else
+    ((FAIL++)); ERRORS+=("FAIL: log missing exact command: $(cat "$LOG_FILE")"); echo "  FAIL: log missing exact command"
+fi
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## What

### Summary
Add JSON-line decision logging, explicit `permissionDecisionReason` on allow responses, and tagging of safe read-only compound patterns in the `dangerous-command-guard` PreToolUse hook.

### Change Type
- [x] Feature (observability / audit trail)

### Affected Components
- `global/hooks/dangerous-command-guard.sh`
- `global/hooks/dangerous-command-guard.ps1`
- `tests/hooks/test-dangerous-command-guard.sh`

## Why

### Problem Solved
Users report that compound Bash commands (e.g. `git status 2>&1 | head -20`) still trigger a permission confirmation prompt even after PR #395 added a read-only git/gh allowlist. The Claude Code permissions engine cannot match allowlist patterns against commands containing pipes or redirects, so the prompt surfaces regardless of allowlist contents. The existing hook already returned `allow`, but there was no way to prove it — making it impossible to tell whether the prompt came from a hook failure or from an upstream permission-system limitation (multi-hook merge, unsandboxed execution paths, permission mode).

### Motivation
- Provide an audit trail so the next time a prompt surfaces, an operator can confirm whether the hook produced `allow` or not.
- Attach `permissionDecisionReason` to `allow` responses so Claude Code receives an explicit rationale, not just a bare verdict.
- Tag the exact class of command users have been hitting (pipe/redirect + git/gh read verb) with a descriptive reason so log analysis is faster.

## How

### Implementation Details
- Every invocation writes one JSON line to `${CLAUDE_LOG_DIR:-~/.claude/logs}/dangerous-command-guard.log` with `ts`, `decision`, `reason`, and the original `command`.
- Logging is best-effort: any filesystem failure is swallowed, it never blocks the actual allow/deny verdict.
- `allow_response` now accepts an optional reason argument and always includes `permissionDecisionReason` in the output JSON.
- Safe read-only compound pattern (`git status|log|diff|...` or `gh pr|issue|run|... view|list|checks`) combined with a pipe or redirect gets an explicit reason string: `Safe read-only compound command (pipe/redirect with git/gh read verb)`. All other commands fall through to the default allow with a generic reason.
- PowerShell counterpart mirrors the same behavior using `CommonHelpers.psm1`.

### Testing Done
- Existing 25 bash tests still pass.
- Added 9 new assertions covering:
  - Safe compound command allow decisions (`git status 2>&1 | head -20`, `git log | head`, `gh pr checks | cat`, `git diff >/dev/null`)
  - Response shape (`permissionDecisionReason` present, dedicated reason for compound patterns)
  - Log file: content exists, contains both `allow` and `deny` entries, preserves the exact command string
- Total: 34 tests pass.
- Live verification after deploy: 6 compound git commands executed in a session, all `allow` without user prompt, all recorded in the log.

### Breaking Changes
None. Decision verdicts (`allow` / `deny`) are unchanged; only the response shape (added reason field) and side effects (log file) are new.

### Rollback Plan
Revert the three changed files; the log directory/file can be left in place (the hook recreates it as needed).

## Where

### Related Issues
Relates to #395 (read-only git/gh allowlist) — the allowlist approach alone cannot cover compound commands; this PR instruments the hook so the limitation is visible rather than silent.