### PR TITLE
feat(schema): add severity enum (S1|S2|S3) to skill frontmatter (P2-a)

### DIFF
--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -83,6 +83,25 @@ The last `NN_*.ext` file in a workspace is the immediate halt-trace anchor: comb
 
 `scripts/check_workspace_prefix.sh` enforces the convention: non-conforming files emit warnings (not failures) during the rollout.
 
+## Severity
+
+Code-review domain skills declare severity in their frontmatter so triage can be automated. Free-form prose previously produced inconsistent merge-block thresholds; the enum collapses that ambiguity.
+
+```yaml
+severity: S1 | S2 | S3              # Primary tier this skill triages at
+finding_levels: [S1, S2, S3]        # Subset of levels this skill emits findings at
+```
+
+| Tier | Meaning | Effect on PR |
+|------|---------|--------------|
+| `S1` | Block-merge | Reviewer must resolve before merge — no exceptions |
+| `S2` | Review-required | Reviewer attention requested; can be acknowledged-and-deferred |
+| `S3` | Advisory | Informational only; no action required |
+
+Both fields are optional and apply to code-review domain skills only (e.g. `code-quality`, `security-audit`, `pr-review`). `doc-review` and `release` are explicitly out of scope — they describe gates, not findings, and would create category errors.
+
+`finding_levels` lists every level the skill may surface. A skill with `severity: S2` and `finding_levels: [S1, S2]` triages at S2 by default but can escalate individual findings to S1.
+
 ## Tier Preset Schema
 
 Skills whose `SKILL.md` body exceeds 5 KB declare tier presets in their frontmatter so callers can load the skill at a depth that matches the task. The schema exposes three tiers — `light`, `standard`, `deep` — each mapping to a list of reference documents and optional flags that shape runtime behavior.

--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.json",
   "title": "Claude Code SKILL.md Frontmatter",
-  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, halt_conditions, on_halt, loop_safe) and tier-preset extension fields (tiers, default_tier).",
+  "description": "Canonical schema for Claude Code 2026 SKILL.md YAML frontmatter. 14 official fields plus claude-config iteration-control extension fields (max_iterations, halt_condition, halt_conditions, on_halt, loop_safe), tier-preset extension fields (tiers, default_tier), and severity extension fields (severity, finding_levels).",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
@@ -165,6 +165,18 @@
       "type": "string",
       "enum": ["light", "standard", "deep"],
       "description": "Tier-preset extension (claude-config): tier applied when the caller omits --tier. Defaults to 'standard' when this field is absent."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["S1", "S2", "S3"],
+      "description": "Severity extension (claude-config): primary severity tier this skill triages at. S1 = block-merge, S2 = review-required, S3 = advisory. Code-review domain only."
+    },
+    "finding_levels": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["S1", "S2", "S3"] },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Severity extension (claude-config): set of severity levels this skill emits findings at. Subset of {S1, S2, S3}; non-empty and unique."
     }
   }
 }

--- a/tests/scripts/test-severity-enum.sh
+++ b/tests/scripts/test-severity-enum.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Test suite for severity / finding_levels schema additions (C1, P2-a)
+# Run: bash tests/scripts/test-severity-enum.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+LINTER="$ROOT_DIR/scripts/spec_lint.py"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH" >&2
+    exit 0
+fi
+if ! "$PYTHON" -c "import yaml, jsonschema" >/dev/null 2>&1; then
+    echo "SKIP: missing PyYAML or jsonschema" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+write_skill() {
+    local path="$1" extra="$2"
+    cat > "$path" <<EOF
+---
+name: $(basename "$path" .md)
+description: SKILL fixture for severity-enum testing covering both severity (single) and finding_levels (array) keys with valid and invalid values.
+$extra
+---
+
+content
+EOF
+}
+
+assert_exit() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (exit $actual)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- expected exit $expected, got $actual")
+        echo "  FAIL: $label"
+    fi
+}
+
+run_lint() {
+    "$PYTHON" "$LINTER" --mode skill --quiet "$1"
+}
+
+echo "=== severity / finding_levels schema tests ==="
+echo ""
+
+# ── Positive: severity S1 / S2 / S3 accepted ─────────────────
+for tier in S1 S2 S3; do
+    lower="$(echo "$tier" | tr '[:upper:]' '[:lower:]')"
+    f="$WORK/sev-$lower.md"
+    write_skill "$f" "severity: $tier"
+    echo "[case: severity=$tier accepted]"
+    run_lint "$f"; rc=$?
+    assert_exit 0 "$rc" "severity=$tier -> exit 0"
+done
+
+# ── Positive: finding_levels arrays accepted ─────────────────
+echo ""
+echo "[case: finding_levels=[S1] accepted]"
+write_skill "$WORK/fl-one.md" "finding_levels: [S1]"
+run_lint "$WORK/fl-one.md"; rc=$?
+assert_exit 0 "$rc" "finding_levels [S1] -> exit 0"
+
+echo ""
+echo "[case: finding_levels=[S1, S2, S3] accepted]"
+write_skill "$WORK/fl-all.md" "finding_levels: [S1, S2, S3]"
+run_lint "$WORK/fl-all.md"; rc=$?
+assert_exit 0 "$rc" "finding_levels all tiers -> exit 0"
+
+# ── Positive: both keys together ─────────────────────────────
+echo ""
+echo "[case: severity + finding_levels combined]"
+write_skill "$WORK/combined.md" $'severity: S2\nfinding_levels: [S1, S2]'
+run_lint "$WORK/combined.md"; rc=$?
+assert_exit 0 "$rc" "severity=S2 + finding_levels=[S1,S2] -> exit 0"
+
+# ── Negative: invalid severity values ────────────────────────
+i=0
+for bad in S0 S4 s1 high HIGH critical; do
+    i=$((i + 1))
+    f="$WORK/bad-sev-$i.md"
+    write_skill "$f" "severity: $bad"
+    echo ""
+    echo "[case: severity=$bad rejected]"
+    out=$(run_lint "$f" 2>&1); rc=$?
+    assert_exit 1 "$rc" "severity=$bad -> exit 1"
+    if echo "$out" | grep -Fq "severity"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: rejection cited the severity field"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: severity=$bad rejection did not mention severity field; output: $out")
+        echo "  FAIL: rejection did not cite severity field"
+    fi
+done
+
+# ── Negative: empty finding_levels array ─────────────────────
+echo ""
+echo "[case: finding_levels=[] rejected]"
+write_skill "$WORK/fl-empty.md" "finding_levels: []"
+run_lint "$WORK/fl-empty.md"; rc=$?
+assert_exit 1 "$rc" "finding_levels [] -> exit 1"
+
+# ── Negative: invalid entry inside finding_levels ────────────
+echo ""
+echo "[case: finding_levels=[S0] rejected]"
+write_skill "$WORK/fl-bad.md" "finding_levels: [S0]"
+run_lint "$WORK/fl-bad.md"; rc=$?
+assert_exit 1 "$rc" "finding_levels [S0] -> exit 1"
+
+echo ""
+echo "[case: finding_levels=[S1, s2] rejected (lowercase)]"
+write_skill "$WORK/fl-mixed.md" "finding_levels: [S1, s2]"
+run_lint "$WORK/fl-mixed.md"; rc=$?
+assert_exit 1 "$rc" "finding_levels mixed-case -> exit 1"
+
+# ── Negative: duplicates inside finding_levels ───────────────
+echo ""
+echo "[case: finding_levels=[S1, S1] rejected (uniqueItems)]"
+write_skill "$WORK/fl-dup.md" "finding_levels: [S1, S1]"
+run_lint "$WORK/fl-dup.md"; rc=$?
+assert_exit 1 "$rc" "finding_levels duplicates -> exit 1"
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #459
Part of #454

## What
Add two optional severity-domain extension fields to `skill-md.schema.json`:
- `severity` — single enum (`S1` | `S2` | `S3`).
- `finding_levels` — array of unique values from the same enum.

Document semantics in `_policy.md` and add a test suite covering valid + invalid values.

## Why
P2-a. Quantified severity is the prerequisite for triage automation. Free-form prose previously produced inconsistent merge-block thresholds across reviewers. Estimated triage time: 60s → 15s per comment. Foundation for C2 (#460) which will annotate code-review domain skills with these fields.

Scope is **code-review domain only** to avoid the doc-review / release category-error noted in ROI analysis — those skills describe gates, not findings.

## Where
- `scripts/schemas/skill-md.schema.json` — `severity` (string enum) + `finding_levels` (array, minItems 1, uniqueItems true).
- `global/skills/_policy.md` — new "Severity" section with tier table and field-relationship note.
- `tests/scripts/test-severity-enum.sh` — new test suite (22 assertions).

## How
1. Schema additions:
   - `severity`: `{ type: string, enum: [S1, S2, S3] }`
   - `finding_levels`: `{ type: array, items: { enum: [S1, S2, S3] }, minItems: 1, uniqueItems: true }`
2. Policy text:
   - Tier semantics table (S1 = block-merge, S2 = review-required, S3 = advisory).
   - Scope note (code-review domain only).
   - Field relationship: `severity` is the default tier, `finding_levels` is the set of levels the skill may emit.
3. Tests cover:
   - 3 positive cases (severity = S1 / S2 / S3)
   - 2 positive cases for `finding_levels` ([S1], [S1, S2, S3])
   - 1 combined case
   - 6 negative severity cases (S0, S4, s1, high, HIGH, critical) — each verified to cite the `severity` field in the rejection
   - 4 negative `finding_levels` cases (empty, [S0], mixed-case, duplicates)

## Acceptance
- [x] Schema accepts S1/S2/S3, rejects others
- [x] Policy text explains threshold semantics
- [x] G1 (spec_lint clean), G4 (severity test green) pass
- [x] PR Size ≤ S (~182 LOC; schema+policy is 32 LOC, the rest is the new test file)

## Test Plan
```bash
bash tests/scripts/test-severity-enum.sh       # 22/22 pass
bash tests/scripts/test-spec-lint.sh           # 37/37 pass (no regression)
bash tests/scripts/test-workspace-prefix.sh    # 15/15 pass (no regression)
bash scripts/validate_skills.sh                # 0 failures
bash scripts/spec_lint.sh                      # 0 violations
```

## SemVer
suite: minor