### PR TITLE
feat(schema): allow halt_conditions array alongside halt_condition (P1-a)

### DIFF
--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -30,13 +30,18 @@ Skills that perform iterative work (retry loops, polling loops, multi-round refi
 
 ```yaml
 max_iterations: <int>          # Hard upper bound on loop iterations
-halt_condition: "<expression>" # Natural language or regex describing success/abort signal
-on_halt: "<action>"            # What to do when halt condition fires (report, escalate, exit)
+halt_condition: "<expression>" # Legacy: natural language or regex describing success/abort signal
+halt_conditions:               # Preferred: structured form (array of {type, expr}); string form also accepted in P1 grace period
+  - { type: success, expr: "<expression>" }
+  - { type: limit,   expr: "<expression>" }
+on_halt: "<action>"            # What to do when a halt condition fires (report, escalate, exit)
 ```
 
 Required for skills whose body contains a polling loop, retry loop, or multi-round iteration (`issue-work`, `pr-work`, `ci-fix`, `release`, `research`, `fleet-orchestrator`). Optional otherwise.
 
 Prefer regex or symbolic halt conditions over free-form prose when the signal is deterministic (CI status, exit codes). Reserve natural language for cases where interpretation is intrinsically subjective.
+
+`halt_condition` (singular, string) is the legacy key. `halt_conditions` (plural) is the structured replacement: array entries are `{type, expr}` where `type ∈ [success, failure, limit, user, fallback]`. Both keys validate during the P1 grace period; A2/A3 will migrate skills and tighten enforcement.
 
 ## Loop-Safety Flag
 

--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.json",
   "title": "Claude Code SKILL.md Frontmatter",
-  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, on_halt, loop_safe) and tier-preset extension fields (tiers, default_tier).",
+  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, halt_conditions, on_halt, loop_safe) and tier-preset extension fields (tiers, default_tier).",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
@@ -24,6 +24,23 @@
           "type": "integer",
           "minimum": 1,
           "description": "Advisory cap on the number of files the skill should enumerate or modify in a single invocation."
+        }
+      }
+    },
+    "haltConditionEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "expr"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["success", "failure", "limit", "user", "fallback"],
+          "description": "Halt category. success=terminal success, failure=stop-on-error, limit=iteration/resource cap, user=human signal, fallback=escalation."
+        },
+        "expr": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Condition expression. Prefer regex or symbolic form for deterministic signals; natural language otherwise."
         }
       }
     }
@@ -116,7 +133,14 @@
     "halt_condition": {
       "type": "string",
       "minLength": 1,
-      "description": "Iteration-control extension (claude-config): plain-language condition that stops the iteration loop early."
+      "description": "Iteration-control extension (claude-config, legacy): plain-language condition that stops the iteration loop early. Superseded by halt_conditions; both accepted during P1 grace period."
+    },
+    "halt_conditions": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "array", "items": { "$ref": "#/$defs/haltConditionEntry" }, "minItems": 1 }
+      ],
+      "description": "Iteration-control extension (claude-config): structured halt conditions. Either a single-string form (legacy compatibility for one-shot rename from halt_condition) or an array of {type, expr} entries. Replaces halt_condition; both keys accepted during the P1 grace period."
     },
     "on_halt": {
       "type": "string",

--- a/tests/scripts/test-spec-lint.sh
+++ b/tests/scripts/test-spec-lint.sh
@@ -239,6 +239,75 @@ echo "[case 10: --strict exits 2 on violations]"
 "$PYTHON" "$LINTER" --mode skill --strict --quiet "$ENUM_SKILL" >/dev/null 2>&1; rc=$?
 assert_exit 2 "$rc" "--strict on violations -> exit 2"
 
+# ── Fixture: halt_conditions array form (A1, P1-a) ───────────
+HALT_ARRAY_SKILL="$WORK/halt-array-skill.md"
+write_file "$HALT_ARRAY_SKILL" '---
+name: halt-array-skill
+description: SKILL.md verifying that the new halt_conditions array form is accepted by the schema.
+max_iterations: 5
+halt_conditions:
+  - { type: success, expr: "All checks pass" }
+  - { type: limit, expr: "max_iterations reached" }
+loop_safe: true
+---
+
+content
+'
+
+echo ""
+echo "[case 10a: halt_conditions array form accepted]"
+out=$(run_lint skill "$HALT_ARRAY_SKILL" 2>&1); rc=$?
+assert_exit 0 "$rc" "halt_conditions array -> exit 0"
+
+# ── Fixture: halt_conditions legacy string form (grace period) ─
+HALT_STRING_SKILL="$WORK/halt-string-skill.md"
+write_file "$HALT_STRING_SKILL" '---
+name: halt-string-skill
+description: SKILL.md verifying that the legacy halt_conditions single-string form is still accepted during the P1 grace period.
+halt_conditions: "All checks pass OR user aborts"
+---
+
+content
+'
+
+echo ""
+echo "[case 10b: halt_conditions legacy string form accepted]"
+out=$(run_lint skill "$HALT_STRING_SKILL" 2>&1); rc=$?
+assert_exit 0 "$rc" "halt_conditions string -> exit 0"
+
+# ── Fixture: halt_conditions empty array (rejected) ──────────
+HALT_EMPTY_SKILL="$WORK/halt-empty-skill.md"
+write_file "$HALT_EMPTY_SKILL" '---
+name: halt-empty-skill
+description: SKILL.md verifying that an empty halt_conditions array is rejected by the schema.
+halt_conditions: []
+---
+
+content
+'
+
+echo ""
+echo "[case 10c: halt_conditions empty array rejected]"
+out=$(run_lint skill "$HALT_EMPTY_SKILL" 2>&1); rc=$?
+assert_exit 1 "$rc" "halt_conditions [] -> exit 1"
+
+# ── Fixture: halt_conditions unknown type (rejected) ─────────
+HALT_BAD_TYPE_SKILL="$WORK/halt-bad-type-skill.md"
+write_file "$HALT_BAD_TYPE_SKILL" '---
+name: halt-bad-type-skill
+description: SKILL.md verifying that an unknown halt_conditions entry type is rejected by the enum.
+halt_conditions:
+  - { type: telepathy, expr: "psychic signal" }
+---
+
+content
+'
+
+echo ""
+echo "[case 10d: halt_conditions unknown entry type rejected]"
+out=$(run_lint skill "$HALT_BAD_TYPE_SKILL" 2>&1); rc=$?
+assert_exit 1 "$rc" "halt_conditions unknown type -> exit 1"
+
 # ── Wrapper invocation ───────────────────────────────────────
 echo ""
 echo "[case 11: spec_lint.sh wrapper works in --mode form]"


### PR DESCRIPTION
Closes #455
Part of #454

## What
Extend `scripts/schemas/skill-md.schema.json` to allow `halt_conditions` as the structured replacement for the legacy `halt_condition` string. Both keys are accepted during the P1 grace period. Type enum: `success | failure | limit | user | fallback`.

## Why
P1 foundation. A2 (#457, migration) and A3 (#458, strict validation) both require the array form to be a valid schema target. Single-string `halt_condition` cannot express compound conditions structurally — only as natural-language OR clauses, which the validator cannot parse.

## Where
- `scripts/schemas/skill-md.schema.json` (+ `$defs.haltConditionEntry`, new `halt_conditions` property with `oneOf [string, array]`)
- `global/skills/_policy.md` (Iteration Control Schema section)
- `tests/scripts/test-spec-lint.sh` (4 new cases: 10a–10d)

## How
1. Added `$defs.haltConditionEntry` with required `{type, expr}`, type enum, and non-empty `expr`.
2. Added `halt_conditions` property with `oneOf: [{ type: string, minLength: 1 }, { type: array, items: $ref haltConditionEntry, minItems: 1 }]`.
3. Kept `halt_condition` (singular) unchanged with a description note pointing to `halt_conditions`.
4. Updated `_policy.md` Iteration Control Schema to show both forms with an explicit grace-period note.
5. Added test cases:
   - 10a: array form accepted (exit 0)
   - 10b: legacy string form accepted (exit 0)
   - 10c: empty array rejected (exit 1)
   - 10d: unknown entry `type` rejected (exit 1)

## Acceptance
- [x] Schema accepts both forms
- [x] All existing 13 SKILL.md still pass `validate_skills.sh` (253/253 pass)
- [x] G1 (spec_lint clean), G3 (test suite green) pass
- [x] PR Size ≤ S (~102 LOC)

## Test Plan
```bash
bash scripts/spec_lint.sh                  # all canonical files pass
bash tests/scripts/test-spec-lint.sh       # 37/37 pass (4 new + 33 existing)
bash scripts/validate_skills.sh            # 253/253 pass, 0 failures
```

## SemVer
suite: minor