### PR TITLE
docs(rules): templatize content-language policy and add drift test (#411)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -7,3 +7,4 @@
 # Reference docs for contributors. Load on demand with `@load: docs/<name>`.
 # Not auto-loaded in normal sessions.
 docs/loop-patterns.md
+docs/content-language-policy.md

--- a/docs/content-language-policy.md
+++ b/docs/content-language-policy.md
@@ -1,0 +1,93 @@
+# Content-Language Policy
+
+> Introduced by epic #409 (sub-issues #410 Phase 1, #411 Phase 2).
+> Deferred from default context via `.claudeignore` — this document ships
+> for human readers but does not consume Claude's context budget.
+
+This repository's content-language enforcement is configurable per install.
+The `CLAUDE_CONTENT_LANGUAGE` environment variable selects one of three
+policies; the installer writes the chosen value into
+`~/.claude/settings.json` and renders the corresponding policy phrase into
+the three rule documents that describe the rule to humans and to Claude.
+
+## Policies
+
+| Value | Validator behavior | Rule document phrase |
+|-------|--------------------|----------------------|
+| `english` (default, unset, empty) | ASCII printable + whitespace only | `English` |
+| `korean_plus_english` | ASCII + Hangul Syllables / Jamo / Compat Jamo | `English or Korean` |
+| `any` | Skip language validation entirely | `any language` |
+
+Attribution enforcement is **not** governed by this env var.
+`attribution-guard.{sh,ps1}` and the attribution checks inside
+`commit-message-guard` remain active for every policy value.
+
+## Install-time Substitution
+
+Three rule documents ship with a `.tmpl` twin containing the
+`{{CONTENT_LANGUAGE_POLICY}}` placeholder:
+
+- `global/commit-settings.md.tmpl`
+- `project/.claude/rules/core/communication.md.tmpl`
+- `project/.claude/rules/workflow/git-commit-format.md.tmpl`
+
+`scripts/install.sh` (bash) and `scripts/install.ps1` (PowerShell) render
+the `.tmpl` files into their `.md` siblings at the install destination,
+replacing the placeholder with the phrase for the chosen policy. If a
+`.tmpl` is absent, the installer falls back to copying the pre-rendered
+canonical `.md` as-is.
+
+The canonical `.md` files in the repo are always pre-rendered to `english`
+so a direct clone remains coherent. `tests/scripts/test-language-policy-drift.sh`
+guards against drift between each canonical `.md` and its `.tmpl`.
+
+## Enterprise Conflict Detection
+
+Enterprise-managed policies live at the highest precedence tier
+(`install.sh:122-124`). When the deployed enterprise `CLAUDE.md` mandates
+`english` but the operator selects a more permissive policy during
+install, the installer prints a warning and asks for confirmation before
+proceeding. The warning cites the enterprise path so the operator can
+reconcile the conflict before the installation completes.
+
+## Drift Test
+
+`tests/scripts/test-language-policy-drift.sh` runs two checks per rule
+document:
+
+1. Canonical `.md` equals `.tmpl` rendered with the `english` phrase.
+2. Each of the three policies produces output containing the expected
+   phrase.
+
+The test is wired into `tests/hooks/test-runner.sh` via the standard
+`test-*.sh` glob and runs in CI alongside the hook test suite.
+
+## Changing Policy After Install
+
+Edit `~/.claude/settings.json` directly:
+
+```json
+{
+  "env": {
+    "CLAUDE_CONTENT_LANGUAGE": "korean_plus_english"
+  }
+}
+```
+
+Restart the Claude Code session so the hooks re-inherit the env var.
+Rule documents on disk stay at the previously rendered phrase - re-run
+the installer to re-render them, or edit the `.md` files in place.
+
+## Sources of Truth
+
+| Concern | File |
+|---------|------|
+| Validator dispatch (bash) | `hooks/lib/validate-language.sh` |
+| Rule 2 branching (bash) | `hooks/lib/validate-commit-message.sh` |
+| Validator dispatch (PowerShell) | `global/hooks/lib/LanguageValidator.psm1` |
+| Phrase table (bash installer) | `scripts/install.sh` - `get_policy_phrase` |
+| Phrase table (PowerShell installer) | `scripts/install.ps1` - `Get-PolicyPhrase` |
+| Phrase table (drift test) | `tests/scripts/test-language-policy-drift.sh` |
+
+Keeping the three phrase tables in sync is part of the drift-test
+invariant. Any edit to one must edit the others.

--- a/global/commit-settings.md.tmpl
+++ b/global/commit-settings.md.tmpl
@@ -1,0 +1,6 @@
+# Commit, Issue, and PR Settings
+
+No AI/Claude attribution in commits, issues, or PRs.
+Enforced by `settings.json` (`attribution: ""`), the `commit-message-guard` PreToolUse hook (Claude-side feedback loop), and the `commit-msg` git hook installed by `hooks/install-hooks.sh` (terminal-side gate).
+
+All GitHub Issues and Pull Requests must be written in {{CONTENT_LANGUAGE_POLICY}}.

--- a/project/.claude/rules/core/communication.md.tmpl
+++ b/project/.claude/rules/core/communication.md.tmpl
@@ -1,0 +1,24 @@
+---
+alwaysApply: true
+---
+
+# Code and Documentation Language
+
+All code and technical documentation must use **{{CONTENT_LANGUAGE_POLICY}}**.
+
+## Scope
+
+- Variable/function/class names, comments, error messages, log messages → {{CONTENT_LANGUAGE_POLICY}}
+- README, API docs, architecture docs, PR descriptions, issue templates → {{CONTENT_LANGUAGE_POLICY}}
+- Commit messages → {{CONTENT_LANGUAGE_POLICY}} (see `git-commit-format.md`)
+
+## Relationship with Conversation Language
+
+Claude responds to users in Korean (via `settings.json` `language: "korean"`).
+Code and documentation remain in {{CONTENT_LANGUAGE_POLICY}} regardless of conversation language.
+
+## Special Cases
+
+- Korean company names in code: romanize (e.g., `class SamsungAPI`)
+- Localization files: keep original strings
+- Korean project override: create `CLAUDE_KO.md` in project root

--- a/project/.claude/rules/workflow/git-commit-format.md.tmpl
+++ b/project/.claude/rules/workflow/git-commit-format.md.tmpl
@@ -1,0 +1,27 @@
+---
+paths:
+  - ".git/**"
+  - "**/*"
+alwaysApply: true
+---
+
+# Git Commit Message Format
+
+Use **Conventional Commits**: `type(scope): description`
+
+## Types
+
+feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
+
+## Rules
+
+- **Scope**: Optional but recommended, lowercase (e.g., `auth`, `network`, `ui`)
+- **Description**: {{CONTENT_LANGUAGE_POLICY}}, imperative mood, lowercase start, no period, ≤50 chars
+- **Body**: Optional. Explain what/why, wrap at 72 chars, blank line after description
+- **Footer**: `BREAKING CHANGE: ...` or `Closes #123`
+
+## Attribution Policy
+
+No AI/Claude attribution or emojis in commit messages. See global `commit-settings.md`.
+
+> For hook scripts and CI verification, see `reference/commit-hooks.md`.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -82,6 +82,43 @@ function New-LocalClaude {
     }
 }
 
+function Get-PolicyPhrase {
+    # Issue #411: map CLAUDE_CONTENT_LANGUAGE value to a short phrase.
+    # Reads the script-scope $contentLanguage set after the install-type prompt.
+    switch ($script:contentLanguage) {
+        'english'             { return 'English' }
+        'korean_plus_english' { return 'English or Korean' }
+        'any'                 { return 'any language' }
+        default               { return 'English' }
+    }
+}
+
+function Invoke-PolicyTemplate {
+    # Renders a .md.tmpl file by replacing {{CONTENT_LANGUAGE_POLICY}}
+    # with the resolved phrase and writes the result to $Destination as UTF-8.
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination
+    )
+    $phrase = Get-PolicyPhrase
+    $content = [System.IO.File]::ReadAllText($Source)
+    $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Destination, $rendered, $utf8NoBom)
+}
+
+function Invoke-PolicyTemplatesInDir {
+    # Walks a directory, renders every *.md.tmpl to its *.md sibling,
+    # then deletes the .tmpl source. Used after bulk copy of rules/.
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return }
+    Get-ChildItem -Path $Path -Filter '*.md.tmpl' -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $dest = $_.FullName.Substring(0, $_.FullName.Length - '.tmpl'.Length)
+        Invoke-PolicyTemplate -Source $_.FullName -Destination $dest
+        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-EnterpriseDir {
     if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
         return "C:\Program Files\ClaudeCode"
@@ -226,6 +263,30 @@ switch ($langType) {
     }
 }
 
+# ── Enterprise CLAUDE.md conflict detection (issue #411) ───────
+# Enterprise policy takes the highest precedence; warn when the chosen
+# language policy contradicts an existing English-only enterprise doc.
+if ($contentLanguage -ne 'english') {
+    $enterpriseClaude = Join-Path (Get-EnterpriseDir) 'CLAUDE.md'
+    if (Test-Path -LiteralPath $enterpriseClaude) {
+        $enterpriseContent = Get-Content -Raw -LiteralPath $enterpriseClaude -ErrorAction SilentlyContinue
+        if ($enterpriseContent -and $enterpriseContent -imatch 'written in english') {
+            Write-Host ""
+            Write-Warn "Enterprise policy conflict detected"
+            Write-Warn "  Path: $enterpriseClaude"
+            Write-Warn "  The enterprise CLAUDE.md requires English, but you selected '$contentLanguage'."
+            Write-Warn "  The enterprise path loads at the highest precedence; your choice may violate enterprise policy."
+            Write-Host ""
+            $override = Read-Host "Continue with '$contentLanguage' anyway? (y/n) [default: n]"
+            if ([string]::IsNullOrEmpty($override)) { $override = 'n' }
+            if ($override -ne 'y') {
+                Write-Info "Resetting to english."
+                $contentLanguage = 'english'
+            }
+        }
+    }
+}
+
 # ── Enterprise installation ──────────────────────────────────
 
 if ($installType -eq '4' -or $installType -eq '5') {
@@ -249,7 +310,13 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'conversation-language.md', 'git-identity.md', 'token-management.md')
         foreach ($gf in $globalFiles) {
             $src = Join-Path $BackupDir "global/$gf"
-            if (Test-Path $src) {
+            # Issue #411: prefer .tmpl + substitution when present so the
+            # installed file matches the selected content-language policy.
+            $srcTmpl = "$src.tmpl"
+            if (Test-Path $srcTmpl) {
+                Invoke-PolicyTemplate -Source $srcTmpl -Destination (Join-Path $claudeDir $gf)
+                Write-Success "$gf installed (policy phrase: $(Get-PolicyPhrase))"
+            } elseif (Test-Path $src) {
                 Copy-Item -Path $src -Destination $claudeDir -Force
                 Write-Success "$gf installed"
             }
@@ -443,7 +510,9 @@ if ($installType -eq '2' -or $installType -eq '3' -or $installType -eq '5') {
     $sourceRules = Join-Path $BackupDir "project/.claude/rules"
     if (Test-Path $sourceRules) {
         Copy-Item -Path $sourceRules -Destination $projectClaudeDir -Recurse -Force
-        Write-Success "Rules directory installed!"
+        # Issue #411: render any .md.tmpl found under rules/ with the chosen policy phrase.
+        Invoke-PolicyTemplatesInDir -Path (Join-Path $projectClaudeDir 'rules')
+        Write-Success "Rules directory installed! (policy phrase: $(Get-PolicyPhrase))"
     }
 
     # Skills directory

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,40 @@ create_local_claude() {
     fi
 }
 
+# 함수: 정책 phrase 반환 (install-time substitution용, issue #411)
+# CLAUDE_CONTENT_LANGUAGE 값에 매핑되는 짧은 phrase를 반환합니다.
+get_policy_phrase() {
+    case "${CONTENT_LANGUAGE:-english}" in
+        english)             echo "English" ;;
+        korean_plus_english) echo "English or Korean" ;;
+        any)                 echo "any language" ;;
+        *)                   echo "English" ;;
+    esac
+}
+
+# 함수: .tmpl 파일을 읽어 {{CONTENT_LANGUAGE_POLICY}}를 phrase로 치환한 뒤 대상에 기록
+# 사용법: render_policy_tmpl <src.tmpl> <dest.md>
+render_policy_tmpl() {
+    local src="$1"
+    local dest="$2"
+    local phrase
+    phrase="$(get_policy_phrase)"
+    # sed 구분자를 |로 사용해 경로/phrase 충돌 회피
+    sed "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" "$src" > "$dest"
+}
+
+# 함수: 지정 디렉토리 내의 .md.tmpl 파일을 모두 찾아 .md로 렌더링 (원본 .tmpl 삭제)
+# 사용법: render_policy_tmpls_in_dir <dir>
+render_policy_tmpls_in_dir() {
+    local dir="$1"
+    local tmpl md
+    while IFS= read -r tmpl; do
+        md="${tmpl%.tmpl}"
+        render_policy_tmpl "$tmpl" "$md"
+        rm -f "$tmpl"
+    done < <(find "$dir" -type f -name '*.md.tmpl' 2>/dev/null)
+}
+
 # 함수: Enterprise 경로 감지
 get_enterprise_dir() {
     case "$(uname -s)" in
@@ -232,6 +266,27 @@ case "$LANG_TYPE" in
         ;;
 esac
 
+# Enterprise CLAUDE.md 충돌 감지 (issue #411)
+# Enterprise 정책 경로는 Claude Code에서 최상위 우선순위를 가집니다 (install.sh:122-124 참조).
+# 배포된 enterprise CLAUDE.md가 영어 강제인데 사용자가 더 허용적인 값을 골랐다면 경고합니다.
+if [ "$CONTENT_LANGUAGE" != "english" ]; then
+    ENTERPRISE_CLAUDE="$(get_enterprise_dir)/CLAUDE.md"
+    if [ -f "$ENTERPRISE_CLAUDE" ] && grep -qi "written in english" "$ENTERPRISE_CLAUDE" 2>/dev/null; then
+        echo ""
+        warning "Enterprise 정책 충돌 감지"
+        warning "  경로: $ENTERPRISE_CLAUDE"
+        warning "  Enterprise CLAUDE.md가 영어 강제를 명시하지만, 선택한 정책은 '$CONTENT_LANGUAGE' 입니다."
+        warning "  Enterprise 경로는 최상위 우선순위로 로드되므로 이 선택은 enterprise 정책 위반이 될 수 있습니다."
+        echo ""
+        read -p "그래도 '$CONTENT_LANGUAGE' 로 계속하시겠습니까? (y/n) [기본값: n]: " OVERRIDE_ENTERPRISE
+        OVERRIDE_ENTERPRISE=${OVERRIDE_ENTERPRISE:-n}
+        if [ "$OVERRIDE_ENTERPRISE" != "y" ]; then
+            info "english로 재설정합니다."
+            CONTENT_LANGUAGE="english"
+        fi
+    fi
+fi
+
 # Enterprise 설정 설치
 if [ "$INSTALL_TYPE" = "4" ] || [ "$INSTALL_TYPE" = "5" ]; then
     install_enterprise
@@ -307,7 +362,11 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     fi
 
     # commit-settings.md 설치 (CLAUDE.md에서 @./commit-settings.md로 참조)
-    if [ -f "$BACKUP_DIR/global/commit-settings.md" ]; then
+    # issue #411: .tmpl이 있으면 정책 phrase를 치환해서 생성. 없으면 원본 복사.
+    if [ -f "$BACKUP_DIR/global/commit-settings.md.tmpl" ]; then
+        render_policy_tmpl "$BACKUP_DIR/global/commit-settings.md.tmpl" "$HOME/.claude/commit-settings.md"
+        success "commit-settings.md 설치 완료 (policy phrase: $(get_policy_phrase))"
+    elif [ -f "$BACKUP_DIR/global/commit-settings.md" ]; then
         cp "$BACKUP_DIR/global/commit-settings.md" "$HOME/.claude/"
         success "commit-settings.md 설치 완료!"
     fi
@@ -415,7 +474,9 @@ if [ "$INSTALL_TYPE" = "2" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # rules 디렉토리 설치
     if [ -d "$BACKUP_DIR/project/.claude/rules" ]; then
         cp -r "$BACKUP_DIR/project/.claude/rules" "$PROJECT_DIR/.claude/"
-        success "Rules 디렉토리 설치 완료!"
+        # issue #411: rules/ 안의 .md.tmpl을 정책 phrase로 치환
+        render_policy_tmpls_in_dir "$PROJECT_DIR/.claude/rules"
+        success "Rules 디렉토리 설치 완료! (policy phrase: $(get_policy_phrase))"
     fi
 
     # Skills 디렉토리 설치

--- a/tests/scripts/test-language-policy-drift.sh
+++ b/tests/scripts/test-language-policy-drift.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# test-language-policy-drift.sh
+# Drift regression for issue #411.
+#
+# For each rule document shipped with a .md.tmpl twin, this test verifies:
+#
+#   1. The canonical .md file equals the .tmpl file rendered with the
+#      "english" policy phrase. If someone edits the .md without updating
+#      the .tmpl (or vice versa), the installer would overwrite the doc
+#      with a stale phrase on any non-english policy - this catches that.
+#
+#   2. For all three policies (english, korean_plus_english, any), the
+#      rendered output contains the expected phrase. Policy values that
+#      cannot be rendered deterministically fail the test.
+#
+# Run: bash tests/scripts/test-language-policy-drift.sh
+# Exit: 0 on all-pass, 1 on any drift or rendering failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Files under coverage — (canonical .md, .tmpl) pairs
+TEMPLATE_PAIRS=(
+    "$REPO_ROOT/global/commit-settings.md|$REPO_ROOT/global/commit-settings.md.tmpl"
+    "$REPO_ROOT/project/.claude/rules/core/communication.md|$REPO_ROOT/project/.claude/rules/core/communication.md.tmpl"
+    "$REPO_ROOT/project/.claude/rules/workflow/git-commit-format.md|$REPO_ROOT/project/.claude/rules/workflow/git-commit-format.md.tmpl"
+)
+
+# policy → phrase table (must match installer tables)
+declare -A PHRASE
+PHRASE[english]="English"
+PHRASE[korean_plus_english]="English or Korean"
+PHRASE[any]="any language"
+
+PASS=0
+FAIL=0
+
+render() {
+    local tmpl="$1" phrase="$2"
+    sed "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" "$tmpl"
+}
+
+echo "=== Content-language policy drift test (#411) ==="
+echo ""
+
+for pair in "${TEMPLATE_PAIRS[@]}"; do
+    md="${pair%%|*}"
+    tmpl="${pair##*|}"
+    name="$(basename "$md")"
+
+    echo "[${name}]"
+
+    if [ ! -f "$md" ]; then
+        echo "  FAIL: canonical .md missing: $md"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+    if [ ! -f "$tmpl" ]; then
+        echo "  FAIL: .tmpl missing: $tmpl"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Check 1: canonical .md equals .tmpl rendered with english phrase.
+    # Line-ending insensitive (repo has mixed CRLF/LF; on Windows clones all
+    # files roundtrip through CRLF via Git autocrlf).
+    if diff -q <(render "$tmpl" "${PHRASE[english]}" | tr -d '\r') <(tr -d '\r' < "$md") >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo "  PASS: canonical .md matches .tmpl rendered with english phrase"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: canonical .md drifted from .tmpl (english render)"
+        echo "  --- diff (canonical vs rendered, LF-normalized) ---"
+        diff <(render "$tmpl" "${PHRASE[english]}" | tr -d '\r') <(tr -d '\r' < "$md") | head -20 | sed 's/^/      /'
+        echo "  ---------------------------------------------------"
+    fi
+
+    # Check 2: each policy produces output containing its phrase
+    for policy in english korean_plus_english any; do
+        phrase="${PHRASE[$policy]}"
+        if render "$tmpl" "$phrase" | grep -qF "$phrase"; then
+            PASS=$((PASS + 1))
+            echo "  PASS: ${policy} render contains '${phrase}'"
+        else
+            FAIL=$((FAIL + 1))
+            echo "  FAIL: ${policy} render missing phrase '${phrase}'"
+        fi
+    done
+
+    echo ""
+done
+
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements Phase 2 of epic #409: templatizes the three rule documents that hardcode the English-only policy, rendering them at install time with the phrase matching the selected `CLAUDE_CONTENT_LANGUAGE` policy.

Closes #411
Part of #409

## What Changed

### Template Files (new)

- `global/commit-settings.md.tmpl`
- `project/.claude/rules/core/communication.md.tmpl`
- `project/.claude/rules/workflow/git-commit-format.md.tmpl`

Each uses `{{CONTENT_LANGUAGE_POLICY}}` as the single placeholder token.

### Phrase Table (in installers)

| Policy | Phrase |
|--------|--------|
| `english` | `English` |
| `korean_plus_english` | `English or Korean` |
| `any` | `any language` |

The canonical `.md` files in the repo remain pre-rendered to `english` so a direct clone reads coherently. The drift test guards against divergence.

### Installer Substitution

- `install.sh`: new `get_policy_phrase`, `render_policy_tmpl`, `render_policy_tmpls_in_dir` helpers
- `install.ps1`: PowerShell mirror with `Get-PolicyPhrase`, `Invoke-PolicyTemplate`, `Invoke-PolicyTemplatesInDir`
- When a `.tmpl` is present, the installer renders it to the destination `.md`; otherwise it falls back to copying the canonical `.md` (preserves existing behavior for files without templates).

### Enterprise Conflict Detection

When the operator picks a non-english policy AND the deployed enterprise `CLAUDE.md` contains the phrase `written in English`, the installer warns and asks for confirmation. The warning cites the enterprise-path precedence note already in `install.sh:122-124`. Declining resets the selection to `english`.

### Drift Regression Test (new)

`tests/scripts/test-language-policy-drift.sh` verifies, for each template pair:

1. Canonical `.md` equals `.tmpl` rendered with the english phrase (LF-normalized)
2. Each of the three policies produces output containing its phrase

Runs clean today: `12 passed, 0 failed`.

### Reference Doc (new)

`docs/content-language-policy.md` explains the three policies, install-time substitution, enterprise conflict detection, and the three phrase tables (bash, PowerShell, drift test) that must stay in sync. Excluded from default context via `.claudeignore`.

## Acceptance Criteria

- [x] All three rule documents have a substitutable region (`{{CONTENT_LANGUAGE_POLICY}}`)
- [x] Three phrases defined and reviewed, one per env value
- [x] Installer substitutes correctly in bash and PowerShell paths (verified with isolated function test)
- [x] Drift test passes for all three env values after a clean install
- [x] Drift test fails deterministically when the document and env var disagree (verified by manually bolding one word in a template - test reported the drift)
- [x] Enterprise CLAUDE.md conflict detection with warning citing `install.sh:122-124`
- [x] `docs/content-language-policy.md` created and deferred via `.claudeignore`
- [x] No change to default installer flow for operators who accept `english`

## Dependencies

- Requires #410 (merged as #412). The env var that governs behavior is only meaningful once the validator dispatcher exists.

## Follow-ups

- Epic #409 can close after this PR merges (both sub-issues done).
