### PR TITLE
fix(settings): register missing hooks in settings.windows.json

### DIFF
--- a/global/hooks/conflict-guard.ps1
+++ b/global/hooks/conflict-guard.ps1
@@ -1,0 +1,76 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# conflict-guard.ps1
+# Guards against git operations that could cause conflicts.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Fail-open: when parsing fails or git is not available, allow the
+# command. This hook is advisory (conflict prevention), not
+# security-critical.
+
+function Respond-Allow {
+    New-HookAllowResponse
+    exit 0
+}
+
+function Respond-Deny {
+    param([string]$Reason)
+    New-HookDenyResponse -Reason $Reason
+    exit 0
+}
+
+$json = Read-HookInput
+if (-not $json) { Respond-Allow }
+
+$cmd = $null
+try { $cmd = $json.tool_input.command } catch { }
+if (-not $cmd) { $cmd = $env:CLAUDE_TOOL_INPUT }
+if (-not $cmd) { Respond-Allow }
+
+# Scope: only check conflict-prone git subcommands.
+if ($cmd -notmatch 'git\s+(merge|rebase|cherry-pick|pull)\b') {
+    Respond-Allow
+}
+
+# Fail-open when git is unavailable.
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Respond-Allow
+}
+
+# Resolve git dir; fail-open outside a repo.
+$gitDir = $null
+try {
+    $gitDir = (& git rev-parse --git-dir 2>$null).Trim()
+} catch { }
+if (-not $gitDir) { Respond-Allow }
+
+# Check 1: existing conflict state.
+if (Test-Path -LiteralPath (Join-Path $gitDir 'MERGE_HEAD')) {
+    Respond-Deny 'A merge is already in progress. Resolve or abort it before starting a new operation.'
+}
+if (Test-Path -LiteralPath (Join-Path $gitDir 'REBASE_HEAD')) {
+    Respond-Deny 'A rebase is already in progress. Resolve or abort it before starting a new operation.'
+}
+if (Test-Path -LiteralPath (Join-Path $gitDir 'CHERRY_PICK_HEAD')) {
+    Respond-Deny 'A cherry-pick is already in progress. Resolve or abort it before starting a new operation.'
+}
+
+# Check 2: uncommitted changes.
+$subMatch = [regex]::Match($cmd, 'git\s+(merge|rebase|cherry-pick|pull)')
+$sub = if ($subMatch.Success) { $subMatch.Groups[1].Value } else { 'operation' }
+
+$dirty = $null
+try {
+    $dirty = (& git status --porcelain 2>$null)
+} catch {
+    Respond-Allow
+}
+if ($dirty) {
+    Respond-Deny "Uncommitted changes detected. Commit or stash changes before running git $sub to prevent data loss."
+}
+
+Respond-Allow

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -92,6 +92,11 @@
           },
           {
             "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/conflict-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-target-guard.ps1",
             "timeout": 5
           },
@@ -254,6 +259,39 @@
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-compact-snapshot.ps1",
             "timeout": 10,
             "async": true
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/post-compact-restore.ps1",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/instructions-loaded-reinforcer.ps1",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/task-created-validator.ps1",
+            "timeout": 5
           }
         ]
       }

--- a/tests/scripts/test-windows-hooks-parity.sh
+++ b/tests/scripts/test-windows-hooks-parity.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Regression test for hook parity between global/settings.json and
+# global/settings.windows.json (issue #421). Extracts every
+# (event, matcher, hook-script-basename) tuple from each file and
+# asserts the sets are equal.
+#
+# Run: bash tests/scripts/test-windows-hooks-parity.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+UNIX_JSON="global/settings.json"
+WIN_JSON="global/settings.windows.json"
+
+if [ ! -f "$UNIX_JSON" ] || [ ! -f "$WIN_JSON" ]; then
+    echo "FAIL: settings files missing" >&2
+    exit 1
+fi
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH"
+    exit 0
+fi
+
+# Build the set of (event, matcher, basename) tuples per file and diff.
+DIFF=$("$PYTHON" - <<'PY' "$UNIX_JSON" "$WIN_JSON"
+import json, os, re, sys
+
+def extract(path):
+    with open(path) as f:
+        data = json.load(f)
+    tuples = set()
+    for event, blocks in (data.get("hooks") or {}).items():
+        for block in blocks or []:
+            matcher = block.get("matcher", "")
+            for hook in block.get("hooks") or []:
+                cmd = hook.get("command", "")
+                # Pull every basename ending in .sh or .ps1 from the
+                # command string (handles compound commands that chain
+                # multiple scripts).
+                for m in re.finditer(r'([A-Za-z0-9_.-]+?)\.(?:sh|ps1)', cmd):
+                    base = m.group(1)
+                    # Collapse common pairs: session-logger.sh start vs
+                    # session-logger.ps1 start — strip trailing args by
+                    # basename alone.
+                    tuples.add((event, matcher, base))
+    return tuples
+
+unix_set = extract(sys.argv[1])
+win_set  = extract(sys.argv[2])
+
+only_unix = sorted(unix_set - win_set)
+only_win  = sorted(win_set - unix_set)
+
+if only_unix or only_win:
+    for t in only_unix:
+        print(f"only in {os.path.basename(sys.argv[1])}: {t}")
+    for t in only_win:
+        print(f"only in {os.path.basename(sys.argv[2])}: {t}")
+    sys.exit(1)
+PY
+)
+STATUS=$?
+
+if [ $STATUS -ne 0 ]; then
+    echo "FAIL: hook parity drift between settings.json and settings.windows.json"
+    echo ""
+    echo "$DIFF"
+    exit 1
+fi
+
+echo "PASS: hook parity between settings.json and settings.windows.json"


### PR DESCRIPTION
Closes #421

## Summary
`global/settings.windows.json` declared `version: "1.12.2"` (parity with
the Linux/macOS `settings.json`) but four hook registrations were
missing, so Windows sessions silently skipped:

| Event | Hook | Status pre-PR |
|-------|------|---------------|
| `PreToolUse: Bash` | `conflict-guard.ps1` | script missing + unregistered |
| `PostCompact` | `post-compact-restore.ps1` | script present, unregistered |
| `InstructionsLoaded` | `instructions-loaded-reinforcer.ps1` | script present, unregistered |
| `TaskCreated` | `task-created-validator.ps1` | script present, unregistered |

The issue body claimed all four `.ps1` scripts existed; in reality
`conflict-guard.ps1` had no PowerShell counterpart. This PR ports it
from `conflict-guard.sh` using the same `CommonHelpers.psm1` response
pattern as `dangerous-command-guard.ps1`.

## Changes
- `global/hooks/conflict-guard.ps1` — new PowerShell port of `conflict-guard.sh` (fail-open, MERGE_HEAD/REBASE_HEAD/CHERRY_PICK_HEAD detection, porcelain dirty-tree check)
- `global/settings.windows.json` — four hook entries added in matcher/event positions matching settings.json
- `tests/scripts/test-windows-hooks-parity.sh` — compares `(event, matcher, hook-script-basename)` tuples between the two settings files

## Deviation from Issue AC
The issue AC asks for `async: true` on `post-compact-restore` and `task-created-validator`, citing Linux/macOS behavior. In practice, `settings.json` does **not** have `async: true` for those hooks (lines 285, 307). Keeping OS parity took precedence over the AC's premise. A separate PR can enable async on both sides if desired.

## Acceptance Criteria
- [x] `conflict-guard.ps1` registered under `PreToolUse: Bash`
- [x] `post-compact-restore.ps1` registered under `PostCompact` (sync, matches settings.json)
- [x] `instructions-loaded-reinforcer.ps1` registered under `InstructionsLoaded`
- [x] `task-created-validator.ps1` registered under `TaskCreated` (sync, matches settings.json)
- [x] Parity test passes: hook event sets equal between the two files
- [ ] Manual Windows 11 smoke test (deferred to reviewer — no Windows host available in this session)

## Test Plan
```bash
bash tests/scripts/test-windows-hooks-parity.sh
# -> PASS: hook parity between settings.json and settings.windows.json

python3 -c "import json; json.load(open('global/settings.windows.json'))"
# -> JSON valid
```