### PR TITLE
feat(skills): document loop_safe frontmatter flag for /loop-compatible skills

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,9 @@
+# claude-config repo-root .claudeignore
+#
+# Scope: governs context loading when editing the claude-config repo itself.
+# The in-tree `global/.claudeignore`, `plugin/.claudeignore`, and `project/.claudeignore`
+# files govern the subtrees they live in.
+
+# Reference docs for contributors. Load on demand with `@load: docs/<name>`.
+# Not auto-loaded in normal sessions.
+docs/loop-patterns.md

--- a/docs/loop-patterns.md
+++ b/docs/loop-patterns.md
@@ -1,0 +1,83 @@
+# Loop-Safety Patterns for Skills
+
+Convention for the `loop_safe` frontmatter field in `global/skills/*/SKILL.md`.
+
+> **Loading**: This doc is not auto-loaded. Load with `@load: docs/loop-patterns` when reviewing or classifying skill loop-safety.
+
+## Why This Flag Exists
+
+The harness-level `/loop` skill wraps any command in a polling or self-pacing loop. A naive user running `/loop issue-work` would create a new PR on every iteration; `/loop release` would attempt to cut a new tag each cycle. `loop_safe` makes this safety property explicit in skill metadata so the `/loop` harness can refuse — or warn on — skills that are not idempotent.
+
+## Rules
+
+1. **Default to `loop_safe: false`.** Only mark `true` when you have actively reasoned that repeated invocation produces no external artifacts and no destructive cascade.
+2. **External artifacts = not loop-safe.** Creates issues, PRs, releases, tags, comments, branches, or destroys resources → `false`.
+3. **Retry is the mechanism → safe.** If the skill's happy path already involves retrying the same action (e.g., `ci-fix` re-pushes a codified fix until CI is green), it is already self-deduplicating and belongs in `true`.
+4. **Read-only or synthesis → safe.** Skills that only read files, run searches, produce reports, or rebuild deterministic outputs from unchanged inputs (doc indexes, review reports, preflight checks) → `true`.
+5. **When in doubt, mark `false`.** False is the safe default; upgrading to `true` is an explicit reasoning step documented in the skill body.
+
+## Examples
+
+### Example 1 — `loop_safe: true` (research)
+
+```yaml
+name: research
+loop_safe: true
+```
+
+**Why**: Each run writes a report file. A second run with the same topic either overwrites the same report (idempotent) or produces a new report file with a timestamped name (no cascade). No external services mutated. No GitHub state changed. Wrapping `/loop research "topic X"` produces repeated refreshes of the same topic — wasteful, but not destructive.
+
+### Example 2 — `loop_safe: false` (issue-work)
+
+```yaml
+name: issue-work
+loop_safe: false
+```
+
+**Why**: Each run creates a branch, commits, opens a PR, monitors CI, merges, and closes an issue. Repeated invocation on the same issue would fail fast (issue already closed), but invocation inside `/loop` with auto-issue-selection would continuously chew through the backlog without a user in the loop — creating PRs and merging them with no oversight. Destructive in aggregate.
+
+### Example 3 — `loop_safe: true` (ci-fix)
+
+```yaml
+name: ci-fix
+loop_safe: true
+```
+
+**Why**: `ci-fix` classifies a failing workflow into one of three patterns and pushes a codified remediation. If the fix succeeds, subsequent invocations find no failing runs and halt (safe). If the fix fails, re-classification either picks a different pattern (also safe — each fix is a distinct commit, not a duplicate) or escalates to the user. The skill's entire contract assumes retry is natural; wrapping it in `/loop` simply automates the retry cadence.
+
+## Anti-Patterns
+
+### Anti-Pattern 1 — "It's mostly read-only"
+
+A skill reads 100 files and writes 1 summary file. The 1% write is enough to make it `loop_safe: false` if that write target is shared state (e.g., a report committed to the repo). Only mark `true` when writes are to throwaway locations or are deterministic re-computations.
+
+### Anti-Pattern 2 — "Retry inside the skill, so /loop is also fine"
+
+Self-retry inside a skill handles transient failures during one invocation. It does NOT imply safety under external looping. Example: `pr-work` retries CI up to 3 times per run, but `/loop pr-work` would re-attempt merges on a merged PR (noisy at best, forced re-merge at worst). `loop_safe: false`.
+
+### Anti-Pattern 3 — "The happy path is idempotent"
+
+Idempotence under the happy path is not sufficient. Consider failure modes: partial state, interruption mid-run, concurrent invocation. A skill that leaves a branch pushed but not merged after a failure is not loop-safe — the second invocation would see the branch, possibly re-push on top of it, and create a divergent history.
+
+## Classification Summary
+
+Current `global/skills/` state:
+
+| `loop_safe: true` | `loop_safe: false` |
+|-------------------|---------------------|
+| `ci-fix` | `branch-cleanup` |
+| `doc-index` | `fleet-orchestrator` |
+| `doc-review` | `harness` |
+| `preflight` | `implement-all-levels` |
+| `research` | `issue-create` |
+|  | `issue-work` |
+|  | `pr-work` |
+|  | `release` |
+
+5 safe, 8 not-safe. When adding a new skill, update this table.
+
+## Related
+
+- Schema: `global/skills/_policy.md` § Loop-Safety Flag
+- Iteration control: `global/skills/_policy.md` § Iteration Control Schema
+- Shared invariants for long loops: `global/skills/_shared/invariants.md`

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -37,3 +37,16 @@ on_halt: "<action>"            # What to do when halt condition fires (report, e
 Required for skills whose body contains a polling loop, retry loop, or multi-round iteration (`issue-work`, `pr-work`, `ci-fix`, `release`, `research`, `fleet-orchestrator`). Optional otherwise.
 
 Prefer regex or symbolic halt conditions over free-form prose when the signal is deterministic (CI status, exit codes). Reserve natural language for cases where interpretation is intrinsically subjective.
+
+## Loop-Safety Flag
+
+Every skill declares whether repeated invocation is idempotent — i.e., wrapping it in the harness `/loop` skill would not duplicate external artifacts, spam services, or corrupt state.
+
+```yaml
+loop_safe: true | false
+```
+
+- `loop_safe: true` — invocations are idempotent, read-only, or self-deduplicating. Safe to wrap in `/loop`. Examples: `research`, `ci-fix` (retry is the mechanism), `doc-index`, `doc-review`, `preflight`.
+- `loop_safe: false` — invocations create external artifacts (PRs, issues, releases, branch deletions) or mutate shared state. Wrapping in `/loop` would produce duplicates or destructive cascades. Examples: `issue-work`, `pr-work`, `release`, `branch-cleanup`, `issue-create`, `harness`, `implement-all-levels`, `fleet-orchestrator`.
+
+Rules and anti-patterns: `docs/loop-patterns.md`.

--- a/global/skills/branch-cleanup/SKILL.md
+++ b/global/skills/branch-cleanup/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 disable-model-invocation: true
 context: fork
 allowed-tools: "Bash(git *)"
+loop_safe: false
 ---
 
 # Branch Cleanup Command

--- a/global/skills/ci-fix/SKILL.md
+++ b/global/skills/ci-fix/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools: "Bash(gh *)"
 max_iterations: 3
 halt_condition: "Workflow run conclusion == success, OR failure maps to an unknown error class not in reference/known-fixes.md"
 on_halt: "Escalate to user with failing log excerpt and classification result"
+loop_safe: true
 ---
 
 # ci-fix Skill

--- a/global/skills/doc-index/SKILL.md
+++ b/global/skills/doc-index/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Write
   - Glob
   - Grep
+loop_safe: true
 ---
 
 # Document Index Generator

--- a/global/skills/doc-review/SKILL.md
+++ b/global/skills/doc-review/SKILL.md
@@ -7,6 +7,7 @@ disable-model-invocation: true
 allowed-tools: "Bash(git *)"
 context: fork
 agent: general-purpose
+loop_safe: true
 ---
 
 # Document Review Command

--- a/global/skills/fleet-orchestrator/SKILL.md
+++ b/global/skills/fleet-orchestrator/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools: "Bash(gh *), Bash(flock *), Bash(jq *)"
 max_iterations: 10
 halt_condition: "All repos reach a terminal worker status (done, failed-after-retries, skipped), OR --max-parallel worker pool drains with no pending items"
 on_halt: "Render final fleet-status table with per-repo outcome and exit"
+loop_safe: false
 ---
 
 # Fleet Orchestrator -- Parallel Multi-Repo Directive Executor

--- a/global/skills/harness/SKILL.md
+++ b/global/skills/harness/SKILL.md
@@ -4,6 +4,7 @@ description: "Design and build domain-specific agent team harnesses. Analyzes pr
 argument-hint: "[domain-or-project-description]"
 user-invocable: true
 disable-model-invocation: true
+loop_safe: false
 ---
 
 # Harness -- Agent Team & Skill Architect

--- a/global/skills/implement-all-levels/SKILL.md
+++ b/global/skills/implement-all-levels/SKILL.md
@@ -4,6 +4,7 @@ description: Enforce complete implementation of all tiers/difficulty levels for 
 argument-hint: "<feature-description> [--solo|--team]"
 user-invocable: true
 disable-model-invocation: true
+loop_safe: false
 ---
 
 # Implement All Levels Command

--- a/global/skills/issue-create/SKILL.md
+++ b/global/skills/issue-create/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "<project-name> [--type bug|feature] [--priority high|medium]"
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh issue *)"
+loop_safe: false
 ---
 
 # Issue Create Command

--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools: "Bash(gh *)"
 max_iterations: 10
 halt_condition: "CI all-green and PR merged, OR 3 identical build/CI failures in a row"
 on_halt: "Convert PR to draft, report failing checks, exit without merging"
+loop_safe: false
 ---
 
 # Issue Work Command

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools: "Bash(gh *)"
 max_iterations: 5
 halt_condition: "All PR checks pass, OR user aborts, OR 3 identical CI failures in a row"
 on_halt: "Report failing checks with gh pr checks output, do not merge"
+loop_safe: false
 ---
 
 # PR Work Command

--- a/global/skills/preflight/SKILL.md
+++ b/global/skills/preflight/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[--only <check>] [--skip <check>] [--verbose]"
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(act *),Bash(docker *),Bash(cmake *)"
+loop_safe: true
 ---
 
 # preflight Skill

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools: "Bash(git *) Bash(gh *)"
 max_iterations: 5
 halt_condition: "Release PR merged and tag published, OR CI failure persists after 3 retries, OR integrity check fails"
 on_halt: "Report incomplete release state, leave tag/PR in whatever state they are in, do not force-publish"
+loop_safe: false
 ---
 
 # Release Command

--- a/global/skills/research/SKILL.md
+++ b/global/skills/research/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools:
 max_iterations: 5
 halt_condition: "Depth target reached (shallow=1 round, standard=3, deep=5), OR user confirms sufficient findings, OR no new sources surface for 2 consecutive rounds"
 on_halt: "Write report with partial findings and explicit coverage-gap section"
+loop_safe: true
 ---
 
 # Research Command


### PR DESCRIPTION
Closes #403

## Summary

Introduces a boolean `loop_safe` field in every SKILL.md frontmatter so the harness `/loop` skill can distinguish idempotent skills from state-mutating ones. Classifies all 13 existing skills, documents the schema in `global/skills/_policy.md`, and publishes rules/examples/anti-patterns in `docs/loop-patterns.md`.

## Classification

| `loop_safe: true` (5) | `loop_safe: false` (8) |
|-------------------------|--------------------------|
| `ci-fix` (retry is the mechanism) | `branch-cleanup` (destructive) |
| `doc-index` (idempotent indexing) | `fleet-orchestrator` (multi-repo mutations) |
| `doc-review` (produces reports only) | `harness` (writes agents/skills) |
| `preflight` (read-only CI reproduction) | `implement-all-levels` (writes code) |
| `research` (synthesis, no external state) | `issue-create` (creates issues) |
|  | `issue-work` (creates PRs, closes issues) |
|  | `pr-work` (commits, merges) |
|  | `release` (creates tags/releases) |

## Changes

| File | Change |
|------|--------|
| `global/skills/_policy.md` | New section: **Loop-Safety Flag** with semantics and examples |
| `global/skills/*/SKILL.md` | `loop_safe` added to every skill frontmatter (13 files) |
| `docs/loop-patterns.md` | NEW — rules, 3 worked examples, 3 anti-patterns, summary table |
| `.claudeignore` | NEW at repo root — defers `docs/loop-patterns.md` from default context |

## Acceptance Criteria

- [x] Schema documented in `_policy.md`
- [x] All 13 skills classified
- [x] `docs/loop-patterns.md` created
- [x] `.claudeignore` updated to defer load
- [ ] No false-positive loop invocations in a manual test — **deferred**, requires `/loop` integration with a `loop_safe` check which is itself follow-up work (the `/loop` skill currently does not read this field).

## Token Impact

- Frontmatter: +5 tokens × 13 skills = +65 tokens one-time
- `docs/loop-patterns.md`: deferred load, 0 impact on normal sessions
- Net: negligible

## Test Plan

- `grep -l '^loop_safe:' global/skills/*/SKILL.md | wc -l` — expect `13`.
- `grep -A2 'Loop-Safety Flag' global/skills/_policy.md` — verify schema entry.
- `cat docs/loop-patterns.md` — verify rules/examples/anti-patterns structure.
- `grep 'loop-patterns.md' .claudeignore` — verify deferral entry.