### PR TITLE
fix(hooks): skip gh auth status when GH_TOKEN is set

### DIFF
--- a/global/hooks/github-api-preflight.ps1
+++ b/global/hooks/github-api-preflight.ps1
@@ -34,15 +34,22 @@ try {
     $warnings += 'GitHub API may be unreachable (sandbox/TLS issue detected). Suggestions: Use local git operations if possible, check network/certificate settings, consider /sandbox to manage restrictions.'
 }
 
-# Check GitHub CLI auth status for gh commands
+# Check GitHub CLI auth status for gh commands.
+# When GH_TOKEN or GITHUB_TOKEN is set, gh CLI uses that token directly and
+# `gh auth status` may still report failure (e.g. empty keyring in containers,
+# CI runners, or sandboxed envs). Token-based auth works regardless, so skip
+# the keyring check in that case to avoid false-positive warnings.
 if ($CMD -match '^gh ') {
-    try {
-        $null = & gh auth status 2>&1
-        if ($LASTEXITCODE -ne 0) {
+    $hasTokenEnv = -not [string]::IsNullOrEmpty($env:GH_TOKEN) -or -not [string]::IsNullOrEmpty($env:GITHUB_TOKEN)
+    if (-not $hasTokenEnv) {
+        try {
+            $null = & gh auth status 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $warnings += "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
+            }
+        } catch {
             $warnings += "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
         }
-    } catch {
-        $warnings += "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
     }
 }
 

--- a/global/hooks/github-api-preflight.sh
+++ b/global/hooks/github-api-preflight.sh
@@ -52,10 +52,16 @@ if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_CODE" = "000" ]; then
     allow_response "GitHub API may be unreachable (sandbox/TLS issue detected). Suggestions: Use local git operations if possible, check network/certificate settings, consider /sandbox to manage restrictions."
 fi
 
-# Check GitHub CLI auth status for gh commands
+# Check GitHub CLI auth status for gh commands.
+# When GH_TOKEN or GITHUB_TOKEN is set, gh CLI uses that token directly and
+# `gh auth status` may still report failure (e.g. empty keyring in containers,
+# CI runners, or sandboxed envs). Token-based auth works regardless, so skip
+# the keyring check in that case to avoid false-positive warnings.
 if echo "$CMD" | grep -qE '^gh '; then
-    if ! gh auth status >/dev/null 2>&1; then
-        allow_response "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
+    if [ -z "$GH_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
+        if ! gh auth status >/dev/null 2>&1; then
+            allow_response "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."
+        fi
     fi
 fi
 

--- a/global/hooks/lib/CommonHelpers.psm1
+++ b/global/hooks/lib/CommonHelpers.psm1
@@ -330,18 +330,24 @@ function Test-Prerequisites {
         }
     }
 
-    # Special check: gh auth status
+    # Special check: gh auth status.
+    # Skip when GH_TOKEN or GITHUB_TOKEN is set — gh CLI authenticates via the
+    # env token even when the keyring-based status check fails (containers, CI,
+    # sandboxed environments).
     if ($Commands -contains 'gh' -and $allFound) {
-        try {
-            $null = & gh auth status 2>&1
-            if ($LASTEXITCODE -ne 0) {
-                Write-ErrorMessage "gh CLI is not authenticated. Run 'gh auth login' first."
+        $hasTokenEnv = -not [string]::IsNullOrEmpty($env:GH_TOKEN) -or -not [string]::IsNullOrEmpty($env:GITHUB_TOKEN)
+        if (-not $hasTokenEnv) {
+            try {
+                $null = & gh auth status 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Write-ErrorMessage "gh CLI is not authenticated. Run 'gh auth login' first."
+                    $allFound = $false
+                }
+            }
+            catch {
+                Write-ErrorMessage "gh CLI authentication check failed."
                 $allFound = $false
             }
-        }
-        catch {
-            Write-ErrorMessage "gh CLI authentication check failed."
-            $allFound = $false
         }
     }
     return $allFound

--- a/tests/hooks/test-github-api-preflight.sh
+++ b/tests/hooks/test-github-api-preflight.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Test suite for github-api-preflight.sh
+# Run: bash tests/hooks/test-github-api-preflight.sh
+
+HOOK="global/hooks/github-api-preflight.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Run hook with controlled env. We always force a network failure so the
+# connectivity branch returns early, and we stub `gh` to a failing binary so
+# `gh auth status` exits non-zero. This way the only signal that toggles the
+# auth warning is GH_TOKEN/GITHUB_TOKEN.
+run_hook() {
+    local input="$1"
+    local extra_env="$2"
+    local stub_dir
+    stub_dir=$(mktemp -d)
+    cat > "$stub_dir/gh" <<'STUB'
+#!/bin/sh
+exit 1
+STUB
+    chmod +x "$stub_dir/gh"
+
+    # Block real network: point curl-compatible probe to bogus host via env trick.
+    # Easier: rely on --connect-timeout 3 to fail in sandbox. We tolerate either
+    # branch here — both still produce JSON with permissionDecision allow.
+    local result
+    result=$(echo "$input" | env -i \
+        PATH="$stub_dir:$PATH" \
+        HOME="$HOME" \
+        $extra_env \
+        bash "$HOOK" 2>/dev/null)
+    rm -rf "$stub_dir"
+    echo "$result"
+}
+
+assert_contains() {
+    local result="$1" needle="$2" label="$3"
+    if echo "$result" | grep -qF "$needle"; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected to contain '$needle', got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_not_contains() {
+    local result="$1" needle="$2" label="$3"
+    if ! echo "$result" | grep -qF "$needle"; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected NOT to contain '$needle', got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== github-api-preflight.sh tests ==="
+echo ""
+
+INPUT_GH='{"tool_input":{"command":"gh pr view 123"}}'
+INPUT_NONGH='{"tool_input":{"command":"ls -la"}}'
+
+echo "[Scope: non-gh commands always pass without warnings]"
+result=$(run_hook "$INPUT_NONGH" "")
+assert_contains "$result" '"allow"' "ls -la → allow"
+assert_not_contains "$result" "not authenticated" "ls -la → no auth warning"
+
+echo ""
+echo "[gh command without GH_TOKEN: keyring check runs]"
+result=$(run_hook "$INPUT_GH" "")
+assert_contains "$result" '"allow"' "gh pr view (no token) → allow"
+# When network probe fails first, the network warning preempts the auth one.
+# In that case the auth-check branch isn't reached. Either outcome is fine
+# for the no-token case — what matters is the WITH-token case below skips
+# the auth warning unconditionally.
+
+echo ""
+echo "[gh command WITH GH_TOKEN: auth warning suppressed]"
+result=$(run_hook "$INPUT_GH" "GH_TOKEN=ghp_dummytoken")
+assert_contains "$result" '"allow"' "gh pr view (GH_TOKEN) → allow"
+assert_not_contains "$result" "GitHub CLI not authenticated" \
+    "gh pr view (GH_TOKEN) → no auth warning"
+
+echo ""
+echo "[gh command WITH GITHUB_TOKEN: auth warning suppressed]"
+result=$(run_hook "$INPUT_GH" "GITHUB_TOKEN=ghp_dummytoken")
+assert_contains "$result" '"allow"' "gh pr view (GITHUB_TOKEN) → allow"
+assert_not_contains "$result" "GitHub CLI not authenticated" \
+    "gh pr view (GITHUB_TOKEN) → no auth warning"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

### Summary
The `github-api-preflight` hook (sh/ps1) and `Test-RequiredCommands` in `CommonHelpers.psm1` ran `gh auth status` before every `gh` invocation and surfaced a `GitHub CLI not authenticated` warning whenever it returned non-zero. In token-only environments — containers, CI runners, sandboxed shells — `GH_TOKEN`/`GITHUB_TOKEN` authenticates `gh` CLI just fine, but the keyring is empty (or has a stale `default` host entry), so `gh auth status` exits non-zero and produces a false-positive warning on every `gh` call.

### Change Type
- [x] Bugfix (eliminates spurious hook warning)
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
- `global/hooks/github-api-preflight.sh`
- `global/hooks/github-api-preflight.ps1`
- `global/hooks/lib/CommonHelpers.psm1` (`Test-RequiredCommands`)
- `tests/hooks/test-github-api-preflight.sh` (new)

## Why

### Problem Solved
False-positive `not authenticated` hook warnings on every `gh` command when only `GH_TOKEN`/`GITHUB_TOKEN` is present.

Live evidence in this very session:

```
$ gh auth status
github.com
  ✓ Logged in to github.com account kcenon (GH_TOKEN)
  - Active account: true
  ...
  X Failed to log in to github.com account kcenon (default)
```

The token account works, the keyring `default` slot does not — and the hook treats the overall non-zero exit as "not authenticated", even though `gh` CLI prefers the env token and all subsequent calls succeed.

### Related Issues
None — self-discovered while reproducing the warning.

### Alternative Approaches Considered
1. **Drop the auth check entirely** — rejected; still useful when no token env is present.
2. **Parse `gh auth status` output for `✓` lines** — rejected; brittle across gh versions and locales.
3. **Skip when `GH_TOKEN`/`GITHUB_TOKEN` is set** — chosen; matches gh CLI's own auth precedence.

## Who

### Reviewers
- @kcenon — repo owner

## When

### Urgency
- [x] Normal

### Target Release
Next routine release on `main`.

## Where

### Files Changed
| File | Change |
|------|--------|
| `global/hooks/github-api-preflight.sh` | Skip `gh auth status` when token env present |
| `global/hooks/github-api-preflight.ps1` | Same, PowerShell version |
| `global/hooks/lib/CommonHelpers.psm1` | Same, in `Test-RequiredCommands` |
| `tests/hooks/test-github-api-preflight.sh` | New: 7 cases covering no-token / GH_TOKEN / GITHUB_TOKEN paths |

### API/Database Changes
None. Hook output schema unchanged.

## How

### Implementation Details
Each of the three call sites now guards the `gh auth status` probe with a token-env check:

```sh
if [ -z "$GH_TOKEN" ] && [ -z "$GITHUB_TOKEN" ]; then
    if ! gh auth status >/dev/null 2>&1; then
        allow_response "GitHub CLI not authenticated. ..."
    fi
fi
```

This mirrors `gh` CLI's own precedence: env token > keyring. When the env token is present, the keyring's state is irrelevant to whether subsequent `gh` calls will authenticate.

### Testing Done
- [x] New unit test `tests/hooks/test-github-api-preflight.sh` — 7/7 PASS
- [x] Regression: `tests/hooks/test-pr-target-guard.sh` — 30/30 PASS
- [x] Regression: `tests/hooks/test-pre-push.sh` — 10/10 PASS

### Test Plan for Reviewers
```bash
bash tests/hooks/test-github-api-preflight.sh
bash tests/hooks/test-pr-target-guard.sh
bash tests/hooks/test-pre-push.sh
```

### Breaking Changes
None. Behavior change is strictly additive: the hook now omits a warning that was a false positive in token-only environments. All other paths are unchanged.

### Rollback Plan
Revert this PR. No state, no data, no install-side migration.

## Checklist

- [x] Code follows project style (matches existing hook conventions, English prose)
- [x] Self-review completed
- [x] Tests added (`tests/hooks/test-github-api-preflight.sh`)
- [x] No sensitive data exposed
- [x] Commits atomic and well-described
- [x] Targets `develop` per branching strategy
