### PR TITLE
feat(workspace): adopt NN_<phase> numeric prefix convention (P3)

### DIFF
--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -56,6 +56,33 @@ loop_safe: true | false
 
 Rules and anti-patterns: `docs/loop-patterns.md`.
 
+## Workspace Layout
+
+Skills that produce per-invocation artifacts write them to a workspace directory using a numeric phase prefix so the filesystem reflects pipeline order:
+
+```
+_workspace/{date}-{n}/NN_<phase>.<ext>
+```
+
+- `{date}` — invocation date in `YYYY-MM-DD` form.
+- `{n}` — 1-based ordinal for invocations in the same day.
+- `NN_` — 2-digit zero-padded phase index (`00_`, `01_`, …, `99_`). The leading zero keeps lexical order aligned with execution order.
+- `<phase>` — lowercase snake_case phase name (e.g. `discovery`, `plan`, `implement`, `review`).
+- `<ext>` — artifact extension (`md`, `json`, `txt`, `log`, …).
+
+Examples:
+
+```
+_workspace/2026-04-26-1/00_discovery.md
+_workspace/2026-04-26-1/01_plan.md
+_workspace/2026-04-26-1/02_implement.log
+_workspace/2026-04-26-1/03_review.md
+```
+
+The last `NN_*.ext` file in a workspace is the immediate halt-trace anchor: combined with `halt_conditions` (P1), it pinpoints where iteration stopped and why. Existing artifacts are point-forward only — no migration is required for prior workspaces.
+
+`scripts/check_workspace_prefix.sh` enforces the convention: non-conforming files emit warnings (not failures) during the rollout.
+
 ## Tier Preset Schema
 
 Skills whose `SKILL.md` body exceeds 5 KB declare tier presets in their frontmatter so callers can load the skill at a depth that matches the task. The schema exposes three tiers — `light`, `standard`, `deep` — each mapping to a list of reference documents and optional flags that shape runtime behavior.

--- a/scripts/check_workspace_prefix.sh
+++ b/scripts/check_workspace_prefix.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Workspace Prefix Linter (warn-only)
+# ====================================
+# Verifies that files inside `_workspace/{date}-{n}/` directories follow
+# the `NN_<phase>.<ext>` convention defined in global/skills/_policy.md.
+#
+# Convention:
+#   NN_       2-digit zero-padded phase index (00..99)
+#   <phase>   lowercase snake_case phase name
+#   <ext>     artifact extension
+#
+# Usage:
+#   scripts/check_workspace_prefix.sh                # scan repo root
+#   scripts/check_workspace_prefix.sh <root>         # scan an explicit root
+#   scripts/check_workspace_prefix.sh --quiet ...    # suppress per-file warnings
+#
+# Exit code: 0 always (warn-only by design during P3 rollout).
+
+set -u
+
+QUIET=0
+ROOT=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --quiet) QUIET=1; shift ;;
+        --help|-h)
+            sed -n '2,18p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) ROOT="$1"; shift ;;
+    esac
+done
+
+if [ -z "$ROOT" ]; then
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    ROOT="$(dirname "$SCRIPT_DIR")"
+fi
+
+if [ ! -d "$ROOT" ]; then
+    echo "check_workspace_prefix: root not found: $ROOT" >&2
+    exit 0
+fi
+
+# NN_<phase>.<ext>
+#   NN          : ^[0-9][0-9]_
+#   <phase>     : [a-z][a-z0-9_]*
+#   <ext>       : \.[a-z0-9]+$
+PREFIX_RE='^[0-9][0-9]_[a-z][a-z0-9_]*\.[a-z0-9]+$'
+
+WS_ROOTS=()
+while IFS= read -r d; do
+    [ -n "$d" ] && WS_ROOTS+=("$d")
+done < <(find "$ROOT" -type d -name "_workspace" -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null)
+
+WARN_COUNT=0
+SCAN_COUNT=0
+
+for ws in "${WS_ROOTS[@]:-}"; do
+    [ -z "${ws:-}" ] && continue
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        SCAN_COUNT=$((SCAN_COUNT + 1))
+        name="$(basename "$f")"
+        if ! [[ "$name" =~ $PREFIX_RE ]]; then
+            WARN_COUNT=$((WARN_COUNT + 1))
+            if [ "$QUIET" -eq 0 ]; then
+                rel="${f#$ROOT/}"
+                echo "WARN: $rel does not match NN_<phase>.<ext> convention"
+            fi
+        fi
+    done < <(find "$ws" -mindepth 2 -type f 2>/dev/null)
+done
+
+if [ "$QUIET" -eq 0 ]; then
+    echo "check_workspace_prefix: scanned=$SCAN_COUNT warnings=$WARN_COUNT roots=${#WS_ROOTS[@]}"
+fi
+
+exit 0

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -436,6 +436,29 @@ else
     record_warning
 fi
 
+# Workspace prefix convention (P3) — warn-only during rollout
+echo ""
+echo "======================================================"
+info "Workspace 접두사 검증 (NN_<phase>.<ext>)"
+echo "======================================================"
+echo ""
+
+if [ -x "$SCRIPT_DIR/check_workspace_prefix.sh" ]; then
+    ws_out="$("$SCRIPT_DIR/check_workspace_prefix.sh" "$BACKUP_DIR" 2>&1)" || true
+    ws_warn="$(echo "$ws_out" | sed -n 's/.*warnings=\([0-9]*\).*/\1/p' | tail -n1)"
+    if [ "${ws_warn:-0}" = "0" ]; then
+        success "check_workspace_prefix: 위반 사항 없음"
+        record_pass
+    else
+        echo "$ws_out"
+        warning "check_workspace_prefix: ${ws_warn}개 파일이 NN_<phase>.<ext> 컨벤션을 따르지 않음 (warn-only)"
+        record_warning
+    fi
+else
+    warning "check_workspace_prefix.sh 누락 — workspace 접두사 검증 건너뜀"
+    record_warning
+fi
+
 # 검증 결과 요약
 echo ""
 echo "======================================================"

--- a/tests/scripts/test-workspace-prefix.sh
+++ b/tests/scripts/test-workspace-prefix.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Test suite for scripts/check_workspace_prefix.sh
+# Run: bash tests/scripts/test-workspace-prefix.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+LINTER="$ROOT_DIR/scripts/check_workspace_prefix.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+assert_contains() {
+    local needle="$1" output="$2" label="$3"
+    if echo "$output" | grep -Fq -- "$needle"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- output did not contain '$needle'")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" output="$2" label="$3"
+    if echo "$output" | grep -Fq -- "$needle"; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- output unexpectedly contained '$needle'")
+        echo "  FAIL: $label"
+    else
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    fi
+}
+
+assert_exit() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (exit $actual)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- expected exit $expected, got $actual")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== check_workspace_prefix.sh tests ==="
+echo ""
+
+# ── Fixture: only conforming files ───────────────────────────
+FIX_GOOD="$WORK/good"
+mkdir -p "$FIX_GOOD/_workspace/2026-04-26-1"
+: > "$FIX_GOOD/_workspace/2026-04-26-1/00_discovery.md"
+: > "$FIX_GOOD/_workspace/2026-04-26-1/01_plan.md"
+: > "$FIX_GOOD/_workspace/2026-04-26-1/02_implement.log"
+
+echo "[case 1: all conforming files -> 0 warnings]"
+out=$(bash "$LINTER" "$FIX_GOOD" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit code 0 (warn-only)"
+assert_contains "scanned=3" "$out" "scanned 3 files"
+assert_contains "warnings=0" "$out" "no warnings"
+
+# ── Fixture: mix of conforming and non-conforming ────────────
+FIX_MIX="$WORK/mix"
+mkdir -p "$FIX_MIX/_workspace/2026-04-26-1"
+: > "$FIX_MIX/_workspace/2026-04-26-1/00_discovery.md"
+: > "$FIX_MIX/_workspace/2026-04-26-1/notes.md"
+: > "$FIX_MIX/_workspace/2026-04-26-1/1_oneDigit.md"
+: > "$FIX_MIX/_workspace/2026-04-26-1/02_PascalCase.md"
+
+echo ""
+echo "[case 2: mixed files -> 3 warnings, exit still 0]"
+out=$(bash "$LINTER" "$FIX_MIX" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit code 0 even with warnings"
+assert_contains "warnings=3" "$out" "3 non-conforming files reported"
+assert_contains "notes.md" "$out" "warns on missing prefix"
+assert_contains "1_oneDigit.md" "$out" "warns on single-digit prefix"
+assert_contains "02_PascalCase.md" "$out" "warns on non-snake_case phase"
+assert_not_contains "00_discovery.md" "$out" "no warning for conforming file"
+
+# ── Fixture: no _workspace directory at all ──────────────────
+FIX_EMPTY="$WORK/empty"
+mkdir -p "$FIX_EMPTY/src"
+: > "$FIX_EMPTY/src/main.go"
+
+echo ""
+echo "[case 3: no _workspace dir -> scan 0 files, no warnings]"
+out=$(bash "$LINTER" "$FIX_EMPTY" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 with no workspace"
+assert_contains "scanned=0" "$out" "scanned 0 files"
+assert_contains "roots=0" "$out" "0 workspace roots"
+
+# ── Quiet mode suppresses per-file output ────────────────────
+echo ""
+echo "[case 4: --quiet suppresses per-file warnings and summary]"
+out=$(bash "$LINTER" --quiet "$FIX_MIX" 2>&1); rc=$?
+assert_exit 0 "$rc" "quiet exit 0"
+assert_not_contains "WARN:" "$out" "no per-file warnings printed"
+assert_not_contains "scanned=" "$out" "no summary line printed"
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #456
Part of #454

## What
Adopt `_workspace/{date}-{n}/NN_<phase>.<ext>` filename convention for skill-produced artifacts. Adds policy text, a standalone warn-only linter, and integrates the linter into `validate_skills.sh`. New test file covers 4 scenarios.

## Why
P3. Numbered prefixes make pipeline order self-evident in the filesystem (`ls _workspace/2026-04-26-1/` sorts both chronologically and logically). Combined with P1 halt_conditions, the last `NN_*.ext` becomes the halt-trace anchor — estimated post-incident diagnosis 30 min → 3 min.

## Where
- `global/skills/_policy.md` — new "Workspace Layout" section.
- `scripts/check_workspace_prefix.sh` — new standalone linter (warn-only).
- `scripts/validate_skills.sh` — calls the linter, records warning (not failure).
- `tests/scripts/test-workspace-prefix.sh` — new test file (15 assertions).

## How
1. Convention documented in `_policy.md`: `NN_` is 2-digit zero-padded; phase is lowercase snake_case.
2. `check_workspace_prefix.sh` walks all `_workspace/*/` dirs under the repo root, validates filenames against `^[0-9][0-9]_[a-z][a-z0-9_]*\.[a-z0-9]+$`, and emits per-file WARN lines + a summary. Always exits 0 during the P3 rollout (warn-only).
3. `validate_skills.sh` invokes the linter alongside `spec_lint`, parses the `warnings=N` summary, records a warning when N>0.
4. Existing artifacts are point-forward only — no migration required.

## Acceptance
- [x] Policy text added (`_policy.md` Workspace Layout section)
- [x] Validator emits warning (not fail) for non-conforming files (verified via fixtures)
- [x] New test passes (15/15)
- [ ] PR Size ≤ S (~90 LOC) — **see note**

**PR size note**: total +247 LOC. The 50-line policy + validator integration is well within S, but the new `check_workspace_prefix.sh` (79 lines) and `test-workspace-prefix.sh` (118 lines) push us into M territory. Splitting further would either skip the test file (poor quality bar) or inline the linter into `validate_skills.sh` (worse separation of concerns). Keeping bundled.

## Test Plan
```bash
bash tests/scripts/test-workspace-prefix.sh   # 15/15 pass
bash tests/scripts/test-spec-lint.sh           # 37/37 pass (no regression)
bash scripts/validate_skills.sh                # 255/255 pass, 0 failures
bash scripts/check_workspace_prefix.sh         # repo has no _workspace yet, scanned=0 warnings=0
```

## SemVer
suite: minor