### PR TITLE
feat(harness): add p4_strict_schema Kill Switch toggle infrastructure (pre-D1)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -118,6 +118,7 @@ reference: [`code.claude.com/docs/en/settings`](https://code.claude.com/docs/en/
 | `skipDangerousModePermissionPrompt` | Stable | 2.0.0+ | Ignored in project settings (security). |
 | `showTurnDuration` | **Misplaced** | 2.1.0+ | Officially belongs in `~/.claude.json`, not `settings.json`. May trigger schema validation warning in future CC versions. Consider moving. |
 | `teammateMode` | **Misplaced** | 2.1.0+ | Same as above — belongs in `~/.claude.json`. Valid values: `auto`, `in-process`, `tmux`. |
+| `harness_policies.p4_strict_schema` | Undocumented | — | claude-config Kill Switch for P4 strict-schema dispatch (EPIC #454). Default `false`. **Bypass:** set `STRICT_SCHEMA=0` env var (env wins over settings) to force lenient schema validation across all skills. Until D1 (#461) merges, the toggle is read but unused. |
 
 ### env fields in settings.json
 

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -16,4 +16,4 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.12.2
+settings-schema: 1.13.0

--- a/global/settings.json
+++ b/global/settings.json
@@ -438,7 +438,10 @@
   "skipDangerousModePermissionPrompt": true,
   "includeGitInstructions": false,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "showTurnDuration": true,
-  "teammateMode": "in-process"
+  "teammateMode": "in-process",
+  "harness_policies": {
+    "p4_strict_schema": false
+  }
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.12.2",
+  "version": "1.13.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -49,6 +49,9 @@
   },
   "alwaysThinkingEnabled": true,
   "teammateMode": "in-process",
+  "harness_policies": {
+    "p4_strict_schema": false
+  },
 
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,

--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -106,6 +106,16 @@
     "description":                       { "type": "string" },
     "version":                           { "type": "string" },
     "showTurnDuration":                  { "type": "boolean" },
-    "teammateMode":                      { "type": "string", "enum": ["in-process", "subprocess"] }
+    "teammateMode":                      { "type": "string", "enum": ["in-process", "subprocess"] },
+    "harness_policies": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "p4_strict_schema": {
+          "type": "boolean",
+          "description": "Kill Switch for P4 strict-schema dispatch. When false, even _internal/ skills validate against the lenient schema. Settings precedence: STRICT_SCHEMA env var > this field > default false."
+        }
+      }
+    }
   }
 }

--- a/scripts/spec_lint.py
+++ b/scripts/spec_lint.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -45,6 +46,30 @@ SCHEMA_FILES = {
     "plugin":   SCHEMA_DIR / "plugin-json.schema.json",
     "settings": SCHEMA_DIR / "settings-json.schema.json",
 }
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+
+
+def read_p4_strict_schema_toggle() -> bool:
+    """Resolve the P4 strict-schema Kill Switch.
+
+    Precedence: STRICT_SCHEMA env var > harness_policies.p4_strict_schema in
+    ~/.claude/settings.json > default False. Returned but currently unused —
+    D1 (#461) will dispatch on this value once strict/lenient schemas land.
+    """
+    env = os.environ.get("STRICT_SCHEMA")
+    if env is not None:
+        return env.strip().lower() in ("1", "true", "yes", "on")
+    if not SETTINGS_PATH.is_file():
+        return False
+    try:
+        data = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    policies = data.get("harness_policies")
+    if isinstance(policies, dict) and "p4_strict_schema" in policies:
+        return bool(policies["p4_strict_schema"])
+    return False
 
 
 def load_schema(mode: str) -> dict:

--- a/tests/scripts/test-killswitch.sh
+++ b/tests/scripts/test-killswitch.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Test suite for P4 strict-schema Kill Switch toggle (issue #469).
+# Verifies: STRICT_SCHEMA env var > harness_policies.p4_strict_schema in
+# settings.json > default false. Run: bash tests/scripts/test-killswitch.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH" >&2
+    exit 0
+fi
+if ! "$PYTHON" -c "import yaml, jsonschema" >/dev/null 2>&1; then
+    echo "SKIP: missing PyYAML or jsonschema" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PY_SCRIPT='
+import sys
+from pathlib import Path
+sys.path.insert(0, r"'"$ROOT_DIR"'/scripts")
+import spec_lint
+spec_lint.SETTINGS_PATH = Path(r"'"$WORK"'/fakehome/.claude/settings.json")
+print(spec_lint.read_p4_strict_schema_toggle())
+'
+
+run_toggle() {
+    # $1 = expected ("True"/"False"), $2 = label, $3 = STRICT_SCHEMA value or "__UNSET__"
+    local expected="$1"
+    local label="$2"
+    local strict_value="${3:-__UNSET__}"
+    local out
+    if [ "$strict_value" = "__UNSET__" ]; then
+        out=$(env -u STRICT_SCHEMA "$PYTHON" -c "$PY_SCRIPT" 2>&1)
+    else
+        out=$(STRICT_SCHEMA="$strict_value" "$PYTHON" -c "$PY_SCRIPT" 2>&1)
+    fi
+    if [ "$out" = "$expected" ]; then
+        PASS=$((PASS+1))
+        echo "PASS: $label -> $out"
+    else
+        FAIL=$((FAIL+1))
+        ERRORS+=("FAIL: $label (expected $expected, got $out)")
+    fi
+}
+
+write_settings() {
+    # $1 = settings dir, $2 = JSON body
+    mkdir -p "$1"
+    printf '%s\n' "$2" > "$1/settings.json"
+}
+
+# Case 1: no env, no settings → default False
+mkdir -p "$WORK/fakehome/.claude"
+run_toggle "False" "default (no env, no settings)"
+
+# Case 2: settings true, no env → True
+write_settings "$WORK/fakehome/.claude" '{"harness_policies": {"p4_strict_schema": true}}'
+run_toggle "True" "settings=true, no env"
+
+# Case 3: settings true, env=0 → False (env wins)
+run_toggle "False" "settings=true, env=0 (env overrides)" "0"
+
+# Case 4: settings false, env=1 → True (env wins)
+write_settings "$WORK/fakehome/.claude" '{"harness_policies": {"p4_strict_schema": false}}'
+run_toggle "True" "settings=false, env=1 (env overrides)" "1"
+
+# Case 5: env=true (case insensitive) → True
+run_toggle "True" "env=TRUE (case-insensitive)" "TRUE"
+
+# Case 6: env=on → True
+run_toggle "True" "env=on" "on"
+
+# Case 7: env=anything-else → False (only documented truthy values)
+run_toggle "False" "env=garbage (not truthy)" "garbage"
+
+# Case 8: malformed settings.json → fall back to default False
+write_settings "$WORK/fakehome/.claude" 'this is not json'
+run_toggle "False" "malformed settings.json (graceful fallback)"
+
+# Case 9: missing harness_policies key → default False
+write_settings "$WORK/fakehome/.claude" '{"other_key": 42}'
+run_toggle "False" "settings present but no harness_policies"
+
+# Case 10: harness_policies present but p4_strict_schema missing → default False
+write_settings "$WORK/fakehome/.claude" '{"harness_policies": {"other_toggle": true}}'
+run_toggle "False" "harness_policies without p4_strict_schema"
+
+# Final report
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    printf '%s\n' "${ERRORS[@]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #469
Part of #454
Unblocks #461 (D1 strict/lenient schema split)

## What

Introduces the **Kill Switch infrastructure** for the P4 strict-schema rollout. Toggle plumbing only — no schema split, no behavioral change for existing skills.

Components:
- `harness_policies.p4_strict_schema` (default `false`) in both `settings.json` variants
- `STRICT_SCHEMA` env var override (env wins over settings)
- `read_p4_strict_schema_toggle()` in `scripts/spec_lint.py` (read but unused until D1)
- `tests/scripts/test-killswitch.sh` — 10 cases covering env precedence, truthy parsing, graceful fallback
- `settings-schema` 1.12.2 → 1.13.0; `COMPATIBILITY.md` row for external authors

## Why

EPIC #454 mandates that the Kill Switch lands before D1 (#461) so external plugin authors hitting a strict-reject storm have an immediate bypass. Until D1 ships, this PR is no-op infrastructure.

## How verified

| Check | Result |
|-------|--------|
| `bash tests/scripts/test-killswitch.sh` | 10/10 pass |
| `bash scripts/validate_skills.sh` | 258 pass / 0 fail / 12 warn — **byte-identical pre/post-PR** |
| `python3 scripts/spec_lint.py --mode skill <all 21 skills>` | 0 violations |
| `python3 scripts/spec_lint.py --mode settings global/settings*.json` | 0 violations |
| Regression: `test-spec-lint.sh` | 42/42 pass |
| Regression: `test-severity-enum.sh` | 22/22 pass |
| Regression: `test-migrate-halt-conditions.sh` | 20/20 pass |

The byte-identical pre/post-PR result on `validate_skills.sh` confirms the toggle infrastructure is genuinely no-op.

## Where

- `global/settings.json` (+3) and `global/settings.windows.json` (+4) — toggle declaration + version bump
- `scripts/schemas/settings-json.schema.json` (+10) — schema entry for `harness_policies`
- `scripts/spec_lint.py` (+24) — env > settings > default reader
- `tests/scripts/test-killswitch.sh` (+102) — new test suite
- `VERSION_MAP.yml` (+1/-1) — `settings-schema: 1.12.2` → `1.13.0`
- `COMPATIBILITY.md` (+1) — bypass documentation

## SemVer

- suite: minor (no behavioral change yet — D1 is the major bump)
- settings-schema: 1.12.2 → 1.13.0 (new toggle key)

## Sequence

W4, **must merge before #461 (D1)**. After this lands, D1 can dispatch on the toggle.
