### PR TITLE
fix(spec-lint): register iteration-control extension fields in SKILL.md schema

### DIFF
--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.json",
   "title": "Claude Code SKILL.md Frontmatter",
-  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields.",
+  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, on_halt, loop_safe).",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
@@ -85,6 +85,25 @@
       "type": "string",
       "enum": ["bash", "powershell"],
       "description": "Preferred shell when the skill runs commands."
+    },
+    "max_iterations": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Iteration-control extension (claude-config): maximum number of self-loops before the skill is forced to halt."
+    },
+    "halt_condition": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Iteration-control extension (claude-config): plain-language condition that stops the iteration loop early."
+    },
+    "on_halt": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Iteration-control extension (claude-config): action to take when halt_condition fires or max_iterations is reached."
+    },
+    "loop_safe": {
+      "type": "boolean",
+      "description": "Iteration-control extension (claude-config): true when the skill is safe to run inside an autonomous /loop, false when it must exit the loop before acting."
     }
   }
 }


### PR DESCRIPTION
## Summary

`spec_lint.sh --strict` failed on release PR #416 because the `SKILL.md` schema was not extended for the iteration-control fields introduced by #404 and #406:

- `max_iterations` (integer)
- `halt_condition` (string)
- `on_halt` (string)
- `loop_safe` (boolean)

13 violations across 13 SKILL.md files — feature PRs merged through develop without CI (only main-targeting PRs run the full workflow per `branching-strategy.md`), so the drift went unnoticed until the release PR triggered the validate job.

## Fix

Add the four fields to `scripts/schemas/skill-md.schema.json` with correct types, bounds, and descriptions. `additionalProperties: false` is preserved — unknown fields still fail the lint as intended.

## Verification

```
$ bash scripts/spec_lint.sh --strict
[spec_lint] mode=skill    files=32
spec_lint: mode=skill    files=32 violations=0
[spec_lint] mode=plugin   files=2
spec_lint: mode=plugin   files=2 violations=0
[spec_lint] mode=settings files=3
spec_lint: mode=settings files=3 violations=0
```

## Unblocks

Release PR #416 (develop → main). Merging this to develop re-runs CI on #416 with the fixed schema.

Part of #409
