### PR TITLE
feat(install): deploy dual-variant hooks for Docker-compatible Windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ notepad $HOME\.claude\git-identity.md
 > **Note**: Requires PowerShell 7+ (`pwsh`). Install via `winget install Microsoft.PowerShell`.
 > If you get an execution policy error, run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
+#### Docker-compatible dual-variant install
+
+`install.ps1` deploys **both** PowerShell (`.ps1`) and bash (`.sh`) variants of
+every hook and utility script into `~/.claude/hooks/` and `~/.claude/scripts/`.
+The `.sh` files are written with LF line endings (UTF-8, no BOM).
+
+This matters when the Windows host's `~/.claude/` is bind-mounted into a Linux
+Claude Code container (e.g. via the companion [claude-docker](https://github.com/kcenon/claude-docker)
+project): the container entrypoint rewrites `pwsh ... -File foo.ps1` hook
+commands to `foo.sh`, which only works if the matching `.sh` file exists on
+the mount. The installer also runs a pairing audit and warns about any `.ps1`
+without a `.sh` sibling (or vice versa) so Docker-side rewrites do not silently
+resolve to missing files.
+
 ### Plugin Installation (Beta)
 
 Install as a Claude Code Plugin for easy distribution and updates:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -42,6 +42,20 @@ function Ensure-Directory {
     }
 }
 
+function Install-BashScript {
+    # Copy a .sh file with UTF-8 (no BOM) encoding and LF-only line endings.
+    # Windows PowerShell's default Copy-Item preserves CRLF, which makes the
+    # script fail when executed by bash in a Linux container bind-mounted
+    # from a Windows host. See Issue #407.
+    param(
+        [Parameter(Mandatory)][string]$SourcePath,
+        [Parameter(Mandatory)][string]$DestinationPath
+    )
+    $content = [System.IO.File]::ReadAllText($SourcePath) -replace "`r`n", "`n"
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($DestinationPath, $content, $utf8NoBom)
+}
+
 function New-LocalClaude {
     param([string]$ProjectDir)
     $localFile = Join-Path $ProjectDir "CLAUDE.local.md"
@@ -225,22 +239,70 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         Write-Success "Hook settings (settings.json) installed! [Windows version]"
     }
 
-    # Install PowerShell hook scripts
+    # Install hook scripts — dual-variant deployment.
+    #
+    # Why both .ps1 and .sh (Issue #407): When the Windows host's ~/.claude is
+    # bind-mounted into a Linux Claude Code container (claude-docker), the
+    # container entrypoint rewrites every `pwsh ... -File foo.ps1` command to
+    # `foo.sh`. The rewrite only works when the matching .sh file is present.
+    # Shipping .ps1 alone leaves every hook reporting "not found" inside the
+    # container even though the host works correctly.
     $hooksSource = Join-Path $BackupDir "global/hooks"
     if (Test-Path $hooksSource) {
         $hooksDir = Join-Path $claudeDir "hooks"
         Ensure-Directory $hooksDir
+
         Copy-Item -Path "$hooksSource\*.ps1" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
-        Write-Success "PowerShell hook scripts (hooks/*.ps1) installed!"
+        Get-ChildItem -Path $hooksSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
+            Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksDir $_.Name)
+        }
+
+        $hooksLibSource = Join-Path $hooksSource 'lib'
+        if (Test-Path $hooksLibSource) {
+            $hooksLibDir = Join-Path $hooksDir 'lib'
+            Ensure-Directory $hooksLibDir
+            Copy-Item -Path "$hooksLibSource\*.ps1" -Destination $hooksLibDir -Force -ErrorAction SilentlyContinue
+            Copy-Item -Path "$hooksLibSource\*.psm1" -Destination $hooksLibDir -Force -ErrorAction SilentlyContinue
+            Get-ChildItem -Path $hooksLibSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
+                Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksLibDir $_.Name)
+            }
+        }
+
+        Copy-Item -Path "$hooksSource\*.json" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
+
+        Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"
     }
 
-    # Install PowerShell statusline and utility scripts
+    # Install utility scripts — dual-variant, same rationale as hooks.
     $scriptsSource = Join-Path $BackupDir "global/scripts"
     if (Test-Path $scriptsSource) {
         $scriptsDir = Join-Path $claudeDir "scripts"
         Ensure-Directory $scriptsDir
+
         Copy-Item -Path "$scriptsSource\*.ps1" -Destination $scriptsDir -Force -ErrorAction SilentlyContinue
-        Write-Success "Statusline scripts (scripts/*.ps1) installed!"
+        Get-ChildItem -Path $scriptsSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
+            Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $scriptsDir $_.Name)
+        }
+
+        Write-Success "Utility scripts installed (scripts/*.ps1 + *.sh)!"
+    }
+
+    # Hook pairing audit: warn on orphans so Docker-side rewrites don't silently
+    # resolve to missing files.
+    $hooksDirForAudit = Join-Path $claudeDir "hooks"
+    if (Test-Path $hooksDirForAudit) {
+        $ps1Stems = @(Get-ChildItem -Path $hooksDirForAudit -Filter '*.ps1' -File -ErrorAction SilentlyContinue | ForEach-Object { $_.BaseName })
+        $shStems  = @(Get-ChildItem -Path $hooksDirForAudit -Filter '*.sh'  -File -ErrorAction SilentlyContinue | ForEach-Object { $_.BaseName })
+        $missingSh  = @($ps1Stems | Where-Object { $_ -notin $shStems })
+        $missingPs1 = @($shStems  | Where-Object { $_ -notin $ps1Stems })
+        if ($missingSh.Count -gt 0 -or $missingPs1.Count -gt 0) {
+            Write-Warn "Hook pairing audit found orphans:"
+            foreach ($stem in $missingSh)  { Write-Host "    - $stem.ps1 has no matching $stem.sh (Linux container hook will 'not found')" }
+            foreach ($stem in $missingPs1) { Write-Host "    - $stem.sh has no matching $stem.ps1 (Windows host hook will 'not found')" }
+            Write-Host "  Add the missing variant to global/hooks/ and re-run install.ps1 to fix."
+        } else {
+            Write-Success "Hook pairing audit passed (all .ps1/.sh stems matched)."
+        }
     }
 
     # Install ccstatusline settings (~/.config/ccstatusline/ — ccstatusline default settings path)
@@ -404,8 +466,8 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         }
     }
     Write-Host "    - ~/.claude/settings.json (Hook settings - Windows)"
-    Write-Host "    - ~/.claude/hooks/ (PowerShell hook scripts)"
-    Write-Host "    - ~/.claude/scripts/ (Statusline scripts)"
+    Write-Host "    - ~/.claude/hooks/ (PowerShell + bash hook scripts, lib/, data)"
+    Write-Host "    - ~/.claude/scripts/ (PowerShell + bash utility scripts)"
     Write-Host "    - ~/.config/ccstatusline/ (ccstatusline settings)"
 }
 

--- a/tests/scripts/test-install-dual-variant.ps1
+++ b/tests/scripts/test-install-dual-variant.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Regression test for scripts/install.ps1 dual-variant hook deployment (Issue #407).
+
+.DESCRIPTION
+    Runs install.ps1 in global-only mode against an isolated scratch $HOME and
+    verifies:
+      1. Both .ps1 and .sh hook variants land in ~/.claude/hooks/
+      2. All installed .sh files use LF-only line endings (no CRLF)
+      3. All installed .sh files are UTF-8 without BOM
+      4. hooks/lib/ and hooks/known-issues.json are present
+      5. scripts/ contains both .ps1 and .sh variants
+      6. Every hook stem present in BOTH variants in the source lands in BOTH
+         variants in the destination. Pre-existing source-level orphans (a
+         .sh with no .ps1 pair, or vice versa) are reported but do not fail
+         the test — fixing source orphans is out of scope for the installer.
+
+    Uses plain PowerShell assertions — no Pester dependency.
+#>
+
+$ErrorActionPreference = 'Continue'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RootDir    = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$Installer  = Join-Path $RootDir 'scripts' 'install.ps1'
+$SrcHooks   = Join-Path $RootDir 'global'  'hooks'
+$SrcScripts = Join-Path $RootDir 'global'  'scripts'
+
+if (-not (Test-Path $Installer)) {
+    Write-Host "FAIL: installer not found at $Installer"
+    exit 1
+}
+
+$script:PASS = 0
+$script:FAIL = 0
+$script:ERRORS = @()
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) {
+        $script:PASS++
+        Write-Host "  PASS: $Message"
+    } else {
+        $script:FAIL++
+        $script:ERRORS += $Message
+        Write-Host "  FAIL: $Message" -ForegroundColor Red
+    }
+}
+
+# Scratch HOME (isolated)
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) "install-ps1-test-$([guid]::NewGuid())"
+New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+Write-Host "Scratch HOME: $scratch"
+
+# Save and override env so the child pwsh initializes $HOME from the scratch path.
+# PowerShell resolves $HOME once at session start from $env:HOME (Unix) or
+# $env:USERPROFILE (Windows). Setting these env vars inside the child's
+# -Command wrapper is too late — they must be set on the parent process
+# before spawning the child.
+$origUserProfile = $env:USERPROFILE
+$origHome        = $env:HOME
+
+try {
+    $env:USERPROFILE = $scratch
+    $env:HOME        = $scratch
+
+    # Inputs for install.ps1 prompts:
+    #   "1" = global-only install type
+    #   "n" = skip npm package install
+    $inputs = "1`nn`n"
+    $inputs | pwsh -NoProfile -File $Installer 2>&1 | Out-String | Write-Host
+
+    $claudeDir  = Join-Path $scratch  '.claude'
+    $hooksDir   = Join-Path $claudeDir 'hooks'
+    $scriptsDir = Join-Path $claudeDir 'scripts'
+
+    # --- Source-level pairing baseline --------------------------------------
+    $srcPs1Stems = @(Get-ChildItem -Path $SrcHooks -Filter '*.ps1' -File | ForEach-Object { $_.BaseName })
+    $srcShStems  = @(Get-ChildItem -Path $SrcHooks -Filter '*.sh'  -File | ForEach-Object { $_.BaseName })
+    $pairedStems = @($srcPs1Stems | Where-Object { $_ -in $srcShStems })
+    $sourceOrphans = @(@($srcPs1Stems | Where-Object { $_ -notin $srcShStems }) +
+                      @($srcShStems  | Where-Object { $_ -notin $srcPs1Stems }))
+    if ($sourceOrphans.Count -gt 0) {
+        Write-Host "  NOTE: source-level orphans (out of scope for this test): $($sourceOrphans -join ', ')"
+    }
+
+    # --- 1-2. Both variants are present for every paired stem ----------------
+    foreach ($stem in $pairedStems) {
+        Assert-True (Test-Path (Join-Path $hooksDir "$stem.ps1")) "hooks/$stem.ps1 installed"
+        Assert-True (Test-Path (Join-Path $hooksDir "$stem.sh"))  "hooks/$stem.sh installed"
+    }
+
+    # --- 3. All installed .sh files use LF only ------------------------------
+    $installedSh = @(Get-ChildItem -Path $hooksDir -Filter '*.sh' -File -ErrorAction SilentlyContinue)
+    Assert-True ($installedSh.Count -ge $pairedStems.Count) "hooks/*.sh count >= paired stems count"
+
+    $crlfOffenders = @()
+    foreach ($f in $installedSh) {
+        $raw = [System.IO.File]::ReadAllText($f.FullName)
+        if ($raw -match "`r`n") { $crlfOffenders += $f.Name }
+    }
+    Assert-True ($crlfOffenders.Count -eq 0) "all hooks/*.sh use LF-only line endings (offenders: $($crlfOffenders -join ', '))"
+
+    # --- 4. All installed .sh files are UTF-8 without BOM --------------------
+    $bomOffenders = @()
+    foreach ($f in $installedSh) {
+        $bytes = [System.IO.File]::ReadAllBytes($f.FullName)
+        if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+            $bomOffenders += $f.Name
+        }
+    }
+    Assert-True ($bomOffenders.Count -eq 0) "all hooks/*.sh are UTF-8 without BOM (offenders: $($bomOffenders -join ', '))"
+
+    # --- 5. Supporting files -------------------------------------------------
+    Assert-True (Test-Path (Join-Path $hooksDir 'lib'))             "hooks/lib/ directory present"
+    Assert-True (Test-Path (Join-Path $hooksDir 'known-issues.json')) "hooks/known-issues.json present"
+
+    # --- 6. Utility scripts: both variants -----------------------------------
+    $ps1Scripts = @(Get-ChildItem -Path $scriptsDir -Filter '*.ps1' -File -ErrorAction SilentlyContinue)
+    $shScripts  = @(Get-ChildItem -Path $scriptsDir -Filter '*.sh'  -File -ErrorAction SilentlyContinue)
+    Assert-True ($ps1Scripts.Count -gt 0) "scripts/*.ps1 present (found $($ps1Scripts.Count))"
+    Assert-True ($shScripts.Count -gt 0)  "scripts/*.sh present (found $($shScripts.Count))"
+
+    $scriptCrlfOffenders = @()
+    foreach ($f in $shScripts) {
+        $raw = [System.IO.File]::ReadAllText($f.FullName)
+        if ($raw -match "`r`n") { $scriptCrlfOffenders += $f.Name }
+    }
+    Assert-True ($scriptCrlfOffenders.Count -eq 0) "all scripts/*.sh use LF-only line endings (offenders: $($scriptCrlfOffenders -join ', '))"
+
+} finally {
+    # Restore parent env first so cleanup does not run against scratch
+    $env:USERPROFILE = $origUserProfile
+    $env:HOME        = $origHome
+
+    if (Test-Path $scratch) {
+        Remove-Item -Path $scratch -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host ""
+Write-Host "================================================"
+Write-Host "Results: $($script:PASS) passed, $($script:FAIL) failed"
+Write-Host "================================================"
+
+if ($script:FAIL -gt 0) {
+    Write-Host "Failures:"
+    foreach ($e in $script:ERRORS) { Write-Host "  - $e" }
+    exit 1
+}
+exit 0


### PR DESCRIPTION
Closes #407

## What

`scripts/install.ps1` now deploys **both** PowerShell (`.ps1`) and bash (`.sh`) variants of every hook and utility script into `~/.claude/hooks/` and `~/.claude/scripts/`, and runs a pairing audit that warns about orphans. The `.sh` files are written with LF line endings and UTF-8 (no BOM).

## Why

Observed failure before this change (Windows host + claude-docker container bind-mounting `~/.claude`):

```
PreToolUse:Edit hook error
Failed with non-blocking status code:
/bin/sh: 1: /home/node/.claude/hooks/pre-edit-read-guard.sh: not found
```

Root cause: `install.ps1` deployed only `.ps1` variants on Windows. `claude-docker/scripts/entrypoint.sh` rewrites `pwsh ... -File foo.ps1` hook commands to `foo.sh`, but the rewrite silently resolved to missing files because the `.sh` counterparts were never installed on the mount. Every `Edit`/`Write`/`Read` tool call surfaced the warning, breaking the read-before-edit guard and flooding session output.

## Where

| Path | Change |
|---|---|
| `scripts/install.ps1` | `Install-BashScript` helper + expanded hooks/scripts copy blocks + pairing audit + updated install summary |
| `tests/scripts/test-install-dual-variant.ps1` | New regression test (plain PowerShell, no Pester) |
| `README.md` | New "Docker-compatible dual-variant install" subsection under Windows (PowerShell) |

## How

### Implementation

1. **`Install-BashScript` helper** (`install.ps1:45-57`): reads source with `[System.IO.File]::ReadAllText`, replaces `\r\n` with `\n`, writes via `[System.IO.File]::WriteAllText` with `UTF8Encoding($false)` so no BOM is emitted.
2. **Dual-variant hooks copy** (`install.ps1:242-274`): Copy `.ps1` as-is; iterate `.sh` through `Install-BashScript`; copy `lib/` subdirectory (`.ps1`/`.psm1`/`.sh`) and top-level `*.json` data files.
3. **Dual-variant scripts copy** (`install.ps1:276-288`): Same pattern for utility scripts.
4. **Pairing audit** (`install.ps1:290-306`): After both copies, compute orphan stems and emit `Write-Warn` entries so Docker-side rewrites do not silently resolve to missing files. Pre-existing source orphans (e.g., `conflict-guard.sh` has no matching `.ps1`) are surfaced but do not halt the installer.

### Verification

```powershell
pwsh -NoProfile -File tests/scripts/test-install-dual-variant.ps1
# Results: 60 passed, 0 failed
```

The test creates an isolated scratch `$HOME`, overrides `USERPROFILE`/`HOME` in the parent process so the child `pwsh` initializes `$HOME` from the scratch path, pipes `"1\nn"` to select global-only install and skip npm, then asserts:

- Every paired stem in `global/hooks/` has both `.ps1` and `.sh` installed
- All installed `.sh` files use LF-only line endings
- All installed `.sh` files are UTF-8 without BOM
- `hooks/lib/` and `hooks/known-issues.json` are present
- `scripts/` contains both `.ps1` and `.sh` variants

### Manual validation on a real claude-docker container

Before: `not found` warning on first `Edit` call (reproducing the bug).
After: entrypoint logs show `rewrote N PowerShell hook(s) to bash`; no hook file-not-found warnings on subsequent `Edit`/`Write`/`Read`.

## Discovered issues (out of scope)

The pairing audit surfaced one **pre-existing source orphan**: `global/hooks/conflict-guard.sh` has no matching `conflict-guard.ps1`. Fixing it is outside this PR's scope ("don't clean up code beyond what your change needs") — suggest a separate follow-up issue to add a PowerShell twin.

## Breaking changes

None. Non-Docker Windows users see identical behavior plus the pairing audit output; the newly installed `.sh` files are inert on Windows hosts.

## Rollback

Revert this PR. No data migration. Re-running the previous installer restores the `.ps1`-only layout.
