### PR TITLE
fix(references): regenerate plugin and skill reference mirrors

### DIFF
--- a/plugin/skills/project-workflow/reference/git-commit-format.md
+++ b/plugin/skills/project-workflow/reference/git-commit-format.md
@@ -16,7 +16,8 @@ feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
 ## Rules
 
 - **Scope**: Optional but recommended, lowercase (e.g., `auth`, `network`, `ui`)
-- **Description**: English, imperative mood, lowercase start, no period, ≤50 chars
+- **Description**: English, imperative mood, no period, ≤50 chars
+- **Description first char**: lowercase ASCII by default; Hangul also accepted under `CLAUDE_CONTENT_LANGUAGE=korean_plus_english`
 - **Body**: Optional. Explain what/why, wrap at 72 chars, blank line after description
 - **Footer**: `BREAKING CHANGE: ...` or `Closes #123`
 

--- a/project/.claude/skills/project-workflow/reference/git-commit-format.md
+++ b/project/.claude/skills/project-workflow/reference/git-commit-format.md
@@ -1,1 +1,28 @@
-../../../rules/workflow/git-commit-format.md
+---
+paths:
+  - ".git/**"
+  - "**/*"
+alwaysApply: true
+---
+
+# Git Commit Message Format
+
+Use **Conventional Commits**: `type(scope): description`
+
+## Types
+
+feat, fix, docs, style, refactor, perf, test, build, ci, chore, security
+
+## Rules
+
+- **Scope**: Optional but recommended, lowercase (e.g., `auth`, `network`, `ui`)
+- **Description**: English, imperative mood, no period, ≤50 chars
+- **Description first char**: lowercase ASCII by default; Hangul also accepted under `CLAUDE_CONTENT_LANGUAGE=korean_plus_english`
+- **Body**: Optional. Explain what/why, wrap at 72 chars, blank line after description
+- **Footer**: `BREAKING CHANGE: ...` or `Closes #123`
+
+## Attribution Policy
+
+No AI/Claude attribution or emojis in commit messages. See global `commit-settings.md`.
+
+> For hook scripts and CI verification, see `reference/commit-hooks.md`.

--- a/project/.claude/skills/project-workflow/reference/github-issue-5w1h.md
+++ b/project/.claude/skills/project-workflow/reference/github-issue-5w1h.md
@@ -1,1 +1,50 @@
-../../../rules/workflow/github-issue-5w1h.md
+---
+alwaysApply: false
+---
+
+# GitHub Issue Guidelines (5W1H Principle)
+
+Follow the **5W1H framework** for comprehensive, actionable issues.
+
+## 5W1H Framework
+
+| # | Question | Key Fields |
+|---|----------|------------|
+| 1 | **What** | Title (≤50 chars), description, current/expected behavior, scope |
+| 2 | **Why** | Problem statement, impact, business value, priority justification |
+| 3 | **Who** | Assignee, reviewer, stakeholders |
+| 4 | **When** | Due date, milestone, dependencies, blockers |
+| 5 | **Where** | Affected files/components, environment, related issues/PRs |
+| 6 | **How** | Technical approach, acceptance criteria, reproduction steps, testing |
+
+> Examples and templates: see `reference/5w1h-examples.md`
+
+## Quick Reference
+
+### Issue Types and Required Fields
+
+| Issue Type | Required 5W1H | Optional |
+|------------|---------------|----------|
+| **Bug** | What, Why, Where, How (reproduce) | When, Who |
+| **Feature** | What, Why, How (criteria) | When, Where, Who |
+| **Task** | What, How (criteria) | Why, When, Where, Who |
+| **Epic** | What, Why, When | Where, How, Who |
+| **Hotfix** | What, Why, Where, How | When (ASAP), Who |
+
+### Issue Splitting Rule
+
+**Issues > 2-3 days MUST be split.** See `reference/issue-examples.md`.
+
+### Auto-Close Keywords (in PRs)
+
+`Closes #N`, `Fixes #N`, `Resolves #N` — closes issue when PR merges.
+
+### Labels
+
+| Category | Common Labels |
+|----------|--------------|
+| **Priority** | `priority/critical`, `priority/high`, `priority/medium`, `priority/low` |
+| **Type** | `type/bug`, `type/feature`, `type/enhancement`, `type/docs` |
+| **Size** | `size/XS`, `size/S`, `size/M`, `size/L`, `size/XL` |
+
+> Full definitions: `reference/label-definitions.md` | Automation: `reference/automation-patterns.md`

--- a/project/.claude/skills/project-workflow/reference/github-pr-5w1h.md
+++ b/project/.claude/skills/project-workflow/reference/github-pr-5w1h.md
@@ -1,1 +1,54 @@
-../../../rules/workflow/github-pr-5w1h.md
+---
+alwaysApply: false
+---
+
+# GitHub Pull Request Guidelines (5W1H Principle)
+
+Follow the **5W1H framework** so reviewers can quickly understand and evaluate changes.
+
+## 5W1H Framework
+
+| # | Question | Key Fields |
+|---|----------|------------|
+| 1 | **What** | Title (`type(scope): desc`), summary, change type, affected components |
+| 2 | **Why** | Problem solved, related issues, business value, alternatives considered |
+| 3 | **Who** | Reviewers, stakeholders, required sign-offs |
+| 4 | **When** | Urgency, target release, deployment notes, dependencies |
+| 5 | **Where** | Files changed, architecture/API/database impact |
+| 6 | **How** | Implementation details, testing done, test plan, breaking changes, rollback |
+
+> Examples and templates: see `reference/5w1h-examples.md`
+
+## Issue Linking (MANDATORY)
+
+Every PR MUST link to at least one issue (unless trivial fix).
+
+- **Close**: `Closes #N`, `Fixes #N`, `Resolves #N`
+- **Reference**: `Relates to #N`, `Part of #N`, `See also #N`
+- **After PR creation**: Add implementation update comment to linked issue(s)
+
+## Quick Reference
+
+### PR Title Conventions
+
+`feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `security`
+
+### PR Size Guidelines
+
+| Size | Lines | Recommendation |
+|------|-------|----------------|
+| **XS** | < 50 | Ideal |
+| **S** | 50-200 | Preferred |
+| **M** | 200-500 | Consider splitting |
+| **L** | 500-1000 | Split if possible |
+| **XL** | > 1000 | Must split |
+
+### Reviewer Checklist
+
+- [ ] Changes match description (What)
+- [ ] Solves stated problem (Why)
+- [ ] Correct reviewers (Who)
+- [ ] No timing issues (When)
+- [ ] Scoped correctly (Where)
+- [ ] Sound implementation, adequate tests (How)
+- [ ] Issue(s) properly linked

--- a/project/.claude/skills/project-workflow/reference/performance-analysis.md
+++ b/project/.claude/skills/project-workflow/reference/performance-analysis.md
@@ -1,1 +1,82 @@
-../../../rules/workflow/performance-analysis.md
+---
+paths:
+  - "**/*"
+alwaysApply: false
+---
+
+# Performance Analysis Procedure
+
+> **Version**: 1.1.0
+> **Extracted from**: workflow.md
+> **Purpose**: Systematic approach for analyzing performance in unfamiliar codebases
+
+## 1. Establish Analysis Constraints
+
+- **Document assumptions**: List all assumptions about the system's behavior
+- **Identify constraints**: Note environmental limitations (network access, execution capabilities, required dependencies)
+- **Define scope**: Clarify what "performance analysis" means in this context (throughput, latency, resource usage, etc.)
+- **List unknowns**: Explicitly state what information is missing or unclear
+
+## 2. Gather Required Information
+
+Before diving into code, determine:
+
+- **Build system**: How to compile/build the project (CMake, Make, scripts, etc.)
+- **Documentation**: Existence of performance-related docs, benchmarks, or profiling guides
+- **Test infrastructure**: Available test data, workloads, or benchmark suites
+- **Execution requirements**: Dependencies, runtime environment, configuration needs
+
+## 3. Progressive Exploration Strategy
+
+Follow this step-by-step approach:
+
+### 3.1 Repository Structure Survey
+- Map directory organization and key source files
+- Locate build scripts, documentation, test files
+- Identify main entry points and core components
+
+### 3.2 Code Flow and Component Analysis
+- Trace thread management and lifecycle
+- Examine queue/synchronization mechanisms
+- Identify potential bottleneck points
+- Review resource allocation patterns
+
+### 3.3 Performance Measurement Point Identification
+- Determine what metrics are currently collected
+- Assess existing logging/monitoring support
+- Identify where new instrumentation could be added
+- Note any existing profiling or benchmark code
+
+### 3.4 Execution and Testing Verification
+- Check for runnable scripts or test suites
+- Execute available benchmarks (with user approval if needed)
+- Collect and analyze output/logs
+- Document any issues preventing execution
+
+### 3.5 Comprehensive Analysis Synthesis
+- Summarize potential performance indicators
+- Highlight expected bottlenecks and optimization opportunities
+- Propose measurement strategies for missing metrics
+- Recommend next steps for performance improvement
+
+## 4. Present Analysis Plan
+
+Before executing the analysis:
+
+- **Share the planned approach**: Present the exploration strategy to the user
+- **Confirm priorities**: Ask if certain aspects should be prioritized or skipped
+- **Get approval for execution**: Request permission before running code or tests
+- **Adjust based on feedback**: Modify the plan according to user input
+
+## 5. Report Findings
+
+When presenting results:
+
+- **Start with executive summary**: High-level findings and key takeaways
+- **Detail methodology**: Explain what was analyzed and how
+- **Present data**: Share metrics, measurements, or observations
+- **Acknowledge limitations**: Be clear about what couldn't be measured or verified
+- **Recommend actions**: Suggest concrete next steps for performance optimization
+
+---
+*Part of the workflow guidelines module*


### PR DESCRIPTION
## Summary

Release PR #416 also failed `check_references.sh` — the canonical rule edit in #414 never propagated to `plugin/skills/project-workflow/reference/git-commit-format.md`. Running `scripts/sync_references.sh` uncovered additional accumulated drift across three other reference mirrors.

## Fix

Ran `scripts/sync_references.sh` which regenerated 8 files (4 canonicals × 2 mirrors):

- `plugin/skills/project-workflow/reference/*`
- `project/.claude/skills/project-workflow/reference/*`

Canonical sources stay unchanged — this PR only updates mirrors.

## Verification

```
$ bash scripts/check_references.sh
check_references: OK (all 4 files match across 2 mirrors)

$ bash scripts/spec_lint.sh --strict
[spec_lint] mode=skill    files=32 violations=0
[spec_lint] mode=plugin   files=2  violations=0
[spec_lint] mode=settings files=3  violations=0
```

## Unblocks

Release PR #416 (develop → main). Together with #417 (schema extension), this clears the two validate-job failures.

Part of #409
