### PR TITLE
fix(schema): accept tier-preset SKILL.md fields

### DIFF
--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -2,10 +2,32 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.json",
   "title": "Claude Code SKILL.md Frontmatter",
-  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, on_halt, loop_safe).",
+  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, on_halt, loop_safe) and tier-preset extension fields (tiers, default_tier).",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
+  "$defs": {
+    "tierEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref_docs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Skill-defined alias keys resolving to reference/*.md files inside the skill's directory."
+        },
+        "deep_checks": {
+          "type": "boolean",
+          "description": "Opt-in flag for deeper verification passes (extra lint, full build, integrity checks)."
+        },
+        "max_files": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Advisory cap on the number of files the skill should enumerate or modify in a single invocation."
+        }
+      }
+    }
+  },
   "properties": {
     "name": {
       "type": "string",
@@ -104,6 +126,21 @@
     "loop_safe": {
       "type": "boolean",
       "description": "Iteration-control extension (claude-config): true when the skill is safe to run inside an autonomous /loop, false when it must exit the loop before acting."
+    },
+    "tiers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "light":    { "$ref": "#/$defs/tierEntry" },
+        "standard": { "$ref": "#/$defs/tierEntry" },
+        "deep":     { "$ref": "#/$defs/tierEntry" }
+      },
+      "description": "Tier-preset extension (claude-config): per-tier loading hints for skills whose SKILL.md body exceeds 5 KB. See global/skills/_policy.md."
+    },
+    "default_tier": {
+      "type": "string",
+      "enum": ["light", "standard", "deep"],
+      "description": "Tier-preset extension (claude-config): tier applied when the caller omits --tier. Defaults to 'standard' when this field is absent."
     }
   }
 }


### PR DESCRIPTION
## What

### Summary
Extend `scripts/schemas/skill-md.schema.json` so the canonical SKILL.md frontmatter schema accepts the tier-preset extension fields (`tiers`, `default_tier`) already used by `global/skills/pr-work/SKILL.md` and `global/skills/issue-work/SKILL.md`.

### Change Type
- [x] Bugfix (unblocks CI)
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
- `scripts/schemas/skill-md.schema.json` — schema only; no skill frontmatter changes

## Why

### Problem Solved
Release PR #445 (`develop` → `main`) is blocked by the `validate` workflow. `scripts/spec_lint.sh --strict` rejects two SKILL.md files for declaring tier-preset fields that are not yet declared in the canonical schema:

```
global/skills/pr-work/SKILL.md:2:<root>: unknown field(s): 'default_tier', 'tiers'
global/skills/issue-work/SKILL.md:2:<root>: unknown field(s): 'default_tier', 'tiers'
spec_lint: mode=skill files=32 violations=2
```

The SKILL.md files adopted the tier-preset shape ahead of the schema update. This PR closes the gap so the schema is the source of truth again.

### Related Issues
- Relates to #445 (release PR currently failing on `validate`)
- Failed run: https://github.com/kcenon/claude-config/actions/runs/24817072135

## Who

### Reviewers
Standard review — schema change only, no behavioural impact on any skill.

### Required Approvals
- [ ] Maintainer approval

## When

### Urgency
- [ ] Normal
- [x] High Priority — blocks the 2026-04-23 release PR

### Target Release
Included in the 2026-04-23 release cut (PR #445) as soon as `develop` is updated with this fix.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `scripts/schemas/skill-md.schema.json` | Add `$defs/tierEntry`, `tiers`, `default_tier` |

### API / Schema Impact
- JSON Schema draft 2020-12 addition
- Backward compatible: existing SKILL.md files without the new fields are still valid (no new required fields)
- Forward strict: `additionalProperties: false` preserved at root and `tierEntry` levels, so typos continue to fail strict lint

## How

### Implementation Details
1. Define a reusable `tierEntry` shape under `$defs` with:
   - `ref_docs`: `string[]` — skill-defined alias keys pointing at `reference/*.md`
   - `deep_checks`: `boolean` — opt-in flag for deeper verification passes
   - `max_files`: `integer` (>= 1) — advisory cap per invocation
2. Add a `tiers` property as an object keyed by `light` / `standard` / `deep`, each `$ref`-ing `tierEntry`.
3. Add a `default_tier` property as an enum over the same three tier names.
4. Update the top-level schema `description` to document the extension.

### Testing Done
- [x] Local `./scripts/spec_lint.sh --strict` passes all modes with zero violations:

```
spec_lint: mode=skill    files=32 violations=0
spec_lint: mode=plugin   files=2  violations=0
spec_lint: mode=settings files=3  violations=0
```

### Test Plan for Reviewers
1. Pull the branch and run `./scripts/spec_lint.sh --strict`
2. Verify `spec_lint: mode=skill files=32 violations=0`
3. Confirm `scripts/schemas/skill-md.schema.json` still declares `additionalProperties: false` at root and inside `tierEntry`

### Breaking Changes
None — purely additive schema change. SKILL.md files that do not use `tiers` / `default_tier` continue to validate unchanged.

### Rollback Plan
Revert the single commit; SKILL.md files in `pr-work` and `issue-work` would then need to drop the tier-preset fields to keep `validate` green (reverse of this PR).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new tests required (schema-only change validated by existing `spec_lint.sh`)
- [x] No sensitive data exposed
- [x] Commit is atomic and well-described
- [x] Related issue / PR linked (#445)
