### PR TITLE
refactor(settings): merge Edit|Write matcher entries

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -73,10 +73,16 @@
     "PreToolUse": [
       {
         "matcher": "Edit|Write|Read",
+        "_note": "Hook order is load-bearing: sensitive-file-guard must run before pre-edit-read-guard so denied files are not tracked. See docs/hooks-ownership.md and issue #424.",
         "hooks": [
           {
             "type": "command",
             "command": "~/.claude/hooks/sensitive-file-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-edit-read-guard.sh",
             "timeout": 5
           }
         ]
@@ -137,16 +143,6 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/team-limit-guard.sh",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/pre-edit-read-guard.sh",
             "timeout": 5
           }
         ]

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -59,10 +59,16 @@
     "PreToolUse": [
       {
         "matcher": "Edit|Write|Read",
+        "_note": "Hook order is load-bearing: sensitive-file-guard must run before pre-edit-read-guard so denied files are not tracked. See docs/hooks-ownership.md and issue #424.",
         "hooks": [
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/sensitive-file-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
             "timeout": 5
           }
         ]
@@ -123,16 +129,6 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/team-limit-guard.ps1",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
             "timeout": 5
           }
         ]

--- a/tests/scripts/test-hook-ordering.sh
+++ b/tests/scripts/test-hook-ordering.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Regression test for issue #424: the PreToolUse Edit|Write|Read matcher
+# entry must register sensitive-file-guard before pre-edit-read-guard.
+# Swapping the order lets denied files reach the read-tracker, which is
+# a load-bearing contract (see the _note key in both settings files).
+#
+# Run: bash tests/scripts/test-hook-ordering.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH"
+    exit 0
+fi
+
+check_file() {
+    local file="$1"
+    "$PYTHON" - "$file" <<'PY'
+import json, re, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+pre = data.get("hooks", {}).get("PreToolUse", [])
+for block in pre:
+    matcher = block.get("matcher", "")
+    if "Edit" in matcher and "Write" in matcher:
+        commands = [h.get("command", "") for h in block.get("hooks", [])]
+        def basename(cmd):
+            m = re.search(r'([A-Za-z0-9_.-]+?)\.(?:sh|ps1)', cmd)
+            return m.group(1) if m else cmd
+        names = [basename(c) for c in commands]
+        if "sensitive-file-guard" not in names:
+            print(f"{path}: sensitive-file-guard missing in {matcher} block")
+            sys.exit(1)
+        if "pre-edit-read-guard" not in names:
+            print(f"{path}: pre-edit-read-guard missing in {matcher} block")
+            sys.exit(1)
+        s_idx = names.index("sensitive-file-guard")
+        p_idx = names.index("pre-edit-read-guard")
+        if s_idx >= p_idx:
+            print(f"{path}: sensitive-file-guard (pos {s_idx}) must precede pre-edit-read-guard (pos {p_idx}) in {matcher}")
+            sys.exit(1)
+        sys.exit(0)
+print(f"{path}: no PreToolUse block covers both Edit and Write")
+sys.exit(1)
+PY
+}
+
+STATUS=0
+for f in global/settings.json global/settings.windows.json; do
+    if ! check_file "$f"; then
+        STATUS=1
+    fi
+done
+
+if [ $STATUS -eq 0 ]; then
+    echo "PASS: hook ordering (sensitive-file-guard before pre-edit-read-guard) preserved in both settings files"
+else
+    exit 1
+fi


### PR DESCRIPTION
Closes #424

## Summary
`global/settings.json` and `global/settings.windows.json` each declared
two separate `PreToolUse` blocks that both covered Edit/Write:

- one matcher `Edit|Write|Read` → `sensitive-file-guard`
- a trailing `Edit|Write` entry → `pre-edit-read-guard`

Claude Code runs both entries in registration order on every Edit/Write.
The resulting sequence (`sensitive-file-guard` → `pre-edit-read-guard`)
is load-bearing: `sensitive-file-guard` must run first so denied files
are never recorded by the read-tracker. Nothing in the JSON expressed
that contract, so a structural sort or refactor could silently break it.

## Changes
- `global/settings.json` — two blocks collapsed into one matcher `Edit|Write|Read` entry with an ordered two-hook list and a `_note` key documenting the ordering contract
- `global/settings.windows.json` — mirrors the same structural change so the OS variants stay parallel
- `tests/scripts/test-hook-ordering.sh` — new: parses each settings file, locates the PreToolUse block covering both Edit and Write, and fails if `sensitive-file-guard` does not precede `pre-edit-read-guard`

## Acceptance Criteria
- [x] `global/settings.json` contains exactly one `PreToolUse` entry covering Edit/Write
- [x] Hooks run in order `sensitive-file-guard` → `pre-edit-read-guard`
- [x] `global/settings.windows.json` reflects the same structural change
- [x] `test-hook-ordering.sh` passes and fails deterministically when order is swapped (verified: `s_idx >= p_idx` branch exits with index mismatch)
- [x] Existing `test-windows-hooks-parity.sh` still passes (parity preserved)
- [ ] Integration test: deny an Edit on `.env` and confirm the read tracker is NOT updated (deferred — requires a live Claude Code session with tracker inspection)

## Test Plan
```bash
bash tests/scripts/test-hook-ordering.sh
# -> PASS: hook ordering preserved in both settings files

bash tests/scripts/test-windows-hooks-parity.sh
# -> PASS: hook parity between settings.json and settings.windows.json

python3 -c "import json; json.load(open('global/settings.json')); json.load(open('global/settings.windows.json'))"
# -> valid
```