### PR TITLE
fix(install): deploy hooks/lib/*.sh from install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -388,6 +388,23 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
             }
         }
 
+        # Shared bash validator library (issue #447 Phase 1). Mirrors the
+        # install.sh block that copies repo-root hooks/lib/*.sh into
+        # ~/.claude/hooks/lib/. pr-language-guard.sh and commit-message-guard.sh
+        # source this library at runtime; without it the hooks fall back to the
+        # inline english-only dispatcher regardless of CLAUDE_CONTENT_LANGUAGE.
+        $sharedLibSource = Join-Path $BackupDir 'hooks/lib'
+        if (Test-Path $sharedLibSource) {
+            $hooksLibDir = Join-Path $hooksDir 'lib'
+            Ensure-Directory $hooksLibDir
+            foreach ($lib in @('validate-commit-message.sh', 'validate-language.sh')) {
+                $libSrc = Join-Path $sharedLibSource $lib
+                if (Test-Path $libSrc) {
+                    Install-BashScript -SourcePath $libSrc -DestinationPath (Join-Path $hooksLibDir $lib)
+                }
+            }
+        }
+
         Copy-Item -Path "$hooksSource\*.json" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
 
         Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"

--- a/tests/hooks/test-pr-language-guard-env.sh
+++ b/tests/hooks/test-pr-language-guard-env.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Regression test for issue #447 Phase 1 / #448.
+#
+# Verifies that pr-language-guard.sh honours CLAUDE_CONTENT_LANGUAGE
+# propagated from the parent shell into the hook subprocess. The original
+# bug: operators set korean_plus_english in settings.json but still saw
+# Korean content rejected, because the shared validator library was not
+# deployed and the inline fallback read the env var in a subprocess that
+# never received it (or never respected it).
+#
+# Scope:
+#   * The policy dispatcher is exercised end-to-end through the hook
+#     (stdin JSON in, permissionDecision JSON out).
+#   * Env var propagation is checked in both exported and unset states.
+#   * Accept and reject samples cover the three supported policies
+#     (english, korean_plus_english, any).
+#
+# Out of scope: the exclusive_bilingual policy (Phase 2 of #447).
+#
+# Run: bash tests/hooks/test-pr-language-guard-env.sh
+# Exit: 0 on all-pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/global/hooks/pr-language-guard.sh"
+
+if [ ! -x "$HOOK" ] && [ ! -r "$HOOK" ]; then
+    echo "FAIL: pr-language-guard.sh not found at $HOOK" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not on PATH; pr-language-guard parses stdin via jq"
+    exit 0
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helper: run the hook with a given env var setting and a gh command, then
+# print the resulting permission decision ("allow" or "deny" or "error").
+# ---------------------------------------------------------------------------
+run_hook() {
+    local policy="$1"      # empty string = unset, otherwise the value
+    local gh_cmd="$2"      # the shell command gh-pr/issue would run
+
+    local payload
+    payload=$(jq -n --arg cmd "$gh_cmd" '{tool_input: {command: $cmd}}')
+
+    local out
+    if [ -z "$policy" ]; then
+        out=$(env -u CLAUDE_CONTENT_LANGUAGE bash "$HOOK" <<<"$payload" 2>/dev/null)
+    else
+        out=$(CLAUDE_CONTENT_LANGUAGE="$policy" bash "$HOOK" <<<"$payload" 2>/dev/null)
+    fi
+
+    local decision
+    decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "error"' 2>/dev/null)
+    printf '%s' "$decision"
+}
+
+assert_decision() {
+    local name="$1" expected="$2" got="$3"
+    if [ "$expected" = "$got" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$name: expected=$expected got=$got")
+        echo "  FAIL: $name (expected=$expected got=$got)"
+    fi
+}
+
+# Quick sanity: make sure the hook actually sourced the shared library
+# rather than falling through to the inline fallback. The deployed layout
+# for this test is repo-relative, so $REPO_ROOT/hooks/lib/validate-language.sh
+# must exist.
+echo "=== Shared validator library available ==="
+if [ -f "$REPO_ROOT/hooks/lib/validate-language.sh" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: hooks/lib/validate-language.sh present for hook to source"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("hooks/lib/validate-language.sh missing at repo root")
+    echo "  FAIL: hooks/lib/validate-language.sh missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Default (unset env): english policy
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CLAUDE_CONTENT_LANGUAGE unset (english default) ==="
+
+assert_decision \
+    "unset env: ASCII title allowed" \
+    "allow" \
+    "$(run_hook "" "gh issue create --title \"Add new feature\" --body \"plain ASCII body\"")"
+
+assert_decision \
+    "unset env: Hangul title denied" \
+    "deny" \
+    "$(run_hook "" "gh issue create --title \"기능 추가\" --body \"plain body\"")"
+
+assert_decision \
+    "unset env: Hangul body denied" \
+    "deny" \
+    "$(run_hook "" "gh issue create --title \"plain title\" --body \"한글 본문\"")"
+
+# ---------------------------------------------------------------------------
+# english policy (explicit)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CLAUDE_CONTENT_LANGUAGE=english ==="
+
+assert_decision \
+    "english: ASCII allowed" \
+    "allow" \
+    "$(run_hook "english" "gh pr create --title \"fix bug\" --body \"ascii body\"")"
+
+assert_decision \
+    "english: Hangul body denied" \
+    "deny" \
+    "$(run_hook "english" "gh pr create --title \"fix bug\" --body \"한글 설명\"")"
+
+# ---------------------------------------------------------------------------
+# korean_plus_english policy (the bug that motivated #447)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CLAUDE_CONTENT_LANGUAGE=korean_plus_english ==="
+
+assert_decision \
+    "korean_plus_english: Hangul title allowed" \
+    "allow" \
+    "$(run_hook "korean_plus_english" "gh issue create --title \"한국어 제목\" --body \"한국어 설명\"")"
+
+assert_decision \
+    "korean_plus_english: mixed ASCII+Hangul body allowed" \
+    "allow" \
+    "$(run_hook "korean_plus_english" "gh pr create --title \"fix\" --body \"fix 버그 수정\"")"
+
+assert_decision \
+    "korean_plus_english: Japanese Hiragana denied" \
+    "deny" \
+    "$(run_hook "korean_plus_english" "gh issue create --title \"fix\" --body \"こんにちは\"")"
+
+# ---------------------------------------------------------------------------
+# any policy
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== CLAUDE_CONTENT_LANGUAGE=any ==="
+
+assert_decision \
+    "any: arbitrary unicode allowed" \
+    "allow" \
+    "$(run_hook "any" "gh issue create --title \"fix\" --body \"Omega Я 中 naive\"")"
+
+# ---------------------------------------------------------------------------
+# Non-gh commands must be ignored regardless of env
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Non-gh commands bypass validation ==="
+
+assert_decision \
+    "non-gh command allowed under english" \
+    "allow" \
+    "$(run_hook "english" "echo 한국어")"
+
+assert_decision \
+    "gh commands outside pr|issue scope allowed" \
+    "allow" \
+    "$(run_hook "english" "gh repo view")"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi
+
+exit 0

--- a/tests/scripts/test-install-deploys-bash-lib.sh
+++ b/tests/scripts/test-install-deploys-bash-lib.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Regression test for issue #447 Phase 1 / #448.
+#
+# Asserts that the shared bash validator library (hooks/lib/validate-*.sh)
+# is deployed to ~/.claude/hooks/lib/ by both installers. Without this,
+# pr-language-guard.sh falls through to its inline english-only fallback
+# regardless of CLAUDE_CONTENT_LANGUAGE.
+#
+# Coverage split:
+#   1. Source-of-truth:   repo-root hooks/lib/ must exist and define the
+#                         validate_content_language dispatcher.
+#   2. Unix installer:    install.sh must contain a block that copies both
+#                         libs from $BACKUP_DIR/hooks/lib/ to
+#                         $HOME/.claude/hooks/lib/.
+#   3. Windows installer: install.ps1 must contain an equivalent block
+#                         using Install-BashScript for CRLF/exec-bit
+#                         normalization (regression guard for the #448 fix).
+#   4. Functional:        replay the install.sh block against a temp HOME
+#                         and verify both libs land, are non-empty, and
+#                         the dispatcher is defined when sourced.
+#
+# Run: bash tests/scripts/test-install-deploys-bash-lib.sh
+# Exit: 0 on all-pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$1")
+    echo "  FAIL: $1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Source-of-truth: repo-root hooks/lib/ contents
+# ---------------------------------------------------------------------------
+echo "=== Source libs in repo-root hooks/lib/ ==="
+
+for lib in validate-commit-message.sh validate-language.sh; do
+    src="$REPO_ROOT/hooks/lib/$lib"
+    if [ ! -f "$src" ]; then
+        fail "$lib missing from repo hooks/lib/"
+        continue
+    fi
+    if [ ! -s "$src" ]; then
+        fail "$lib exists but is empty"
+        continue
+    fi
+    pass "$lib present and non-empty"
+done
+
+# Dispatcher must be defined by validate-language.sh (covers both installers'
+# deployment contract — the hook sources this file by name).
+if (. "$REPO_ROOT/hooks/lib/validate-language.sh" && command -v validate_content_language >/dev/null 2>&1); then
+    pass "validate-language.sh defines validate_content_language"
+else
+    fail "validate-language.sh does not define validate_content_language when sourced"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. install.sh: deployment block present
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== install.sh deployment block ==="
+
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+if [ ! -f "$INSTALL_SH" ]; then
+    fail "scripts/install.sh missing"
+elif ! grep -q 'BACKUP_DIR/hooks/lib' "$INSTALL_SH"; then
+    fail "install.sh does not reference \$BACKUP_DIR/hooks/lib"
+else
+    pass "install.sh references \$BACKUP_DIR/hooks/lib"
+fi
+
+if grep -q 'validate-commit-message.sh validate-language.sh' "$INSTALL_SH"; then
+    pass "install.sh iterates both shared libs"
+else
+    fail "install.sh shared-lib loop does not cover both libs"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. install.ps1: deployment block present (regression guard for #448)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== install.ps1 deployment block ==="
+
+INSTALL_PS1="$REPO_ROOT/scripts/install.ps1"
+if [ ! -f "$INSTALL_PS1" ]; then
+    fail "scripts/install.ps1 missing"
+elif ! grep -q "Join-Path \$BackupDir 'hooks/lib'" "$INSTALL_PS1"; then
+    fail "install.ps1 does not reference repo-root hooks/lib (regression)"
+else
+    pass "install.ps1 references repo-root hooks/lib"
+fi
+
+if grep -q "validate-commit-message.sh.*validate-language.sh\|'validate-commit-message.sh', 'validate-language.sh'" "$INSTALL_PS1"; then
+    pass "install.ps1 iterates both shared libs"
+else
+    fail "install.ps1 shared-lib list does not cover both libs"
+fi
+
+if grep -q 'Install-BashScript.*sharedLibSource\|Install-BashScript -SourcePath \$libSrc' "$INSTALL_PS1"; then
+    pass "install.ps1 uses Install-BashScript for CRLF normalization"
+else
+    fail "install.ps1 does not use Install-BashScript for shared-lib copy"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Functional: replay the install.sh block against a temp HOME
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Functional replay into temp HOME ==="
+
+WORK="$(mktemp -d 2>/dev/null || mktemp -d -t claude-install-bash-lib)"
+if [ -z "$WORK" ] || [ ! -d "$WORK" ]; then
+    fail "unable to create temp working directory (mktemp failed)"
+    echo ""
+    echo "Passed: $PASS"
+    echo "Failed: $FAIL"
+    exit 1
+fi
+trap 'rm -rf -- "$WORK" 2>/dev/null || true' EXIT
+
+HOME_TMP="$WORK/home"
+mkdir -p "$HOME_TMP"
+
+# Minimal stubs mirroring install.sh helpers the block depends on.
+ensure_dir() { mkdir -p "$1"; }
+
+# Replay the deployment block with BACKUP_DIR pointing at the repo root.
+BACKUP_DIR="$REPO_ROOT"
+HOME="$HOME_TMP"
+if [ -d "$BACKUP_DIR/hooks/lib" ]; then
+    ensure_dir "$HOME/.claude/hooks/lib"
+    for lib in validate-commit-message.sh validate-language.sh; do
+        if [ -f "$BACKUP_DIR/hooks/lib/$lib" ]; then
+            cp "$BACKUP_DIR/hooks/lib/$lib" "$HOME/.claude/hooks/lib/"
+            chmod +x "$HOME/.claude/hooks/lib/$lib"
+        fi
+    done
+fi
+
+for lib in validate-commit-message.sh validate-language.sh; do
+    deployed="$HOME/.claude/hooks/lib/$lib"
+    if [ ! -f "$deployed" ]; then
+        fail "$lib not deployed to temp \$HOME"
+        continue
+    fi
+    if [ ! -s "$deployed" ]; then
+        fail "$lib deployed but empty"
+        continue
+    fi
+    if [ ! -x "$deployed" ]; then
+        fail "$lib deployed but not executable"
+        continue
+    fi
+    pass "$lib deployed, non-empty, and executable"
+done
+
+# Dispatcher must be defined after sourcing the deployed file.
+if (. "$HOME/.claude/hooks/lib/validate-language.sh" && command -v validate_content_language >/dev/null 2>&1); then
+    pass "deployed validate-language.sh defines validate_content_language"
+else
+    fail "deployed validate-language.sh does not define validate_content_language"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What

Fix the Windows installer to deploy the shared bash validator library (hooks/lib/validate-language.sh and validate-commit-message.sh) to `~/.claude/hooks/lib/`, matching the behaviour install.sh already has on macOS/Linux. Adds two regression tests that lock the invariant for both installers.

Closes #448
Part of #447 (Phase 1 only; Phase 2 exclusive_bilingual policy stays on the epic).

### Change Type
- [x] Bugfix

### Affected Components
- scripts/install.ps1 (17 insertions)
- tests/scripts/test-install-deploys-bash-lib.sh (new)
- tests/hooks/test-pr-language-guard-env.sh (new)

## Why

On Windows, `~/.claude/hooks/lib/` contained only the PowerShell modules (`LanguageValidator.psm1`, `CommonHelpers.psm1`, `rotate.ps1`, `rotate.sh`). The bash validator library was silently dropped because install.ps1 line 380-388 copied `global/hooks/lib/*` but never `hooks/lib/*.sh` from the repo root. As a result `pr-language-guard.sh` walked both candidate paths, missed the library, and fell through to its inline fallback (pr-language-guard.sh:74-107). The fallback defaults to the english branch, so operators who set `CLAUDE_CONTENT_LANGUAGE=korean_plus_english` in settings.json saw Korean titles/bodies rejected with the english-only error message.

The Unix installer (scripts/install.sh line 388-397) already copies both libs, so this was a platform-parity gap.

## Where

- scripts/install.ps1 - added a block mirroring install.sh that copies repo-root hooks/lib/validate-commit-message.sh and validate-language.sh via Install-BashScript into the deployed hooks/lib/. Install-BashScript handles CRLF to LF and UTF-8 no-BOM, which matters for the claude-docker bind-mount scenario tracked in #407.
- tests/scripts/test-install-deploys-bash-lib.sh - new regression test covering (1) repo-root source-of-truth, (2) the install.sh deployment block, (3) the install.ps1 deployment block, and (4) a functional replay of the install.sh block into a temp HOME.
- tests/hooks/test-pr-language-guard-env.sh - new end-to-end hook test exercising CLAUDE_CONTENT_LANGUAGE propagation across all three supported policies (english, korean_plus_english, any) plus the unset default.

## How

### Implementation

```powershell
$sharedLibSource = Join-Path $BackupDir 'hooks/lib'
if (Test-Path $sharedLibSource) {
    $hooksLibDir = Join-Path $hooksDir 'lib'
    Ensure-Directory $hooksLibDir
    foreach ($lib in @('validate-commit-message.sh', 'validate-language.sh')) {
        $libSrc = Join-Path $sharedLibSource $lib
        if (Test-Path $libSrc) {
            Install-BashScript -SourcePath $libSrc -DestinationPath (Join-Path $hooksLibDir $lib)
        }
    }
}
```

Whitelist loop (not `*.sh`) matches install.sh's conservative pattern so adding a new bash helper is an explicit change in both installers.

### Testing Done

Local run (macOS, bash 3.2):

| Suite | Result |
| --- | --- |
| tests/scripts/test-install-deploys-bash-lib.sh | 11 passed, 0 failed |
| tests/hooks/test-pr-language-guard-env.sh | 12 passed, 0 failed |
| tests/hooks/test-language-validator.sh (existing) | 35 passed, 0 failed |
| tests/scripts/test-windows-hooks-parity.sh (existing) | passed |
| tests/hooks/test-runner.sh aggregate | 324 passed, 1 failed (pre-existing markdown-anchor-validator failure unrelated to this change) |

### Test Plan for Reviewers

```bash
# New tests
bash tests/scripts/test-install-deploys-bash-lib.sh
bash tests/hooks/test-pr-language-guard-env.sh

# Negative regression guard: revert install.ps1 and re-run
git checkout HEAD~2 -- scripts/install.ps1
bash tests/scripts/test-install-deploys-bash-lib.sh  # should fail on the install.ps1 checks
```

### Breaking Changes

None. New install flow is additive; existing deployments already have the bash libs on macOS/Linux, and on Windows they were missing in a way that silently degraded behaviour - the fix restores the documented policy.

### Rollback Plan

Revert the PR. No data migrations, no dependency changes.