### PR TITLE
fix(install): preserve local commit-settings.md on sync

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -92,11 +92,28 @@ function Install-GlobalSettings {
         New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
     }
 
-    # Copy files
+    # Load install-manifest helper (SHA-256-based preservation of local edits)
+    $manifestHelper = Join-Path $InstallDir 'scripts' 'install-manifest.ps1'
+    if (Test-Path -LiteralPath $manifestHelper) {
+        . $manifestHelper
+    }
+
+    # Copy files (manifest-guarded: local edits preserved by default)
     $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'conversation-language.md', 'git-identity.md', 'token-management.md')
     foreach ($gf in $globalFiles) {
-        $src = Join-Path $InstallDir 'global' $gf
-        if (Test-Path -LiteralPath $src) {
+        $src  = Join-Path $InstallDir 'global' $gf
+        $dest = Join-Path $ClaudeDir $gf
+        if (-not (Test-Path -LiteralPath $src)) { continue }
+
+        if (Get-Command Invoke-GuardedCopy -ErrorAction SilentlyContinue) {
+            if (Invoke-GuardedCopy -Src $src -Dest $dest -Key $gf) {
+                Write-Ok "$gf 설치됨"
+            }
+            else {
+                Write-Info "$gf 로컬 변경 유지"
+            }
+        }
+        else {
             Copy-Item -LiteralPath $src -Destination $ClaudeDir -Force
             Write-Ok "$gf 설치됨"
         }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -91,9 +91,20 @@ install_global() {
     # ~/.claude 디렉토리 생성
     mkdir -p "$CLAUDE_DIR"
 
-    # 파일 복사
+    # 설치 매니페스트 헬퍼 로드 (SHA-256 해시 기반 로컬 변경 보존)
+    # shellcheck disable=SC1091
+    source "$INSTALL_DIR/scripts/install-manifest.sh"
+
+    # 파일 복사 (매니페스트 가드: 로컬 편집은 기본적으로 유지)
     for gf in CLAUDE.md commit-settings.md conversation-language.md git-identity.md token-management.md; do
-        [ -f "$INSTALL_DIR/global/$gf" ] && cp "$INSTALL_DIR/global/$gf" "$CLAUDE_DIR/" && ok "$gf 설치됨"
+        src="$INSTALL_DIR/global/$gf"
+        dest="$CLAUDE_DIR/$gf"
+        [ -f "$src" ] || continue
+        if guarded_copy "$src" "$dest" "$gf"; then
+            success "$gf 설치됨"
+        else
+            info "$gf 로컬 변경 유지"
+        fi
     done
 
     # tmux 설정 설치

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,111 @@
+# Install Behavior
+
+`bootstrap.sh` (POSIX) and `bootstrap.ps1` (Windows) preserve local
+customizations of global rule files across re-installs by recording a
+SHA-256 manifest.
+
+## Manifest
+
+Location: `~/.claude/.install-manifest.json`
+
+Format:
+
+```json
+{
+  "schema": 1,
+  "files": {
+    "CLAUDE.md": "sha256-hex",
+    "commit-settings.md": "sha256-hex",
+    "conversation-language.md": "sha256-hex",
+    "git-identity.md": "sha256-hex",
+    "token-management.md": "sha256-hex"
+  }
+}
+```
+
+The manifest is written on successful copy and updated whenever the
+installer replaces a file. It is created on first install and survives
+across re-runs.
+
+## Copy Decision
+
+On each run, the installer compares three hashes per tracked file:
+
+- `src_hash` — the hash of the incoming template under `$INSTALL_DIR/global/<file>`
+- `dest_hash` — the hash of the current `~/.claude/<file>`
+- `stored_hash` — the hash recorded in `.install-manifest.json`
+
+| Condition | Outcome |
+|-----------|---------|
+| destination missing | copy and record `src_hash` |
+| `src_hash == dest_hash` | no-op (record `src_hash` if manifest is empty) |
+| `dest_hash == stored_hash` and `src_hash != dest_hash` | silent upgrade; record `src_hash` |
+| destination diverges from both | prompt user (keep / overwrite) |
+
+The "diverges from both" case means the user has locally edited the
+file after the last install. In interactive mode the installer prints
+the diff (first 40 lines) and prompts:
+
+```
+  [k]eep local / [o]verwrite (default: keep):
+```
+
+Pressing `Enter` keeps the local file unchanged. The manifest is not
+updated in this case, so subsequent re-installs will prompt again until
+the user either overwrites or aligns their local file with an upstream
+version.
+
+## Non-Interactive Override
+
+For CI or unattended installs, bypass the prompt with either:
+
+```bash
+BOOTSTRAP_FORCE=1 bash bootstrap.sh
+```
+
+```powershell
+$env:BOOTSTRAP_FORCE = '1'; pwsh -File bootstrap.ps1
+```
+
+With `BOOTSTRAP_FORCE=1`, divergent files are overwritten and the
+manifest is refreshed.
+
+## Toolchain Fallback
+
+The POSIX path uses `python3` (or `python`) for JSON manipulation and
+`shasum -a 256` or `sha256sum` for hashing. If none of these are
+available on the system, the installer falls back to the previous
+unconditional copy behavior for backwards compatibility.
+
+PowerShell uses the built-in `Get-FileHash` and `ConvertTo-Json` /
+`ConvertFrom-Json` cmdlets, so no additional dependencies are required
+on Windows.
+
+## Tracked Files
+
+The manifest currently tracks these entries (see `bootstrap.sh`
+`install_global` and `bootstrap.ps1` `Install-GlobalSettings`):
+
+- `CLAUDE.md`
+- `commit-settings.md`
+- `conversation-language.md`
+- `git-identity.md`
+- `token-management.md`
+
+Other installed artifacts (`tmux.conf`, `ccstatusline/settings.json`,
+plugin resources, project templates) remain unconditional copies — add
+them to the manifest block in future issues if their customizations
+need to be preserved.
+
+## Regression Test
+
+`tests/scripts/test-install-preserves-customization.sh` covers the
+keep / overwrite / force-flag paths of the manifest helper directly.
+Run it from the repository root:
+
+```bash
+bash tests/scripts/test-install-preserves-customization.sh
+```
+
+The test is skipped on systems without `python3`/`python` — on such
+systems the installer itself also falls back to unconditional copy.

--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -1,0 +1,137 @@
+# install-manifest.ps1
+# PowerShell counterpart of scripts/install-manifest.sh.
+# Provides Invoke-GuardedCopy for preserving local customizations across
+# re-installs of bootstrap.ps1.
+#
+# Usage (dot-source):
+#   . "$InstallDir/scripts/install-manifest.ps1"
+#   Invoke-GuardedCopy -Src $src -Dest $dest -Key $key
+#
+# Environment:
+#   MANIFEST_PATH    override manifest location
+#   BOOTSTRAP_FORCE  "1" bypasses the divergence prompt and overwrites
+
+$script:ManifestSchema = 1
+
+function Get-ManifestPath {
+    if ($env:MANIFEST_PATH) { return $env:MANIFEST_PATH }
+    return (Join-Path $HOME '.claude' '.install-manifest.json')
+}
+
+function Get-FileSha256 {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLower()
+}
+
+function Read-ManifestEntry {
+    param([Parameter(Mandatory)][string]$Key)
+    $manifestPath = Get-ManifestPath
+    if (-not (Test-Path -LiteralPath $manifestPath)) { return '' }
+    try {
+        $m = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        if ($m.files -and $m.files.PSObject.Properties.Name -contains $Key) {
+            return [string]$m.files.$Key
+        }
+    }
+    catch { }
+    return ''
+}
+
+function Write-ManifestEntry {
+    param(
+        [Parameter(Mandatory)][string]$Key,
+        [Parameter(Mandatory)][string]$Sha
+    )
+    $manifestPath = Get-ManifestPath
+    $dir = Split-Path -Parent $manifestPath
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $manifest = $null
+    if (Test-Path -LiteralPath $manifestPath) {
+        try {
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw |
+                ConvertFrom-Json -ErrorAction Stop
+        }
+        catch { $manifest = $null }
+    }
+
+    # Rebuild into a hashtable so updates are deterministic.
+    $files = @{}
+    if ($manifest -and $manifest.files) {
+        foreach ($prop in $manifest.files.PSObject.Properties) {
+            $files[$prop.Name] = [string]$prop.Value
+        }
+    }
+    $files[$Key] = $Sha
+
+    $out = [ordered]@{
+        schema = $script:ManifestSchema
+        files  = $files
+    }
+    $out | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+}
+
+function Invoke-GuardedCopy {
+    <#
+    .SYNOPSIS
+    Copies Src to Dest with manifest-based preservation of local edits.
+    .OUTPUTS
+    System.Boolean. $true when the file was copied (or no change was
+    needed), $false when the local file was kept by user choice.
+    #>
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string]$Src,
+        [Parameter(Mandatory)][string]$Dest,
+        [Parameter(Mandatory)][string]$Key
+    )
+
+    if (-not (Test-Path -LiteralPath $Src)) { return $true }
+
+    # Fresh install for this destination.
+    if (-not (Test-Path -LiteralPath $Dest)) {
+        Copy-Item -LiteralPath $Src -Destination $Dest -Force
+        $sha = Get-FileSha256 -Path $Src
+        if ($sha) { Write-ManifestEntry -Key $Key -Sha $sha }
+        return $true
+    }
+
+    $srcSha    = Get-FileSha256 -Path $Src
+    $destSha   = Get-FileSha256 -Path $Dest
+    $storedSha = Read-ManifestEntry -Key $Key
+
+    if ($srcSha -and ($srcSha -eq $destSha)) {
+        if (-not $storedSha) { Write-ManifestEntry -Key $Key -Sha $srcSha }
+        return $true
+    }
+
+    if ($storedSha -and ($destSha -eq $storedSha)) {
+        Copy-Item -LiteralPath $Src -Destination $Dest -Force
+        Write-ManifestEntry -Key $Key -Sha $srcSha
+        return $true
+    }
+
+    # Divergence: destination differs from both source and stored hash.
+    if ($env:BOOTSTRAP_FORCE -eq '1') {
+        Copy-Item -LiteralPath $Src -Destination $Dest -Force
+        Write-ManifestEntry -Key $Key -Sha $srcSha
+        return $true
+    }
+
+    Write-Host ''
+    Write-Host "  Local changes detected in: $Dest"
+    Write-Host '  Incoming version differs from both local and the last install.'
+    $choice = Read-Host '  [k]eep local / [o]verwrite (default: keep)'
+    if ([string]::IsNullOrEmpty($choice)) { $choice = 'k' }
+
+    if ($choice -match '^[oO]$') {
+        Copy-Item -LiteralPath $Src -Destination $Dest -Force
+        Write-ManifestEntry -Key $Key -Sha $srcSha
+        return $true
+    }
+
+    return $false
+}

--- a/scripts/install-manifest.sh
+++ b/scripts/install-manifest.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# install-manifest.sh
+# Helpers for guarded copy with SHA-256 manifest, preserving local
+# customizations across re-installs of bootstrap.sh.
+#
+# Usage (source this file):
+#   source "$INSTALL_DIR/scripts/install-manifest.sh"
+#   guarded_copy "$src" "$dest" "$key"
+#
+# Environment:
+#   MANIFEST_PATH    override manifest location
+#   BOOTSTRAP_FORCE  "1" bypasses the divergence prompt and overwrites
+
+MANIFEST_PATH="${MANIFEST_PATH:-$HOME/.claude/.install-manifest.json}"
+MANIFEST_SCHEMA=1
+
+# Detect an available JSON tool (python3 preferred, python fallback).
+_manifest_json_tool=""
+if command -v python3 >/dev/null 2>&1; then
+    _manifest_json_tool="python3"
+elif command -v python >/dev/null 2>&1; then
+    _manifest_json_tool="python"
+fi
+
+manifest_available() {
+    [ -n "$_manifest_json_tool" ]
+}
+
+_manifest_hash() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" 2>/dev/null | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" 2>/dev/null | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+_manifest_read() {
+    local key="$1"
+    [ -f "$MANIFEST_PATH" ] || return 0
+    MANIFEST_PATH="$MANIFEST_PATH" KEY="$key" "$_manifest_json_tool" <<'PY'
+import json, os
+p = os.environ["MANIFEST_PATH"]
+k = os.environ["KEY"]
+try:
+    with open(p) as f:
+        m = json.load(f)
+    print(m.get("files", {}).get(k, ""), end="")
+except Exception:
+    pass
+PY
+}
+
+_manifest_write() {
+    local key="$1" sha="$2"
+    mkdir -p "$(dirname "$MANIFEST_PATH")"
+    MANIFEST_PATH="$MANIFEST_PATH" KEY="$key" SHA="$sha" \
+    SCHEMA="$MANIFEST_SCHEMA" "$_manifest_json_tool" <<'PY'
+import json, os
+p = os.environ["MANIFEST_PATH"]
+k = os.environ["KEY"]
+v = os.environ["SHA"]
+schema = int(os.environ["SCHEMA"])
+try:
+    with open(p) as f:
+        m = json.load(f)
+    if not isinstance(m, dict):
+        m = {}
+except Exception:
+    m = {}
+m["schema"] = schema
+m.setdefault("files", {})[k] = v
+with open(p, "w") as f:
+    json.dump(m, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+# guarded_copy <src> <dest> <key>
+# Returns 0 when the file was copied (or no change needed), 1 when the
+# local file was kept by user choice.
+guarded_copy() {
+    local src="$1" dest="$2" key="$3"
+    [ -f "$src" ] || return 0
+
+    # Fall back to unconditional copy if no JSON tool is available.
+    if ! manifest_available; then
+        cp "$src" "$dest"
+        return 0
+    fi
+
+    # Destination missing — first install; copy and record.
+    if [ ! -f "$dest" ]; then
+        cp "$src" "$dest"
+        local sha
+        sha=$(_manifest_hash "$src")
+        [ -n "$sha" ] && _manifest_write "$key" "$sha"
+        return 0
+    fi
+
+    local src_sha dest_sha stored_sha
+    src_sha=$(_manifest_hash "$src")
+    dest_sha=$(_manifest_hash "$dest")
+    stored_sha=$(_manifest_read "$key")
+
+    # Nothing to do.
+    if [ -n "$src_sha" ] && [ "$src_sha" = "$dest_sha" ]; then
+        [ -z "$stored_sha" ] && _manifest_write "$key" "$src_sha"
+        return 0
+    fi
+
+    # Destination matches stored hash → safe upgrade, no local edits.
+    if [ -n "$stored_sha" ] && [ "$dest_sha" = "$stored_sha" ]; then
+        cp "$src" "$dest"
+        _manifest_write "$key" "$src_sha"
+        return 0
+    fi
+
+    # Divergence: destination differs from both source and stored hash.
+    if [ "${BOOTSTRAP_FORCE:-0}" = "1" ]; then
+        cp "$src" "$dest"
+        _manifest_write "$key" "$src_sha"
+        return 0
+    fi
+
+    echo ""
+    echo "  Local changes detected in: $dest"
+    echo "  Incoming version differs from both local and the last install."
+    if command -v diff >/dev/null 2>&1; then
+        diff -u "$dest" "$src" 2>/dev/null | head -40 || true
+    fi
+    local choice
+    read -r -p "  [k]eep local / [o]verwrite (default: keep): " choice
+    choice=${choice:-k}
+
+    case "$choice" in
+        o|O)
+            cp "$src" "$dest"
+            _manifest_write "$key" "$src_sha"
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/tests/scripts/test-install-preserves-customization.sh
+++ b/tests/scripts/test-install-preserves-customization.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Regression test for scripts/install-manifest.sh (issue #420).
+# Verifies that guarded_copy preserves local customizations when the user
+# chooses [k]eep, and honors BOOTSTRAP_FORCE=1 to overwrite.
+#
+# Run: bash tests/scripts/test-install-preserves-customization.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+HELPER="$ROOT_DIR/scripts/install-manifest.sh"
+
+if [ ! -f "$HELPER" ]; then
+    echo "FAIL: helper not found: $HELPER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Each case runs in its own manifest path and temp files.
+new_case() {
+    local name="$1"
+    CASE_DIR="$WORK/$name"
+    mkdir -p "$CASE_DIR"
+    export MANIFEST_PATH="$CASE_DIR/manifest.json"
+    unset BOOTSTRAP_FORCE
+}
+
+# shellcheck disable=SC1090
+source "$HELPER"
+
+if ! manifest_available; then
+    echo "SKIP: no python3/python on PATH; guarded_copy requires JSON tool"
+    exit 0
+fi
+
+assert_equal() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label: expected '$expected', got '$actual'")
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label: '$needle' not found in output")
+    fi
+}
+
+# --- Case 1: first install records the hash -------------------------------
+new_case "first-install"
+src="$CASE_DIR/source.md"
+dest="$CASE_DIR/dest.md"
+printf 'v1 content\n' > "$src"
+guarded_copy "$src" "$dest" "source.md"
+assert_equal "first-install: dest exists" "v1 content" "$(cat "$dest")"
+assert_contains "first-install: manifest has hash" "source.md" "$(cat "$MANIFEST_PATH")"
+
+# --- Case 2: re-install with no local edit upgrades silently --------------
+new_case "clean-upgrade"
+src="$CASE_DIR/source.md"
+dest="$CASE_DIR/dest.md"
+printf 'v1\n' > "$src"
+guarded_copy "$src" "$dest" "source.md"   # first install
+printf 'v2\n' > "$src"                      # new upstream version
+guarded_copy "$src" "$dest" "source.md"   # should upgrade silently
+assert_equal "clean-upgrade: dest reflects v2" "v2" "$(cat "$dest")"
+
+# --- Case 3: local edit preserved on [k] (default) ------------------------
+new_case "keep-local"
+src="$CASE_DIR/source.md"
+dest="$CASE_DIR/dest.md"
+printf 'v1\n' > "$src"
+guarded_copy "$src" "$dest" "source.md"
+printf 'locally edited\n' > "$dest"
+printf 'v2\n' > "$src"
+# Feed empty input to read -> default keep
+if echo "" | guarded_copy "$src" "$dest" "source.md" >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("keep-local: guarded_copy should have returned non-zero on keep")
+else
+    PASS=$((PASS + 1))
+fi
+assert_equal "keep-local: dest unchanged" "locally edited" "$(cat "$dest")"
+
+# --- Case 4: [o] overwrites local edit ------------------------------------
+new_case "overwrite-choice"
+src="$CASE_DIR/source.md"
+dest="$CASE_DIR/dest.md"
+printf 'v1\n' > "$src"
+guarded_copy "$src" "$dest" "source.md"
+printf 'locally edited\n' > "$dest"
+printf 'v2\n' > "$src"
+echo "o" | guarded_copy "$src" "$dest" "source.md" >/dev/null
+assert_equal "overwrite-choice: dest reflects v2" "v2" "$(cat "$dest")"
+
+# --- Case 5: BOOTSTRAP_FORCE=1 bypasses prompt ----------------------------
+new_case "force-flag"
+src="$CASE_DIR/source.md"
+dest="$CASE_DIR/dest.md"
+printf 'v1\n' > "$src"
+guarded_copy "$src" "$dest" "source.md"
+printf 'locally edited\n' > "$dest"
+printf 'v2\n' > "$src"
+BOOTSTRAP_FORCE=1 guarded_copy "$src" "$dest" "source.md"
+assert_equal "force-flag: dest reflects v2" "v2" "$(cat "$dest")"
+
+# --- Summary --------------------------------------------------------------
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi


### PR DESCRIPTION
Closes #420

## Summary
Re-running `bootstrap.sh`/`bootstrap.ps1` previously overwrote every file under
`~/.claude` on every run, silently reverting any local edits — the observed
symptom was a Korean `CLAUDE_CONTENT_LANGUAGE` line in `commit-settings.md`
being reverted without warning.

This PR introduces a SHA-256 manifest at `~/.claude/.install-manifest.json`
and routes the global-file copy loop through a guarded helper that
classifies each destination as fresh / safe-upgrade / divergent:

- fresh → copy and record hash
- safe upgrade (destination matches recorded hash) → copy silently and update manifest
- divergent (destination differs from both source and recorded hash) → prompt `[k]eep / [o]verwrite`, default keep

`BOOTSTRAP_FORCE=1` bypasses the prompt for CI.

## Changes
- `scripts/install-manifest.sh` / `scripts/install-manifest.ps1` — helper with hash + guarded-copy logic
- `bootstrap.sh` / `bootstrap.ps1` — source the helper and route global-file copies through it
- `tests/scripts/test-install-preserves-customization.sh` — regression test covering first-install, clean-upgrade, keep-local, overwrite-choice, and force-flag cases
- `docs/install.md` — documents the manifest format and copy decision

The POSIX helper falls back to the previous unconditional copy if neither
`python3` nor `python` is available, preserving backwards compatibility on
minimal systems. PowerShell uses built-in `Get-FileHash` / `ConvertTo-Json`
so Windows needs no extra dependency.

## Acceptance Criteria
- [x] Fresh install writes `.install-manifest.json` with SHA-256 entries for every copied file
- [x] Re-running with no local edits copies silently and updates the manifest
- [x] Re-running with a local edit prompts the user and preserves the edit when `[k]` is chosen
- [x] `BOOTSTRAP_FORCE=1` bypasses the prompt
- [x] Regression test covers keep / overwrite paths
- [x] `bootstrap.ps1` mirrors the behavior on Windows
- [x] Manifest format documented in `docs/install.md`

## Test Plan
```bash
bash tests/scripts/test-install-preserves-customization.sh
# -> Passed: 7 / Failed: 0
```

Manual smoke test (bash): edit `~/.claude/commit-settings.md`, re-run
`bootstrap.sh`; at the prompt press Enter to keep — the edit survives.