### PR TITLE
feat(hooks): add content-language dispatcher and installer prompt (#410)

### DIFF
--- a/global/hooks/commit-message-guard.ps1
+++ b/global/hooks/commit-message-guard.ps1
@@ -1,6 +1,7 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'LanguageValidator.psm1') -Force
 
 # commit-message-guard.ps1
 # Deterministic git commit message validator
@@ -70,9 +71,11 @@ if ($msg -notmatch $ccRegex) {
 # Extract description (everything after the first ': ')
 $desc = $msg -replace '^[^:]*:\s*', ''
 
-# Rule 2: Description starts with a lowercase letter
-if ($desc.Length -eq 0 -or $desc[0] -cnotmatch '[a-z]') {
-    New-HookDenyResponse -Reason 'Commit message description must start with a lowercase letter.'
+# Rule 2: Description first-char check (dispatched via CLAUDE_CONTENT_LANGUAGE).
+# Default policy ("english") preserves the pre-dispatcher behavior exactly.
+$descCheck = Test-CommitDescriptionFirstChar -Description $desc
+if (-not $descCheck.Valid) {
+    New-HookDenyResponse -Reason $descCheck.Reason
     exit 0
 }
 

--- a/global/hooks/lib/LanguageValidator.psm1
+++ b/global/hooks/lib/LanguageValidator.psm1
@@ -1,0 +1,189 @@
+#Requires -Version 7.0
+# LanguageValidator.psm1 — Shared PowerShell content-language validators.
+#
+# PowerShell mirror of hooks/lib/validate-language.sh and Rule 2 of
+# hooks/lib/validate-commit-message.sh. The bash libraries are the
+# authoritative source of truth; keep the character sets in sync with them.
+#
+# The CLAUDE_CONTENT_LANGUAGE environment variable selects the policy:
+#   - english (default, unset, or empty) → ASCII printable + whitespace only
+#   - korean_plus_english → ASCII + Hangul syllables/Jamo/Compat Jamo
+#   - any → validation skipped (always valid)
+#
+# NOTE: These validators do NOT gate AI/Claude attribution. attribution-guard.ps1
+# and the attribution checks in commit-message-guard.ps1 remain active for
+# every policy value — attribution blocking is a hard rule, not a language
+# concern. See issue #410 for the scope boundary.
+
+# Get-ContentLanguagePolicy
+# Returns the resolved policy string (english | korean_plus_english | any).
+# Unknown values fall back to english and write a warning to stderr.
+function Get-ContentLanguagePolicy {
+    $policy = $env:CLAUDE_CONTENT_LANGUAGE
+    if ([string]::IsNullOrEmpty($policy)) {
+        return 'english'
+    }
+    switch ($policy) {
+        'english'              { return 'english' }
+        'korean_plus_english'  { return 'korean_plus_english' }
+        'any'                  { return 'any' }
+        default {
+            [Console]::Error.WriteLine("CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, any.")
+            return 'english'
+        }
+    }
+}
+
+# Test-CodePointAllowed
+# Internal helper — returns $true if the code point is inside one of the
+# allowed ranges for the given policy.
+function Test-CodePointAllowed {
+    param(
+        [Parameter(Mandatory)][int]$CodePoint,
+        [Parameter(Mandatory)][string]$Policy
+    )
+    # ASCII printable + whitespace (shared across english and korean_plus_english)
+    if (($CodePoint -ge 0x20 -and $CodePoint -le 0x7E) -or
+        ($CodePoint -ge 0x09 -and $CodePoint -le 0x0D)) {
+        return $true
+    }
+    if ($Policy -eq 'korean_plus_english') {
+        # Hangul Syllables / Jamo / Compat Jamo
+        if (($CodePoint -ge 0xAC00 -and $CodePoint -le 0xD7A3) -or
+            ($CodePoint -ge 0x1100 -and $CodePoint -le 0x11FF) -or
+            ($CodePoint -ge 0x3130 -and $CodePoint -le 0x318F)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+# Find-FirstDisallowedElement
+# Returns the first grapheme cluster that is not allowed under the given
+# policy, or $null if every element is allowed. Uses StringInfo so
+# surrogate pairs count as a single element.
+function Find-FirstDisallowedElement {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [Parameter(Mandatory)][string]$Policy
+    )
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return $null
+    }
+
+    $info = [System.Globalization.StringInfo]::new($Text)
+    for ($i = 0; $i -lt $info.LengthInTextElements; $i++) {
+        $elem = $info.SubstringByTextElements($i, 1)
+        $cp = [Char]::ConvertToUtf32($elem, 0)
+        if (-not (Test-CodePointAllowed -CodePoint $cp -Policy $Policy)) {
+            return $elem
+        }
+    }
+    return $null
+}
+
+# Test-ContentLanguage
+# Returns a PSCustomObject with:
+#   Valid  [bool]   - $true when the text satisfies the resolved policy
+#   Policy [string] - the resolved policy
+#   Reason [string] - user-facing rejection message when Valid is $false
+# Callers translate Reason into New-HookDenyResponse payloads.
+function Test-ContentLanguage {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text
+    )
+
+    $policy = Get-ContentLanguagePolicy
+
+    if ([string]::IsNullOrEmpty($Text) -or $policy -eq 'any') {
+        return [PSCustomObject]@{
+            Valid  = $true
+            Policy = $policy
+            Reason = ''
+        }
+    }
+
+    $bad = Find-FirstDisallowedElement -Text $Text -Policy $policy
+    if ($null -eq $bad) {
+        return [PSCustomObject]@{
+            Valid  = $true
+            Policy = $policy
+            Reason = ''
+        }
+    }
+
+    switch ($policy) {
+        'korean_plus_english' {
+            $reason = "Text contains characters outside the English+Korean policy (first: '$bad'). CLAUDE_CONTENT_LANGUAGE=korean_plus_english allows ASCII and Hangul only."
+        }
+        default {
+            $reason = "Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+        }
+    }
+
+    return [PSCustomObject]@{
+        Valid  = $false
+        Policy = $policy
+        Reason = $reason
+    }
+}
+
+# Test-CommitDescriptionFirstChar
+# Applies Rule 2 of the commit-message validator under the resolved policy.
+# Returns a PSCustomObject mirroring Test-ContentLanguage.
+function Test-CommitDescriptionFirstChar {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Description
+    )
+
+    $policy = Get-ContentLanguagePolicy
+
+    if ($policy -eq 'any') {
+        return [PSCustomObject]@{ Valid = $true; Policy = $policy; Reason = '' }
+    }
+
+    if ([string]::IsNullOrEmpty($Description)) {
+        return [PSCustomObject]@{
+            Valid  = $false
+            Policy = $policy
+            Reason = 'Commit message description must not be empty.'
+        }
+    }
+
+    $first = $Description[0]
+
+    if ($policy -eq 'korean_plus_english') {
+        $cp = [Char]::ConvertToUtf32($Description, 0)
+        $isLowerAscii = ($first -ge 'a' -and $first -le 'z')
+        $isHangul = (($cp -ge 0xAC00 -and $cp -le 0xD7A3) -or
+                     ($cp -ge 0x1100 -and $cp -le 0x11FF) -or
+                     ($cp -ge 0x3130 -and $cp -le 0x318F))
+        if ($isLowerAscii -or $isHangul) {
+            return [PSCustomObject]@{ Valid = $true; Policy = $policy; Reason = '' }
+        }
+        return [PSCustomObject]@{
+            Valid  = $false
+            Policy = $policy
+            Reason = 'Commit message description must start with a lowercase letter or a Hangul character (CLAUDE_CONTENT_LANGUAGE=korean_plus_english).'
+        }
+    }
+
+    # english (default)
+    if ($first -cmatch '[a-z]') {
+        return [PSCustomObject]@{ Valid = $true; Policy = $policy; Reason = '' }
+    }
+    return [PSCustomObject]@{
+        Valid  = $false
+        Policy = $policy
+        Reason = 'Commit message description must start with a lowercase letter.'
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-ContentLanguagePolicy'
+    'Test-CodePointAllowed'
+    'Find-FirstDisallowedElement'
+    'Test-ContentLanguage'
+    'Test-CommitDescriptionFirstChar'
+)

--- a/global/hooks/pr-language-guard.ps1
+++ b/global/hooks/pr-language-guard.ps1
@@ -1,46 +1,22 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'LanguageValidator.psm1') -Force
 
 # pr-language-guard.ps1
 # Blocks gh pr/issue create|edit|comment commands whose --title or --body
-# contains non-ASCII characters.
+# violates the resolved CLAUDE_CONTENT_LANGUAGE policy.
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always - decision is in JSON)
 # Response format: hookSpecificOutput with hookEventName
 #
-# Enforces the "All GitHub Issues and Pull Requests must be written in
-# English" rule from commit-settings.md. Mirrors the commit-message-guard
-# enforcement model that proved effective for commit messages.
-#
-# Allowed bytes: ASCII printable (0x20-0x7E) and ASCII whitespace
-# (0x09-0x0D = tab, LF, VT, FF, CR). Anything else is rejected.
+# Enforces the content-language rule from commit-settings.md. Default
+# policy ("english", when CLAUDE_CONTENT_LANGUAGE is unset) matches the
+# pre-dispatcher behavior byte-for-byte. See issue #410 for the dispatcher
+# design.
 #
 # NOTE: --body using $(...) substitution, heredocs, or --body-file is
 # not parseable at this layer and the hook returns "allow" for those.
-
-# Returns the first non-ASCII text element, or $null if all elements are ASCII.
-# Uses StringInfo to walk grapheme clusters so surrogate pairs (emoji,
-# CJK extensions in supplementary planes) are reported as a single unit.
-function Get-FirstNonAscii {
-    param([string]$Text)
-
-    if ([string]::IsNullOrEmpty($Text)) {
-        return $null
-    }
-
-    $info = [System.Globalization.StringInfo]::new($Text)
-    for ($i = 0; $i -lt $info.LengthInTextElements; $i++) {
-        $elem = $info.SubstringByTextElements($i, 1)
-        $cp = [Char]::ConvertToUtf32($elem, 0)
-        # ASCII printable (0x20-0x7E) or whitespace (0x09-0x0D)
-        if (($cp -ge 0x20 -and $cp -le 0x7E) -or ($cp -ge 0x09 -and $cp -le 0x0D)) {
-            continue
-        }
-        return $elem
-    }
-    return $null
-}
 
 # Extracts the value for a given long/short flag from a shell command string.
 # Tries double-quoted then single-quoted forms; supports --flag value,
@@ -115,18 +91,18 @@ $body  = Get-FlagValue -Command $CMD -LongFlag '--body'  -ShortFlag '-b'
 
 # Validate title
 if ($title) {
-    $bad = Get-FirstNonAscii -Text $title
-    if ($null -ne $bad) {
-        New-HookDenyResponse -Reason "PR/issue --title rejected: Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+    $result = Test-ContentLanguage -Text $title
+    if (-not $result.Valid) {
+        New-HookDenyResponse -Reason "PR/issue --title rejected: $($result.Reason)"
         exit 0
     }
 }
 
 # Validate body
 if ($body) {
-    $bad = Get-FirstNonAscii -Text $body
-    if ($null -ne $bad) {
-        New-HookDenyResponse -Reason "PR/issue --body rejected: Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+    $result = Test-ContentLanguage -Text $body
+    if (-not $result.Valid) {
+        New-HookDenyResponse -Reason "PR/issue --body rejected: $($result.Reason)"
         exit 0
     }
 }

--- a/global/hooks/pr-language-guard.sh
+++ b/global/hooks/pr-language-guard.sh
@@ -68,20 +68,41 @@ if [ -n "$VALIDATOR" ]; then
 fi
 
 # Inline fallback so the hook still works when the shared library is missing.
-# Keep rules in sync with hooks/lib/validate-language.sh.
-if ! command -v validate_english_only >/dev/null 2>&1; then
-    validate_english_only() {
+# Keep rules in sync with hooks/lib/validate-language.sh. Default policy is
+# "english" when CLAUDE_CONTENT_LANGUAGE is unset — byte-identical to the
+# pre-dispatcher behavior.
+if ! command -v validate_content_language >/dev/null 2>&1; then
+    validate_content_language() {
         local text="$1"
+        local policy="${CLAUDE_CONTENT_LANGUAGE:-english}"
+
         if [ -z "$text" ]; then
             return 0
         fi
-        if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
-            local sample
-            sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
-            echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
-            return 1
-        fi
-        return 0
+
+        case "$policy" in
+            any)
+                return 0
+                ;;
+            korean_plus_english)
+                if ! printf '%s' "$text" | perl -CSDA -ne '
+                    exit 1 if /[^\x{09}-\x{0D}\x{20}-\x{7E}\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/
+                ' 2>/dev/null; then
+                    echo "Text contains characters outside the English+Korean policy. CLAUDE_CONTENT_LANGUAGE=korean_plus_english allows ASCII and Hangul only." >&2
+                    return 1
+                fi
+                return 0
+                ;;
+            *)
+                if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+                    local sample
+                    sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
+                    echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
+                    return 1
+                fi
+                return 0
+                ;;
+        esac
     }
 fi
 
@@ -153,14 +174,14 @@ extract_quoted_value() {
 TITLE=$(extract_quoted_value "$CMD" "--title" "-t")
 BODY=$(extract_quoted_value "$CMD" "--body"  "-b")
 
-# --- Validate ---
+# --- Validate (dispatches on CLAUDE_CONTENT_LANGUAGE, default english) ---
 if [ -n "$TITLE" ]; then
-    REASON=$(validate_english_only "$TITLE" 2>&1) || \
+    REASON=$(validate_content_language "$TITLE" 2>&1) || \
         deny_response "PR/issue --title rejected: $REASON"
 fi
 
 if [ -n "$BODY" ]; then
-    REASON=$(validate_english_only "$BODY" 2>&1) || \
+    REASON=$(validate_content_language "$BODY" 2>&1) || \
         deny_response "PR/issue --body rejected: $REASON"
 fi
 

--- a/hooks/lib/validate-commit-message.sh
+++ b/hooks/lib/validate-commit-message.sh
@@ -60,13 +60,34 @@ validate_commit_message() {
     desc=$(printf '%s' "$msg" | sed -E 's/^[^:]*:[[:space:]]*//')
 
     # Rule 2: Description starts with a lowercase ASCII letter
-    local first_char
-    first_char=$(printf '%s' "$desc" | head -c1)
-    case "$first_char" in
-        a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z) ;;
+    # Gated by CLAUDE_CONTENT_LANGUAGE (see issue #410):
+    #   - english (default) / unset → enforce lowercase ASCII
+    #   - korean_plus_english → allow Hangul first char as well
+    #   - any → skip first-char check (Conv. Commits type is still enforced)
+    # The Conventional Commits type/scope portion (feat, fix, etc.) stays
+    # ASCII-only under every policy — only the description is relaxed.
+    local policy="${CLAUDE_CONTENT_LANGUAGE:-english}"
+    case "$policy" in
+        any)
+            : ;;
+        korean_plus_english)
+            if ! printf '%s' "$desc" | perl -CSDA -ne '
+                exit 1 unless /^[a-z\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/
+            ' 2>/dev/null; then
+                echo "Commit message description must start with a lowercase letter or a Hangul character (CLAUDE_CONTENT_LANGUAGE=korean_plus_english)." >&2
+                return 1
+            fi
+            ;;
         *)
-            echo "Commit message description must start with a lowercase letter." >&2
-            return 1
+            local first_char
+            first_char=$(printf '%s' "$desc" | head -c1)
+            case "$first_char" in
+                a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z) ;;
+                *)
+                    echo "Commit message description must start with a lowercase letter." >&2
+                    return 1
+                    ;;
+            esac
             ;;
     esac
 

--- a/hooks/lib/validate-language.sh
+++ b/hooks/lib/validate-language.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 # validate-language.sh
 # Shared text language validation library.
-# Single source of truth for the "English-only" rule applied to GitHub
+# Single source of truth for the content-language rule applied to GitHub
 # Issue and Pull Request titles and bodies created via the gh CLI.
 #
 # Sourced by:
 #   - global/hooks/pr-language-guard.sh (PreToolUse — Claude-side feedback loop)
 #
-# The rule mirrors commit-settings.md: "All GitHub Issues and Pull Requests
-# must be written in English." The terminal-side enforcement layer for git
-# commits lives in validate-commit-message.sh; this library is the analogous
-# gate for gh pr/issue commands intercepted at the Bash tool boundary.
+# The default rule mirrors commit-settings.md: "All GitHub Issues and Pull
+# Requests must be written in English." The terminal-side enforcement layer
+# for git commits lives in validate-commit-message.sh; this library is the
+# analogous gate for gh pr/issue commands intercepted at the Bash tool
+# boundary.
+#
+# The CLAUDE_CONTENT_LANGUAGE environment variable selects the policy
+# (see validate_content_language below). See issue #410 for the design.
 #
 # Usage:
 #   . /path/to/validate-language.sh
-#   if ! validate_english_only "$body"; then
+#   if ! validate_content_language "$body"; then
 #       echo "invalid" >&2
 #   fi
+#
+# The legacy validate_english_only entry point is preserved for callers
+# that want the default policy explicitly, independent of the env var.
 
 # validate_english_only <text>
 # Returns 0 on valid (English-only or empty), 1 on invalid.
@@ -45,4 +52,70 @@ validate_english_only() {
     fi
 
     return 0
+}
+
+# validate_english_or_korean <text>
+# Returns 0 on valid, 1 on invalid. On failure, prints reason to stderr.
+#
+# Accepts:
+#   - ASCII printable (U+0020-U+007E) and ASCII whitespace (U+0009-U+000D)
+#   - Hangul Syllables (U+AC00-U+D7A3)
+#   - Hangul Jamo (U+1100-U+11FF)
+#   - Hangul Compatibility Jamo (U+3130-U+318F)
+#
+# Anything else — accented Latin, CJK outside Hangul, emoji, general
+# symbols — fails. perl -CSDA forces UTF-8 input decoding regardless of
+# locale. Exit 1 inside the perl one-liner signals a match was found.
+validate_english_or_korean() {
+    local text="$1"
+
+    if [ -z "$text" ]; then
+        return 0
+    fi
+
+    if ! printf '%s' "$text" | perl -CSDA -ne '
+        exit 1 if /[^\x{09}-\x{0D}\x{20}-\x{7E}\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/
+    ' 2>/dev/null; then
+        local sample
+        sample=$(printf '%s' "$text" | perl -CSDA -ne '
+            while (/([^\x{09}-\x{0D}\x{20}-\x{7E}\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]+)/g) {
+                print $1; exit;
+            }
+        ' 2>/dev/null)
+        echo "Text contains characters outside the English+Korean policy (first run: '$sample'). CLAUDE_CONTENT_LANGUAGE=korean_plus_english allows ASCII and Hangul only." >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# validate_content_language <text>
+# Dispatcher — selects the validator based on CLAUDE_CONTENT_LANGUAGE:
+#   - english (default, unset, or empty) → validate_english_only
+#   - korean_plus_english → validate_english_or_korean
+#   - any → skip validation (always returns 0)
+#
+# NOTE: This dispatcher does NOT control AI/Claude attribution enforcement.
+# attribution-guard.{sh,ps1} and validate_no_attribution remain active for
+# every policy value — attribution blocking is a hard rule, not a language
+# concern. See issue #410 for the scope boundary.
+validate_content_language() {
+    local text="$1"
+    local policy="${CLAUDE_CONTENT_LANGUAGE:-english}"
+
+    case "$policy" in
+        ""|english)
+            validate_english_only "$text"
+            ;;
+        korean_plus_english)
+            validate_english_or_korean "$text"
+            ;;
+        any)
+            return 0
+            ;;
+        *)
+            echo "CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, any." >&2
+            validate_english_only "$text"
+            ;;
+    esac
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -203,6 +203,29 @@ Write-Host ""
 $installType = Read-Host "Selection (1-5) [default: 3]"
 if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
 
+# ── Content language policy (CLAUDE_CONTENT_LANGUAGE) ─────────
+# Default "english" preserves current behavior byte-for-byte. The
+# dispatcher falls back to english when the env var is unset, so we skip
+# writing settings.json at all for option 1.
+Write-Host ""
+Write-Info "Select content-language policy (commit / PR / issue validation scope):"
+Write-Host "  1) English (default, identical to current behavior)"
+Write-Host "  2) Korean + English (accept Hangul)"
+Write-Host "  3) Any (skip language validation; AI attribution block stays on)"
+Write-Host ""
+
+$langType = Read-Host "Selection (1-3) [default: 1]"
+if ([string]::IsNullOrEmpty($langType)) { $langType = '1' }
+switch ($langType) {
+    '1'     { $contentLanguage = 'english' }
+    '2'     { $contentLanguage = 'korean_plus_english' }
+    '3'     { $contentLanguage = 'any' }
+    default {
+        Write-Warn "Unknown selection: $langType. Using english."
+        $contentLanguage = 'english'
+    }
+}
+
 # ── Enterprise installation ──────────────────────────────────
 
 if ($installType -eq '4' -or $installType -eq '5') {
@@ -235,8 +258,38 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
     # Install settings.windows.json as settings.json
     $settingsSource = Join-Path $BackupDir "global/settings.windows.json"
     if (Test-Path $settingsSource) {
-        Copy-Item -Path $settingsSource -Destination (Join-Path $claudeDir "settings.json") -Force
+        $destSettings = Join-Path $claudeDir "settings.json"
+        Copy-Item -Path $settingsSource -Destination $destSettings -Force
         Write-Success "Hook settings (settings.json) installed! [Windows version]"
+
+        # Write CLAUDE_CONTENT_LANGUAGE under env only when the user chose
+        # a non-default policy. "english" matches the dispatcher default so
+        # touching the file would add churn for no behavior change.
+        if ($contentLanguage -ne 'english') {
+            try {
+                $settingsObj = Get-Content -Raw -LiteralPath $destSettings | ConvertFrom-Json
+                if (-not $settingsObj.PSObject.Properties.Name -contains 'env') {
+                    $settingsObj | Add-Member -NotePropertyName 'env' -NotePropertyValue ([PSCustomObject]@{})
+                }
+                if (-not $settingsObj.env) {
+                    $settingsObj.env = [PSCustomObject]@{}
+                }
+                if ($settingsObj.env.PSObject.Properties.Name -contains 'CLAUDE_CONTENT_LANGUAGE') {
+                    $settingsObj.env.CLAUDE_CONTENT_LANGUAGE = $contentLanguage
+                } else {
+                    $settingsObj.env | Add-Member -NotePropertyName 'CLAUDE_CONTENT_LANGUAGE' -NotePropertyValue $contentLanguage -Force
+                }
+                ($settingsObj | ConvertTo-Json -Depth 32) | Set-Content -LiteralPath $destSettings -Encoding UTF8
+                Write-Success "CLAUDE_CONTENT_LANGUAGE=$contentLanguage written to settings.json"
+            }
+            catch {
+                Write-Warn "Failed to write CLAUDE_CONTENT_LANGUAGE automatically: $_"
+                Write-Host "  Add this manually to ~/.claude/settings.json under env:"
+                Write-Host "    `"CLAUDE_CONTENT_LANGUAGE`": `"$contentLanguage`""
+            }
+        } else {
+            Write-Info "CLAUDE_CONTENT_LANGUAGE=english (default; settings.json unchanged)"
+        }
     }
 
     # Install hook scripts — dual-variant deployment.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,28 @@ echo ""
 read -p "선택 (1-5) [기본값: 3]: " INSTALL_TYPE
 INSTALL_TYPE=${INSTALL_TYPE:-3}
 
+# 컨텐츠 언어 정책 선택 (CLAUDE_CONTENT_LANGUAGE)
+# Global / Enterprise 설치 경로에서만 settings.json을 갱신합니다.
+# 기본값 english는 settings.json을 건드리지 않습니다 (dispatcher 기본값과 일치).
+echo ""
+info "컨텐츠 언어 정책을 선택하세요 (commit / PR / issue 검증 범위):"
+echo "  1) English (기본, 현재 동작과 완전 동일)"
+echo "  2) Korean + English (Hangul 허용)"
+echo "  3) Any (언어 검증 없음 — 단, AI 귀속 차단은 유지)"
+echo ""
+read -p "선택 (1-3) [기본값: 1]: " LANG_TYPE
+LANG_TYPE=${LANG_TYPE:-1}
+
+case "$LANG_TYPE" in
+    1) CONTENT_LANGUAGE="english" ;;
+    2) CONTENT_LANGUAGE="korean_plus_english" ;;
+    3) CONTENT_LANGUAGE="any" ;;
+    *)
+        warning "알 수 없는 입력: $LANG_TYPE. english로 진행합니다."
+        CONTENT_LANGUAGE="english"
+        ;;
+esac
+
 # Enterprise 설정 설치
 if [ "$INSTALL_TYPE" = "4" ] || [ "$INSTALL_TYPE" = "5" ]; then
     install_enterprise
@@ -235,6 +257,25 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     if [ -f "$BACKUP_DIR/global/settings.json" ]; then
         cp "$BACKUP_DIR/global/settings.json" "$HOME/.claude/"
         success "Hook 설정 (settings.json) 설치 완료!"
+
+        # CLAUDE_CONTENT_LANGUAGE env 주입
+        # english(기본)은 dispatcher 기본값과 일치하므로 파일을 건드리지 않습니다.
+        if [ "$CONTENT_LANGUAGE" != "english" ]; then
+            if command -v jq >/dev/null 2>&1; then
+                tmpfile=$(mktemp)
+                jq --arg v "$CONTENT_LANGUAGE" \
+                   '.env = (.env // {}) | .env.CLAUDE_CONTENT_LANGUAGE = $v' \
+                   "$HOME/.claude/settings.json" > "$tmpfile" \
+                   && mv "$tmpfile" "$HOME/.claude/settings.json" \
+                   && success "CLAUDE_CONTENT_LANGUAGE=$CONTENT_LANGUAGE 을 settings.json에 기록했습니다."
+            else
+                warning "jq가 설치되어 있지 않아 CLAUDE_CONTENT_LANGUAGE를 자동 설정할 수 없습니다."
+                echo "  수동으로 ~/.claude/settings.json 의 env 섹션에 다음을 추가하세요:"
+                echo "    \"CLAUDE_CONTENT_LANGUAGE\": \"$CONTENT_LANGUAGE\""
+            fi
+        else
+            info "CLAUDE_CONTENT_LANGUAGE=english (기본값, settings.json 무변경)"
+        fi
     fi
 
     # hooks 디렉토리 설치 (외부 스크립트)
@@ -245,11 +286,15 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         success "Hook 스크립트 (hooks/) 설치 완료!"
     fi
 
-    # 공유 검증 라이브러리 설치 (commit-message-guard.sh에서 사용)
-    if [ -f "$BACKUP_DIR/hooks/lib/validate-commit-message.sh" ]; then
+    # 공유 검증 라이브러리 설치 (commit-message-guard.sh 및 pr-language-guard.sh에서 사용)
+    if [ -d "$BACKUP_DIR/hooks/lib" ]; then
         ensure_dir "$HOME/.claude/hooks/lib"
-        cp "$BACKUP_DIR/hooks/lib/validate-commit-message.sh" "$HOME/.claude/hooks/lib/"
-        chmod +x "$HOME/.claude/hooks/lib/validate-commit-message.sh"
+        for lib in validate-commit-message.sh validate-language.sh; do
+            if [ -f "$BACKUP_DIR/hooks/lib/$lib" ]; then
+                cp "$BACKUP_DIR/hooks/lib/$lib" "$HOME/.claude/hooks/lib/"
+                chmod +x "$HOME/.claude/hooks/lib/$lib"
+            fi
+        done
         success "공유 검증 라이브러리 설치 완료!"
     fi
 

--- a/tests/hooks/test-language-validator.ps1
+++ b/tests/hooks/test-language-validator.ps1
@@ -1,0 +1,111 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Matrix tests for global/hooks/lib/LanguageValidator.psm1 (issue #410).
+.DESCRIPTION
+    PowerShell mirror of tests/hooks/test-language-validator.sh. Asserts
+    Test-ContentLanguage and Test-CommitDescriptionFirstChar behave
+    identically to the bash dispatchers across english, korean_plus_english,
+    and any policies.
+
+    Uses plain PowerShell assertions - no Pester dependency.
+#>
+
+$ErrorActionPreference = 'Continue'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$Module  = Join-Path $RootDir 'global' 'hooks' 'lib' 'LanguageValidator.psm1'
+
+Import-Module $Module -Force
+
+$script:PASS = 0
+$script:FAIL = 0
+
+function Invoke-LangCase {
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][bool]$ExpectedValid,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Policy,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [switch]$Commit
+    )
+    $env:CLAUDE_CONTENT_LANGUAGE = $Policy
+    try {
+        if ($Commit) {
+            $r = Test-CommitDescriptionFirstChar -Description $Text
+        } else {
+            $r = Test-ContentLanguage -Text $Text
+        }
+    }
+    finally {
+        $env:CLAUDE_CONTENT_LANGUAGE = $null
+    }
+
+    if ($r.Valid -eq $ExpectedValid) {
+        $script:PASS++
+        Write-Host "  PASS: $Name"
+    } else {
+        $script:FAIL++
+        Write-Host "  FAIL: $Name (expected Valid=$ExpectedValid, got=$($r.Valid))" -ForegroundColor Red
+    }
+}
+
+Write-Host "=== LanguageValidator.psm1 — Test-ContentLanguage ==="
+Write-Host ""
+Write-Host "[english policy]"
+Invoke-LangCase -Name "unset policy accepts ASCII"          -ExpectedValid $true  -Policy ''          -Text "simple ASCII"
+Invoke-LangCase -Name "english rejects Hangul"              -ExpectedValid $false -Policy 'english'   -Text "한국어"
+Invoke-LangCase -Name "english rejects accented Latin"      -ExpectedValid $false -Policy 'english'   -Text "café"
+Invoke-LangCase -Name "english rejects emoji"               -ExpectedValid $false -Policy 'english'   -Text "party 🎉"
+
+Write-Host ""
+Write-Host "[korean_plus_english policy]"
+Invoke-LangCase -Name "korean+en accepts Hangul syllables"  -ExpectedValid $true  -Policy 'korean_plus_english' -Text "한국어"
+Invoke-LangCase -Name "korean+en accepts Jamo"              -ExpectedValid $true  -Policy 'korean_plus_english' -Text "ㄱㄴㄷ"
+Invoke-LangCase -Name "korean+en accepts mixed"             -ExpectedValid $true  -Policy 'korean_plus_english' -Text "fix 버그"
+Invoke-LangCase -Name "korean+en rejects Japanese"          -ExpectedValid $false -Policy 'korean_plus_english' -Text "こんにちは"
+Invoke-LangCase -Name "korean+en rejects Chinese"           -ExpectedValid $false -Policy 'korean_plus_english' -Text "你好"
+Invoke-LangCase -Name "korean+en rejects emoji"             -ExpectedValid $false -Policy 'korean_plus_english' -Text "rocket 🚀"
+
+Write-Host ""
+Write-Host "[any policy]"
+Invoke-LangCase -Name "any accepts Japanese"                -ExpectedValid $true  -Policy 'any'       -Text "こんにちは"
+Invoke-LangCase -Name "any accepts emoji"                   -ExpectedValid $true  -Policy 'any'       -Text "fête 🎉"
+Invoke-LangCase -Name "any accepts mixed unicode"           -ExpectedValid $true  -Policy 'any'       -Text "Ω Я 中"
+
+Write-Host ""
+Write-Host "[empty input always valid]"
+Invoke-LangCase -Name "english + empty"                     -ExpectedValid $true  -Policy 'english'              -Text ""
+Invoke-LangCase -Name "korean+en + empty"                   -ExpectedValid $true  -Policy 'korean_plus_english'  -Text ""
+Invoke-LangCase -Name "any + empty"                         -ExpectedValid $true  -Policy 'any'                  -Text ""
+
+Write-Host ""
+Write-Host "[unknown policy falls back to english]"
+Invoke-LangCase -Name "martian rejects Hangul"              -ExpectedValid $false -Policy 'martian'   -Text "한국어"
+Invoke-LangCase -Name "martian accepts ASCII"               -ExpectedValid $true  -Policy 'martian'   -Text "plain"
+
+Write-Host ""
+Write-Host "=== Test-CommitDescriptionFirstChar ==="
+Write-Host ""
+Write-Host "[english policy — lowercase ASCII only]"
+Invoke-LangCase -Name "english accepts 'add feature'"       -ExpectedValid $true  -Policy 'english'  -Text "add feature" -Commit
+Invoke-LangCase -Name "english rejects 'Add feature'"       -ExpectedValid $false -Policy 'english'  -Text "Add feature" -Commit
+Invoke-LangCase -Name "english rejects '기능 추가'"           -ExpectedValid $false -Policy 'english'  -Text "기능 추가" -Commit
+
+Write-Host ""
+Write-Host "[korean_plus_english policy — accepts Hangul first char]"
+Invoke-LangCase -Name "korean+en accepts 'add'"             -ExpectedValid $true  -Policy 'korean_plus_english'  -Text "add"       -Commit
+Invoke-LangCase -Name "korean+en accepts '기능 추가'"         -ExpectedValid $true  -Policy 'korean_plus_english'  -Text "기능 추가"  -Commit
+Invoke-LangCase -Name "korean+en rejects 'Add'"             -ExpectedValid $false -Policy 'korean_plus_english'  -Text "Add"       -Commit
+
+Write-Host ""
+Write-Host "[any policy — Rule 2 bypassed]"
+Invoke-LangCase -Name "any accepts 'Mixed Case'"            -ExpectedValid $true  -Policy 'any'      -Text "Mixed Case" -Commit
+Invoke-LangCase -Name "any accepts 'Начало'"                -ExpectedValid $true  -Policy 'any'      -Text "Начало"    -Commit
+
+Write-Host ""
+Write-Host "=== Results: $($script:PASS) passed, $($script:FAIL) failed ==="
+
+if ($script:FAIL -gt 0) { exit 1 }
+exit 0

--- a/tests/hooks/test-language-validator.sh
+++ b/tests/hooks/test-language-validator.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# test-language-validator.sh
+# Matrix tests for the CLAUDE_CONTENT_LANGUAGE dispatcher introduced in #410.
+# Covers hooks/lib/validate-language.sh and the Rule 2 branch in
+# hooks/lib/validate-commit-message.sh.
+#
+# Exit codes: 0 on all-pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../../hooks/lib/validate-language.sh
+. "$REPO_ROOT/hooks/lib/validate-language.sh"
+# shellcheck source=../../hooks/lib/validate-commit-message.sh
+. "$REPO_ROOT/hooks/lib/validate-commit-message.sh"
+
+PASS=0
+FAIL=0
+
+# run_case <name> <expected 0|1> <policy> <fn> <args...>
+run_case() {
+    local name="$1" expected="$2" policy="$3" fn="$4"
+    shift 4
+
+    local got
+    if [ -n "$policy" ]; then
+        CLAUDE_CONTENT_LANGUAGE="$policy" "$fn" "$@" >/dev/null 2>&1
+    else
+        unset CLAUDE_CONTENT_LANGUAGE
+        "$fn" "$@" >/dev/null 2>&1
+    fi
+    got=$?
+
+    if [ "$got" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $name (expected exit=$expected, got=$got)"
+    fi
+}
+
+echo "=== validate-language.sh (PR/issue content) ==="
+
+echo ""
+echo "[english policy — default, unset, empty]"
+run_case "unset env accepts ASCII"               0 ""        validate_content_language "simple ASCII text"
+run_case "english rejects Hangul"                1 "english" validate_content_language "한국어 텍스트"
+run_case "english rejects accented Latin"        1 "english" validate_content_language "naïve café"
+run_case "english rejects emoji"                 1 "english" validate_content_language "party 🎉"
+
+echo ""
+echo "[korean_plus_english policy]"
+run_case "korean+en accepts Hangul syllables"    0 "korean_plus_english" validate_content_language "한국어"
+run_case "korean+en accepts Hangul Jamo"         0 "korean_plus_english" validate_content_language "ㄱㄴㄷ"
+run_case "korean+en accepts mixed ASCII+Hangul"  0 "korean_plus_english" validate_content_language "fix 버그 수정"
+run_case "korean+en rejects Japanese"            1 "korean_plus_english" validate_content_language "こんにちは"
+run_case "korean+en rejects Chinese"             1 "korean_plus_english" validate_content_language "你好"
+run_case "korean+en rejects emoji"               1 "korean_plus_english" validate_content_language "rocket 🚀"
+
+echo ""
+echo "[any policy]"
+run_case "any accepts Japanese"                  0 "any"     validate_content_language "こんにちは"
+run_case "any accepts emoji + accented"          0 "any"     validate_content_language "fête 🎉 café"
+run_case "any accepts arbitrary Unicode"         0 "any"     validate_content_language "Ω Я 中"
+
+echo ""
+echo "[empty input always valid]"
+run_case "english + empty"                       0 "english" validate_content_language ""
+run_case "korean_plus_english + empty"           0 "korean_plus_english" validate_content_language ""
+run_case "any + empty"                           0 "any"     validate_content_language ""
+
+echo ""
+echo "[unknown policy falls back to english]"
+run_case "unknown policy rejects Hangul"         1 "martian" validate_content_language "한국어"
+run_case "unknown policy accepts ASCII"          0 "martian" validate_content_language "plain text"
+
+echo ""
+echo "=== validate-commit-message.sh (Rule 2 branching) ==="
+
+echo ""
+echo "[english policy — Rule 2 enforces lowercase ASCII]"
+run_case "english accepts lowercase ASCII commit"  0 "english" validate_commit_message "feat: add feature"
+run_case "english rejects uppercase first char"    1 "english" validate_commit_message "feat: Add feature"
+run_case "english rejects Hangul first char"       1 "english" validate_commit_message "feat: 기능 추가"
+
+echo ""
+echo "[korean_plus_english policy — Hangul first char allowed]"
+run_case "korean+en accepts lowercase ASCII"       0 "korean_plus_english" validate_commit_message "feat: add feature"
+run_case "korean+en accepts Hangul first"          0 "korean_plus_english" validate_commit_message "feat: 기능 추가"
+run_case "korean+en rejects uppercase first"       1 "korean_plus_english" validate_commit_message "feat: Add feature"
+
+echo ""
+echo "[any policy — Rule 2 bypassed]"
+run_case "any accepts uppercase first"             0 "any"     validate_commit_message "feat: Mixed Case Text"
+run_case "any accepts Russian first"               0 "any"     validate_commit_message "feat: Начало"
+
+echo ""
+echo "[attribution hard rule — MUST block under every policy]"
+run_case "english blocks 'generated with claude'"       1 "english"              validate_commit_message "feat: generated with claude"
+run_case "korean+en blocks 'claude' string"             1 "korean_plus_english"  validate_commit_message "feat: claude assisted"
+run_case "any blocks 'anthropic' string"                1 "any"                  validate_commit_message "feat: anthropic reviewed"
+
+echo ""
+echo "[emoji hard rule — MUST block under every policy]"
+run_case "english blocks emoji"                         1 "english"              validate_commit_message "feat: add 🎉"
+run_case "korean+en blocks emoji"                       1 "korean_plus_english"  validate_commit_message "feat: 기능 🎉 추가"
+run_case "any blocks emoji"                             1 "any"                  validate_commit_message "feat: add 🎉"
+
+echo ""
+echo "[Conventional Commits format — MUST be enforced under every policy]"
+run_case "english rejects missing type"                 1 "english"              validate_commit_message "just a message"
+run_case "korean+en rejects missing type"               1 "korean_plus_english"  validate_commit_message "버그 수정"
+run_case "any rejects missing type"                     1 "any"                  validate_commit_message "just a message"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements Phase 1 of the epic (#409): a runtime `CLAUDE_CONTENT_LANGUAGE` dispatcher for the content-language validators, and an installer prompt that writes the chosen value into `~/.claude/settings.json`.

Closes #410
Part of #409

## What Changed

### Dispatcher (hooks/lib + global/hooks/lib)

- `hooks/lib/validate-language.sh` - new `validate_content_language` dispatcher, new `validate_english_or_korean` helper
- `hooks/lib/validate-commit-message.sh` - Rule 2 (first-char lowercase) now branches on policy
- `global/hooks/lib/LanguageValidator.psm1` (new) - PowerShell mirror with `Test-ContentLanguage` and `Test-CommitDescriptionFirstChar`
- `global/hooks/pr-language-guard.{sh,ps1}` - call dispatcher instead of ASCII-only validator
- `global/hooks/commit-message-guard.ps1` - Rule 2 delegates to the new module

### Policy Values

| Value | Behavior |
|-------|----------|
| `english` (default / unset / empty) | byte-identical to prior behavior |
| `korean_plus_english` | accept ASCII + Hangul syllables/Jamo/Compat Jamo |
| `any` | skip language validation entirely |

### Installer Prompts

- `scripts/install.sh` and `scripts/install.ps1` ask a second question after install-type selection
- default answer (english) leaves `settings.json` untouched
- non-default answers write `env.CLAUDE_CONTENT_LANGUAGE` via `jq` (bash) or JSON roundtrip (PowerShell)
- latent fix: `install.sh` now copies `validate-language.sh` into `~/.claude/hooks/lib/` (only `validate-commit-message.sh` was copied before)

### Tests

- `tests/hooks/test-language-validator.sh` (new, 35 cases)
- `tests/hooks/test-language-validator.ps1` (new, 26 cases)
- matrix across all three policies for both entry points
- explicit invariant checks: attribution keywords, emojis, Conv. Commits format rejected under every policy

## Scope Boundary

Attribution enforcement is NOT governed by the new env var. `attribution-guard.{sh,ps1}` and the attribution checks in `commit-message-guard` remain active for every policy value - the scope boundary is documented in every dispatcher entry point.

## Acceptance Criteria

- [x] Fresh install answering "1) English" - dispatcher default + settings.json unchanged = byte-identical behavior
- [x] `korean_plus_english` accepts commit messages with Hangul first char (verified in test suite)
- [x] `korean_plus_english` accepts PR bodies with Hangul (verified in test suite)
- [x] `any` accepts arbitrary Unicode
- [x] All three policies still reject attribution keywords (verified in test suite)
- [x] Dispatcher functions include comments pointing to this issue and naming the three valid values
- [x] PowerShell validator has unit tests mirroring the bash library tests
- [x] No regression in existing `validate-*.sh` tests (`test-commit-msg.sh` 29/29 pass)

## Follow-ups

- #411 (Phase 2) will templatize the rule documents that hardcode the English-only policy sentence
- The pre-existing failures in `tests/hooks/test-commit-message-guard.sh` are orthogonal to this PR (verified by running the same test suite before applying any changes)
