### PR TITLE
refactor(plugin): annotate code-review skills with severity (#460)

### DIFF
--- a/plugin/skills/ci-debugging/SKILL.md
+++ b/plugin/skills/ci-debugging/SKILL.md
@@ -7,6 +7,7 @@ context: fork
 argument-hint: "<run-id-or-url>"
 paths: ".github/workflows/**, Makefile, CMakeLists.txt"
 when_to_use: "CI failure, build error, test timeout"
+finding_levels: [S1, S2, S3]
 ---
 
 # CI/CD Debugging Skill
@@ -121,3 +122,15 @@ Priority order:
 
 ## Reference Documents (Import Syntax)
 @./reference/common-failures.md
+
+## Output
+
+Findings emitted by this skill (root-cause classifications, fix recommendations) MUST include a `severity:` field:
+
+| Severity | Meaning |
+|----------|---------|
+| S1 | Block-merge: build broken, all checks failing, branch unmergeable |
+| S2 | Review-required: intermittent failure, platform-specific regression |
+| S3 | Advisory: warning-only, log noise, non-blocking dependency drift |
+
+When a finding's severity is ambiguous, default to `S3` (advisory) per the false-positive playbook.

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -6,6 +6,7 @@ model: sonnet
 context: fork
 agent: Explore
 argument-hint: "<file-or-directory>"
+finding_levels: [S1, S2, S3]
 ---
 
 # Performance Review Skill
@@ -71,15 +72,14 @@ Return a structured report at the end of analysis:
 ```markdown
 ## Performance Review Report
 
-| Category | Findings |
+| Severity | Findings |
 |----------|----------|
-| Critical (clear regression) | N items |
-| High (measured hotspot) | N items |
-| Medium (suspected hotspot) | N items |
-| Low (style/maintainability) | N items |
+| S1 (block-merge: clear regression) | N items |
+| S2 (review-required: measured/suspected hotspot) | N items |
+| S3 (advisory: style/maintainability) | N items |
 
-### Critical Findings
-1. `file.ext:line` — finding + recommended optimization + expected gain
+### S1 Findings
+1. `file.ext:line` — severity: S1 — finding + recommended optimization + expected gain
 2. ...
 
 ### Hotspot Map
@@ -93,3 +93,5 @@ Return a structured report at the end of analysis:
 - Profiling data referenced: yes/no
 - Categories not evaluated (need runtime data): ...
 ```
+
+Each finding MUST include a `severity:` field (`S1`, `S2`, or `S3`). When a finding's severity is ambiguous, default to `S3` (advisory) per the false-positive playbook.

--- a/plugin/skills/security-audit/SKILL.md
+++ b/plugin/skills/security-audit/SKILL.md
@@ -6,6 +6,7 @@ model: sonnet
 context: fork
 agent: Explore
 argument-hint: "<file-or-directory>"
+finding_levels: [S1, S2, S3]
 ---
 
 # Security Audit Skill
@@ -65,22 +66,23 @@ Return a structured report at the end of analysis:
 ```markdown
 ## Security Audit Report
 
-| Category | Findings |
+| Severity | Findings |
 |----------|----------|
-| Critical | N items |
-| High | N items |
-| Medium | N items |
-| Low | N items |
+| S1 (block-merge) | N items |
+| S2 (review-required) | N items |
+| S3 (advisory) | N items |
 
-### Critical Findings
-1. `file.ext:line` — finding + recommended fix
+### S1 Findings
+1. `file.ext:line` — severity: S1 — finding + recommended fix
 2. ...
 
-### High Findings
-1. ...
+### S2 Findings
+1. `file.ext:line` — severity: S2 — finding + recommended fix
 
 ### Coverage
 - Files inspected: N
 - OWASP categories evaluated: 1, 2, 3, ...
 - Categories not applicable: ...
 ```
+
+Each finding MUST include a `severity:` field (`S1`, `S2`, or `S3`). When a finding's severity is ambiguous, default to `S3` (advisory) per the false-positive playbook.


### PR DESCRIPTION
Closes #460
Part of #454

## Summary
Apply the severity schema (added in #465 / C1) to the 3 code-review domain plugin skills. Each skill declares `finding_levels: [S1, S2, S3]` in frontmatter and its output template now requires a `severity:` field per finding.

## Changes
- `plugin/skills/security-audit/SKILL.md` — frontmatter annotation; output template Critical/High/Medium/Low → S1/S2/S3 mapping
- `plugin/skills/performance-review/SKILL.md` — frontmatter annotation; output template Critical/High/Medium/Low → S1/S2/S3 mapping
- `plugin/skills/ci-debugging/SKILL.md` — frontmatter annotation; new minimal Output section (this skill previously had no output template)

## Out of Scope
`doc-review` and `release` are explicitly out of scope per `_policy.md`: they describe gates, not findings. No other code-review domain skills exist in this repo (verified `grep -lE 'review|audit|find'` against `global/` and `plugin/`).

## Default for Ambiguous Findings
Each skill's output template documents that ambiguous severity defaults to **S3** (advisory), consistent with the false-positive playbook in the issue body.

## Acceptance
- [x] 3 plugin skills annotated
- [x] Output template documents the required `severity:` field
- [x] Schema validation passes (`spec_lint.py --mode skill` exit 0 across all 3)
- [x] PR Size ≤ S (33 insertions / 16 deletions = ~17 LOC net)

## Test Plan
```
python3 scripts/spec_lint.py --mode skill --quiet plugin/skills/{security-audit,performance-review,ci-debugging}/SKILL.md
```

## SemVer
suite: patch, plugin: minor