### PR TITLE
feat(install): r7 polish — agent-language template, fail-fast scripts, helper tests

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -11,7 +11,13 @@ on:
       - 'plugin/hooks/**'
       - 'scripts/install.sh'
       - 'scripts/install.ps1'
+      - 'scripts/install-manifest.sh'
+      - 'scripts/install-manifest.ps1'
+      - 'bootstrap.sh'
+      - 'bootstrap.ps1'
       - 'tests/scripts/test-plugin-*.sh'
+      - 'tests/scripts/test-install-manifest-helpers.*'
+      - 'tests/scripts/test-install-permissions-policy.sh'
 
 jobs:
   test:
@@ -61,6 +67,16 @@ jobs:
         # Validates probe-driven per-hook stand-down plus failure modes
         # (unknown schema, malformed JSON, missing key).
         run: bash tests/scripts/test-plugin-fallback.sh
+
+      - name: Run install manifest helper tests
+        run: bash tests/scripts/test-install-manifest-helpers.sh
+
+      - name: Run install manifest helper tests (PowerShell)
+        run: pwsh tests/scripts/test-install-manifest-helpers.ps1
+
+      - name: Run install permissions policy lint
+        # Lint test: install.sh must enforce 700 / 600 / 644 on tracked files.
+        run: bash tests/scripts/test-install-permissions-policy.sh
 
   shellcheck:
     runs-on: ${{ matrix.os }}

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -99,7 +99,7 @@ function Install-GlobalSettings {
     }
 
     # Copy files (manifest-guarded: local edits preserved by default)
-    $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'conversation-language.md', 'git-identity.md', 'token-management.md')
+    $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'git-identity.md', 'token-management.md')
     foreach ($gf in $globalFiles) {
         $src  = Join-Path $InstallDir 'global' $gf
         $dest = Join-Path $ClaudeDir $gf
@@ -112,11 +112,69 @@ function Install-GlobalSettings {
             else {
                 Write-Info "$gf 로컬 변경 유지"
             }
-        }
-        else {
+        } else {
             Copy-Item -LiteralPath $src -Destination $ClaudeDir -Force
             Write-Ok "$gf 설치됨"
         }
+    }
+
+    # conversation-language.md 템플릿 처리
+    $tmplPath = Join-Path $InstallDir 'global' 'conversation-language.md.tmpl'
+    if (Test-Path -LiteralPath $tmplPath) {
+        Write-Host ""
+        Write-Info "Select Agent Conversation Language:"
+        Write-Host "  1) English"
+        Write-Host "  2) Korean"
+        $agentLangType = Read-Host "Selection (1-2) [default: 2]"
+        if ([string]::IsNullOrEmpty($agentLangType)) { $agentLangType = '2' }
+        
+        if ($agentLangType -eq '1') {
+            $displayLang = "English"
+            $script:agentLanguage = "english"
+        } else {
+            $displayLang = "Korean"
+            $script:agentLanguage = "korean"
+        }
+
+        $dest = Join-Path $ClaudeDir "conversation-language.md"
+        if (Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest $dest -Key "conversation-language.md" -DisplayLang $displayLang) {
+            Write-Ok "conversation-language.md 설치됨 (언어: $displayLang)"
+        } else {
+            Write-Info "conversation-language.md 로컬 변경 유지"
+        }
+    } else {
+        $script:agentLanguage = "korean"
+        # Static-file fallback. The default repo ships only the .tmpl, so this
+        # branch is unreachable in normal use. It exists to support fork users
+        # who replace the .tmpl with a hand-edited static .md — preserving
+        # their file via Invoke-GuardedCopy instead of silently dropping it.
+        $staticMd = Join-Path $InstallDir 'global' 'conversation-language.md'
+        if (Test-Path -LiteralPath $staticMd) {
+            $dest = Join-Path $ClaudeDir 'conversation-language.md'
+            if (Invoke-GuardedCopy -Src $staticMd -Dest $dest -Key "conversation-language.md") {
+                Write-Ok "conversation-language.md 설치됨"
+            } else {
+                Write-Info "conversation-language.md 로컬 변경 유지"
+            }
+        }
+    }
+
+    # Content language policy selection (CLAUDE_CONTENT_LANGUAGE)
+    Write-Host ""
+    Write-Info "Select content-language policy (commit / PR / issue validation scope):"
+    Write-Host "  1) English (Default, identical to current behavior)"
+    Write-Host "  2) Korean + English (Allows Hangul, inline mixing permitted)"
+    Write-Host "  3) Exclusive bilingual (English or Korean per document, no inline mixing)"
+    Write-Host "  4) Any (No language validation — AI attribution block maintained)"
+    $langType = Read-Host "Selection (1-4) [default: 1]"
+    if ([string]::IsNullOrEmpty($langType)) { $langType = '1' }
+    
+    switch ($langType) {
+        '1'     { $contentLanguage = 'english' }
+        '2'     { $contentLanguage = 'korean_plus_english' }
+        '3'     { $contentLanguage = 'exclusive_bilingual' }
+        '4'     { $contentLanguage = 'any' }
+        default { $contentLanguage = 'english' }
     }
 
     # tmux config installation
@@ -131,7 +189,7 @@ function Install-GlobalSettings {
         Write-Ok "tmux 설정 설치 완료"
     }
 
-    # ccstatusline settings
+    # settings.json (ccstatusline)
     $ccstatuslineSrc = Join-Path $InstallDir 'global' 'ccstatusline'
     if (Test-Path -LiteralPath $ccstatuslineSrc -PathType Container) {
         $ccstatuslineDst = Join-Path $HOME '.config' 'ccstatusline'
@@ -140,6 +198,23 @@ function Install-GlobalSettings {
         }
         Copy-Item -Path (Join-Path $ccstatuslineSrc 'settings.json') -Destination $ccstatuslineDst -Force
         Write-Ok "ccstatusline 설정 설치 완료"
+    }
+
+    # settings.json (Claude Code)
+    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # Update-ClaudeSettingsJson (below) injects them and is responsible
+    # for idempotent reset when the policy returns to default ("english").
+    $settingsSrc = Join-Path $InstallDir 'global' 'settings.json'
+    if (Test-Path -LiteralPath $settingsSrc) {
+        $settingsDst = Join-Path $ClaudeDir 'settings.json'
+        Copy-Item -Path $settingsSrc -Destination $settingsDst -Force
+
+        if (Update-ClaudeSettingsJson -SettingsPath $settingsDst -AgentLang $script:agentLanguage -ContentLang $contentLanguage) {
+            Write-Ok "settings.json (에이전트: $($script:agentLanguage), 컨텐츠: $contentLanguage) 설치 완료"
+        } else {
+            Write-Ok "settings.json 설치 완료 (기본값)"
+        }
     }
 
     # npm package installation (statusline dependencies)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -96,7 +96,7 @@ install_global() {
     source "$INSTALL_DIR/scripts/install-manifest.sh"
 
     # 파일 복사 (매니페스트 가드: 로컬 편집은 기본적으로 유지)
-    for gf in CLAUDE.md commit-settings.md conversation-language.md git-identity.md token-management.md; do
+    for gf in CLAUDE.md commit-settings.md git-identity.md token-management.md; do
         src="$INSTALL_DIR/global/$gf"
         dest="$CLAUDE_DIR/$gf"
         [ -f "$src" ] || continue
@@ -106,6 +106,76 @@ install_global() {
             info "$gf 로컬 변경 유지"
         fi
     done
+
+    # conversation-language.md 템플릿 처리
+    if [ -f "$INSTALL_DIR/global/conversation-language.md.tmpl" ]; then
+        echo ""
+        info "Select Agent Conversation Language:"
+        echo "  1) English"
+        echo "  2) Korean"
+        read -p "Selection (1-2) [default: 2]: " AGENT_LANG_TYPE
+        AGENT_LANG_TYPE=${AGENT_LANG_TYPE:-2}
+        
+        if [ "$AGENT_LANG_TYPE" = "1" ]; then
+            DISPLAY_LANG="English"
+            AGENT_LANGUAGE="english"
+        else
+            DISPLAY_LANG="Korean"
+            AGENT_LANGUAGE="korean"
+        fi
+
+        if guarded_template_copy "$INSTALL_DIR/global/conversation-language.md.tmpl" "$CLAUDE_DIR/conversation-language.md" "conversation-language.md" "$DISPLAY_LANG"; then
+            success "conversation-language.md 설치됨 (언어: $DISPLAY_LANG)"
+        else
+            info "conversation-language.md 로컬 변경 유지"
+        fi
+    else
+        AGENT_LANGUAGE="korean"
+        # Static-file fallback. The default repo ships only the .tmpl, so this
+        # branch is unreachable in normal use. It exists to support fork users
+        # who replace the .tmpl with a hand-edited static .md — preserving
+        # their file via guarded_copy instead of silently dropping it.
+        if [ -f "$INSTALL_DIR/global/conversation-language.md" ]; then
+            if guarded_copy "$INSTALL_DIR/global/conversation-language.md" "$CLAUDE_DIR/conversation-language.md" "conversation-language.md"; then
+                success "conversation-language.md 설치됨"
+            else
+                info "conversation-language.md 로컬 변경 유지"
+            fi
+        fi
+    fi
+
+    # Content language policy selection (CLAUDE_CONTENT_LANGUAGE)
+    echo ""
+    info "Select content-language policy (commit / PR / issue validation scope):"
+    echo "  1) English (Default, identical to current behavior)"
+    echo "  2) Korean + English (Allows Hangul, inline mixing permitted)"
+    echo "  3) Exclusive bilingual (English or Korean per document, no inline mixing)"
+    echo "  4) Any (No language validation — AI attribution block maintained)"
+    read -p "Selection (1-4) [default: 1]: " LANG_TYPE
+    LANG_TYPE=${LANG_TYPE:-1}
+
+    case "$LANG_TYPE" in
+        1) CONTENT_LANGUAGE="english" ;;
+        2) CONTENT_LANGUAGE="korean_plus_english" ;;
+        3) CONTENT_LANGUAGE="exclusive_bilingual" ;;
+        4) CONTENT_LANGUAGE="any" ;;
+        *) CONTENT_LANGUAGE="english" ;;
+    esac
+
+    # settings.json install (Claude Code settings)
+    # Intentionally bypasses guarded_copy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # update_claude_settings_json (below) injects them and is responsible
+    # for idempotent reset when the policy returns to default ("english").
+    if [ -f "$INSTALL_DIR/global/settings.json" ]; then
+        cp "$INSTALL_DIR/global/settings.json" "$HOME/.claude/settings.json"
+
+        if update_claude_settings_json "$HOME/.claude/settings.json" "${AGENT_LANGUAGE:-korean}" "$CONTENT_LANGUAGE"; then
+            success "settings.json (에이전트: ${AGENT_LANGUAGE:-korean}, 컨텐츠: $CONTENT_LANGUAGE) 설치 완료"
+        else
+            success "settings.json 설치 완료 (기본값)"
+        fi
+    fi
 
     # tmux 설정 설치
     if [ -f "$INSTALL_DIR/global/tmux.conf" ]; then

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ across re-runs.
 
 On each run, the installer compares three hashes per tracked file:
 
-- `src_hash` — the hash of the incoming template under `$INSTALL_DIR/global/<file>`
+- `src_hash` — the hash of the incoming file under `$INSTALL_DIR/global/<file>` (if a `.tmpl` exists, this is the hash of the dynamically rendered output, e.g. for `conversation-language.md`)
 - `dest_hash` — the hash of the current `~/.claude/<file>`
 - `stored_hash` — the hash recorded in `.install-manifest.json`
 
@@ -81,6 +81,38 @@ PowerShell uses the built-in `Get-FileHash` and `ConvertTo-Json` /
 `ConvertFrom-Json` cmdlets, so no additional dependencies are required
 on Windows.
 
+## Template Files
+
+Some tracked files are rendered dynamically before the manifest copy
+logic runs. Currently:
+
+| Template | Output | Placeholders |
+|----------|--------|--------------|
+| `conversation-language.md.tmpl` | `conversation-language.md` | `{{AGENT_LANGUAGE_POLICY}}` → `English` / `Korean` |
+
+Render pipeline (`guarded_template_copy` in
+`scripts/install-manifest.sh` and `Invoke-GuardedTemplateCopy` in
+`scripts/install-manifest.ps1`):
+
+1. Detect `.tmpl` source.
+2. Substitute placeholders into a temp file (sed for POSIX,
+   `-replace` for PowerShell).
+3. Pass the temp file through the standard manifest copy decision
+   (see "Copy Decision" above).
+4. `src_hash` is computed from the **rendered output**, not the raw
+   template, so the manifest reflects the user's policy choice.
+
+Selecting a different policy on re-install produces a different
+`src_hash`, which triggers a silent upgrade if the user has not
+locally edited the file, or a "diverges from both" prompt otherwise.
+
+`settings.json` follows a different rule: it bypasses the manifest
+entirely so policy attributes (`.language`,
+`.env.CLAUDE_CONTENT_LANGUAGE`) are enforced on every install.
+`update_claude_settings_json` / `Update-ClaudeSettingsJson` injects
+the values and removes them when the policy returns to the default
+("english"), keeping the file idempotent.
+
 ## Tracked Files
 
 The manifest currently tracks these entries (see `bootstrap.sh`
@@ -88,7 +120,7 @@ The manifest currently tracks these entries (see `bootstrap.sh`
 
 - `CLAUDE.md`
 - `commit-settings.md`
-- `conversation-language.md`
+- `conversation-language.md` *(rendered from `.tmpl` — see Template Files above)*
 - `git-identity.md`
 - `token-management.md`
 

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -5,6 +5,7 @@ Global settings applied every session. Routing index only — procedural detail 
 ## Core Settings
 
 @./commit-settings.md
+@./conversation-language.md
 
 ## Always-on Invariants
 

--- a/global/conversation-language.md.tmpl
+++ b/global/conversation-language.md.tmpl
@@ -1,0 +1,7 @@
+# Agent Conversation Language
+
+All conversational responses, reasoning processes (thinking), subagent commands, and tool executions MUST be performed in **{{AGENT_LANGUAGE_POLICY}}**.
+When analyzing outputs, writing code comments (unless directed otherwise by project rules), and communicating with the user, strictly use **{{AGENT_LANGUAGE_POLICY}}**.
+
+This rule applies universally across all `CLAUDE.md` and their sub-functions (Skills, Hooks, Tasks, Agents).
+If project specific rules conflict with this, prioritize the project specific language rule only for the output required by that specific project rule. But keep the conversation in **{{AGENT_LANGUAGE_POLICY}}**.

--- a/scripts/backup.ps1
+++ b/scripts/backup.ps1
@@ -64,8 +64,15 @@ if ($backupType -eq '4' -or $backupType -eq '5') {
 
         $entRules = Join-Path $enterpriseDir 'rules'
         if (Test-Path -LiteralPath $entRules -PathType Container) {
-            Copy-Item -Path (Join-Path $entRules '*') -Destination (Join-Path $tempBackup 'enterprise' 'rules') -Recurse -Force -ErrorAction SilentlyContinue
-            Write-SuccessMessage "rules 디렉토리 백업됨"
+            $items = Get-ChildItem -Path $entRules
+            if ($items.Count -gt 0) {
+                try {
+                    Copy-Item -Path (Join-Path $entRules '*') -Destination (Join-Path $tempBackup 'enterprise' 'rules') -Recurse -Force -ErrorAction Stop
+                    Write-SuccessMessage "rules 디렉토리 백업됨"
+                } catch {
+                    Write-ErrorMessage "rules 디렉토리 백업 실패: $_"
+                }
+            }
         }
     }
     else {
@@ -106,8 +113,15 @@ if ($backupType -eq '1' -or $backupType -eq '3' -or $backupType -eq '5') {
     if (Test-Path -LiteralPath $hooksDir -PathType Container) {
         $hooksBackup = Join-Path $tempBackup 'global' 'hooks'
         Ensure-Directory $hooksBackup | Out-Null
-        Copy-Item -Path (Join-Path $hooksDir '*.sh') -Destination $hooksBackup -Force -ErrorAction SilentlyContinue
-        Write-SuccessMessage "hooks 디렉토리 백업됨"
+        $items = Get-ChildItem -Path $hooksDir -Filter '*.sh'
+        if ($items.Count -gt 0) {
+            try {
+                Copy-Item -Path (Join-Path $hooksDir '*.sh') -Destination $hooksBackup -Force -ErrorAction Stop
+                Write-SuccessMessage "hooks 디렉토리 백업됨"
+            } catch {
+                Write-ErrorMessage "hooks 디렉토리 백업 실패: $_"
+            }
+        }
     }
 }
 
@@ -199,8 +213,12 @@ if ($replace -eq 'y') {
         }
         Ensure-Directory $entDest | Out-Null
         Ensure-Directory (Join-Path $entDest 'rules') | Out-Null
-        Copy-Item -Path (Join-Path $entTemp '*') -Destination $entDest -Recurse -Force -ErrorAction SilentlyContinue
-        Write-SuccessMessage "Enterprise 백업 업데이트됨"
+        try {
+            Copy-Item -Path (Join-Path $entTemp '*') -Destination $entDest -Recurse -Force -ErrorAction Stop
+            Write-SuccessMessage "Enterprise 백업 업데이트됨"
+        } catch {
+            Write-ErrorMessage "Enterprise 백업 업데이트 실패: $_"
+        }
     }
 
     # Update global directory
@@ -212,8 +230,12 @@ if ($replace -eq 'y') {
             Remove-Item -LiteralPath $globalDest -Recurse -Force
         }
         Ensure-Directory $globalDest | Out-Null
-        Copy-Item -Path (Join-Path $globalTemp '*') -Destination $globalDest -Recurse -Force -ErrorAction SilentlyContinue
-        Write-SuccessMessage "글로벌 백업 업데이트됨"
+        try {
+            Copy-Item -Path (Join-Path $globalTemp '*') -Destination $globalDest -Recurse -Force -ErrorAction Stop
+            Write-SuccessMessage "글로벌 백업 업데이트됨"
+        } catch {
+            Write-ErrorMessage "글로벌 백업 업데이트 실패: $_"
+        }
     }
 
     # Update project directory
@@ -225,8 +247,12 @@ if ($replace -eq 'y') {
             Remove-Item -LiteralPath $projDest -Recurse -Force
         }
         Ensure-Directory $projDest | Out-Null
-        Copy-Item -Path (Join-Path $projTemp '*') -Destination $projDest -Recurse -Force -ErrorAction SilentlyContinue
-        Write-SuccessMessage "프로젝트 백업 업데이트됨"
+        try {
+            Copy-Item -Path (Join-Path $projTemp '*') -Destination $projDest -Recurse -Force -ErrorAction Stop
+            Write-SuccessMessage "프로젝트 백업 업데이트됨"
+        } catch {
+            Write-ErrorMessage "프로젝트 백업 업데이트 실패: $_"
+        }
     }
 
     # Remove temporary backup

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -88,8 +88,8 @@ if [ "$BACKUP_TYPE" = "4" ] || [ "$BACKUP_TYPE" = "5" ]; then
             warning "CLAUDE.md 없음"
         fi
 
-        if [ -d "$ENTERPRISE_DIR/rules" ]; then
-            cp -r "$ENTERPRISE_DIR/rules"/* "$TEMP_BACKUP/enterprise/rules/" 2>/dev/null || true
+        if [ -d "$ENTERPRISE_DIR/rules" ] && [ -n "$(ls -A "$ENTERPRISE_DIR/rules" 2>/dev/null)" ]; then
+            cp -r "$ENTERPRISE_DIR/rules"/* "$TEMP_BACKUP/enterprise/rules/" || error "rules 디렉토리 백업 실패"
             success "rules 디렉토리 백업됨"
         fi
     else
@@ -132,9 +132,9 @@ if [ "$BACKUP_TYPE" = "1" ] || [ "$BACKUP_TYPE" = "3" ] || [ "$BACKUP_TYPE" = "5
     fi
 
     # hooks 디렉토리 백업
-    if [ -d "$HOME/.claude/hooks" ]; then
+    if [ -d "$HOME/.claude/hooks" ] && [ -n "$(ls -A "$HOME/.claude/hooks"/*.sh 2>/dev/null)" ]; then
         mkdir -p "$TEMP_BACKUP/global/hooks"
-        cp "$HOME/.claude/hooks"/*.sh "$TEMP_BACKUP/global/hooks/" 2>/dev/null || true
+        cp "$HOME/.claude/hooks"/*.sh "$TEMP_BACKUP/global/hooks/" || error "hooks 디렉토리 백업 실패"
         success "hooks 디렉토리 백업됨"
     fi
 fi
@@ -207,25 +207,25 @@ REPLACE=${REPLACE:-y}
 
 if [ "$REPLACE" = "y" ]; then
     # enterprise 디렉토리 업데이트
-    if [ -d "$TEMP_BACKUP/enterprise" ] && [ "$(ls -A $TEMP_BACKUP/enterprise 2>/dev/null)" ]; then
+    if [ -d "$TEMP_BACKUP/enterprise" ] && [ -n "$(ls -A "$TEMP_BACKUP/enterprise" 2>/dev/null)" ]; then
         mkdir -p "$BACKUP_DIR/enterprise/rules"
         rm -rf "$BACKUP_DIR/enterprise"/*
         mkdir -p "$BACKUP_DIR/enterprise/rules"
-        cp -r "$TEMP_BACKUP/enterprise"/* "$BACKUP_DIR/enterprise/" 2>/dev/null || true
+        cp -r "$TEMP_BACKUP/enterprise"/* "$BACKUP_DIR/enterprise/" || error "Enterprise 백업 업데이트 실패"
         success "Enterprise 백업 업데이트됨"
     fi
 
     # global 디렉토리 업데이트
-    if [ -d "$TEMP_BACKUP/global" ] && [ "$(ls -A $TEMP_BACKUP/global)" ]; then
+    if [ -d "$TEMP_BACKUP/global" ] && [ -n "$(ls -A "$TEMP_BACKUP/global" 2>/dev/null)" ]; then
         rm -rf "$BACKUP_DIR/global"/*
-        cp -r "$TEMP_BACKUP/global"/* "$BACKUP_DIR/global/" 2>/dev/null || true
+        cp -r "$TEMP_BACKUP/global"/* "$BACKUP_DIR/global/" || error "글로벌 백업 업데이트 실패"
         success "글로벌 백업 업데이트됨"
     fi
 
     # project 디렉토리 업데이트
-    if [ -d "$TEMP_BACKUP/project" ] && [ "$(ls -A $TEMP_BACKUP/project)" ]; then
+    if [ -d "$TEMP_BACKUP/project" ] && [ -n "$(ls -A "$TEMP_BACKUP/project" 2>/dev/null)" ]; then
         rm -rf "$BACKUP_DIR/project"/*
-        cp -r "$TEMP_BACKUP/project"/* "$BACKUP_DIR/project/" 2>/dev/null || true
+        cp -r "$TEMP_BACKUP/project"/* "$BACKUP_DIR/project/" || error "프로젝트 백업 업데이트 실패"
         success "프로젝트 백업 업데이트됨"
     fi
 

--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -135,3 +135,79 @@ function Invoke-GuardedCopy {
 
     return $false
 }
+
+function Invoke-GuardedTemplateCopy {
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string]$SrcTmpl,
+        [Parameter(Mandatory)][string]$Dest,
+        [Parameter(Mandatory)][string]$Key,
+        [Parameter(Mandatory)][string]$DisplayLang
+    )
+
+    if (-not (Test-Path -LiteralPath $SrcTmpl)) { return $true }
+
+    $tmpLang = Join-Path ([System.IO.Path]::GetTempPath()) "conversation-language_$([guid]::NewGuid()).md"
+    $tmplContent = [System.IO.File]::ReadAllText($SrcTmpl)
+    $rendered = $tmplContent -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $DisplayLang
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($tmpLang, $rendered, $utf8NoBom)
+    
+    $result = Invoke-GuardedCopy -Src $tmpLang -Dest $Dest -Key $Key
+    
+    Remove-Item -LiteralPath $tmpLang -Force -ErrorAction SilentlyContinue
+    return $result
+}
+
+function Update-ClaudeSettingsJson {
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string]$SettingsPath,
+        [Parameter(Mandatory)][string]$AgentLang,
+        [Parameter(Mandatory)][string]$ContentLang
+    )
+
+    if (-not (Test-Path -LiteralPath $SettingsPath)) { return $true }
+
+    try {
+        $settingsObj = Get-Content -Raw -LiteralPath $SettingsPath | ConvertFrom-Json
+        
+        # Update agent language
+        if ($settingsObj.PSObject.Properties.Name -contains 'language') {
+            $settingsObj.language = $AgentLang
+        } else {
+            $settingsObj | Add-Member -NotePropertyName 'language' -NotePropertyValue $AgentLang -Force
+        }
+
+        if ($ContentLang -ne 'english') {
+            if (-not ($settingsObj.PSObject.Properties.Name -contains 'env')) {
+                $settingsObj | Add-Member -NotePropertyName 'env' -NotePropertyValue ([PSCustomObject]@{})
+            }
+            if (-not $settingsObj.env) {
+                $settingsObj.env = [PSCustomObject]@{}
+            }
+            if ($settingsObj.env.PSObject.Properties.Name -contains 'CLAUDE_CONTENT_LANGUAGE') {
+                $settingsObj.env.CLAUDE_CONTENT_LANGUAGE = $ContentLang
+            } else {
+                $settingsObj.env | Add-Member -NotePropertyName 'CLAUDE_CONTENT_LANGUAGE' -NotePropertyValue $ContentLang -Force
+            }
+        } else {
+            # Idempotent reset for english policy
+            if (($settingsObj.PSObject.Properties.Name -contains 'env') -and ($settingsObj.env)) {
+                if ($settingsObj.env.PSObject.Properties.Name -contains 'CLAUDE_CONTENT_LANGUAGE') {
+                    $settingsObj.env.PSObject.Properties.Remove('CLAUDE_CONTENT_LANGUAGE')
+                    
+                    # If env is now empty, remove it entirely to keep settings.json clean
+                    if ($settingsObj.env.PSObject.Properties.Count -eq 0) {
+                        $settingsObj.PSObject.Properties.Remove('env')
+                    }
+                }
+            }
+        }
+
+        ($settingsObj | ConvertTo-Json -Depth 32) | Set-Content -LiteralPath $SettingsPath -Encoding UTF8
+        return $true
+    } catch {
+        return $false
+    }
+}

--- a/scripts/install-manifest.sh
+++ b/scripts/install-manifest.sh
@@ -147,3 +147,47 @@ guarded_copy() {
             ;;
     esac
 }
+
+# guarded_template_copy <src_tmpl> <dest> <key> <display_lang>
+guarded_template_copy() {
+    local src_tmpl="$1" dest="$2" key="$3" display_lang="$4"
+    [ -f "$src_tmpl" ] || return 0
+
+    local tmp_lang
+    tmp_lang=$(mktemp)
+    sed "s/{{AGENT_LANGUAGE_POLICY}}/$display_lang/g" "$src_tmpl" > "$tmp_lang"
+    
+    local result
+    if guarded_copy "$tmp_lang" "$dest" "$key"; then
+        result=0
+    else
+        result=1
+    fi
+    rm -f "$tmp_lang"
+    return "$result"
+}
+
+# update_claude_settings_json <settings_json_path> <agent_language> <content_language>
+update_claude_settings_json() {
+    local settings_path="$1" agent_lang="$2" content_lang="$3"
+    [ -f "$settings_path" ] || return 0
+
+    if command -v jq >/dev/null 2>&1; then
+        local tmpfile
+        tmpfile=$(mktemp)
+        if [ "$content_lang" != "english" ]; then
+            jq --arg v "$content_lang" --arg lang "$agent_lang" \
+               '.env = (.env // {}) | .env.CLAUDE_CONTENT_LANGUAGE = $v | .language = $lang' \
+               "$settings_path" > "$tmpfile"
+        else
+            # Idempotent reset for english policy
+            jq --arg lang "$agent_lang" \
+               'del(.env.CLAUDE_CONTENT_LANGUAGE) | if .env == {} then del(.env) else . end | .language = $lang' \
+               "$settings_path" > "$tmpfile"
+        fi
+        mv "$tmpfile" "$settings_path"
+        return 0
+    else
+        return 1
+    fi
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -102,6 +102,9 @@ function Invoke-PolicyTemplate {
         [Parameter(Mandatory)][string]$Destination
     )
     $phrase = Get-PolicyPhrase
+    
+    # Note: Agent language substitution is handled by Invoke-GuardedTemplateCopy.
+
     $content = [System.IO.File]::ReadAllText($Source)
     $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
@@ -208,8 +211,15 @@ function Install-Enterprise {
     # Copy rules directory
     $sourceRules = Join-Path $BackupDir "enterprise/rules"
     if (Test-Path $sourceRules) {
-        Copy-Item -Path "$sourceRules\*" -Destination $rulesDir -Recurse -Force -ErrorAction SilentlyContinue
-        Write-Success "rules directory installed"
+        $items = Get-ChildItem -Path $sourceRules
+        if ($items.Count -gt 0) {
+            try {
+                Copy-Item -Path "$sourceRules\*" -Destination $rulesDir -Recurse -Force -ErrorAction Stop
+                Write-Success "rules directory installed"
+            } catch {
+                Write-Err "Failed to copy rules: $_"
+            }
+        }
     }
 
     Write-Success "Enterprise settings installation complete!"
@@ -247,10 +257,10 @@ if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
 # writing settings.json at all for option 1.
 Write-Host ""
 Write-Info "Select content-language policy (commit / PR / issue validation scope):"
-Write-Host "  1) English (default, identical to current behavior)"
-Write-Host "  2) Korean + English (accept Hangul; inline mixing allowed)"
-Write-Host "  3) Exclusive bilingual (document-level English or Korean; no inline mixing)"
-Write-Host "  4) Any (skip language validation; AI attribution block stays on)"
+Write-Host "  1) English (Default, identical to current behavior)"
+Write-Host "  2) Korean + English (Allows Hangul, inline mixing permitted)"
+Write-Host "  3) Exclusive bilingual (English or Korean per document, no inline mixing)"
+Write-Host "  4) Any (No language validation — AI attribution block maintained)"
 Write-Host ""
 
 $langType = Read-Host "Selection (1-4) [default: 1]"
@@ -263,6 +273,24 @@ switch ($langType) {
     default {
         Write-Warn "Unknown selection: $langType. Using english."
         $contentLanguage = 'english'
+    }
+}
+
+# ── Agent Conversation Language ──────────────────────────────────
+Write-Host ""
+Write-Info "Select Agent Conversation Language:"
+Write-Host "  1) English"
+Write-Host "  2) Korean"
+Write-Host ""
+
+$agentLangType = Read-Host "Selection (1-2) [default: 2]"
+if ([string]::IsNullOrEmpty($agentLangType)) { $agentLangType = '2' }
+switch ($agentLangType) {
+    '1'     { $agentLanguage = 'english' }
+    '2'     { $agentLanguage = 'korean' }
+    default {
+        Write-Warn "Unknown selection: $agentLangType. Using korean."
+        $agentLanguage = 'korean'
     }
 }
 
@@ -309,56 +337,71 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
     $claudeDir = Join-Path $HOME ".claude"
     Ensure-Directory $claudeDir
 
-    # Copy configuration files
-        $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'conversation-language.md', 'git-identity.md', 'token-management.md')
-        foreach ($gf in $globalFiles) {
-            $src = Join-Path $BackupDir "global/$gf"
-            # Issue #411: prefer .tmpl + substitution when present so the
-            # installed file matches the selected content-language policy.
-            $srcTmpl = "$src.tmpl"
-            if (Test-Path $srcTmpl) {
-                Invoke-PolicyTemplate -Source $srcTmpl -Destination (Join-Path $claudeDir $gf)
+    # Load install-manifest helper (fail-fast — fallback paths assume this loaded)
+    $manifestHelper = Join-Path $BackupDir 'scripts\install-manifest.ps1'
+    if (-not (Test-Path -LiteralPath $manifestHelper)) {
+        throw "install-manifest.ps1 helper not found at: $manifestHelper"
+    }
+    . $manifestHelper
+
+    # Copy configuration files (manifest-guarded)
+    $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'git-identity.md', 'token-management.md')
+    foreach ($gf in $globalFiles) {
+        $src = Join-Path $BackupDir "global/$gf"
+        # Issue #411: prefer .tmpl + substitution when present
+        $srcTmpl = "$src.tmpl"
+        if (Test-Path $srcTmpl) {
+            # Render to a temporary file using the existing policy substitution
+            $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "policy_$([guid]::NewGuid()).md"
+            Invoke-PolicyTemplate -Source $srcTmpl -Destination $tmpFile
+            if (Invoke-GuardedCopy -Src $tmpFile -Dest (Join-Path $claudeDir $gf) -Key $gf) {
                 Write-Success "$gf installed (policy phrase: $(Get-PolicyPhrase))"
-            } elseif (Test-Path $src) {
-                Copy-Item -Path $src -Destination $claudeDir -Force
+            } else {
+                Write-Info "$gf local changes preserved"
+            }
+            Remove-Item -LiteralPath $tmpFile -Force -ErrorAction SilentlyContinue
+        } elseif (Test-Path $src) {
+            if (Invoke-GuardedCopy -Src $src -Dest (Join-Path $claudeDir $gf) -Key $gf) {
                 Write-Success "$gf installed"
+            } else {
+                Write-Info "$gf local changes preserved"
             }
         }
+    }
+
+    # conversation-language.md template rendering
+    $tmplPath = Join-Path $BackupDir "global/conversation-language.md.tmpl"
+    if (Test-Path $tmplPath) {
+        if ($agentLanguage -eq 'english') {
+            $displayLang = "English"
+        } else {
+            $displayLang = "Korean"
+        }
+        
+        if (Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest (Join-Path $claudeDir "conversation-language.md") -Key "conversation-language.md" -DisplayLang $displayLang) {
+            Write-Success "conversation-language.md installed (Language: $displayLang)"
+        } else {
+            Write-Info "conversation-language.md local changes preserved"
+        }
+    }
 
     # Install settings.windows.json as settings.json
+    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # Update-ClaudeSettingsJson (below) injects them and is responsible
+    # for idempotent reset when the policy returns to default ("english").
     $settingsSource = Join-Path $BackupDir "global/settings.windows.json"
     if (Test-Path $settingsSource) {
         $destSettings = Join-Path $claudeDir "settings.json"
         Copy-Item -Path $settingsSource -Destination $destSettings -Force
         Write-Success "Hook settings (settings.json) installed! [Windows version]"
 
-        # Write CLAUDE_CONTENT_LANGUAGE under env only when the user chose
-        # a non-default policy. "english" matches the dispatcher default so
-        # touching the file would add churn for no behavior change.
-        if ($contentLanguage -ne 'english') {
-            try {
-                $settingsObj = Get-Content -Raw -LiteralPath $destSettings | ConvertFrom-Json
-                if (-not $settingsObj.PSObject.Properties.Name -contains 'env') {
-                    $settingsObj | Add-Member -NotePropertyName 'env' -NotePropertyValue ([PSCustomObject]@{})
-                }
-                if (-not $settingsObj.env) {
-                    $settingsObj.env = [PSCustomObject]@{}
-                }
-                if ($settingsObj.env.PSObject.Properties.Name -contains 'CLAUDE_CONTENT_LANGUAGE') {
-                    $settingsObj.env.CLAUDE_CONTENT_LANGUAGE = $contentLanguage
-                } else {
-                    $settingsObj.env | Add-Member -NotePropertyName 'CLAUDE_CONTENT_LANGUAGE' -NotePropertyValue $contentLanguage -Force
-                }
-                ($settingsObj | ConvertTo-Json -Depth 32) | Set-Content -LiteralPath $destSettings -Encoding UTF8
-                Write-Success "CLAUDE_CONTENT_LANGUAGE=$contentLanguage written to settings.json"
-            }
-            catch {
-                Write-Warn "Failed to write CLAUDE_CONTENT_LANGUAGE automatically: $_"
-                Write-Host "  Add this manually to ~/.claude/settings.json under env:"
-                Write-Host "    `"CLAUDE_CONTENT_LANGUAGE`": `"$contentLanguage`""
-            }
+        # Write CLAUDE_CONTENT_LANGUAGE under env, and update agent language
+        if (Update-ClaudeSettingsJson -SettingsPath $destSettings -AgentLang $agentLanguage -ContentLang $contentLanguage) {
+            Write-Success "settings.json updated with language=$agentLanguage and CLAUDE_CONTENT_LANGUAGE=$contentLanguage"
         } else {
-            Write-Info "CLAUDE_CONTENT_LANGUAGE=english (default; settings.json unchanged)"
+            Write-Warn "Failed to automatically update settings.json"
+            Write-Host "  Please update ~/.claude/settings.json manually with language settings."
         }
     }
 
@@ -375,7 +418,14 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         $hooksDir = Join-Path $claudeDir "hooks"
         Ensure-Directory $hooksDir
 
-        Copy-Item -Path "$hooksSource\*.ps1" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
+        try {
+            $ps1Items = Get-ChildItem -Path $hooksSource -Filter '*.ps1' -File
+            if ($ps1Items.Count -gt 0) {
+                Copy-Item -Path "$hooksSource\*.ps1" -Destination $hooksDir -Force -ErrorAction Stop
+            }
+        } catch {
+            Write-Err "Failed to copy hook scripts: $_"
+        }
         Get-ChildItem -Path $hooksSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
             Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksDir $_.Name)
         }
@@ -384,8 +434,18 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         if (Test-Path $hooksLibSource) {
             $hooksLibDir = Join-Path $hooksDir 'lib'
             Ensure-Directory $hooksLibDir
-            Copy-Item -Path "$hooksLibSource\*.ps1" -Destination $hooksLibDir -Force -ErrorAction SilentlyContinue
-            Copy-Item -Path "$hooksLibSource\*.psm1" -Destination $hooksLibDir -Force -ErrorAction SilentlyContinue
+            try {
+                $ps1Items = Get-ChildItem -Path $hooksLibSource -Filter '*.ps1' -File
+                if ($ps1Items.Count -gt 0) {
+                    Copy-Item -Path "$hooksLibSource\*.ps1" -Destination $hooksLibDir -Force -ErrorAction Stop
+                }
+                $psm1Items = Get-ChildItem -Path $hooksLibSource -Filter '*.psm1' -File
+                if ($psm1Items.Count -gt 0) {
+                    Copy-Item -Path "$hooksLibSource\*.psm1" -Destination $hooksLibDir -Force -ErrorAction Stop
+                }
+            } catch {
+                Write-Err "Failed to copy hook lib scripts: $_"
+            }
             Get-ChildItem -Path $hooksLibSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
                 Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksLibDir $_.Name)
             }
@@ -408,7 +468,14 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
             }
         }
 
-        Copy-Item -Path "$hooksSource\*.json" -Destination $hooksDir -Force -ErrorAction SilentlyContinue
+        try {
+            $jsonItems = Get-ChildItem -Path $hooksSource -Filter '*.json' -File
+            if ($jsonItems.Count -gt 0) {
+                Copy-Item -Path "$hooksSource\*.json" -Destination $hooksDir -Force -ErrorAction Stop
+            }
+        } catch {
+            Write-Err "Failed to copy json configurations: $_"
+        }
 
         Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"
 
@@ -441,7 +508,14 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         $scriptsDir = Join-Path $claudeDir "scripts"
         Ensure-Directory $scriptsDir
 
-        Copy-Item -Path "$scriptsSource\*.ps1" -Destination $scriptsDir -Force -ErrorAction SilentlyContinue
+        try {
+            $ps1Items = Get-ChildItem -Path $scriptsSource -Filter '*.ps1' -File
+            if ($ps1Items.Count -gt 0) {
+                Copy-Item -Path "$scriptsSource\*.ps1" -Destination $scriptsDir -Force -ErrorAction Stop
+            }
+        } catch {
+            Write-Err "Failed to copy utility scripts: $_"
+        }
         Get-ChildItem -Path $scriptsSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
             Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $scriptsDir $_.Name)
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,8 +51,22 @@ error() {
 ensure_dir() {
     local dir="$1"
     if [ ! -d "$dir" ]; then
-        mkdir -p "$dir"
+        mkdir -p "$dir" || error "디렉토리 생성 실패: $dir"
         success "디렉토리 생성: $dir"
+    fi
+}
+
+# 함수: 의존성 확인
+check_dependencies() {
+    local missing_deps=0
+    for cmd in cp mkdir chmod grep sed; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            error "필수 명령어 '$cmd'가 설치되어 있지 않습니다."
+            missing_deps=1
+        fi
+    done
+    if [ $missing_deps -ne 0 ]; then
+        exit 1
     fi
 }
 
@@ -189,12 +203,12 @@ install_enterprise() {
             sudo mkdir -p "$enterprise_dir/rules"
 
             # 파일 복사
-            sudo cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/"
+            sudo cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/" || error "CLAUDE.md 복사 실패"
             success "CLAUDE.md 설치됨"
 
             # rules 디렉토리 복사
-            if [ -d "$BACKUP_DIR/enterprise/rules" ]; then
-                sudo cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" 2>/dev/null || true
+            if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+                sudo cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" || error "rules 복사 실패"
                 success "rules 디렉토리 설치됨"
             fi
 
@@ -202,16 +216,18 @@ install_enterprise() {
             sudo chmod 755 "$enterprise_dir"
             sudo chmod 644 "$enterprise_dir/CLAUDE.md"
             sudo chmod 755 "$enterprise_dir/rules"
-            sudo chmod 644 "$enterprise_dir/rules"/* 2>/dev/null || true
+            if [ -n "$(ls -A "$enterprise_dir/rules" 2>/dev/null)" ]; then
+                sudo chmod 644 "$enterprise_dir/rules"/* || error "rules 권한 설정 실패"
+            fi
         else
             # sudo 불필요
             mkdir -p "$enterprise_dir"
             mkdir -p "$enterprise_dir/rules"
-            cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/"
+            cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/" || error "CLAUDE.md 복사 실패"
             success "CLAUDE.md 설치됨"
 
-            if [ -d "$BACKUP_DIR/enterprise/rules" ]; then
-                cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" 2>/dev/null || true
+            if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+                cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" || error "rules 복사 실패"
                 success "rules 디렉토리 설치됨"
             fi
         fi
@@ -219,11 +235,11 @@ install_enterprise() {
         # Windows
         mkdir -p "$enterprise_dir"
         mkdir -p "$enterprise_dir/rules"
-        cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/"
+        cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$enterprise_dir/" || error "CLAUDE.md 복사 실패"
         success "CLAUDE.md 설치됨"
 
-        if [ -d "$BACKUP_DIR/enterprise/rules" ]; then
-            cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" 2>/dev/null || true
+        if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+            cp -r "$BACKUP_DIR/enterprise/rules"/* "$enterprise_dir/rules/" || error "rules 복사 실패"
             success "rules 디렉토리 설치됨"
         fi
     fi
@@ -232,6 +248,9 @@ install_enterprise() {
     echo ""
     warning "중요: enterprise/CLAUDE.md를 조직 정책에 맞게 수정하세요!"
 }
+
+# 의존성 확인
+check_dependencies
 
 # 설치 타입 선택
 echo ""
@@ -245,17 +264,17 @@ echo ""
 read -p "선택 (1-5) [기본값: 3]: " INSTALL_TYPE
 INSTALL_TYPE=${INSTALL_TYPE:-3}
 
-# 컨텐츠 언어 정책 선택 (CLAUDE_CONTENT_LANGUAGE)
-# Global / Enterprise 설치 경로에서만 settings.json을 갱신합니다.
-# 기본값 english는 settings.json을 건드리지 않습니다 (dispatcher 기본값과 일치).
+# Content language policy selection (CLAUDE_CONTENT_LANGUAGE)
+# Only the Global / Enterprise install paths touch settings.json.
+# Default "english" matches the dispatcher default and leaves settings.json untouched.
 echo ""
-info "컨텐츠 언어 정책을 선택하세요 (commit / PR / issue 검증 범위):"
-echo "  1) English (기본, 현재 동작과 완전 동일)"
-echo "  2) Korean + English (Hangul 허용, 인라인 혼용 가능)"
-echo "  3) Exclusive bilingual (문서 단위 영어 또는 한국어, 인라인 혼용 금지)"
-echo "  4) Any (언어 검증 없음 — 단, AI 귀속 차단은 유지)"
+info "Select content-language policy (commit / PR / issue validation scope):"
+echo "  1) English (Default, identical to current behavior)"
+echo "  2) Korean + English (Allows Hangul, inline mixing permitted)"
+echo "  3) Exclusive bilingual (English or Korean per document, no inline mixing)"
+echo "  4) Any (No language validation — AI attribution block maintained)"
 echo ""
-read -p "선택 (1-4) [기본값: 1]: " LANG_TYPE
+read -p "Selection (1-4) [default: 1]: " LANG_TYPE
 LANG_TYPE=${LANG_TYPE:-1}
 
 case "$LANG_TYPE" in
@@ -264,8 +283,26 @@ case "$LANG_TYPE" in
     3) CONTENT_LANGUAGE="exclusive_bilingual" ;;
     4) CONTENT_LANGUAGE="any" ;;
     *)
-        warning "알 수 없는 입력: $LANG_TYPE. english로 진행합니다."
+        warning "Unknown selection: $LANG_TYPE. Falling back to english."
         CONTENT_LANGUAGE="english"
+        ;;
+esac
+
+# Agent Conversation Language selection
+echo ""
+info "Select Agent Conversation Language:"
+echo "  1) English"
+echo "  2) Korean"
+echo ""
+read -p "Selection (1-2) [default: 2]: " AGENT_LANG_TYPE
+AGENT_LANG_TYPE=${AGENT_LANG_TYPE:-2}
+
+case "$AGENT_LANG_TYPE" in
+    1) AGENT_LANGUAGE="english" ;;
+    2) AGENT_LANGUAGE="korean" ;;
+    *)
+        warning "Unknown selection: $AGENT_LANG_TYPE. Falling back to korean."
+        AGENT_LANGUAGE="korean"
         ;;
 esac
 
@@ -305,34 +342,64 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
 
     # ~/.claude 디렉토리 생성
     ensure_dir "$HOME/.claude"
+    chmod 700 "$HOME/.claude"
 
-    # 파일 설치
-    for gf in CLAUDE.md commit-settings.md conversation-language.md git-identity.md token-management.md; do
-        [ -f "$BACKUP_DIR/global/$gf" ] && cp "$BACKUP_DIR/global/$gf" "$HOME/.claude/" && success "$gf 설치됨"
+    # 설치 매니페스트 헬퍼 로드
+    # shellcheck disable=SC1091
+    source "$BACKUP_DIR/scripts/install-manifest.sh"
+
+    # 파일 설치 (매니페스트 가드 사용)
+    for gf in CLAUDE.md commit-settings.md git-identity.md token-management.md; do
+        if [ -f "$BACKUP_DIR/global/$gf" ]; then
+            if guarded_copy "$BACKUP_DIR/global/$gf" "$HOME/.claude/$gf" "$gf"; then
+                if [ "$gf" = "git-identity.md" ] || [ "$gf" = "token-management.md" ]; then
+                    chmod 600 "$HOME/.claude/$gf"
+                else
+                    chmod 644 "$HOME/.claude/$gf"
+                fi
+                success "$gf 설치됨"
+            else
+                info "$gf 로컬 변경 유지"
+            fi
+        fi
     done
 
-    # settings.json 설치 (Hook 설정)
+    # conversation-language.md 템플릿 렌더링
+    if [ -f "$BACKUP_DIR/global/conversation-language.md.tmpl" ]; then
+        if [ "$AGENT_LANGUAGE" = "english" ]; then
+            DISPLAY_LANG="English"
+        else
+            DISPLAY_LANG="Korean"
+        fi
+        
+        if guarded_template_copy "$BACKUP_DIR/global/conversation-language.md.tmpl" "$HOME/.claude/conversation-language.md" "conversation-language.md" "$DISPLAY_LANG"; then
+            chmod 644 "$HOME/.claude/conversation-language.md"
+            success "conversation-language.md 설치됨 (언어: $DISPLAY_LANG)"
+        else
+            info "conversation-language.md 로컬 변경 유지"
+        fi
+    fi
+
+    # settings.json install (Hook configuration)
+    # Intentionally bypasses guarded_copy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # update_claude_settings_json (below) injects them and is responsible
+    # for idempotent reset when the policy returns to default ("english").
     if [ -f "$BACKUP_DIR/global/settings.json" ]; then
         cp "$BACKUP_DIR/global/settings.json" "$HOME/.claude/"
         success "Hook 설정 (settings.json) 설치 완료!"
 
-        # CLAUDE_CONTENT_LANGUAGE env 주입
-        # english(기본)은 dispatcher 기본값과 일치하므로 파일을 건드리지 않습니다.
-        if [ "$CONTENT_LANGUAGE" != "english" ]; then
-            if command -v jq >/dev/null 2>&1; then
-                tmpfile=$(mktemp)
-                jq --arg v "$CONTENT_LANGUAGE" \
-                   '.env = (.env // {}) | .env.CLAUDE_CONTENT_LANGUAGE = $v' \
-                   "$HOME/.claude/settings.json" > "$tmpfile" \
-                   && mv "$tmpfile" "$HOME/.claude/settings.json" \
-                   && success "CLAUDE_CONTENT_LANGUAGE=$CONTENT_LANGUAGE 을 settings.json에 기록했습니다."
-            else
-                warning "jq가 설치되어 있지 않아 CLAUDE_CONTENT_LANGUAGE를 자동 설정할 수 없습니다."
+        # CLAUDE_CONTENT_LANGUAGE env 주입 및 Agent Language 속성 업데이트
+        if update_claude_settings_json "$HOME/.claude/settings.json" "$AGENT_LANGUAGE" "$CONTENT_LANGUAGE"; then
+            success "settings.json: language=$AGENT_LANGUAGE, CLAUDE_CONTENT_LANGUAGE=$CONTENT_LANGUAGE 업데이트 완료."
+        else
+            warning "jq가 설치되어 있지 않아 settings.json을 자동 업데이트할 수 없습니다."
+            if [ "$CONTENT_LANGUAGE" != "english" ]; then
                 echo "  수동으로 ~/.claude/settings.json 의 env 섹션에 다음을 추가하세요:"
                 echo "    \"CLAUDE_CONTENT_LANGUAGE\": \"$CONTENT_LANGUAGE\""
             fi
-        else
-            info "CLAUDE_CONTENT_LANGUAGE=english (기본값, settings.json 무변경)"
+            echo "  그리고 루트 레벨에 다음을 추가/수정하세요:"
+            echo "    \"language\": \"$AGENT_LANGUAGE\""
         fi
     fi
 

--- a/scripts/sync.ps1
+++ b/scripts/sync.ps1
@@ -349,7 +349,14 @@ if ($syncDirection -eq '1') {
                 Copy-Item -LiteralPath $enterpriseMd -Destination $enterpriseDir -Force
                 $backupEntRules = Join-Path $BackupDir 'enterprise' 'rules'
                 if (Test-Path $backupEntRules) {
-                    Copy-Item -Path (Join-Path $backupEntRules '*') -Destination (Join-Path $enterpriseDir 'rules') -Recurse -Force -ErrorAction SilentlyContinue
+                    $items = Get-ChildItem -Path $backupEntRules
+                    if ($items.Count -gt 0) {
+                        try {
+                            Copy-Item -Path (Join-Path $backupEntRules '*') -Destination (Join-Path $enterpriseDir 'rules') -Recurse -Force -ErrorAction Stop
+                        } catch {
+                            Write-ErrorMessage "Enterprise rules 동기화 실패: $_"
+                        }
+                    }
                 }
                 Write-SuccessMessage "Enterprise CLAUDE.md -> 시스템"
             }
@@ -410,7 +417,14 @@ else {
             Copy-Item -LiteralPath $sysEntMd -Destination $entBackup -Force
             $sysEntRules = Join-Path $enterpriseDir 'rules'
             if (Test-Path $sysEntRules) {
-                Copy-Item -Path (Join-Path $sysEntRules '*') -Destination (Join-Path $entBackup 'rules') -Recurse -Force -ErrorAction SilentlyContinue
+                $items = Get-ChildItem -Path $sysEntRules
+                if ($items.Count -gt 0) {
+                    try {
+                        Copy-Item -Path (Join-Path $sysEntRules '*') -Destination (Join-Path $entBackup 'rules') -Recurse -Force -ErrorAction Stop
+                    } catch {
+                        Write-ErrorMessage "Enterprise rules 백업 실패: $_"
+                    }
+                }
             }
             Write-SuccessMessage "Enterprise CLAUDE.md -> 백업"
         }

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -73,6 +73,20 @@ warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 error() { echo -e "${RED}❌ $1${NC}"; }
 highlight() { echo -e "${CYAN}🔸 $1${NC}"; }
 
+# 함수: 의존성 확인
+check_dependencies() {
+    local missing_deps=0
+    for cmd in cp mkdir rm diff; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            error "필수 명령어 '$cmd'가 설치되어 있지 않습니다."
+            missing_deps=1
+        fi
+    done
+    if [ $missing_deps -ne 0 ]; then
+        exit 1
+    fi
+}
+
 # 함수: Enterprise 경로 감지
 get_enterprise_dir() {
     case "$(uname -s)" in
@@ -116,6 +130,9 @@ compare_files() {
         fi
     fi
 }
+
+# 의존성 확인
+check_dependencies
 
 # 동기화 방향 선택
 echo ""
@@ -362,16 +379,22 @@ if [ "$SYNC_DIRECTION" = "1" ]; then
                 if [ ! -w "$(dirname "$ENTERPRISE_DIR")" ]; then
                     sudo mkdir -p "$ENTERPRISE_DIR/rules"
                     sudo cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$ENTERPRISE_DIR/"
-                    [ -d "$BACKUP_DIR/enterprise/rules" ] && sudo cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" 2>/dev/null || true
+                    if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+                        sudo cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" || error "Enterprise rules 동기화 실패"
+                    fi
                 else
                     mkdir -p "$ENTERPRISE_DIR/rules"
                     cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$ENTERPRISE_DIR/"
-                    [ -d "$BACKUP_DIR/enterprise/rules" ] && cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" 2>/dev/null || true
+                    if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+                        cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" || error "Enterprise rules 동기화 실패"
+                    fi
                 fi
             else
                 mkdir -p "$ENTERPRISE_DIR/rules"
                 cp "$BACKUP_DIR/enterprise/CLAUDE.md" "$ENTERPRISE_DIR/"
-                [ -d "$BACKUP_DIR/enterprise/rules" ] && cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" 2>/dev/null || true
+                if [ -d "$BACKUP_DIR/enterprise/rules" ] && [ -n "$(ls -A "$BACKUP_DIR/enterprise/rules" 2>/dev/null)" ]; then
+                    cp -r "$BACKUP_DIR/enterprise/rules"/* "$ENTERPRISE_DIR/rules/" || error "Enterprise rules 동기화 실패"
+                fi
             fi
             success "Enterprise CLAUDE.md → 시스템"
         fi
@@ -444,7 +467,9 @@ else
         if [ -f "$ENTERPRISE_DIR/CLAUDE.md" ]; then
             mkdir -p "$BACKUP_DIR/enterprise/rules"
             cp "$ENTERPRISE_DIR/CLAUDE.md" "$BACKUP_DIR/enterprise/"
-            [ -d "$ENTERPRISE_DIR/rules" ] && cp -r "$ENTERPRISE_DIR/rules"/* "$BACKUP_DIR/enterprise/rules/" 2>/dev/null || true
+            if [ -d "$ENTERPRISE_DIR/rules" ] && [ -n "$(ls -A "$ENTERPRISE_DIR/rules" 2>/dev/null)" ]; then
+                cp -r "$ENTERPRISE_DIR/rules"/* "$BACKUP_DIR/enterprise/rules/" || error "Enterprise rules 동기화 실패"
+            fi
             success "Enterprise CLAUDE.md → 백업"
         fi
     fi

--- a/tests/scripts/test-install-manifest-helpers.ps1
+++ b/tests/scripts/test-install-manifest-helpers.ps1
@@ -1,0 +1,80 @@
+# test-install-manifest-helpers.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+
+. (Join-Path $repoRoot "scripts\install-manifest.ps1")
+
+$testDir = Join-Path ([System.IO.Path]::GetTempPath()) "claude_test_$([guid]::NewGuid())"
+New-Item -ItemType Directory -Path $testDir | Out-Null
+
+try {
+    $env:HOME = $testDir
+    $claudeDir = Join-Path $testDir ".claude"
+    New-Item -ItemType Directory -Path $claudeDir | Out-Null
+    
+    $manifestPath = Join-Path $claudeDir ".install-manifest.json"
+    Set-ManifestPath $manifestPath
+
+    # Test Update-ClaudeSettingsJson
+    $settingsPath = Join-Path $testDir "settings.json"
+    '{"test": 1}' | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+
+    Update-ClaudeSettingsJson -SettingsPath $settingsPath -AgentLang "english" -ContentLang "korean_plus_english" | Out-Null
+
+    $content = Get-Content -Raw -LiteralPath $settingsPath | ConvertFrom-Json
+    if ($content.language -ne "english") {
+        throw "FAIL: Agent language not updated"
+    }
+    if ($content.env.CLAUDE_CONTENT_LANGUAGE -ne "korean_plus_english") {
+        throw "FAIL: Content language not updated"
+    }
+    Write-Host "Update-ClaudeSettingsJson: PASS"
+
+    # Test Invoke-GuardedTemplateCopy
+    $tmplPath = Join-Path $testDir "tmpl.md"
+    $destPath = Join-Path $testDir "dest.md"
+    "Language policy: {{AGENT_LANGUAGE_POLICY}}" | Set-Content -LiteralPath $tmplPath -Encoding UTF8
+
+    $global:ManifestForceOverride = $true
+
+    Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest $destPath -Key "dest.md" -DisplayLang "Korean" | Out-Null
+
+    $destContent = Get-Content -Raw -LiteralPath $destPath
+    if (-not ($destContent -match "Language policy: Korean")) {
+        throw "FAIL: Template not rendered properly"
+    }
+
+    $manifestContent = Get-Content -Raw -LiteralPath $manifestPath
+    if (-not ($manifestContent -match "dest.md")) {
+        throw "FAIL: Manifest not updated"
+    }
+
+    Write-Host "Invoke-GuardedTemplateCopy: PASS"
+
+    # Idempotent reset: english policy must remove .env.CLAUDE_CONTENT_LANGUAGE
+    # and prune an empty .env object left over from a prior non-default selection.
+    '{"test": 1}' | Set-Content -LiteralPath $settingsPath -Encoding UTF8
+    Update-ClaudeSettingsJson -SettingsPath $settingsPath -AgentLang "english" -ContentLang "korean_plus_english" | Out-Null
+    $stage1 = Get-Content -Raw -LiteralPath $settingsPath | ConvertFrom-Json
+    if ($stage1.env.CLAUDE_CONTENT_LANGUAGE -ne "korean_plus_english") {
+        throw "FAIL: idempotent setup did not write CLAUDE_CONTENT_LANGUAGE"
+    }
+
+    Update-ClaudeSettingsJson -SettingsPath $settingsPath -AgentLang "english" -ContentLang "english" | Out-Null
+    $stage2 = Get-Content -Raw -LiteralPath $settingsPath | ConvertFrom-Json
+    if ($stage2.PSObject.Properties.Name -contains 'env') {
+        throw "FAIL: idempotent reset left an empty .env object"
+    }
+    $rawAfter = Get-Content -Raw -LiteralPath $settingsPath
+    if ($rawAfter -match 'CLAUDE_CONTENT_LANGUAGE') {
+        throw "FAIL: idempotent reset did not remove CLAUDE_CONTENT_LANGUAGE"
+    }
+    Write-Host "Update-ClaudeSettingsJson idempotent reset: PASS"
+
+    Write-Host "All helper tests passed!"
+} finally {
+    Remove-Item -LiteralPath $testDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/scripts/test-install-manifest-helpers.sh
+++ b/tests/scripts/test-install-manifest-helpers.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# test-install-manifest-helpers.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$REPO_ROOT/scripts/install-manifest.sh"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export MANIFEST_PATH="$TEST_DIR/.claude/.install-manifest.json"
+
+export HOME="$TEST_DIR"
+mkdir -p "$HOME/.claude"
+
+# Mock guarded_copy to write to manifest directly without prompt
+export BOOTSTRAP_FORCE=1
+
+# Test update_claude_settings_json
+echo '{"test": 1}' > "$TEST_DIR/settings.json"
+update_claude_settings_json "$TEST_DIR/settings.json" "english" "korean_plus_english"
+
+if ! grep -q '"language": "english"' "$TEST_DIR/settings.json"; then
+    echo "FAIL: Agent language not updated"
+    exit 1
+fi
+
+if ! grep -q '"CLAUDE_CONTENT_LANGUAGE": "korean_plus_english"' "$TEST_DIR/settings.json"; then
+    echo "FAIL: Content language not updated"
+    exit 1
+fi
+
+echo "update_claude_settings_json: PASS"
+
+# Test guarded_template_copy
+cat << 'EOF' > "$TEST_DIR/tmpl.md"
+Language policy: {{AGENT_LANGUAGE_POLICY}}
+EOF
+
+guarded_template_copy "$TEST_DIR/tmpl.md" "$TEST_DIR/dest.md" "dest.md" "Korean"
+
+if ! grep -q 'Language policy: Korean' "$TEST_DIR/dest.md"; then
+    echo "FAIL: Template not rendered properly"
+    exit 1
+fi
+
+if ! grep -q "dest.md" "$TEST_DIR/.claude/.install-manifest.json"; then
+    echo "FAIL: Manifest not updated"
+    exit 1
+fi
+
+echo "guarded_template_copy: PASS"
+
+# Test idempotent reset: english policy must remove .env.CLAUDE_CONTENT_LANGUAGE
+# left over from a prior non-default selection.
+if command -v jq >/dev/null 2>&1; then
+    cat << 'EOF' > "$TEST_DIR/settings.json"
+{"test": 1}
+EOF
+    update_claude_settings_json "$TEST_DIR/settings.json" "english" "korean_plus_english"
+    if ! grep -q '"CLAUDE_CONTENT_LANGUAGE": "korean_plus_english"' "$TEST_DIR/settings.json"; then
+        echo "FAIL: idempotent setup did not write CLAUDE_CONTENT_LANGUAGE"
+        exit 1
+    fi
+
+    update_claude_settings_json "$TEST_DIR/settings.json" "english" "english"
+    if grep -q 'CLAUDE_CONTENT_LANGUAGE' "$TEST_DIR/settings.json"; then
+        echo "FAIL: idempotent reset did not remove CLAUDE_CONTENT_LANGUAGE"
+        cat "$TEST_DIR/settings.json"
+        exit 1
+    fi
+    if grep -q '"env"' "$TEST_DIR/settings.json"; then
+        echo "FAIL: idempotent reset left an empty .env object"
+        cat "$TEST_DIR/settings.json"
+        exit 1
+    fi
+    echo "update_claude_settings_json idempotent reset: PASS"
+else
+    echo "update_claude_settings_json idempotent reset: SKIP (jq missing)"
+fi
+
+echo "All helper tests passed!"
+exit 0

--- a/tests/scripts/test-install-permissions-policy.sh
+++ b/tests/scripts/test-install-permissions-policy.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Lint-style regression test: install.sh must enforce a strict permission
+# policy on tracked files installed under ~/.claude.
+#
+# Policy:
+#   ~/.claude                                  → 700 (owner-only directory)
+#   ~/.claude/git-identity.md                  → 600 (sensitive: git author config)
+#   ~/.claude/token-management.md              → 600 (sensitive: API token notes)
+#   ~/.claude/CLAUDE.md, commit-settings.md    → 644 (world-readable docs)
+#   ~/.claude/conversation-language.md         → 644 (world-readable docs)
+#
+# This is a lint test — it greps install.sh to ensure the policy lines exist.
+# It does not invoke install.sh end-to-end (which is interactive and would
+# require a fake HOME + sudo shim). A future improvement is to extract the
+# chmod block into a sourceable helper and call it directly.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL="$ROOT_DIR/scripts/install.sh"
+
+if [ ! -f "$INSTALL" ]; then
+    echo "FAIL: install.sh not found: $INSTALL" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+check() {
+    local label="$1" pattern="$2"
+    if grep -qE -- "$pattern" "$INSTALL"; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label: pattern not present in install.sh — $pattern")
+    fi
+}
+
+# 1. ~/.claude directory must be tightened to 0700 (owner only).
+check "claude_dir_700" 'chmod 700 "\$HOME/\.claude"'
+
+# 2. The 600-permission branch must cover both sensitive files.
+#    This grep is loose (matches the && chain) so internal whitespace doesn't
+#    break the test.
+check "sensitive_600_branch_git_identity"  '"\$gf" = "git-identity\.md"'
+check "sensitive_600_branch_token_mgmt"    '"\$gf" = "token-management\.md"'
+check "sensitive_chmod_600"                'chmod 600 "\$HOME/\.claude/\$gf"'
+
+# 3. Default branch must apply 0644 to non-sensitive tracked files.
+check "default_chmod_644" 'chmod 644 "\$HOME/\.claude/\$gf"'
+
+# 4. conversation-language.md is rendered separately (Phase 5 helper) and
+#    must also be set to 0644 explicitly.
+check "conversation_lang_644" 'chmod 644 "\$HOME/\.claude/conversation-language\.md"'
+
+# --- Summary --------------------------------------------------------------
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi


### PR DESCRIPTION
## What

### Summary
Completes the install-r7 polish pass with three logical commits:

1. `feat(install)` — per-install Agent Conversation Language selection wired into the existing `CLAUDE_CONTENT_LANGUAGE` pipeline, rendered from a new `.tmpl` file.
2. `refactor(scripts)` — fail-fast hardening for `backup.{sh,ps1}` and `sync.{sh,ps1}`, replacing silent error suppression with explicit failure paths.
3. `test(install)` — regression coverage for the new helpers and a lint test for the permission policy enforced by `scripts/install.sh`.

### Change Type
- [x] Feature (Agent Conversation Language flow)
- [x] Refactor (fail-fast in backup/sync)
- [x] Test (helpers + policy lint)

### Affected Components
| Area | Files |
|------|-------|
| Entry points | `bootstrap.{sh,ps1}`, `scripts/install.{sh,ps1}` |
| Helpers | `scripts/install-manifest.{sh,ps1}` (new helpers) |
| Backup / Sync | `scripts/backup.{sh,ps1}`, `scripts/sync.{sh,ps1}` |
| Templates / Config | `global/conversation-language.md.tmpl` (new), `global/CLAUDE.md` |
| Tests | `tests/scripts/test-install-manifest-helpers.{sh,ps1}` (new), `tests/scripts/test-install-permissions-policy.sh` (new) |
| CI | `.github/workflows/validate-hooks.yml` |
| Docs | `docs/install.md` |

## Why

### Problem Solved
- Agent-side conversation language was implicit and not configurable per install. Users could set `CLAUDE_CONTENT_LANGUAGE` for prose output, but the language used for reasoning, tool execution, and subagent commands had no install-time control surface.
- Backup and sync scripts swallowed errors via `|| true` (POSIX) and `-ErrorAction SilentlyContinue` (PowerShell), masking broken state on reinstall flows. A failed `cp` or `chmod` left users in an inconsistent state with no signal.
- The new manifest helpers (`guarded_template_copy`, `update_claude_settings_json`) shipped without regression coverage. The 700/600/644 chmod policy in `scripts/install.sh` had no lint guard against accidental drift.

### Motivation
- Make the Agent Conversation Language a first-class install choice, alongside `CLAUDE_CONTENT_LANGUAGE`.
- Eliminate silent failure modes that hide install/backup/sync breakage.
- Lock in the new helper contracts and the chmod policy before they spread further.

## How

### Implementation Highlights

**Template flow (`feat`):**
- New `global/conversation-language.md.tmpl` with `{{AGENT_LANGUAGE_POLICY}}` placeholder, imported via `@./conversation-language.md` from `global/CLAUDE.md`.
- New helpers in `scripts/install-manifest.{sh,ps1}`:
  - `guarded_template_copy <src.tmpl> <dest> <key> <display_lang>` — renders the placeholder with `sed` / `-replace`, then delegates to the existing `guarded_copy` so the rendered output participates in the same SHA-256 manifest divergence detection.
  - `update_claude_settings_json <settings_path> <agent_lang> <content_lang>` — writes `.language` + `.env.CLAUDE_CONTENT_LANGUAGE`, with idempotent reset on the default `english` policy that deletes the env entry and prunes any resulting empty `.env` object.
- All four entry points (`bootstrap.{sh,ps1}`, `scripts/install.{sh,ps1}`) prompt for both Agent and Content language with English labels.
- `install.ps1` now trusts the dot-sourced helper and fail-fasts when missing instead of carrying unreachable `Get-Command` fallbacks.
- `settings.json` copy intentionally bypasses manifest gating (commented in all 4 entry points) so policy attributes are enforced every run.

**Fail-fast (`refactor`):**
- POSIX: `|| true` suppression on `cp` / `chmod` replaced with `|| error "..."`. Empty-directory checks added with `[ -n "$(ls -A ...)" ]` guards before glob expansion to avoid `no such file or directory` on empty dirs.
- PowerShell: `-ErrorAction SilentlyContinue` replaced with `-ErrorAction Stop` wrapped in `try/catch + Write-ErrorMessage`, with a `Get-ChildItem` count guard before each `Copy-Item`.
- `sync.sh` now runs `check_dependencies` for `cp`/`mkdir`/`rm`/`diff` at script start to fail before any partial state mutation.

**Tests (`test`):**
- `tests/scripts/test-install-manifest-helpers.{sh,ps1}` — verifies that `update_claude_settings_json` writes `language` + `CLAUDE_CONTENT_LANGUAGE`, and that a follow-up call with the default `english` policy idempotently removes the env entry plus any empty `.env` object. Also covers `guarded_template_copy` rendering and manifest registration.
- `tests/scripts/test-install-permissions-policy.sh` — lint test that greps `install.sh` for the 700/600/644 chmod policy on `~/.claude` and the sensitive vs default branches.
- `.github/workflows/validate-hooks.yml` registers the three new tests and extends the `paths` trigger to cover install-manifest helpers, bootstrap, and the new test files themselves.

### Testing Done
- [x] `bash tests/scripts/test-install-manifest-helpers.sh` — **3/3 PASS** (`update_claude_settings_json`, `guarded_template_copy`, idempotent reset)
- [x] `bash tests/scripts/test-install-permissions-policy.sh` — **6/6 PASS**
- [ ] PowerShell-side tests (`*.ps1`) not executed locally; will run in `validate-hooks.yml` CI.

### Test Plan for Reviewers
1. Pull the branch and run both new sh tests; confirm green.
2. Inspect the `.tmpl` render path in `scripts/install-manifest.sh:152-168` — verify the tempfile is removed even when `guarded_copy` returns 1 (keep local).
3. Review the idempotent-reset jq pipeline in `scripts/install-manifest.sh:184-187` — verify the empty-`.env` prune logic.
4. Manually run `bash bootstrap.sh` in a throwaway `$HOME` and confirm both Agent and Content language prompts appear, with English labels.

### Breaking Changes
None. Existing manifest gating is preserved; new helpers are additive. The default `english` policy preserves current behavior.

### Rollback
1. Revert this PR.
2. No schema changes, no migrations, no data loss.
3. The new template file is gated by the `@./conversation-language.md` import in `global/CLAUDE.md`; if the template is removed but the import remains, the import becomes a no-op rather than a hard error.

## Where

### Files Changed (17 files, +883/-121)
| Directory | Files | Type |
|-----------|-------|------|
| `bootstrap.{sh,ps1}` | 2 | Modified |
| `scripts/install.{sh,ps1}` | 2 | Modified |
| `scripts/install-manifest.{sh,ps1}` | 2 | Modified (new helpers) |
| `scripts/backup.{sh,ps1}` | 2 | Modified (fail-fast) |
| `scripts/sync.{sh,ps1}` | 2 | Modified (fail-fast) |
| `global/conversation-language.md.tmpl` | 1 | New |
| `global/CLAUDE.md` | 1 | Modified (+1 line) |
| `docs/install.md` | 1 | Modified |
| `tests/scripts/*.{sh,ps1}` | 3 | New |
| `.github/workflows/validate-hooks.yml` | 1 | Modified |

### API / Schema Changes
- New shell helpers: `guarded_template_copy`, `update_claude_settings_json` (POSIX + PowerShell).
- `~/.claude/settings.json` may now contain `.language` and `.env.CLAUDE_CONTENT_LANGUAGE`.
- No DB / wire-format changes.

## When

### Urgency
- [x] Normal — fold into the next `develop` → `main` release window.

### Dependencies
- Depends on: prior `r6` install pipeline merged on `develop`.
- Blocks: nothing currently open.

## Who

### Reviewers
- @kcenon (author / repo owner)

### Required Approvals
- [ ] Code owner (install scripts)

## Checklist
- [x] Code follows project style guidelines (Conventional Commits, English commit bodies)
- [x] Self-review completed
- [x] Tests added (3 new test scripts)
- [x] Documentation updated (`docs/install.md` Template Files section)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (3 logical commits)
- [x] Targets `develop` per project branching strategy
