### PR TITLE
feat(lang): add exclusive_bilingual content-language policy

### DIFF
--- a/docs/content-language-policy.md
+++ b/docs/content-language-policy.md
@@ -16,11 +16,82 @@ the three rule documents that describe the rule to humans and to Claude.
 |-------|--------------------|----------------------|
 | `english` (default, unset, empty) | ASCII printable + whitespace only | `English` |
 | `korean_plus_english` | ASCII + Hangul Syllables / Jamo / Compat Jamo | `English or Korean` |
+| `exclusive_bilingual` | Per-document mode: English-only (if no Hangul) or Korean-only with ASCII permitted inside four allowed containers (if any Hangul syllable present) | `English or Korean (document-exclusive)` |
 | `any` | Skip language validation entirely | `any language` |
 
 Attribution enforcement is **not** governed by this env var.
 `attribution-guard.{sh,ps1}` and the attribution checks inside
 `commit-message-guard` remain active for every policy value.
+
+## The `exclusive_bilingual` Policy (issue #447)
+
+`exclusive_bilingual` enforces **document-level language exclusivity**:
+each title, body, or commit description is validated as either an
+English-only document or a Korean-only document, never a mix of bare
+Korean prose with inline English tokens.
+
+### Mode selection
+
+Mode is chosen per document, automatically:
+
+- **English mode** — the text contains zero Hangul syllable characters
+  (U+AC00 to U+D7A3). Validation is identical to the `english` policy:
+  ASCII printable (0x20 to 0x7E) and whitespace only. Any accented
+  Latin, CJK, or emoji is rejected.
+- **Korean mode** — the text contains at least one Hangul syllable.
+  After stripping the four allowed ASCII containers below, the residual
+  text must contain zero `[A-Za-z]` characters.
+
+### Allowed ASCII containers in Korean mode
+
+The validator strips these in the order listed and then scans what
+remains for bare English letters. Strip order matters: fenced blocks
+are handled first so backticks inside a fence are not mis-stripped as
+inline code, and the translation form is stripped last so nested
+parentheses inside a code block are preserved inside the code.
+
+1. **Fenced code blocks** — triple backticks, multi-line.
+2. **Inline code** — single backticks, single-line.
+3. **URLs** — `https?://` followed by non-whitespace.
+4. **`한국어(English)` translation form** — a Hangul run followed by
+   optional whitespace and a parenthesized ASCII expression on one
+   line. Use this for unavoidable proper nouns that have an established
+   Korean translation.
+
+### Accept / reject matrix
+
+Drawn from the original `#447` design. Reviewers can use this table to
+reason about edge cases in PR descriptions and issue bodies.
+
+| Input | Verdict | Remediation |
+|-------|---------|-------------|
+| `PR을 만든다` | reject | `` `PR`을 만든다 `` wrapped, or `풀 리퀘스트(PR)를 만든다` |
+| `/pr-work 를 실행` | reject | `` `/pr-work` `` wrapped in backticks |
+| `GitHub Actions에서` | reject | `깃허브 액션(GitHub Actions)에서` |
+| `버전 v1.10.0 배포` | reject | `버전 1.10.0 배포` or `` `v1.10.0` `` wrapped |
+| `훅(hook)을 설치` | accept | --- |
+| `https://example.com 참조` | accept | --- |
+| ``이슈 `#247` 참조`` | accept | `#` plus digits is ASCII-non-letter, no wrap required |
+
+Pure-English documents under `exclusive_bilingual` behave identically
+to `english` — there is no regression for existing English-only PRs.
+
+### When to choose this policy
+
+Pick `exclusive_bilingual` when:
+
+- You author documentation, PRs, and issues in Korean but want to avoid
+  drift into the loose mixed-language style that `korean_plus_english`
+  permits.
+- You want the translation form (`한국어(English)`) to be the single
+  canonical remediation for unavoidable English terms, producing a
+  consistent voice across the repository.
+
+Pick `korean_plus_english` instead if:
+
+- Your workflow routinely mixes Korean prose with bare English tokens
+  (product names, CLI commands) and wrapping them all in backticks or
+  translation forms would be disruptive.
 
 ## Install-time Substitution
 
@@ -56,7 +127,7 @@ reconcile the conflict before the installation completes.
 document:
 
 1. Canonical `.md` equals `.tmpl` rendered with the `english` phrase.
-2. Each of the three policies produces output containing the expected
+2. Each of the four policies produces output containing the expected
    phrase.
 
 The test is wired into `tests/hooks/test-runner.sh` via the standard

--- a/global/hooks/lib/LanguageValidator.psm1
+++ b/global/hooks/lib/LanguageValidator.psm1
@@ -8,6 +8,11 @@
 # The CLAUDE_CONTENT_LANGUAGE environment variable selects the policy:
 #   - english (default, unset, or empty) → ASCII printable + whitespace only
 #   - korean_plus_english → ASCII + Hangul syllables/Jamo/Compat Jamo
+#   - exclusive_bilingual → per-document: english_only when text has no
+#                           Hangul syllables, otherwise korean_with_tech_terms
+#                           (bare English tokens rejected; only ASCII inside
+#                           fenced/inline code, URLs, or 한국어(English)
+#                           translation forms is allowed in Korean mode)
 #   - any → validation skipped (always valid)
 #
 # NOTE: These validators do NOT gate AI/Claude attribution. attribution-guard.ps1
@@ -26,9 +31,10 @@ function Get-ContentLanguagePolicy {
     switch ($policy) {
         'english'              { return 'english' }
         'korean_plus_english'  { return 'korean_plus_english' }
+        'exclusive_bilingual'  { return 'exclusive_bilingual' }
         'any'                  { return 'any' }
         default {
-            [Console]::Error.WriteLine("CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, any.")
+            [Console]::Error.WriteLine("CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, exclusive_bilingual, any.")
             return 'english'
         }
     }
@@ -83,6 +89,53 @@ function Find-FirstDisallowedElement {
     return $null
 }
 
+# Test-KoreanWithTechTerms
+# Korean-mode branch of the exclusive_bilingual policy (issue #447).
+# Strips the four allowed ASCII containers (fenced code, inline code,
+# URLs, 한국어(English) translation form) and then rejects any residual
+# [A-Za-z] character as a bare English token.
+#
+# Strip ordering matches the bash sibling in
+# hooks/lib/validate-language.sh::validate_korean_with_tech_terms:
+#   1. Fenced code blocks.
+#   2. Inline code.
+#   3. URLs.
+#   4. 한글(English) translation form.
+#
+# Returns a PSCustomObject mirroring Test-ContentLanguage.
+function Test-KoreanWithTechTerms {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text
+    )
+
+    if ([string]::IsNullOrEmpty($Text)) {
+        return [PSCustomObject]@{ Valid = $true; Policy = 'exclusive_bilingual'; Reason = '' }
+    }
+
+    $stripped = $Text
+    # 1. Fenced code blocks — (?s) makes . match newlines; non-greedy.
+    $stripped = [regex]::Replace($stripped, '(?s)```.*?```', '')
+    # 2. Inline code — single backtick, no newlines crossed.
+    $stripped = [regex]::Replace($stripped, '`[^`\n]*`', '')
+    # 3. URLs — https?:// runs of non-whitespace.
+    $stripped = [regex]::Replace($stripped, 'https?://\S+', '')
+    # 4. 한글(English) translation form — Hangul run followed by optional
+    #    whitespace and a parenthesized ASCII expression on one line.
+    $stripped = [regex]::Replace($stripped, '[가-힣]+\s*\([^)\n]*\)', '')
+
+    $m = [regex]::Match($stripped, '[A-Za-z]+')
+    if ($m.Success) {
+        $sample = $m.Value
+        return [PSCustomObject]@{
+            Valid  = $false
+            Policy = 'exclusive_bilingual'
+            Reason = "Korean-mode policy violation: bare English token '$sample' detected. Wrap in backticks or use the '한국어(English)' form. CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual requires document-level language exclusivity."
+        }
+    }
+
+    return [PSCustomObject]@{ Valid = $true; Policy = 'exclusive_bilingual'; Reason = '' }
+}
+
 # Test-ContentLanguage
 # Returns a PSCustomObject with:
 #   Valid  [bool]   - $true when the text satisfies the resolved policy
@@ -102,6 +155,18 @@ function Test-ContentLanguage {
             Policy = $policy
             Reason = ''
         }
+    }
+
+    # exclusive_bilingual routes per-document based on Hangul presence
+    # (see issue #447). Delegate to the helpers before the generic
+    # character whitelist path below.
+    if ($policy -eq 'exclusive_bilingual') {
+        if ($Text -match '[가-힣]') {
+            return Test-KoreanWithTechTerms -Text $Text
+        }
+        # No Hangul — validate as english. Reuse the whitelist path
+        # below by dropping through with a forced english policy.
+        $policy = 'english'
     }
 
     $bad = Find-FirstDisallowedElement -Text $Text -Policy $policy
@@ -184,6 +249,7 @@ Export-ModuleMember -Function @(
     'Get-ContentLanguagePolicy'
     'Test-CodePointAllowed'
     'Find-FirstDisallowedElement'
+    'Test-KoreanWithTechTerms'
     'Test-ContentLanguage'
     'Test-CommitDescriptionFirstChar'
 )

--- a/hooks/lib/validate-language.sh
+++ b/hooks/lib/validate-language.sh
@@ -89,10 +89,52 @@ validate_english_or_korean() {
     return 0
 }
 
+# validate_korean_with_tech_terms <text>
+# Returns 0 on valid, 1 on invalid. On failure, prints reason to stderr.
+#
+# Korean-mode branch of the exclusive_bilingual policy (issue #447). The
+# rule: after stripping the four allowed ASCII containers below, the
+# residual text must contain zero [A-Za-z] characters. Bare English
+# tokens inline with Korean prose are rejected with a remediation hint.
+#
+# Allowed ASCII containers (strip in this order — see issue #447):
+#   1. Fenced code blocks — triple backticks.
+#   2. Inline code — single backticks.
+#   3. URLs — https?://... runs of non-whitespace.
+#   4. Parenthesized ASCII immediately preceded by a Hangul run —
+#      the 한국어(English) translation form.
+#
+# Strip ordering matters: fenced first so nested backticks inside fences
+# are not mis-stripped; then inline code so parenthesized content inside
+# backticks is preserved inside the code; then URLs; finally the
+# translation form.
+validate_korean_with_tech_terms() {
+    local text="$1"
+    [ -z "$text" ] && return 0
+
+    local stripped
+    stripped=$(printf '%s' "$text" | perl -CSDA -0777 -pe '
+        s/```[\s\S]*?```//g;
+        s/`[^`\n]*`//g;
+        s{https?://\S+}{}g;
+        s/[\x{AC00}-\x{D7A3}]+\s*\([^)\n]*\)//g;
+    ' 2>/dev/null)
+
+    if printf '%s' "$stripped" | LC_ALL=C grep -qE '[A-Za-z]'; then
+        local sample
+        sample=$(printf '%s' "$stripped" | LC_ALL=C grep -oE '[A-Za-z]+' | head -n1)
+        echo "Korean-mode policy violation: bare English token '$sample' detected. Wrap in backticks or use the '한국어(English)' form. CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual requires document-level language exclusivity." >&2
+        return 1
+    fi
+    return 0
+}
+
 # validate_content_language <text>
 # Dispatcher — selects the validator based on CLAUDE_CONTENT_LANGUAGE:
 #   - english (default, unset, or empty) → validate_english_only
 #   - korean_plus_english → validate_english_or_korean
+#   - exclusive_bilingual → english_only when text has no Hangul syllables,
+#                           otherwise validate_korean_with_tech_terms
 #   - any → skip validation (always returns 0)
 #
 # NOTE: This dispatcher does NOT control AI/Claude attribution enforcement.
@@ -110,11 +152,21 @@ validate_content_language() {
         korean_plus_english)
             validate_english_or_korean "$text"
             ;;
+        exclusive_bilingual)
+            # Hangul syllable detection routes the document to the
+            # appropriate mode. No Hangul = English mode = strict ASCII
+            # whitelist. Any Hangul = Korean mode = strip-then-scan.
+            if printf '%s' "$text" | perl -CSDA -ne 'exit 1 if /[\x{AC00}-\x{D7A3}]/' 2>/dev/null; then
+                validate_english_only "$text"
+            else
+                validate_korean_with_tech_terms "$text"
+            fi
+            ;;
         any)
             return 0
             ;;
         *)
-            echo "CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, any." >&2
+            echo "CLAUDE_CONTENT_LANGUAGE has unknown value '$policy'. Valid values: english, korean_plus_english, exclusive_bilingual, any." >&2
             validate_english_only "$text"
             ;;
     esac

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,6 +88,7 @@ function Get-PolicyPhrase {
     switch ($script:contentLanguage) {
         'english'             { return 'English' }
         'korean_plus_english' { return 'English or Korean' }
+        'exclusive_bilingual' { return 'English or Korean (document-exclusive)' }
         'any'                 { return 'any language' }
         default               { return 'English' }
     }
@@ -247,16 +248,18 @@ if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
 Write-Host ""
 Write-Info "Select content-language policy (commit / PR / issue validation scope):"
 Write-Host "  1) English (default, identical to current behavior)"
-Write-Host "  2) Korean + English (accept Hangul)"
-Write-Host "  3) Any (skip language validation; AI attribution block stays on)"
+Write-Host "  2) Korean + English (accept Hangul; inline mixing allowed)"
+Write-Host "  3) Exclusive bilingual (document-level English or Korean; no inline mixing)"
+Write-Host "  4) Any (skip language validation; AI attribution block stays on)"
 Write-Host ""
 
-$langType = Read-Host "Selection (1-3) [default: 1]"
+$langType = Read-Host "Selection (1-4) [default: 1]"
 if ([string]::IsNullOrEmpty($langType)) { $langType = '1' }
 switch ($langType) {
     '1'     { $contentLanguage = 'english' }
     '2'     { $contentLanguage = 'korean_plus_english' }
-    '3'     { $contentLanguage = 'any' }
+    '3'     { $contentLanguage = 'exclusive_bilingual' }
+    '4'     { $contentLanguage = 'any' }
     default {
         Write-Warn "Unknown selection: $langType. Using english."
         $contentLanguage = 'english'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,7 @@ get_policy_phrase() {
     case "${CONTENT_LANGUAGE:-english}" in
         english)             echo "English" ;;
         korean_plus_english) echo "English or Korean" ;;
+        exclusive_bilingual) echo "English or Korean (document-exclusive)" ;;
         any)                 echo "any language" ;;
         *)                   echo "English" ;;
     esac
@@ -250,16 +251,18 @@ INSTALL_TYPE=${INSTALL_TYPE:-3}
 echo ""
 info "컨텐츠 언어 정책을 선택하세요 (commit / PR / issue 검증 범위):"
 echo "  1) English (기본, 현재 동작과 완전 동일)"
-echo "  2) Korean + English (Hangul 허용)"
-echo "  3) Any (언어 검증 없음 — 단, AI 귀속 차단은 유지)"
+echo "  2) Korean + English (Hangul 허용, 인라인 혼용 가능)"
+echo "  3) Exclusive bilingual (문서 단위 영어 또는 한국어, 인라인 혼용 금지)"
+echo "  4) Any (언어 검증 없음 — 단, AI 귀속 차단은 유지)"
 echo ""
-read -p "선택 (1-3) [기본값: 1]: " LANG_TYPE
+read -p "선택 (1-4) [기본값: 1]: " LANG_TYPE
 LANG_TYPE=${LANG_TYPE:-1}
 
 case "$LANG_TYPE" in
     1) CONTENT_LANGUAGE="english" ;;
     2) CONTENT_LANGUAGE="korean_plus_english" ;;
-    3) CONTENT_LANGUAGE="any" ;;
+    3) CONTENT_LANGUAGE="exclusive_bilingual" ;;
+    4) CONTENT_LANGUAGE="any" ;;
     *)
         warning "알 수 없는 입력: $LANG_TYPE. english로 진행합니다."
         CONTENT_LANGUAGE="english"

--- a/tests/hooks/test-language-validator.sh
+++ b/tests/hooks/test-language-validator.sh
@@ -70,7 +70,35 @@ echo ""
 echo "[empty input always valid]"
 run_case "english + empty"                       0 "english" validate_content_language ""
 run_case "korean_plus_english + empty"           0 "korean_plus_english" validate_content_language ""
+run_case "exclusive_bilingual + empty"           0 "exclusive_bilingual" validate_content_language ""
 run_case "any + empty"                           0 "any"     validate_content_language ""
+
+echo ""
+echo "[exclusive_bilingual policy — issue #447 accept/reject matrix]"
+# English-mode branch (no Hangul syllable → validate_english_only applies).
+run_case "excl: pure ASCII accepted (english mode)" 0 "exclusive_bilingual" validate_content_language "Add a new feature via gh pr create"
+run_case "excl: pure ASCII rejects accented Latin"  1 "exclusive_bilingual" validate_content_language "naive cafe that is naïve"
+
+# Korean-mode branch (Hangul present → validate_korean_with_tech_terms).
+# Reject rows from issue #447 matrix.
+run_case "excl: 'PR을 만든다' rejected"              1 "exclusive_bilingual" validate_content_language "PR을 만든다"
+run_case "excl: '/pr-work 를 실행' rejected"         1 "exclusive_bilingual" validate_content_language "/pr-work 를 실행"
+run_case "excl: 'GitHub Actions에서' rejected"       1 "exclusive_bilingual" validate_content_language "GitHub Actions에서"
+run_case "excl: '버전 v1.10.0 배포' rejected"       1 "exclusive_bilingual" validate_content_language "버전 v1.10.0 배포"
+
+# Accept rows from issue #447 matrix.
+run_case "excl: '훅(hook)을 설치' accepted"          0 "exclusive_bilingual" validate_content_language "훅(hook)을 설치"
+run_case "excl: URL reference accepted"              0 "exclusive_bilingual" validate_content_language "https://example.com 참조"
+run_case "excl: backtick-wrapped token accepted"     0 "exclusive_bilingual" validate_content_language "이슈 \`#247\` 참조"
+
+# Fenced-code block strip.
+run_case "excl: fenced-code block accepted"          0 "exclusive_bilingual" validate_content_language "한국어 설명
+
+\`\`\`bash
+echo hello
+\`\`\`
+
+끝"
 
 echo ""
 echo "[unknown policy falls back to english]"

--- a/tests/scripts/test-language-policy-drift.sh
+++ b/tests/scripts/test-language-policy-drift.sh
@@ -32,6 +32,7 @@ TEMPLATE_PAIRS=(
 declare -A PHRASE
 PHRASE[english]="English"
 PHRASE[korean_plus_english]="English or Korean"
+PHRASE[exclusive_bilingual]="English or Korean (document-exclusive)"
 PHRASE[any]="any language"
 
 PASS=0


### PR DESCRIPTION
## What

Adds the exclusive_bilingual value to the CLAUDE_CONTENT_LANGUAGE dispatcher. Documents are validated per-document as either English-only or Korean-only; the Korean branch accepts ASCII only inside four designated containers (fenced code, inline code, URLs, and the Korean(English) translation form).

Closes #447 (Phase 2 of the epic, completing the remaining AC after Phase 1 landed via #449).

### Change Type
- [x] Feature (new opt-in policy value)

### Affected Components
- hooks/lib/validate-language.sh (+61)
- global/hooks/lib/LanguageValidator.psm1 (+62)
- scripts/install.sh (+3, reflow menu)
- scripts/install.ps1 (+3, reflow menu)
- tests/hooks/test-language-validator.sh (+28, 35->46 cases)
- tests/scripts/test-language-policy-drift.sh (+1 phrase row)
- docs/content-language-policy.md (+72 policy section + table row + drift sentence)

## Why

korean_plus_english allows bare English words mixed inline with Korean prose (PR을 만든다, GitHub Actions에서, /pr-work 실행). The author's convention for this repository is stricter: each document is either English-only, or Korean-only with technical terms constrained to the Korean(English) parenthesized form, backtick-delimited inline code, fenced code blocks, or URLs. No existing policy value expressed this.

Existing english, korean_plus_english, and any policy values stay unchanged - this is an additive, opt-in policy. Default for new installs stays english.

## Where

### Validator implementations

- hooks/lib/validate-language.sh - new validate_korean_with_tech_terms function plus exclusive_bilingual branch in validate_content_language. Hangul-syllable detection routes to validate_english_only for English-mode documents and to validate_korean_with_tech_terms for Korean-mode documents.
- global/hooks/lib/LanguageValidator.psm1 - new Test-KoreanWithTechTerms function mirroring the strip order (fenced -> inline -> URL -> translation form), plus routing in Test-ContentLanguage and the exclusive_bilingual branch in Get-ContentLanguagePolicy. Exported via Export-ModuleMember.

### Install-time substitution

- scripts/install.sh - get_policy_phrase returns 'English or Korean (document-exclusive)' for the new value. Interactive menu gains option 3 with any reflowed to option 4.
- scripts/install.ps1 - Get-PolicyPhrase and the Selection prompt mirror the bash changes.

### Tests and drift guard

- tests/hooks/test-language-validator.sh - 11 new cases covering the accept/reject matrix plus empty-input, pure-ASCII english-mode acceptance, english-mode rejection of accented Latin, and a fenced-code block acceptance.
- tests/scripts/test-language-policy-drift.sh - new PHRASE[exclusive_bilingual] row so the installer phrase table and the drift-test phrase table stay in sync.

### Documentation

- docs/content-language-policy.md - new 'The exclusive_bilingual Policy' section with mode-selection rule, four allowed containers (strip order rationale), the 7-row accept/reject matrix with remediation column, and a 'When to choose this policy' subsection.

## How

### Bash sketch (matches issue #447)

```bash
validate_korean_with_tech_terms() {
    local text="$1"
    [ -z "$text" ] && return 0
    local stripped
    stripped=$(printf '%s' "$text" | perl -CSDA -0777 -pe '
        s/\`\`\`[\s\S]*?\`\`\`//g;
        s/\`[^\`\n]*\`//g;
        s{https?://\S+}{}g;
        s/[\x{AC00}-\x{D7A3}]+\s*\([^)\n]*\)//g;
    ' 2>/dev/null)
    ...
}

exclusive_bilingual)
    if printf '%s' "$text" | perl -CSDA -ne 'exit 1 if /[\x{AC00}-\x{D7A3}]/' 2>/dev/null; then
        validate_english_only "$text"
    else
        validate_korean_with_tech_terms "$text"
    fi
    ;;
```

PowerShell uses [regex]::Replace with the same four patterns in the same order; both sides write identical rejection messages so the user sees the same remediation hint regardless of host OS.

### Testing Done

Local run (macOS):

| Suite | Result |
| --- | --- |
| tests/hooks/test-language-validator.sh | 46 passed, 0 failed (11 new exclusive_bilingual cases) |
| tests/hooks/test-runner.sh aggregate | 335 passed, 1 failed (markdown-anchor-validator, pre-existing) |
| tests/scripts/test-install-deploys-bash-lib.sh | 11 passed (Phase 1 guard still green) |
| tests/scripts/test-windows-hooks-parity.sh | passed |
| tests/scripts/test-language-policy-drift.sh | cannot run locally (declare -A needs bash 4+; macOS bash 3.2 limitation, pre-existing) - verified on CI |

PowerShell module not run locally (pwsh not installed). PS parity is exercised by validate-hooks.yml at release time when this lands on main.

### Out of Scope

1. hooks/lib/validate-commit-message.sh Rule 2 - the commit-msg first-char dispatcher is not extended for exclusive_bilingual. It falls through to the strict english branch (lowercase ASCII required). The issue's AC did not require this and a behavior-consistency follow-up can be filed if desired.
2. Windows PowerShell tests - PS-side unit tests for Test-KoreanWithTechTerms are not added in this PR; the validate-hooks.yml matrix on macOS/Ubuntu pwsh imports the module and rejects on syntax errors, and the bash matrix is authoritative for the behavior contract.

### Breaking Changes

None. All existing policy values unchanged. New menu option is additive.

### Rollback Plan

Revert the four commits on this branch. No migrations. Users who selected the new policy during install will see their settings.json value stay on disk; they can manually change it back to english/korean_plus_english without a re-install.