### PR TITLE
refactor(skills): migrate halt_condition to halt_conditions array (#457)

### DIFF
--- a/global/skills/ci-fix/SKILL.md
+++ b/global/skills/ci-fix/SKILL.md
@@ -6,7 +6,9 @@ user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(gh *)"
 max_iterations: 3
-halt_condition: "Workflow run conclusion == success, OR failure maps to an unknown error class not in reference/known-fixes.md"
+halt_conditions:
+  - { type: success,  expr: "Workflow run conclusion == success" }
+  - { type: fallback, expr: "failure maps to an unknown error class not in reference/known-fixes.md" }
 on_halt: "Escalate to user with failing log excerpt and classification result"
 loop_safe: true
 ---

--- a/global/skills/fleet-orchestrator/SKILL.md
+++ b/global/skills/fleet-orchestrator/SKILL.md
@@ -6,7 +6,9 @@ user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(gh *), Bash(flock *), Bash(jq *)"
 max_iterations: 10
-halt_condition: "All repos reach a terminal worker status (done, failed-after-retries, skipped), OR --max-parallel worker pool drains with no pending items"
+halt_conditions:
+  - { type: success, expr: "All repos reach a terminal worker status (done, failed-after-retries, skipped)" }
+  - { type: limit,   expr: "--max-parallel worker pool drains with no pending items" }
 on_halt: "Render final fleet-status table with per-repo outcome and exit"
 loop_safe: false
 ---

--- a/global/skills/issue-work/SKILL.md
+++ b/global/skills/issue-work/SKILL.md
@@ -6,7 +6,9 @@ user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
 max_iterations: 10
-halt_condition: "CI all-green and PR merged, OR 3 identical build/CI failures in a row"
+halt_conditions:
+  - { type: success, expr: "CI all-green and PR merged" }
+  - { type: limit,   expr: "3 identical build/CI failures in a row" }
 on_halt: "Convert PR to draft, report failing checks, exit without merging"
 loop_safe: false
 tiers:

--- a/global/skills/pr-work/SKILL.md
+++ b/global/skills/pr-work/SKILL.md
@@ -6,7 +6,10 @@ user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
 max_iterations: 5
-halt_condition: "All PR checks pass, OR user aborts, OR 3 identical CI failures in a row"
+halt_conditions:
+  - { type: success, expr: "All PR checks pass" }
+  - { type: user,    expr: "user aborts" }
+  - { type: limit,   expr: "3 identical CI failures in a row" }
 on_halt: "Report failing checks with gh pr checks output, do not merge"
 loop_safe: false
 tiers:

--- a/global/skills/release/SKILL.md
+++ b/global/skills/release/SKILL.md
@@ -7,7 +7,10 @@ disable-model-invocation: true
 context: fork
 allowed-tools: "Bash(git *) Bash(gh *)"
 max_iterations: 5
-halt_condition: "Release PR merged and tag published, OR CI failure persists after 3 retries, OR integrity check fails"
+halt_conditions:
+  - { type: success, expr: "Release PR merged and tag published" }
+  - { type: limit,   expr: "CI failure persists after 3 retries" }
+  - { type: failure, expr: "integrity check fails" }
 on_halt: "Report incomplete release state, leave tag/PR in whatever state they are in, do not force-publish"
 loop_safe: false
 ---

--- a/global/skills/research/SKILL.md
+++ b/global/skills/research/SKILL.md
@@ -15,7 +15,10 @@ allowed-tools:
   - Bash
   - Agent
 max_iterations: 5
-halt_condition: "Depth target reached (shallow=1 round, standard=3, deep=5), OR user confirms sufficient findings, OR no new sources surface for 2 consecutive rounds"
+halt_conditions:
+  - { type: limit, expr: "Depth target reached (shallow=1 round, standard=3, deep=5)" }
+  - { type: user,  expr: "user confirms sufficient findings" }
+  - { type: limit, expr: "no new sources surface for 2 consecutive rounds" }
 on_halt: "Write report with partial findings and explicit coverage-gap section"
 loop_safe: true
 ---

--- a/scripts/migrate_halt_conditions.sh
+++ b/scripts/migrate_halt_conditions.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Migrate legacy halt_condition (string) -> halt_conditions (array of {type, expr})
+# =================================================================================
+# Reads SKILL.md frontmatter, splits the legacy halt_condition string on " OR "
+# delimiters, and proposes a halt_conditions array. Type is inferred from
+# keyword heuristics:
+#
+#   success    "all-green", "merged", "complete", "tag published", "reach terminal"
+#   limit      "N retries", "N rounds", "drains", "in a row"
+#   user       "user", "human", "aborts", "confirms"
+#   failure    "fail", "error", "integrity"
+#   fallback   "unknown", "escalat"
+#
+# Compound clauses (any clause containing " AND " or "; ") are flagged for
+# manual review — the migrator will not attempt to split them.
+#
+# Usage:
+#   scripts/migrate_halt_conditions.sh                # dry-run repo defaults
+#   scripts/migrate_halt_conditions.sh path/to/SKILL.md ...
+#   scripts/migrate_halt_conditions.sh --quiet ...    # suppress non-diff lines
+#
+# Exit code: 0 on success; 1 if any input file lacks halt_condition.
+
+set -u
+
+QUIET=0
+FILES=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --quiet) QUIET=1; shift ;;
+        --help|-h)
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) FILES+=("$1"); shift ;;
+    esac
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    ROOT="$(dirname "$SCRIPT_DIR")"
+    for s in ci-fix fleet-orchestrator issue-work pr-work release research; do
+        f="$ROOT/global/skills/$s/SKILL.md"
+        [ -f "$f" ] && FILES+=("$f")
+    done
+fi
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "migrate_halt_conditions: python3/python not in PATH" >&2
+    exit 2
+fi
+
+EXIT_CODE=0
+for f in "${FILES[@]}"; do
+    [ "$QUIET" -eq 0 ] && echo "=== $f ==="
+    if ! "$PYTHON" - "$f" "$QUIET" <<'PY'
+import re, sys
+
+path = sys.argv[1]
+quiet = sys.argv[2] == "1"
+
+KEYWORD_RULES = [
+    ("user",     re.compile(r"\b(user|human|aborts?|confirms?)\b", re.I)),
+    ("fallback", re.compile(r"\b(unknown|escalat)\w*", re.I)),
+    ("limit",    re.compile(r"\b(\d+\s+(retries|rounds|attempts)|in a row|drains?|target reached|consecutive|persists?\s+after)\b", re.I)),
+    ("success",  re.compile(r"\b(all[- ]green|all\s+[\w\s]*pass(es)?|merged|published|complete[ds]?|reach(es)?\s+terminal|success|\bpass\b)\b", re.I)),
+    ("failure",  re.compile(r"\b(fail\w*|error\w*|integrity)\b", re.I)),
+]
+
+def classify(clause: str) -> str:
+    for ttype, rx in KEYWORD_RULES:
+        if rx.search(clause):
+            return ttype
+    return "failure"
+
+with open(path) as fh:
+    text = fh.read()
+
+m = re.search(r'^halt_condition:\s*"([^"]+)"\s*$', text, re.M)
+if not m:
+    if re.search(r'^halt_conditions:\s*$', text, re.M):
+        print(f"  OK: already migrated (halt_conditions array present)")
+        sys.exit(0)
+    print(f"  SKIP: no halt_condition string found in {path}")
+    sys.exit(1)
+
+original = m.group(1)
+if not quiet:
+    print(f'  ORIGINAL: halt_condition: "{original}"')
+
+clauses = [c.strip().rstrip(",;").strip() for c in re.split(r"\s*,?\s+OR\s+", original) if c.strip()]
+compound = any(re.search(r"\s+AND\s+|;\s", c) for c in clauses)
+
+if not quiet:
+    print("  PROPOSED:")
+    print("  halt_conditions:")
+    for c in clauses:
+        ttype = classify(c)
+        print(f'    - {{ type: {ttype}, expr: "{c}" }}')
+    if compound:
+        print("  [MANUAL REVIEW: compound clause(s) detected]")
+PY
+    then
+        EXIT_CODE=1
+    fi
+done
+
+exit $EXIT_CODE

--- a/tests/scripts/test-migrate-halt-conditions.sh
+++ b/tests/scripts/test-migrate-halt-conditions.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Test suite for scripts/migrate_halt_conditions.sh (A2, P1-b)
+# Run: bash tests/scripts/test-migrate-halt-conditions.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+MIGRATOR="$ROOT_DIR/scripts/migrate_halt_conditions.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+write_skill_legacy() {
+    local path="$1" cond="$2"
+    cat > "$path" <<EOF
+---
+name: $(basename "$path" .md)
+description: SKILL fixture for migrate_halt_conditions testing.
+max_iterations: 3
+halt_condition: "$cond"
+on_halt: "report and exit"
+loop_safe: true
+---
+
+content
+EOF
+}
+
+write_skill_migrated() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+---
+name: already-migrated
+description: SKILL fixture already in array form.
+max_iterations: 3
+halt_conditions:
+  - { type: success, expr: "all done" }
+  - { type: limit,   expr: "3 retries" }
+on_halt: "report and exit"
+loop_safe: true
+---
+
+content
+EOF
+}
+
+write_skill_neither() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+---
+name: no-halt
+description: SKILL fixture with neither halt_condition nor halt_conditions.
+loop_safe: true
+---
+
+content
+EOF
+}
+
+assert_contains() {
+    local needle="$1" output="$2" label="$3"
+    if echo "$output" | grep -Fq -- "$needle"; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- output did not contain '$needle'")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" output="$2" label="$3"
+    if echo "$output" | grep -Fq -- "$needle"; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- output unexpectedly contained '$needle'")
+        echo "  FAIL: $label"
+    else
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    fi
+}
+
+assert_exit() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label (exit $actual)"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- expected exit $expected, got $actual")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== migrate_halt_conditions.sh tests ==="
+echo ""
+
+# ── Case 1: simple "X OR Y" → success/limit array ────────────
+echo "[case 1: simple two-clause halt_condition]"
+F1="$WORK/case1.md"
+write_skill_legacy "$F1" "CI all-green and PR merged, OR 3 identical CI failures in a row"
+out=$(bash "$MIGRATOR" "$F1" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 on legacy file"
+assert_contains "halt_conditions:" "$out" "proposes array form"
+assert_contains "type: success" "$out" "classifies success clause"
+assert_contains "type: limit" "$out" "classifies limit clause"
+assert_contains 'expr: "CI all-green and PR merged"' "$out" "trailing comma stripped"
+
+# ── Case 2: three-clause with user signal ────────────────────
+echo ""
+echo "[case 2: three-clause with user signal]"
+F2="$WORK/case2.md"
+write_skill_legacy "$F2" "All checks pass, OR user aborts, OR 3 identical failures in a row"
+out=$(bash "$MIGRATOR" "$F2" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 on three-clause"
+assert_contains "type: success" "$out" "first clause classified success"
+assert_contains "type: user" "$out" "user clause classified"
+assert_contains "type: limit" "$out" "limit clause classified"
+
+# ── Case 3: compound clause flagged for manual review ────────
+echo ""
+echo "[case 3: compound 'X AND Y' clause]"
+F3="$WORK/case3.md"
+write_skill_legacy "$F3" "Migration step succeeds AND verification passes, OR rollback triggered"
+out=$(bash "$MIGRATOR" "$F3" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 on compound"
+assert_contains "MANUAL REVIEW" "$out" "compound flagged for review"
+
+# ── Case 4: already-migrated file → OK / exit 0 ──────────────
+echo ""
+echo "[case 4: already-migrated file is idempotent]"
+F4="$WORK/case4.md"
+write_skill_migrated "$F4"
+out=$(bash "$MIGRATOR" "$F4" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 on already-migrated"
+assert_contains "OK: already migrated" "$out" "reports already-migrated"
+assert_not_contains "PROPOSED" "$out" "no proposal generated"
+
+# ── Case 5: file with neither key → SKIP / exit 1 ────────────
+echo ""
+echo "[case 5: neither halt_condition nor halt_conditions]"
+F5="$WORK/case5.md"
+write_skill_neither "$F5"
+out=$(bash "$MIGRATOR" "$F5" 2>&1); rc=$?
+assert_exit 1 "$rc" "exit 1 when no halt key present"
+assert_contains "SKIP" "$out" "reports SKIP for missing key"
+
+# ── Case 6: --quiet suppresses ORIGINAL/PROPOSED labels ──────
+echo ""
+echo "[case 6: --quiet flag]"
+F6="$WORK/case6.md"
+write_skill_legacy "$F6" "All green, OR 3 retries"
+out=$(bash "$MIGRATOR" --quiet "$F6" 2>&1); rc=$?
+assert_exit 0 "$rc" "exit 0 with --quiet"
+assert_not_contains "ORIGINAL:" "$out" "no ORIGINAL line"
+assert_not_contains "PROPOSED:" "$out" "no PROPOSED line"
+
+# ── Case 7: deterministic — same input twice yields same output
+echo ""
+echo "[case 7: deterministic dry-run output]"
+F7="$WORK/case7.md"
+write_skill_legacy "$F7" "Workflow run conclusion == success, OR failure maps to unknown error"
+out1=$(bash "$MIGRATOR" "$F7" 2>&1)
+out2=$(bash "$MIGRATOR" "$F7" 2>&1)
+if [ "$out1" = "$out2" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: identical output on repeat invocation"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: dry-run not deterministic")
+    echo "  FAIL: dry-run output differs between runs"
+fi
+
+# ── Summary ──────────────────────────────────────────────────
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #457
Part of #454

## Summary
Convert legacy `halt_condition` string field to `halt_conditions` array of `{type, expr}` entries across 6 iterative skills. Adds a deterministic migration helper and a 7-case test suite.

## Changes
- **`scripts/migrate_halt_conditions.sh`** (new, 113 LOC) — bash + python3 dry-run helper. Splits `X OR Y` clauses, classifies via keyword heuristics (`success/failure/limit/user/fallback`), flags compound clauses (containing `AND` or `;`) for manual review. Idempotent (already-migrated files report OK, exit 0).
- **6 SKILL.md frontmatter migrations** (`ci-fix`, `fleet-orchestrator`, `issue-work`, `pr-work`, `release`, `research`)
- **`tests/scripts/test-migrate-halt-conditions.sh`** (new, 199 LOC) — 20 assertions across 7 cases.

## Manual Review (per acceptance criterion 3)
Two files were manually classified instead of relying on the heuristic:
- **`fleet-orchestrator`** — first clause contains substring `failed-after-retries` inside a parenthesized list of terminal states; the heuristic routes to `failure` but the semantic intent is `success` (every repo reached a terminal state, including failures-after-retries which are also terminal).
- **`research`** — first clause is a parameterized depth target (`shallow=1, standard=3, deep=5`). Compound parameters require human classification: `limit`.

The other 4 files matched the heuristic exactly.

## Acceptance
- [x] All 6 files validate against new schema (`spec_lint.py --mode skill` exit 0)
- [x] Migrator produces deterministic dry-run diff (verified by test case 7: byte-identical output across re-runs)
- [x] No semantic change to halt behavior (manually verified for the 2 flagged files)
- [x] PR Size ≤ M (333 LOC: 21 in 6 frontmatter + 113 helper + 199 tests)

## Test Plan
```
python3 -m pip install --break-system-packages --user pyyaml jsonschema
bash tests/scripts/test-migrate-halt-conditions.sh   # 20/20 expected
python3 scripts/spec_lint.py --mode skill --quiet global/skills/{ci-fix,fleet-orchestrator,issue-work,pr-work,release,research}/SKILL.md
scripts/migrate_halt_conditions.sh                    # post-migration: all OK, exit 0
```

## SemVer
suite: no bump (refactor only)