### PR TITLE
refactor(hooks): consolidate PostToolUse formatter hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,22 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Claude Code 프로젝트 설정 - 자동 포매팅 및 코드 품질",
-  "version": "1.1.0",
+  "description": "Claude Code 프로젝트 설정 - PostToolUse formatter is owned by plugin/hooks/hooks.json (see docs/hooks-ownership.md)",
+  "version": "1.2.0",
 
-  "alwaysThinkingEnabled": true,
-
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'FILE=\"${CLAUDE_FILE_PATH:-}\"; if [ -z \"$FILE\" ] || [ ! -f \"$FILE\" ]; then exit 0; fi; EXT=\"${FILE##*.}\"; case \"$EXT\" in py) if command -v black >/dev/null 2>&1; then black --quiet \"$FILE\" 2>/dev/null; fi; if command -v isort >/dev/null 2>&1; then isort --quiet \"$FILE\" 2>/dev/null; fi;; ts|tsx|js|jsx|json|md) if command -v npx >/dev/null 2>&1 && [ -f \"$(dirname \"$FILE\")/node_modules/.bin/prettier\" ] || command -v prettier >/dev/null 2>&1; then npx prettier --write \"$FILE\" 2>/dev/null; fi;; cpp|cc|cxx|h|hpp|hxx) if command -v clang-format >/dev/null 2>&1; then clang-format -i \"$FILE\" 2>/dev/null; fi;; kt|kts) if command -v ktlint >/dev/null 2>&1; then ktlint -F \"$FILE\" 2>/dev/null; fi;; go) if command -v gofmt >/dev/null 2>&1; then gofmt -w \"$FILE\" 2>/dev/null; fi;; rs) if command -v rustfmt >/dev/null 2>&1; then rustfmt \"$FILE\" 2>/dev/null; fi;; esac; exit 0'",
-            "timeout": 30
-          }
-        ]
-      }
-    ]
-  }
+  "alwaysThinkingEnabled": true
 }

--- a/docs/hooks-ownership.md
+++ b/docs/hooks-ownership.md
@@ -1,0 +1,60 @@
+# Hooks Ownership
+
+Claude Code merges the `hooks` arrays from every active settings source
+(user, project, enterprise, plugins) without deduplication. Every entry
+runs. To prevent latency and message noise from duplicate registrations,
+each hook is owned by exactly one settings file; other surfaces must
+not declare it.
+
+`tests/scripts/test-no-duplicate-formatter.sh` enforces this for the
+PostToolUse formatter. Extend the script when introducing new hooks
+that could be registered from multiple surfaces.
+
+## Ownership Table
+
+| Hook event | Matcher | Hook script / inline | Owner file |
+|------------|---------|----------------------|------------|
+| `PreToolUse` | `Edit\|Write\|Read` | `sensitive-file-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `dangerous-command-guard.{sh,ps1}` et al. | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `TeamCreate` | `team-limit-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Edit\|Write` | `pre-edit-read-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `markdown-anchor-validator.sh` | `project/.claude/settings.json` (project-only override) |
+| `SessionStart` | — | `session-logger`, `version-check` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionStart` | — | `export TZ=Asia/Seoul` | `project/.claude/settings.json` |
+| `SessionEnd` | — | `session-logger end` + `cleanup` | `global/settings.json` + `global/settings.windows.json` |
+| `UserPromptSubmit` | — | `prompt-validator.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `Stop` | — | `session-logger stop` | `global/settings.json` + `global/settings.windows.json` |
+| `PostToolUse` | `Edit\|Write` | inline formatter (black/isort/prettier/clang-format/ktlint/gofmt/rustfmt) | **`plugin/hooks/hooks.json`** (canonical; do not duplicate in settings files) |
+| `PostToolUse` | `Task\|Agent` | `post-task-checkpoint.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PostToolUse` | `Read` | `pre-edit-read-guard.{sh,ps1}` (tracker) | `global/settings.json` + `global/settings.windows.json` |
+| `PostToolUseFailure` | `.*` | `tool-failure-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `SubagentStart`/`SubagentStop` | `.*` | `subagent-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreCompact` | — | `pre-compact-snapshot.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PostCompact` | — | `post-compact-restore.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `InstructionsLoaded` | — | `instructions-loaded-reinforcer.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `TaskCreated` | — | `task-created-validator.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `WorktreeCreate`/`WorktreeRemove` | — | `worktree-create.{sh,ps1}` / `worktree-remove.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `TaskCompleted` | — | `task-completed-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `ConfigChange` | — | `config-change-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `TeammateIdle` | — | `session-logger teammate-idle` | `global/settings.json` + `global/settings.windows.json` |
+
+"`global/settings.json` + `global/settings.windows.json`" means the
+same hook is installed from either file depending on OS; only one of
+the two files is the active surface at runtime, so there is no
+duplicate execution.
+
+The plugin bundle (`plugin/hooks/hooks.json`) also registers simplified
+inline `PreToolUse: Edit|Write|Read` and `PreToolUse: Bash` guards; see
+issue #423 for the plan to make these standalone-only when the full
+global suite is installed.
+
+## Adding a new hook
+
+1. Choose a single owner file from the table above (typically
+   `global/settings.json` + `global/settings.windows.json` for OS-wide
+   hooks, or `project/.claude/settings.json` for project-scoped ones).
+2. Do not add the same entry to any other file.
+3. If the hook might reasonably be registered from multiple surfaces
+   (for example, a formatter or a language-specific linter), extend
+   `tests/scripts/test-no-duplicate-formatter.sh` with a matching
+   pattern so CI catches accidental duplication.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -7,7 +7,8 @@
           {
             "type": "command",
             "command": "bash -c 'FILE=\"${CLAUDE_FILE_PATH:-}\"; if [ -z \"$FILE\" ] || [ ! -f \"$FILE\" ]; then exit 0; fi; EXT=\"${FILE##*.}\"; case \"$EXT\" in py) if command -v black >/dev/null 2>&1; then black --quiet \"$FILE\" 2>/dev/null; fi; if command -v isort >/dev/null 2>&1; then isort --quiet \"$FILE\" 2>/dev/null; fi;; ts|tsx|js|jsx|json|md) if command -v npx >/dev/null 2>&1 && [ -f \"$(dirname \"$FILE\")/node_modules/.bin/prettier\" ] || command -v prettier >/dev/null 2>&1; then npx prettier --write \"$FILE\" 2>/dev/null; fi;; cpp|cc|cxx|h|hpp|hxx) if command -v clang-format >/dev/null 2>&1; then clang-format -i \"$FILE\" 2>/dev/null; fi;; kt|kts) if command -v ktlint >/dev/null 2>&1; then ktlint -F \"$FILE\" 2>/dev/null; fi;; go) if command -v gofmt >/dev/null 2>&1; then gofmt -w \"$FILE\" 2>/dev/null; fi;; rs) if command -v rustfmt >/dev/null 2>&1; then rustfmt \"$FILE\" 2>/dev/null; fi;; esac; exit 0'",
-            "timeout": 30
+            "timeout": 30,
+            "async": true
           }
         ]
       }

--- a/project/.claude/settings.json
+++ b/project/.claude/settings.json
@@ -36,19 +36,6 @@
           }
         ]
       }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'FILE=\"${CLAUDE_FILE_PATH:-}\"; if [ -z \"$FILE\" ] || [ ! -f \"$FILE\" ]; then exit 0; fi; EXT=\"${FILE##*.}\"; case \"$EXT\" in py) if command -v black >/dev/null 2>&1; then black --quiet \"$FILE\" 2>/dev/null; fi; if command -v isort >/dev/null 2>&1; then isort --quiet \"$FILE\" 2>/dev/null; fi;; ts|tsx|js|jsx|json|md) if command -v npx >/dev/null 2>&1 && [ -f \"$(dirname \"$FILE\")/node_modules/.bin/prettier\" ] || command -v prettier >/dev/null 2>&1; then npx prettier --write \"$FILE\" 2>/dev/null; fi;; cpp|cc|cxx|h|hpp|hxx) if command -v clang-format >/dev/null 2>&1; then clang-format -i \"$FILE\" 2>/dev/null; fi;; kt|kts) if command -v ktlint >/dev/null 2>&1; then ktlint -F \"$FILE\" 2>/dev/null; fi;; go) if command -v gofmt >/dev/null 2>&1; then gofmt -w \"$FILE\" 2>/dev/null; fi;; rs) if command -v rustfmt >/dev/null 2>&1; then rustfmt \"$FILE\" 2>/dev/null; fi;; esac; exit 0'",
-            "timeout": 30,
-            "async": true
-          }
-        ]
-      }
     ]
   }
 }

--- a/tests/scripts/test-no-duplicate-formatter.sh
+++ b/tests/scripts/test-no-duplicate-formatter.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Guard test for issue #422: the PostToolUse Edit|Write formatter hook
+# (black/isort/prettier/clang-format/ktlint/gofmt/rustfmt one-liner) must
+# be registered in exactly one file. The canonical owner is
+# plugin/hooks/hooks.json.
+#
+# Run: bash tests/scripts/test-no-duplicate-formatter.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# `black --quiet` is a stable substring of the formatter one-liner and
+# does not appear in any other tracked hook.
+PATTERN='black --quiet'
+SCAN_TARGETS=(
+    "plugin/hooks"
+    "plugin-lite"
+    ".claude"
+    "project/.claude"
+    "global"
+    "enterprise"
+)
+
+EXISTING=()
+for t in "${SCAN_TARGETS[@]}"; do
+    [ -e "$t" ] && EXISTING+=("$t")
+done
+
+MATCHES=$(grep -rlF --include='*.json' "$PATTERN" "${EXISTING[@]}" 2>/dev/null || true)
+COUNT=0
+[ -n "$MATCHES" ] && COUNT=$(echo "$MATCHES" | wc -l | tr -d ' ')
+
+if [ "$COUNT" -gt 1 ]; then
+    echo "FAIL: PostToolUse formatter registered in $COUNT files (expected 1)"
+    echo "$MATCHES" | sed 's/^/  - /'
+    echo ""
+    echo "Canonical owner: plugin/hooks/hooks.json. Remove duplicates."
+    exit 1
+fi
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "FAIL: PostToolUse formatter not found in any tracked settings file"
+    exit 1
+fi
+
+CANONICAL=$(echo "$MATCHES")
+if [ "$CANONICAL" != "plugin/hooks/hooks.json" ]; then
+    echo "FAIL: formatter registered in '$CANONICAL'; expected plugin/hooks/hooks.json"
+    exit 1
+fi
+
+echo "PASS: formatter owned by $CANONICAL"


### PR DESCRIPTION
Closes #422

## Summary
The PostToolUse Edit|Write formatter one-liner was registered in three
surfaces that Claude Code merges at runtime, so every file edit could
fire `black`/`isort`/`prettier`/`clang-format`/`ktlint`/`gofmt`/`rustfmt`
up to three times (each with a 30 s timeout).

| Pre-PR registrations | Post-PR |
|----------------------|---------|
| `.claude/settings.json` (sync) | removed |
| `project/.claude/settings.json` (`async: true`) | removed |
| `plugin/hooks/hooks.json` (sync) | single canonical entry, `async: true` promoted |

## Changes
- `plugin/hooks/hooks.json` — canonical entry; `async: true` promoted from the template so formatting never blocks the next tool call
- `.claude/settings.json` — hooks block removed; description updated to point at `docs/hooks-ownership.md`
- `project/.claude/settings.json` — PostToolUse block removed (other entries preserved)
- `docs/hooks-ownership.md` — new: per-hook owner table and rules for adding new hooks
- `tests/scripts/test-no-duplicate-formatter.sh` — new: scans every tracked settings surface for the formatter signature and fails if it appears in more than one file or in a file other than the canonical owner

## Acceptance Criteria
- [x] Formatter lives in exactly one file (`plugin/hooks/hooks.json`)
- [x] `project/.claude/settings.json` no longer carries a `PostToolUse: Edit|Write` entry
- [x] `.claude/settings.json` no longer carries the same entry
- [x] `test-no-duplicate-formatter.sh` passes and fails deterministically when a duplicate is reintroduced
- [x] `docs/hooks-ownership.md` enumerates ownership for every currently registered hook

## Test Plan
```bash
bash tests/scripts/test-no-duplicate-formatter.sh
# -> PASS: formatter owned by plugin/hooks/hooks.json

python3 -c "import json; [json.load(open(f)) for f in ['.claude/settings.json','project/.claude/settings.json','plugin/hooks/hooks.json']]"
# -> JSON valid
```

Manually reintroducing the pattern into `.claude/settings.json` and
re-running the test produces the expected FAIL with the offending path.