### PR TITLE
feat(agents): add applies_to and keywords frontmatter to 8 agents

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -8,6 +8,34 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for established project patterns and past review findings before starting."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - review
+  - quality
+  - security
+  - performance
+  - maintainability
+  - refactor
+  - bug
+  - vulnerability
 ---
 
 # Code Reviewer Agent

--- a/plugin/agents/codebase-analyzer.md
+++ b/plugin/agents/codebase-analyzer.md
@@ -8,6 +8,34 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for previously identified architecture patterns and conventions in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - architecture
+  - analysis
+  - patterns
+  - conventions
+  - dependencies
+  - exploration
+  - module
+  - structure
 ---
 
 # Codebase Analyzer Agent

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -8,6 +8,39 @@ maxTurns: 20
 effort: high
 memory: project
 initialPrompt: "Check your memory for known dependency issues and prior audit results in this project."
+applies_to:
+  - "**/package.json"
+  - "**/package-lock.json"
+  - "**/yarn.lock"
+  - "**/pnpm-lock.yaml"
+  - "**/Gemfile"
+  - "**/Gemfile.lock"
+  - "**/go.mod"
+  - "**/go.sum"
+  - "**/requirements*.txt"
+  - "**/Pipfile"
+  - "**/Pipfile.lock"
+  - "**/pyproject.toml"
+  - "**/poetry.lock"
+  - "**/Cargo.toml"
+  - "**/Cargo.lock"
+  - "**/composer.json"
+  - "**/composer.lock"
+  - "**/pom.xml"
+  - "**/build.gradle"
+  - "**/build.gradle.kts"
+  - "**/*.csproj"
+  - "**/*.fsproj"
+keywords:
+  - security
+  - cve
+  - vulnerability
+  - license
+  - dependency
+  - dependencies
+  - audit
+  - outdated
+  - supply-chain
 ---
 
 # Dependency Auditor Agent

--- a/plugin/agents/documentation-writer.md
+++ b/plugin/agents/documentation-writer.md
@@ -8,6 +8,23 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for established documentation patterns and style conventions in this project."
+applies_to:
+  - "**/*.md"
+  - "**/*.mdx"
+  - "**/*.rst"
+  - "**/*.adoc"
+  - "**/README*"
+  - "**/CHANGELOG*"
+  - "**/CONTRIBUTING*"
+  - "**/docs/**"
+keywords:
+  - docs
+  - documentation
+  - readme
+  - changelog
+  - api-reference
+  - comments
+  - docstring
 ---
 
 # Documentation Writer Agent

--- a/plugin/agents/qa-reviewer.md
+++ b/plugin/agents/qa-reviewer.md
@@ -8,6 +8,32 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for known boundary mismatches and integration patterns in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/routes/**"
+  - "**/api/**"
+  - "**/*.graphql"
+  - "**/*.openapi.yaml"
+  - "**/*.openapi.yml"
+  - "**/*.openapi.json"
+  - "**/openapi.yaml"
+  - "**/openapi.yml"
+  - "**/schema.json"
+keywords:
+  - integration
+  - contract
+  - api
+  - endpoint
+  - route
+  - boundary
+  - qa
+  - coherence
+  - shape
 ---
 
 # QA Reviewer Agent

--- a/plugin/agents/refactor-assistant.md
+++ b/plugin/agents/refactor-assistant.md
@@ -8,6 +8,33 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for past refactoring decisions and established patterns in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - refactor
+  - rename
+  - extract
+  - inline
+  - cleanup
+  - deduplicate
+  - simplify
 ---
 
 # Refactor Assistant Agent

--- a/plugin/agents/structure-explorer.md
+++ b/plugin/agents/structure-explorer.md
@@ -7,6 +7,28 @@ temperature: 0.1
 maxTurns: 15
 effort: medium
 memory: local
+applies_to:
+  - "**/Makefile"
+  - "**/CMakeLists.txt"
+  - "**/*.mk"
+  - "**/Dockerfile*"
+  - "**/.github/workflows/*.yml"
+  - "**/.github/workflows/*.yaml"
+  - "**/.gitlab-ci.yml"
+  - "**/package.json"
+  - "**/Cargo.toml"
+  - "**/go.mod"
+  - "**/pyproject.toml"
+  - "**/setup.py"
+keywords:
+  - structure
+  - exploration
+  - directory
+  - entry-point
+  - build
+  - ci
+  - workflow
+  - onboarding
 ---
 
 # Structure Explorer Agent

--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -8,6 +8,30 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for known test coverage gaps and established test patterns in this project."
+applies_to:
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/test/**"
+  - "**/tests/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.spec.js"
+  - "**/*_test.go"
+  - "**/*Test.java"
+  - "**/src/test/**"
+keywords:
+  - test
+  - testing
+  - coverage
+  - unit
+  - integration
+  - e2e
+  - mock
+  - fixture
 ---
 
 # Test Strategist Agent

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -8,6 +8,34 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for established project patterns and past review findings before starting."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - review
+  - quality
+  - security
+  - performance
+  - maintainability
+  - refactor
+  - bug
+  - vulnerability
 ---
 
 # Code Reviewer Agent

--- a/project/.claude/agents/codebase-analyzer.md
+++ b/project/.claude/agents/codebase-analyzer.md
@@ -8,6 +8,34 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for previously identified architecture patterns and conventions in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - architecture
+  - analysis
+  - patterns
+  - conventions
+  - dependencies
+  - exploration
+  - module
+  - structure
 ---
 
 # Codebase Analyzer Agent

--- a/project/.claude/agents/dependency-auditor.md
+++ b/project/.claude/agents/dependency-auditor.md
@@ -8,6 +8,39 @@ maxTurns: 20
 effort: high
 memory: project
 initialPrompt: "Check your memory for known dependency issues and prior audit results in this project."
+applies_to:
+  - "**/package.json"
+  - "**/package-lock.json"
+  - "**/yarn.lock"
+  - "**/pnpm-lock.yaml"
+  - "**/Gemfile"
+  - "**/Gemfile.lock"
+  - "**/go.mod"
+  - "**/go.sum"
+  - "**/requirements*.txt"
+  - "**/Pipfile"
+  - "**/Pipfile.lock"
+  - "**/pyproject.toml"
+  - "**/poetry.lock"
+  - "**/Cargo.toml"
+  - "**/Cargo.lock"
+  - "**/composer.json"
+  - "**/composer.lock"
+  - "**/pom.xml"
+  - "**/build.gradle"
+  - "**/build.gradle.kts"
+  - "**/*.csproj"
+  - "**/*.fsproj"
+keywords:
+  - security
+  - cve
+  - vulnerability
+  - license
+  - dependency
+  - dependencies
+  - audit
+  - outdated
+  - supply-chain
 ---
 
 # Dependency Auditor Agent

--- a/project/.claude/agents/documentation-writer.md
+++ b/project/.claude/agents/documentation-writer.md
@@ -8,6 +8,23 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for established documentation patterns and style conventions in this project."
+applies_to:
+  - "**/*.md"
+  - "**/*.mdx"
+  - "**/*.rst"
+  - "**/*.adoc"
+  - "**/README*"
+  - "**/CHANGELOG*"
+  - "**/CONTRIBUTING*"
+  - "**/docs/**"
+keywords:
+  - docs
+  - documentation
+  - readme
+  - changelog
+  - api-reference
+  - comments
+  - docstring
 ---
 
 # Documentation Writer Agent

--- a/project/.claude/agents/qa-reviewer.md
+++ b/project/.claude/agents/qa-reviewer.md
@@ -8,6 +8,32 @@ maxTurns: 30
 effort: high
 memory: project
 initialPrompt: "Check your memory for known boundary mismatches and integration patterns in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/routes/**"
+  - "**/api/**"
+  - "**/*.graphql"
+  - "**/*.openapi.yaml"
+  - "**/*.openapi.yml"
+  - "**/*.openapi.json"
+  - "**/openapi.yaml"
+  - "**/openapi.yml"
+  - "**/schema.json"
+keywords:
+  - integration
+  - contract
+  - api
+  - endpoint
+  - route
+  - boundary
+  - qa
+  - coherence
+  - shape
 ---
 
 # QA Reviewer Agent

--- a/project/.claude/agents/refactor-assistant.md
+++ b/project/.claude/agents/refactor-assistant.md
@@ -8,6 +8,33 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for past refactoring decisions and established patterns in this project."
+applies_to:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.py"
+  - "**/*.go"
+  - "**/*.rs"
+  - "**/*.java"
+  - "**/*.kt"
+  - "**/*.cpp"
+  - "**/*.cc"
+  - "**/*.c"
+  - "**/*.h"
+  - "**/*.hpp"
+  - "**/*.rb"
+  - "**/*.php"
+  - "**/*.cs"
+  - "**/*.swift"
+keywords:
+  - refactor
+  - rename
+  - extract
+  - inline
+  - cleanup
+  - deduplicate
+  - simplify
 ---
 
 # Refactor Assistant Agent

--- a/project/.claude/agents/structure-explorer.md
+++ b/project/.claude/agents/structure-explorer.md
@@ -7,6 +7,28 @@ temperature: 0.1
 maxTurns: 15
 effort: medium
 memory: local
+applies_to:
+  - "**/Makefile"
+  - "**/CMakeLists.txt"
+  - "**/*.mk"
+  - "**/Dockerfile*"
+  - "**/.github/workflows/*.yml"
+  - "**/.github/workflows/*.yaml"
+  - "**/.gitlab-ci.yml"
+  - "**/package.json"
+  - "**/Cargo.toml"
+  - "**/go.mod"
+  - "**/pyproject.toml"
+  - "**/setup.py"
+keywords:
+  - structure
+  - exploration
+  - directory
+  - entry-point
+  - build
+  - ci
+  - workflow
+  - onboarding
 ---
 
 # Structure Explorer Agent

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -8,6 +8,30 @@ maxTurns: 25
 effort: high
 memory: project
 initialPrompt: "Check your memory for known test coverage gaps and established test patterns in this project."
+applies_to:
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/test/**"
+  - "**/tests/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.spec.js"
+  - "**/*_test.go"
+  - "**/*Test.java"
+  - "**/src/test/**"
+keywords:
+  - test
+  - testing
+  - coverage
+  - unit
+  - integration
+  - e2e
+  - mock
+  - fixture
 ---
 
 # Test Strategist Agent


### PR DESCRIPTION
## What

### Summary
Adds `applies_to` and `keywords` YAML frontmatter fields to each of the 8
agent definitions in `plugin/agents/` and `project/.claude/agents/` (16 files).
No body text or other frontmatter fields are modified.

### Change Type
- [x] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
- `plugin/agents/*.md` (8 files)
- `project/.claude/agents/*.md` (8 files, kept in sync with the plugin copies via `scripts/install.sh` / `scripts/backup.sh`)

## Why

### Problem Solved
#402 (Top-K routing in `fleet-orchestrator`) is deferred pending 2-3 weeks
of telemetry data. Its Technical Approach, however, splits cleanly:

1. Agent-side metadata (`applies_to`, `keywords`) — zero-risk, no data dependency.
2. Orchestrator-side scoring + `--top-k` flag — depends on telemetry to justify.

Shipping step 1 now gives reviewers explicit, documented relevance boundaries
per agent, and makes the data source ready the moment #402 unblocks.

### Related Issues
- Closes #434 (this prep slice)
- Part of #402 (Top-K routing) — this PR does NOT implement scoring, does NOT add `--top-k`, and does NOT unblock the telemetry prerequisite on #402.

## Who

### Reviewers
- skill-system maintainers

## When

### Urgency
- [x] Normal

### Target Release
Next develop → main release cycle. No release-blocking dependency.

## Where

### Files Changed
| Directory | Files | Change |
|-----------|-------|--------|
| `plugin/agents/` | 8 | frontmatter fields added |
| `project/.claude/agents/` | 8 | frontmatter fields added (matches plugin) |

### API Changes
None. `applies_to` and `keywords` are new fields not yet read by any runtime
code path (fleet-orchestrator references agents by name, not by file).

## How

### Implementation Details
- YAML block-style lists used for `applies_to` and `keywords` — more
  diff-friendly than comma-separated strings when entries contain glob
  special characters (`*`, `/`).
- Glob patterns scoped to each agent's declared purpose (see per-agent
  table below).
- Keyword lists derived from each agent's description line.
- Plugin and project copies carry IDENTICAL frontmatter; divergence
  stays confined to body text (pre-existing, not touched here).

### Per-Agent Summary

| Agent | applies_to (globs) | keywords |
|-------|-------------------|----------|
| code-reviewer | 18 (broad source code) | 8 |
| codebase-analyzer | 18 (broad source code) | 8 |
| dependency-auditor | 22 (manifests / lockfiles) | 9 |
| documentation-writer | 8 (md / rst / README / CHANGELOG / docs) | 7 |
| qa-reviewer | 15 (API surfaces + broad code) | 9 |
| refactor-assistant | 18 (broad source code) | 7 |
| structure-explorer | 12 (build / CI configs) | 8 |
| test-strategist | 14 (test files) | 8 |

### Testing Done
- [x] YAML validity check on all 16 files (`yaml.safe_load` each frontmatter block)
- [x] `applies_to` and `keywords` present and non-empty in all 16 files
- [x] plugin/project pairs have identical frontmatter for each of the 8 agents
- [x] `git diff --stat` confirms 410 insertions, 0 deletions (pure addition)

### Breaking Changes
None. Fields are additive and currently unread by any code path.

### Rollback Plan
`git revert` this commit. No state or schema changes.

## Checklist

- [x] Code follows project style guidelines (YAML block lists, consistent with skill frontmatter conventions)
- [x] Self-review completed
- [x] Tests added/updated (YAML validation script in commit message / description)
- [x] Documentation updated (acceptance criteria in linked issue)
- [x] No sensitive data exposed
- [x] Commits are atomic (single commit, single concern)
- [x] Related issue(s) linked with closing keywords (`Closes #434`, `Part of #402`)
- [ ] Comment added to #402 after merge (tracked in post-merge step)
