### PR TITLE
feat(validate): require halt_conditions for iterative skills (P1-c)

### DIFF
--- a/global/skills/doc-index/SKILL.md
+++ b/global/skills/doc-index/SKILL.md
@@ -10,6 +10,10 @@ allowed-tools:
   - Glob
   - Grep
 loop_safe: true
+halt_conditions:
+  - { type: success, expr: "all index files generated under docs/.index/" }
+  - { type: failure, expr: "manifest generation or write step errors out" }
+on_halt: "Report which index files were produced before failure and stop"
 ---
 
 # Document Index Generator

--- a/global/skills/doc-review/SKILL.md
+++ b/global/skills/doc-review/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: "Bash(git *)"
 context: fork
 agent: general-purpose
 loop_safe: true
+halt_conditions:
+  - { type: success, expr: "review report emitted with all in-scope findings" }
+  - { type: failure, expr: "fatal error reading the docs directory or scope cannot be resolved" }
+on_halt: "Emit partial report listing what was reviewed and what was skipped"
 ---
 
 # Document Review Command

--- a/global/skills/preflight/SKILL.md
+++ b/global/skills/preflight/SKILL.md
@@ -6,6 +6,10 @@ user-invocable: true
 disable-model-invocation: false
 allowed-tools: "Bash(act *),Bash(docker *),Bash(cmake *)"
 loop_safe: true
+halt_conditions:
+  - { type: success, expr: "all selected preflight checks complete with non-zero failures = 0" }
+  - { type: failure, expr: "any selected check reports failure or its runner errors out" }
+on_halt: "Print per-check summary table and exit non-zero if any check failed"
 ---
 
 # preflight Skill

--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -6,6 +6,20 @@
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "anyOf": [
+          { "required": ["max_iterations"] },
+          { "properties": { "loop_safe": { "const": true } }, "required": ["loop_safe"] }
+        ]
+      },
+      "then": {
+        "required": ["halt_conditions"],
+        "$comment": "P1-c (issue #458): iterative skills (max_iterations declared, or loop_safe == true) MUST declare halt_conditions so a self-loop is forced to terminate explicitly."
+      }
+    }
+  ],
   "$defs": {
     "tierEntry": {
       "type": "object",

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -200,14 +200,20 @@ validate_skill() {
     fi
 
     # 6. 프론트매터 대 본문 일관성 (drift)
-    if echo "$frontmatter" | grep -qE "^(max_iterations|halt_condition):"; then
+    if echo "$frontmatter" | grep -qE "^(max_iterations|halt_condition|halt_conditions):"; then
         if ! grep -qiE "(loop|retry|iteration|poll)" "$skill_file"; then
-            warning "max_iterations/halt_condition 선언되었으나 본문에 loop/retry/iteration/poll 참조 없음"
+            warning "max_iterations/halt_condition(s) 선언되었으나 본문에 loop/retry/iteration/poll 참조 없음"
             record_warning
         else
             success "loop 메타데이터 본문 일관성 확인"
             record_pass
         fi
+    fi
+
+    # 6a. P1-c (issue #458): legacy halt_condition 단일 키 deprecation
+    if echo "$frontmatter" | grep -qE "^halt_condition:[[:space:]]"; then
+        warning "halt_condition (legacy) 키가 사용됨 — halt_conditions array form으로 마이그레이션 필요 (P1 grace period; 다음 릴리즈에서 제거 예정)"
+        record_warning
     fi
 
     if echo "$frontmatter" | grep -qE "^loop_safe:[[:space:]]*false"; then

--- a/tests/scripts/test-spec-lint.sh
+++ b/tests/scripts/test-spec-lint.sh
@@ -308,6 +308,56 @@ echo "[case 10d: halt_conditions unknown entry type rejected]"
 out=$(run_lint skill "$HALT_BAD_TYPE_SKILL" 2>&1); rc=$?
 assert_exit 1 "$rc" "halt_conditions unknown type -> exit 1"
 
+# ── Fixture: max_iterations without halt_conditions (P1-c, #458) ─
+ITER_NO_HALT_SKILL="$WORK/iter-no-halt-skill.md"
+write_file "$ITER_NO_HALT_SKILL" '---
+name: iter-no-halt-skill
+description: SKILL.md declaring max_iterations but missing halt_conditions. Must be rejected by the P1-c conditional-required rule.
+max_iterations: 5
+---
+
+content
+'
+
+echo ""
+echo "[case 10e: P1-c — max_iterations without halt_conditions rejected]"
+out=$(run_lint skill "$ITER_NO_HALT_SKILL" 2>&1); rc=$?
+assert_exit 1 "$rc" "max_iterations without halt_conditions -> exit 1"
+assert_output_contains "'halt_conditions' is a required property" "$out" "missing halt_conditions error"
+
+# ── Fixture: loop_safe true without halt_conditions (P1-c, #458) ─
+LOOP_NO_HALT_SKILL="$WORK/loop-no-halt-skill.md"
+write_file "$LOOP_NO_HALT_SKILL" '---
+name: loop-no-halt-skill
+description: SKILL.md declaring loop_safe true but missing halt_conditions. Must be rejected by the P1-c conditional-required rule.
+loop_safe: true
+---
+
+content
+'
+
+echo ""
+echo "[case 10f: P1-c — loop_safe: true without halt_conditions rejected]"
+out=$(run_lint skill "$LOOP_NO_HALT_SKILL" 2>&1); rc=$?
+assert_exit 1 "$rc" "loop_safe: true without halt_conditions -> exit 1"
+assert_output_contains "'halt_conditions' is a required property" "$out" "missing halt_conditions error"
+
+# ── Fixture: loop_safe false without halt_conditions (allowed) ───
+LOOP_FALSE_SKILL="$WORK/loop-false-skill.md"
+write_file "$LOOP_FALSE_SKILL" '---
+name: loop-false-skill
+description: SKILL.md with loop_safe false and no halt_conditions. P1-c rule does not apply when loop_safe is false.
+loop_safe: false
+---
+
+content
+'
+
+echo ""
+echo "[case 10g: P1-c — loop_safe: false without halt_conditions accepted]"
+out=$(run_lint skill "$LOOP_FALSE_SKILL" 2>&1); rc=$?
+assert_exit 0 "$rc" "loop_safe: false without halt_conditions -> exit 0"
+
 # ── Wrapper invocation ───────────────────────────────────────
 echo ""
 echo "[case 11: spec_lint.sh wrapper works in --mode form]"


### PR DESCRIPTION
Closes #458

## What
JSON Schema `if/then` rule: when `max_iterations` is declared OR `loop_safe == true`, `halt_conditions` becomes required. Adds deprecation warning for legacy single-string `halt_condition` key during the P1 grace period.

## Why
P1-c (final step of #454-A series). A1 introduced the array schema, A2 (#457) migrated existing data, A3 closes the regression path: from this PR forward, no iterative skill can ship without explicit halt conditions.

## Where
- `scripts/schemas/skill-md.schema.json` — `allOf[if/then]` block
- `scripts/validate_skills.sh` — legacy key deprecation warning
- `tests/scripts/test-spec-lint.sh` — 3 new cases (10e/10f/10g)
- `global/skills/{doc-index,doc-review,preflight}/SKILL.md` — added `halt_conditions` (each was `loop_safe: true` without halt rules)

## How
- Schema change uses standard JSON Schema 2020-12 conditional. `Draft202012Validator` already loaded by spec_lint.py picks it up automatically — no Python changes.
- Legacy `halt_condition` (singular) key triggers a warn-only record in `validate_skills.sh`; full removal scheduled for next release cycle.
- 3 single-pass skills got success/failure halt pairs to satisfy the new rule.

## Acceptance
- [x] All 13 iterative SKILL.md pass under new rules (`spec_lint` clean)
- [x] Removing `halt_conditions` from a `loop_safe: true` SKILL.md causes lint failure (case 10f)
- [x] G1 / G3 gates pass (validate_skills.sh: 258/258, test-spec-lint.sh: 42/42, test-migrate-halt-conditions.sh: 20/20)
- [x] PR Size ≤ S (~86 LOC)

## SemVer
suite: minor