### PR TITLE
refactor(rules): carve out code identifier scope from content-language policy

### DIFF
--- a/project/.claude/rules/core/communication.md
+++ b/project/.claude/rules/core/communication.md
@@ -4,18 +4,20 @@ alwaysApply: true
 
 # Code and Documentation Language
 
-All code and technical documentation must use **English**.
+Prose (comments, documentation, PR/issue bodies, commit descriptions) uses **English**.
+Code identifiers (variables, functions, classes, files) always use **English** due to language syntax requirements.
 
 ## Scope
 
-- Variable/function/class names, comments, error messages, log messages → English
+- Variable/function/class/file names → English (language syntax requirement)
+- Comments, error messages, log messages → English
 - README, API docs, architecture docs, PR descriptions, issue templates → English
 - Commit messages → English (see `git-commit-format.md`)
 
 ## Relationship with Conversation Language
 
 Claude responds to users in Korean (via `settings.json` `language: "korean"`).
-Code and documentation remain in English regardless of conversation language.
+Prose content remains in English regardless of conversation language.
 
 ## Special Cases
 

--- a/project/.claude/rules/core/communication.md.tmpl
+++ b/project/.claude/rules/core/communication.md.tmpl
@@ -4,18 +4,20 @@ alwaysApply: true
 
 # Code and Documentation Language
 
-All code and technical documentation must use **{{CONTENT_LANGUAGE_POLICY}}**.
+Prose (comments, documentation, PR/issue bodies, commit descriptions) uses **{{CONTENT_LANGUAGE_POLICY}}**.
+Code identifiers (variables, functions, classes, files) always use **English** due to language syntax requirements.
 
 ## Scope
 
-- Variable/function/class names, comments, error messages, log messages → {{CONTENT_LANGUAGE_POLICY}}
+- Variable/function/class/file names → English (language syntax requirement)
+- Comments, error messages, log messages → {{CONTENT_LANGUAGE_POLICY}}
 - README, API docs, architecture docs, PR descriptions, issue templates → {{CONTENT_LANGUAGE_POLICY}}
 - Commit messages → {{CONTENT_LANGUAGE_POLICY}} (see `git-commit-format.md`)
 
 ## Relationship with Conversation Language
 
 Claude responds to users in Korean (via `settings.json` `language: "korean"`).
-Code and documentation remain in {{CONTENT_LANGUAGE_POLICY}} regardless of conversation language.
+Prose content remains in {{CONTENT_LANGUAGE_POLICY}} regardless of conversation language.
 
 ## Special Cases
 

--- a/project/.claude/rules/workflow/git-commit-format.md
+++ b/project/.claude/rules/workflow/git-commit-format.md
@@ -16,7 +16,8 @@ feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
 ## Rules
 
 - **Scope**: Optional but recommended, lowercase (e.g., `auth`, `network`, `ui`)
-- **Description**: English, imperative mood, lowercase start, no period, ≤50 chars
+- **Description**: English, imperative mood, no period, ≤50 chars
+- **Description first char**: lowercase ASCII by default; Hangul also accepted under `CLAUDE_CONTENT_LANGUAGE=korean_plus_english`
 - **Body**: Optional. Explain what/why, wrap at 72 chars, blank line after description
 - **Footer**: `BREAKING CHANGE: ...` or `Closes #123`
 

--- a/project/.claude/rules/workflow/git-commit-format.md.tmpl
+++ b/project/.claude/rules/workflow/git-commit-format.md.tmpl
@@ -16,7 +16,8 @@ feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
 ## Rules
 
 - **Scope**: Optional but recommended, lowercase (e.g., `auth`, `network`, `ui`)
-- **Description**: {{CONTENT_LANGUAGE_POLICY}}, imperative mood, lowercase start, no period, ≤50 chars
+- **Description**: {{CONTENT_LANGUAGE_POLICY}}, imperative mood, no period, ≤50 chars
+- **Description first char**: lowercase ASCII by default; Hangul also accepted under `CLAUDE_CONTENT_LANGUAGE=korean_plus_english`
 - **Body**: Optional. Explain what/why, wrap at 72 chars, blank line after description
 - **Footer**: `BREAKING CHANGE: ...` or `Closes #123`
 

--- a/project/CLAUDE.md
+++ b/project/CLAUDE.md
@@ -7,7 +7,7 @@ Rules use YAML frontmatter for automatic loading. Defer to language-specific con
 
 Loaded every session via `alwaysApply: true`:
 - `core/principles.md` -- Think, Minimize, Surgical Precision, Verify
-- `core/communication.md` -- English for code/docs, Korean for conversation
+- `core/communication.md` -- Code identifiers in English, prose per `CLAUDE_CONTENT_LANGUAGE` policy
 - `core/environment.md` -- KST timezone, Korean locale, platform notes
 - `workflow/git-commit-format.md` -- Conventional Commits format
 - `workflow/session-resume.md` -- Resume interrupted workflows


### PR DESCRIPTION
## Summary

Follow-up refinement to the Phase 2 templates (#411). The original templates collapsed code identifier naming into the same placeholder as prose, which produces semantically broken renders under non-english policies.

Part of #409

## Problem

The Phase 2 template used a single `{{CONTENT_LANGUAGE_POLICY}}` placeholder for every language-dependent phrase, including:

- "Variable/function/class names → {{CONTENT_LANGUAGE_POLICY}}"

Under `korean_plus_english` this renders to "Variable names → English or Korean", which is factually wrong — language syntax requires ASCII identifiers in every mainstream language.

Under `any` it renders to "Variable names → any language", which is actively harmful guidance.

Similarly, `git-commit-format.md` hardcoded "lowercase start" in the Description rule, contradicting the Hangul-first-char allowance that the validator's `korean_plus_english` branch already supports.

## Fix

### `communication.md` + `.tmpl`

Split the identifier-vs-prose concern:

| Before | After |
|--------|-------|
| Variable/function/class names, comments, error messages, log messages → {{CONTENT_LANGUAGE_POLICY}} | Variable/function/class/file names → English (language syntax requirement)  \|  Comments, error messages, log messages → {{CONTENT_LANGUAGE_POLICY}} |

The identifier bullet is now a hardcoded English directive. Only the prose bullets follow the policy phrase.

### `git-commit-format.md` + `.tmpl`

Removed "lowercase start" from the main Description bullet. Added a separate bullet describing the first-char convention that explicitly references the `korean_plus_english` branch of the validator.

| Before | After |
|--------|-------|
| **Description**: {{phrase}}, imperative mood, lowercase start, no period, ≤50 chars | **Description**: {{phrase}}, imperative mood, no period, ≤50 chars  \|  **Description first char**: lowercase ASCII by default; Hangul also accepted under `CLAUDE_CONTENT_LANGUAGE=korean_plus_english` |

### `project/CLAUDE.md:10`

Descriptor updated from "English for code/docs, Korean for conversation" to "Code identifiers in English, prose per `CLAUDE_CONTENT_LANGUAGE` policy" so the one-line summary matches the more nuanced rule document.

## Verification

- Drift test (`tests/scripts/test-language-policy-drift.sh`): **12/12 passing**
- Canonical `.md` files regenerated from the new templates with the english phrase — direct checkout remains coherent
- Hook tests still pass with no regression

## Out of Scope

- No validator change. The identifier carve-out is a documentation concern; the validator already accepts ASCII in every policy (so identifiers pass regardless).
- No new policy value. The three existing policies (english, korean_plus_english, any) still map to the three phrases.
