### PR TITLE
feat(skills): standardize halt_condition/max_iterations metadata

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -37,7 +37,7 @@ Global settings for all Claude Code sessions. Project-specific `CLAUDE.md` files
 - When a required toolchain (Go, Rust, CMake, npm) is not installed locally, skip local build verification and rely on CI. Do not attempt to install toolchains without asking the user first.
 - Validate incrementally: build and test after each logical change, not after all changes are complete. This catches errors early and reduces first-CI-run failures.
 - After large refactoring or migration, run a full build, collect ALL errors, and fix them in one batch before rebuilding. Do not fix one error at a time.
-- If the same approach fails 3 consecutive times, stop and propose alternative strategies to the user.
+- If the same approach fails 3 consecutive times, stop and propose alternative strategies to the user. Iterative skills encode this as `max_iterations` and `halt_condition` fields in their frontmatter — see `global/skills/_policy.md` §Iteration Control Schema.
 
 ## Standard Workflows
 

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -23,3 +23,17 @@ This rule exists because long multi-phase requests otherwise incur repeated "con
 - Batch processing: 2-second pause between items, 0.3-second pause between API calls during discovery
 - Batch mode: max 200 repos for cross-repo discovery, max 100 items per repo
 - Batch failure: continue to next item on failure, present summary at end
+
+## Iteration Control Schema
+
+Skills that perform iterative work (retry loops, polling loops, multi-round refinement) declare halting semantics in their frontmatter. This elevates the prose rule "if the same approach fails 3 times, stop and propose alternatives" (`global/CLAUDE.md`) to machine-readable, per-skill metadata.
+
+```yaml
+max_iterations: <int>          # Hard upper bound on loop iterations
+halt_condition: "<expression>" # Natural language or regex describing success/abort signal
+on_halt: "<action>"            # What to do when halt condition fires (report, escalate, exit)
+```
+
+Required for skills whose body contains a polling loop, retry loop, or multi-round iteration (`issue-work`, `pr-work`, `ci-fix`, `release`, `research`, `fleet-orchestrator`). Optional otherwise.
+
+Prefer regex or symbolic halt conditions over free-form prose when the signal is deterministic (CI status, exit codes). Reserve natural language for cases where interpretation is intrinsically subjective.

--- a/global/skills/ci-fix/SKILL.md
+++ b/global/skills/ci-fix/SKILL.md
@@ -5,6 +5,9 @@ argument-hint: "[pr-number] [--pattern msvc-c4996|cmake-fetchcontent|cpp-lib-for
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(gh *)"
+max_iterations: 3
+halt_condition: "Workflow run conclusion == success, OR failure maps to an unknown error class not in reference/known-fixes.md"
+on_halt: "Escalate to user with failing log excerpt and classification result"
 ---
 
 # ci-fix Skill
@@ -73,11 +76,15 @@ Follow this deterministic sequence. Stop at the first match.
 
 ## Escalation
 
-| Condition | Action |
-|-----------|--------|
-| Classifier does not match | Print the first 80 lines of the log; ask the user to either add a new pattern to `known-fixes.md` or hand off. |
-| Fix applied but CI still red | Re-classify once. On a second miss, convert the PR to draft and escalate. |
-| 20-minute budget exceeded | Report current check table; do **not** merge. |
+This table operationalizes the skill's frontmatter `halt_condition` and `on_halt` fields. Every condition below is a terminal halt state that consumes one of the `max_iterations: 3` budget slots.
+
+| Condition | Action | Halt |
+|-----------|--------|------|
+| Classifier does not match | Print the first 80 lines of the log; ask the user to either add a new pattern to `known-fixes.md` or hand off. | yes — unknown error class |
+| Fix applied but CI still red | Re-classify once. On a second miss, convert the PR to draft and escalate. | yes — after 2nd miss |
+| 20-minute budget exceeded | Report current check table; do **not** merge. | yes — time budget |
+
+**Example halt trace**: CI reports `cmake-fetchcontent` → fix applied → CI still fails with `msvc-c4996` → re-classify and apply C4996 fix → CI still fails with a fourth pattern not in `known-fixes.md` → `halt_condition` matches (unknown class) → skill exits per `on_halt` (escalate to user with diagnosis).
 
 ## Time Budget
 

--- a/global/skills/fleet-orchestrator/SKILL.md
+++ b/global/skills/fleet-orchestrator/SKILL.md
@@ -5,6 +5,9 @@ argument-hint: "<repos-spec> <directive-spec> [--max-parallel N] [--retry N] [--
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(gh *), Bash(flock *), Bash(jq *)"
+max_iterations: 10
+halt_condition: "All repos reach a terminal worker status (done, failed-after-retries, skipped), OR --max-parallel worker pool drains with no pending items"
+on_halt: "Render final fleet-status table with per-repo outcome and exit"
 ---
 
 # Fleet Orchestrator -- Parallel Multi-Repo Directive Executor

--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -5,6 +5,9 @@ argument-hint: "[project-name] [issue-number] [--solo|--team] [--limit N] [--dry
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
+max_iterations: 10
+halt_condition: "CI all-green and PR merged, OR 3 identical build/CI failures in a row"
+on_halt: "Convert PR to draft, report failing checks, exit without merging"
 ---
 
 # Issue Work Command

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -5,6 +5,9 @@ argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-ru
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
+max_iterations: 5
+halt_condition: "All PR checks pass, OR user aborts, OR 3 identical CI failures in a row"
+on_halt: "Report failing checks with gh pr checks output, do not merge"
 ---
 
 # PR Work Command

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -6,6 +6,9 @@ user-invocable: true
 disable-model-invocation: true
 context: fork
 allowed-tools: "Bash(git *) Bash(gh *)"
+max_iterations: 5
+halt_condition: "Release PR merged and tag published, OR CI failure persists after 3 retries, OR integrity check fails"
+on_halt: "Report incomplete release state, leave tag/PR in whatever state they are in, do not force-publish"
 ---
 
 # Release Command

--- a/global/skills/research/SKILL.md
+++ b/global/skills/research/SKILL.md
@@ -14,6 +14,9 @@ allowed-tools:
   - Glob
   - Bash
   - Agent
+max_iterations: 5
+halt_condition: "Depth target reached (shallow=1 round, standard=3, deep=5), OR user confirms sufficient findings, OR no new sources surface for 2 consecutive rounds"
+on_halt: "Write report with partial findings and explicit coverage-gap section"
 ---
 
 # Research Command


### PR DESCRIPTION
Closes #399

## Summary

Adds three frontmatter fields — `max_iterations`, `halt_condition`, `on_halt` — to every iterative skill, elevating the prose rule from `global/CLAUDE.md` ("if the same approach fails 3 times, stop") to machine-readable per-skill metadata.

## Changes

| File | Change |
|------|--------|
| `global/skills/_policy.md` | New section: **Iteration Control Schema** |
| `global/skills/issue-work/SKILL.md` | max_iterations=10, halt on CI green OR 3 identical failures |
| `global/skills/pr-work/SKILL.md` | max_iterations=5, halt on all-green OR manual abort |
| `global/skills/ci-fix/SKILL.md` | max_iterations=3, halt on success OR unknown error class; Escalation section extended with halt trace example |
| `global/skills/release/SKILL.md` | max_iterations=5, halt on merged tag OR CI failure after 3 retries |
| `global/skills/research/SKILL.md` | max_iterations=5, halt on depth reached OR no new sources for 2 rounds |
| `global/skills/fleet-orchestrator/SKILL.md` | max_iterations=10, halt when all workers reach terminal state |
| `global/CLAUDE.md` | 3-fail rule now cross-references the schema |

## Acceptance Criteria

- [x] All six iterative skills carry the three fields
- [x] `_policy.md` documents the schema
- [x] `ci-fix` demonstrates halting via concrete trace example
- [x] `global/CLAUDE.md` references the metadata fields

## Test Plan

- Verify frontmatter parses: `head -15` each of the 6 SKILL.md files; expect three new lines per file.
- Verify schema entry: `grep -A12 'Iteration Control Schema' global/skills/_policy.md`.
- Verify cross-reference: `grep 'max_iterations' global/CLAUDE.md`.

## Token Impact

~90-150 tokens one-time frontmatter. Net positive — prevents unbounded failure loops.