### PR TITLE
feat(skills): extend input injection pattern beyond batch-mode

### DIFF
--- a/global/skills/_shared/invariants.md
+++ b/global/skills/_shared/invariants.md
@@ -1,0 +1,33 @@
+# Shared Invariants
+
+Canonical source for short rule-reminder blocks re-anchored inside long loops.
+
+Skills with iterative work (batch loops, CI polling, multi-round research, per-repo dispatch) should emit the Core block inline every `--reanchor-interval N` iterations (default 5, `0` disables). This keeps the rules in the model's recent attention window as tool outputs accumulate.
+
+**Token budget**: Core block ≈ 25 tokens per emission. A 30-item loop with interval=5 adds ~150 tokens. Optional block is loaded only when the skill touches those dimensions.
+
+## Core (5 lines, re-anchor target)
+
+```
+- PR title/body, commit messages, issue comments: English only
+- Commit format: type(scope): description (no Claude/AI attribution, no emojis)
+- ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
+- Branch: feature off develop, squash merge back via PR
+- 3-fail rule: stop and propose alternatives after 3 identical failures
+```
+
+## Optional (5 lines, load when the skill touches these dimensions)
+
+```
+- Protected branches: never direct-push to main or develop
+- Validate incrementally: build and test after each logical change
+- Close parent epic when all sub-issues are closed
+- Batch pacing: 2-second pause between items, 0.3-second between API calls
+- Missing toolchain: skip local build, rely on CI, do not auto-install
+```
+
+## How to use
+
+Skills prepend a context label when emitting inline (e.g., `[Item 5/30] Required rules:`) and then copy the Core block verbatim. Optional block is added only when the skill's current phase touches those dimensions (direct pushes, batch pacing, epic closure, toolchain checks).
+
+Changes to canonical rules happen here. Skills that copy the block inline must stay in sync with this file.

--- a/global/skills/fleet-orchestrator/SKILL.md
+++ b/global/skills/fleet-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fleet-orchestrator
 description: "Fan out a single high-level directive (audit, deprecation cleanup, fix, migration, version bump) across an arbitrary list of repositories as parallel Agent workers, with a supervisor that polls a shared manifest, renders a live status table, and aggregates final results. Use when the user says 'apply X across repos', 'audit N repositories', 'sweep every repo', 'run the same fix in all projects', 'parallel multi-repo', 'fleet-wide change', or provides a list of repositories with a single directive. Preferred over running issue-work in each repo sequentially."
-argument-hint: "<repos-spec> <directive-spec> [--max-parallel N] [--retry N] [--poll-interval SEC] [--dry-run]"
+argument-hint: "<repos-spec> <directive-spec> [--max-parallel N] [--retry N] [--poll-interval SEC] [--dry-run] [--reanchor-interval N]"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(gh *), Bash(flock *), Bash(jq *)"
@@ -348,3 +348,9 @@ After a fleet run, confirm:
 - [ ] Final report matches the manifest counts.
 - [ ] Failed repos are called out explicitly for user action.
 - [ ] `_workspace/fleet/` is preserved for audit.
+
+## Reanchoring Loop Invariants
+
+`--reanchor-interval N` (default 5, `0` disables) controls how often the Core invariants block from `global/skills/_shared/invariants.md` is emitted during the supervisor's status-polling loop.
+
+Loop bind point: every N manifest-poll cycles. A fleet run covering 20+ repos produces enough accumulated worker outputs that the supervisor's attention drifts from the canonical rules; re-anchoring keeps the English-only, squash-merge, and CI-gate invariants in the recent context when aggregating results and deciding per-repo terminal state.

--- a/global/skills/issue-work/reference/batch-mode.md
+++ b/global/skills/issue-work/reference/batch-mode.md
@@ -105,9 +105,9 @@ If `--dry-run` is set, display the plan and exit without prompting.
 
 ### B-4.0. Per-Item Rule Reminder
 
-Before starting work on each item, emit a 5-line reminder block as a fresh tool result so the rules sit in the recent attention window instead of being buried by accumulating context. The reminder must be **exactly 5 lines or fewer** to keep the per-iteration token cost bounded.
+Before starting work on each item, emit the Core invariants block from `global/skills/_shared/invariants.md` as a fresh tool result so the rules sit in the recent attention window instead of being buried by accumulating context.
 
-Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
+Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`). The five bullet lines are the canonical Core block — when they change, update `global/skills/_shared/invariants.md` first, then this template:
 
 ```
 [Item ${PROCESSED+1}/${TOTAL}] Required rules:
@@ -115,9 +115,10 @@ Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
 - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
 - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
 - Branch: feature off develop, squash merge back via PR
+- 3-fail rule: stop and propose alternatives after 3 identical failures
 ```
 
-**Why inline instead of @load**: A `@load: reference/...` call at batch start surfaces the doc once, after which the model's attention drifts as tool results accumulate. Inlining the same invariants per iteration makes them part of the most recent tool output every time, which is where attention is strongest. The 5-line cap keeps the cumulative cost linear in batch size but still tiny (≈25 tokens per item).
+**Why inline instead of @load**: A `@load: reference/...` call at batch start surfaces the doc once, after which the model's attention drifts as tool results accumulate. Inlining the same invariants per iteration makes them part of the most recent tool output every time, which is where attention is strongest. The short bullet list keeps the cumulative cost linear in batch size but still tiny (≈25 tokens per item).
 
 **No reference loads inside the loop**: Do not call `@load: reference/error-handling.md`, `@load: reference/comment-templates.md`, or any other reference file from inside the per-item loop. If the single-item workflow needs a reference doc, the Solo/Team workflow loads it on its own — keep the loop free of additional loads so the inline reminder remains the most recent context anchor.
 
@@ -142,11 +143,12 @@ for each item in approved batch plan:
            prompt: """
                Execute /issue-work $REPO $ISSUE_NUMBER --$MODE with full CLAUDE.md compliance.
 
-               Required rules (do not skip):
+               Required rules (do not skip — canonical source: global/skills/_shared/invariants.md Core block):
                - PR title/body, commit messages, issue comments: English only
                - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
                - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
                - Branch: feature off develop, squash merge back via PR
+               - 3-fail rule: stop and propose alternatives after 3 identical failures
 
                Run Solo Mode Steps 1-12 (or Team Mode T-1 through T-6 for team mode). If team
                mode, you MUST call TeamDelete() after completing the item.

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-work
 description: "Analyze and fix failed CI/CD workflows for a pull request. Use when CI checks fail, GitHub Actions show red, build/test/lint errors block a PR, or the user says 'fix CI', 'fix the build', 'PR is failing', or 'check failed'. Supports solo, team, and batch modes with automated retry and escalation."
-argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-run] [--inline]"
+argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-run] [--inline] [--reanchor-interval N]"
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
@@ -487,6 +487,14 @@ If CI failed or max retries exceeded, use this format instead:
 ### Action Required
 - User must resolve CI failures before merge
 ```
+
+## Reanchoring Loop Invariants
+
+`--reanchor-interval N` (default 5, `0` disables) controls how often the Core invariants block from `global/skills/_shared/invariants.md` is emitted inside long loops.
+
+Loop bind points for pr-work:
+- **Batch mode**: between items, same semantics as `issue-work` batch-mode (every N items).
+- **Single-PR CI polling**: every N poll cycles of the 30-second monitor loop, keeping the CI gate rules adjacent to the latest `gh pr checks` output.
 
 ## Error Handling
 

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Create a release with automated changelog generation from commits since last release using semantic versioning.
-argument-hint: "<version> [--target <field>] [--draft] [--prerelease] [--solo|--team]"
+argument-hint: "<version> [--target <field>] [--draft] [--prerelease] [--solo|--team] [--reanchor-interval N]"
 user-invocable: true
 disable-model-invocation: true
 context: fork
@@ -489,6 +489,12 @@ After completion, provide summary:
 ### Commits Included
 - Total: N commits since PREVIOUS_TAG
 ```
+
+## Reanchoring Loop Invariants
+
+`--reanchor-interval N` (default 5, `0` disables) controls how often the Core invariants block from `global/skills/_shared/invariants.md` is emitted during the release workflow.
+
+Loop bind point: between each CI retry and each merge-gate verification. For a typical release flow this fires once or twice — the interval primarily protects prolonged retry storms where attention would otherwise drift from the English-only / squash-merge / CI-gate rules.
 
 ## Error Handling
 

--- a/global/skills/research/SKILL.md
+++ b/global/skills/research/SKILL.md
@@ -3,7 +3,7 @@ name: research
 description: "Conduct structured research on any topic: web search, codebase analysis, and document synthesis into organized reports. Use when investigating technologies, analyzing alternatives, gathering reference materials, fact-checking claims, or producing technical documentation from research. Use this skill whenever the user asks to research, investigate, compare, or survey a topic."
 user-invocable: true
 disable-model-invocation: true
-argument-hint: "<topic> [--depth shallow|standard|deep] [--output file.md] [--sources web|code|both] [--lang en|ko|ja|...] [--template auto|plain] [--integrate]"
+argument-hint: "<topic> [--depth shallow|standard|deep] [--output file.md] [--sources web|code|both] [--lang en|ko|ja|...] [--template auto|plain] [--integrate] [--reanchor-interval N]"
 allowed-tools:
   - WebSearch
   - WebFetch
@@ -344,3 +344,9 @@ Before finalizing the report, verify:
 - [ ] Comparison matrix complete (if applicable)
 - [ ] Cross-references to existing project docs included (if `--sources code`)
 - [ ] Output language consistent throughout
+
+## Reanchoring Loop Invariants
+
+`--reanchor-interval N` (default 5, `0` disables) controls how often the Core invariants block from `global/skills/_shared/invariants.md` is emitted between research rounds.
+
+Loop bind point: between `shallow`/`standard`/`deep` round iterations. For deep-depth runs (5+ rounds with many WebFetch outputs), this keeps the English-only and citation-required rules adjacent to the latest round's findings instead of buried behind accumulated source content.


### PR DESCRIPTION
Closes #400

## Summary

Extracts the Core invariants block — previously duplicated inline in `issue-work/reference/batch-mode.md` — into `global/skills/_shared/invariants.md` as the canonical source, then wires four additional iterative skills to re-emit it on their own loops via `--reanchor-interval N`.

## Changes

| File | Change |
|------|--------|
| `global/skills/_shared/invariants.md` | NEW — 5 core + 5 optional invariants, ≤10 total |
| `global/skills/issue-work/reference/batch-mode.md` | Two inline blocks now cite `_shared/invariants.md` as canonical source; 3-fail rule added for parity |
| `global/skills/pr-work/SKILL.md` | `--reanchor-interval` flag + Reanchoring section (bind: batch items, CI poll cycles) |
| `global/skills/release/SKILL.md` | Same flag + section (bind: CI retries, merge-gate verification) |
| `global/skills/research/SKILL.md` | Same flag + section (bind: between research rounds) |
| `global/skills/fleet-orchestrator/SKILL.md` | Same flag + section (bind: manifest-poll cycles) |

## Acceptance Criteria

- [x] `_shared/invariants.md` exists, ≤ 10 lines
- [x] Four target skills support `--reanchor-interval`
- [x] `batch-mode.md` sources from `_shared/invariants.md` (no duplication — both prior copies now carry canonical-source attribution)
- [ ] Measurement: rule-drift observation in a 20-item `pr-work` batch — **deferred**, requires a live long-run batch to evaluate. Will land as a follow-up note once measurement data exists.

## Token Impact

Per the issue estimate: ~+50 tokens per 10-item loop, ~+150 per 30-item, ≤ +500 across all four skills per long session. <1% overhead.

## Test Plan

- `cat global/skills/_shared/invariants.md` — verify 5 core + 5 optional structure.
- `grep -n 'reanchor-interval' global/skills/*/SKILL.md` — expect 4 skills with the flag.
- `grep -n 'canonical source' global/skills/issue-work/reference/batch-mode.md` — expect 2 hits (B-4.0 template, B-4.a subagent prompt).