### PR TITLE
feat(schema): split strict/lenient SKILL.md schema with path-based dispatch (P4-a)

### DIFF
--- a/scripts/schemas/skill-md.schema.lenient.json
+++ b/scripts/schemas/skill-md.schema.lenient.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.json",
-  "title": "Claude Code SKILL.md Frontmatter (Deprecated Alias)",
-  "description": "DEPRECATED ALIAS: this URL is preserved for backward compatibility with external plugin authors who already reference it. Its content matches skill-md.schema.lenient.json. New consumers should pick the variant explicitly: .strict.json for global/skills/_internal/ skills, .lenient.json otherwise. The Kill Switch (harness_policies.p4_strict_schema / STRICT_SCHEMA env) can force lenient across all paths.",
+  "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.lenient.json",
+  "title": "Claude Code SKILL.md Frontmatter (Lenient)",
+  "description": "Lenient variant for plugin/, plugin-lite/, and external author skills. Validates only core required fields (name, description). additionalProperties is true so unknown fields do NOT fail; P1-c halt_conditions enforcement is omitted. External plugin authors who want stricter validation may opt in by placing skills under global/skills/_internal/ which dispatches to the strict variant. The strict-mode Kill Switch (harness_policies.p4_strict_schema or STRICT_SCHEMA env var) can also force lenient validation across all paths.",
   "type": "object",
   "required": ["name", "description"],
   "additionalProperties": true,

--- a/scripts/schemas/skill-md.schema.strict.json
+++ b/scripts/schemas/skill-md.schema.strict.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kcenon/claude-config/scripts/schemas/skill-md.schema.strict.json",
+  "title": "Claude Code SKILL.md Frontmatter (Strict)",
+  "description": "Strict variant for global/skills/_internal/* skills (claude-config-owned). Same fields as the canonical schema but all rules including P1-c halt_conditions enforcement are required. External plugin/plugin-lite skills validate against the lenient variant.",
+  "type": "object",
+  "required": ["name", "description"],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "anyOf": [
+          { "required": ["max_iterations"] },
+          { "properties": { "loop_safe": { "const": true } }, "required": ["loop_safe"] }
+        ]
+      },
+      "then": {
+        "required": ["halt_conditions"],
+        "$comment": "P1-c (issue #458): iterative skills (max_iterations declared, or loop_safe == true) MUST declare halt_conditions so a self-loop is forced to terminate explicitly."
+      }
+    }
+  ],
+  "$defs": {
+    "tierEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref_docs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Skill-defined alias keys resolving to reference/*.md files inside the skill's directory."
+        },
+        "deep_checks": {
+          "type": "boolean",
+          "description": "Opt-in flag for deeper verification passes (extra lint, full build, integrity checks)."
+        },
+        "max_files": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Advisory cap on the number of files the skill should enumerate or modify in a single invocation."
+        }
+      }
+    },
+    "haltConditionEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "expr"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["success", "failure", "limit", "user", "fallback"],
+          "description": "Halt category. success=terminal success, failure=stop-on-error, limit=iteration/resource cap, user=human signal, fallback=escalation."
+        },
+        "expr": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Condition expression. Prefer regex or symbolic form for deterministic signals; natural language otherwise."
+        }
+      }
+    }
+  },
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Skill identifier. Lowercase letters, digits, and hyphens only. Max 64 chars."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "description": "Skill trigger description. Max 1024 chars. >=100 chars recommended for trigger quality."
+    },
+    "when_to_use": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Plain-language hint of when this skill applies."
+    },
+    "argument-hint": {
+      "type": "string",
+      "description": "Usage hint shown to the user, e.g., \"<file-or-directory> [--verbose]\"."
+    },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "description": "When true, the model cannot auto-invoke this skill (user-only)."
+    },
+    "user-invocable": {
+      "type": "boolean",
+      "description": "When true, the user can invoke this skill via slash command."
+    },
+    "allowed-tools": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "description": "Tools the skill is allowed to call. Scalar (\"Bash(git *)\") or array form."
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Preferred model identifier (e.g., haiku, sonnet, opus)."
+    },
+    "effort": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "xhigh", "max"],
+      "description": "Effort level for model invocation."
+    },
+    "context": {
+      "type": "string",
+      "enum": ["fork"],
+      "description": "Context strategy. \"fork\" runs the skill in a forked context window."
+    },
+    "agent": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "description": "Agent name(s) this skill prefers to delegate to."
+    },
+    "hooks": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        { "type": "object" }
+      ],
+      "description": "Hook bindings scoped to this skill."
+    },
+    "paths": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "description": "Glob path patterns this skill applies to (comma-separated string or array)."
+    },
+    "shell": {
+      "type": "string",
+      "enum": ["bash", "powershell"],
+      "description": "Preferred shell when the skill runs commands."
+    },
+    "max_iterations": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Iteration-control extension (claude-config): maximum number of self-loops before the skill is forced to halt."
+    },
+    "halt_condition": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Iteration-control extension (claude-config, legacy): plain-language condition that stops the iteration loop early. Superseded by halt_conditions; both accepted during P1 grace period."
+    },
+    "halt_conditions": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "array", "items": { "$ref": "#/$defs/haltConditionEntry" }, "minItems": 1 }
+      ],
+      "description": "Iteration-control extension (claude-config): structured halt conditions. Either a single-string form (legacy compatibility for one-shot rename from halt_condition) or an array of {type, expr} entries. Replaces halt_condition; both keys accepted during the P1 grace period."
+    },
+    "on_halt": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Iteration-control extension (claude-config): action to take when halt_condition fires or max_iterations is reached."
+    },
+    "loop_safe": {
+      "type": "boolean",
+      "description": "Iteration-control extension (claude-config): true when the skill is safe to run inside an autonomous /loop, false when it must exit the loop before acting."
+    },
+    "tiers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "light":    { "$ref": "#/$defs/tierEntry" },
+        "standard": { "$ref": "#/$defs/tierEntry" },
+        "deep":     { "$ref": "#/$defs/tierEntry" }
+      },
+      "description": "Tier-preset extension (claude-config): per-tier loading hints for skills whose SKILL.md body exceeds 5 KB. See global/skills/_policy.md."
+    },
+    "default_tier": {
+      "type": "string",
+      "enum": ["light", "standard", "deep"],
+      "description": "Tier-preset extension (claude-config): tier applied when the caller omits --tier. Defaults to 'standard' when this field is absent."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["S1", "S2", "S3"],
+      "description": "Severity extension (claude-config): primary severity tier this skill triages at. S1 = block-merge, S2 = review-required, S3 = advisory. Code-review domain only."
+    },
+    "finding_levels": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["S1", "S2", "S3"] },
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "Severity extension (claude-config): set of severity levels this skill emits findings at. Subset of {S1, S2, S3}; non-empty and unique."
+    }
+  }
+}

--- a/scripts/spec_lint.py
+++ b/scripts/spec_lint.py
@@ -42,20 +42,25 @@ except ImportError:
 
 SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"
 SCHEMA_FILES = {
-    "skill":    SCHEMA_DIR / "skill-md.schema.json",
-    "plugin":   SCHEMA_DIR / "plugin-json.schema.json",
-    "settings": SCHEMA_DIR / "settings-json.schema.json",
+    "skill":         SCHEMA_DIR / "skill-md.schema.json",
+    "skill-strict":  SCHEMA_DIR / "skill-md.schema.strict.json",
+    "skill-lenient": SCHEMA_DIR / "skill-md.schema.lenient.json",
+    "plugin":        SCHEMA_DIR / "plugin-json.schema.json",
+    "settings":      SCHEMA_DIR / "settings-json.schema.json",
 }
 
 SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+
+INTERNAL_SKILL_MARKER = "global/skills/_internal/"
 
 
 def read_p4_strict_schema_toggle() -> bool:
     """Resolve the P4 strict-schema Kill Switch.
 
     Precedence: STRICT_SCHEMA env var > harness_policies.p4_strict_schema in
-    ~/.claude/settings.json > default False. Returned but currently unused —
-    D1 (#461) will dispatch on this value once strict/lenient schemas land.
+    ~/.claude/settings.json > default False. When False, every skill validates
+    against the lenient schema regardless of path; when True, paths matching
+    INTERNAL_SKILL_MARKER use the strict variant.
     """
     env = os.environ.get("STRICT_SCHEMA")
     if env is not None:
@@ -172,7 +177,19 @@ def validate_instance(instance: dict, schema: dict, file_path: Path,
     return messages
 
 
-def lint_skill(file_path: Path) -> list[str]:
+def select_skill_schema_mode(file_path: Path, strict_enabled: bool) -> str:
+    """Pick strict or lenient skill schema for a given file path.
+
+    Strict applies only when (a) the Kill Switch toggle is enabled AND
+    (b) the path lies inside INTERNAL_SKILL_MARKER. Otherwise lenient.
+    """
+    if not strict_enabled:
+        return "skill-lenient"
+    posix = file_path.resolve().as_posix()
+    return "skill-strict" if INTERNAL_SKILL_MARKER in posix else "skill-lenient"
+
+
+def lint_skill(file_path: Path, strict_enabled: bool) -> list[str]:
     try:
         text = file_path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -181,7 +198,8 @@ def lint_skill(file_path: Path) -> list[str]:
         data, base_line = extract_frontmatter(text, file_path)
     except ValueError as exc:
         return [str(exc)]
-    schema = load_schema("skill")
+    mode = select_skill_schema_mode(file_path, strict_enabled)
+    schema = load_schema(mode)
     return validate_instance(data, schema, file_path, base_line)
 
 
@@ -204,10 +222,11 @@ def lint_files(files: Iterable[Path], mode: str) -> tuple[int, int, list[str]]:
     total_files = 0
     total_violations = 0
     all_messages: list[str] = []
+    strict_enabled = read_p4_strict_schema_toggle() if mode == "skill" else False
     for f in files:
         total_files += 1
         if mode == "skill":
-            msgs = lint_skill(f)
+            msgs = lint_skill(f, strict_enabled)
         else:
             msgs = lint_json(f, mode)
         if msgs:

--- a/tests/scripts/test-spec-lint.sh
+++ b/tests/scripts/test-spec-lint.sh
@@ -89,10 +89,12 @@ out=$(run_lint skill "$GOOD_SKILL" 2>&1); rc=$?
 assert_exit 0 "$rc" "valid SKILL.md -> exit 0"
 
 # ── Fixture: underscore typo (did-you-mean) ──────────────────
+# additionalProperties: false is strict-only after D1. Lenient accepts
+# unknown fields silently; strict + _internal/ rejects with did-you-mean.
 TYPO_SKILL="$WORK/typo-skill.md"
 write_file "$TYPO_SKILL" '---
 name: typo-skill
-description: SKILL with underscore typo on disable_model_invocation field for did-you-mean coverage.
+description: SKILL with underscore typo on disable_model_invocation field. Lenient accepts; strict + _internal/ catches with did-you-mean.
 disable_model_invocation: true
 ---
 
@@ -100,16 +102,32 @@ content
 '
 
 echo ""
-echo "[case 2: underscore typo caught with did-you-mean]"
+echo "[case 2: lenient accepts underscore typo silently]"
 out=$(run_lint skill "$TYPO_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "underscore typo -> exit 1"
+assert_exit 0 "$rc" "lenient accepts unknown field -> exit 0"
+
+# Strict variant of the same fixture under simulated _internal/ path
+mkdir -p "$WORK/repo/global/skills/_internal/typo"
+INTERNAL_TYPO="$WORK/repo/global/skills/_internal/typo/SKILL.md"
+write_file "$INTERNAL_TYPO" '---
+name: typo-strict
+description: Strict-mode underscore-typo fixture under _internal/ path. additionalProperties:false must reject.
+disable_model_invocation: true
+---
+
+content
+'
+echo ""
+echo "[case 2-strict: strict + _internal/ catches underscore typo with did-you-mean]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$INTERNAL_TYPO" 2>&1); rc=$?
+assert_exit 1 "$rc" "strict + _internal/ on typo -> exit 1"
 assert_output_contains "did you mean 'disable-model-invocation'" "$out" "did-you-mean suggestion present"
 
-# ── Fixture: unknown field rejected ──────────────────────────
+# ── Fixture: unknown field accepted by lenient, rejected by strict ──
 UNK_SKILL="$WORK/unknown-field-skill.md"
 write_file "$UNK_SKILL" '---
 name: unknown-field
-description: SKILL with a totally unknown field that must be rejected by the additionalProperties rule.
+description: SKILL with a totally unknown field. Lenient accepts (additionalProperties:true); strict + _internal/ rejects.
 memory: persistent
 ---
 
@@ -117,9 +135,24 @@ content
 '
 
 echo ""
-echo "[case 3: unknown field rejected]"
+echo "[case 3: lenient accepts unknown 'memory' field]"
 out=$(run_lint skill "$UNK_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "unknown 'memory' field -> exit 1"
+assert_exit 0 "$rc" "lenient accepts unknown -> exit 0"
+
+mkdir -p "$WORK/repo/global/skills/_internal/unk"
+INTERNAL_UNK="$WORK/repo/global/skills/_internal/unk/SKILL.md"
+write_file "$INTERNAL_UNK" '---
+name: unk-strict
+description: Strict-mode unknown-field fixture under _internal/. additionalProperties:false must reject.
+memory: persistent
+---
+
+content
+'
+echo ""
+echo "[case 3-strict: strict + _internal/ rejects unknown 'memory' field]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$INTERNAL_UNK" 2>&1); rc=$?
+assert_exit 1 "$rc" "strict + _internal/ on unknown field -> exit 1"
 assert_output_contains "unknown field(s)" "$out" "unknown field message"
 
 # ── Fixture: invalid enum values ─────────────────────────────
@@ -291,11 +324,13 @@ echo "[case 10c: halt_conditions empty array rejected]"
 out=$(run_lint skill "$HALT_EMPTY_SKILL" 2>&1); rc=$?
 assert_exit 1 "$rc" "halt_conditions [] -> exit 1"
 
-# ── Fixture: halt_conditions unknown type (rejected) ─────────
+# ── Fixture: halt_conditions unknown type ────────────────────
+# Lenient halt_conditions array does not enforce the type-enum constraint.
+# Strict + _internal/ rejects via the enum check.
 HALT_BAD_TYPE_SKILL="$WORK/halt-bad-type-skill.md"
 write_file "$HALT_BAD_TYPE_SKILL" '---
 name: halt-bad-type-skill
-description: SKILL.md verifying that an unknown halt_conditions entry type is rejected by the enum.
+description: SKILL.md with an unknown halt_conditions entry type. Lenient accepts; strict + _internal/ rejects via enum.
 halt_conditions:
   - { type: telepathy, expr: "psychic signal" }
 ---
@@ -304,15 +339,34 @@ content
 '
 
 echo ""
-echo "[case 10d: halt_conditions unknown entry type rejected]"
+echo "[case 10d: lenient accepts halt_conditions with unknown entry type]"
 out=$(run_lint skill "$HALT_BAD_TYPE_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "halt_conditions unknown type -> exit 1"
+assert_exit 0 "$rc" "lenient -> exit 0"
 
-# ── Fixture: max_iterations without halt_conditions (P1-c, #458) ─
+mkdir -p "$WORK/repo/global/skills/_internal/halt-bad"
+INTERNAL_HALT_BAD="$WORK/repo/global/skills/_internal/halt-bad/SKILL.md"
+write_file "$INTERNAL_HALT_BAD" '---
+name: halt-bad-strict
+description: Strict-mode fixture for halt_conditions enum violation under _internal/ path.
+halt_conditions:
+  - { type: telepathy, expr: "psychic signal" }
+---
+
+content
+'
+echo ""
+echo "[case 10d-strict: strict + _internal/ rejects unknown halt_conditions type]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$INTERNAL_HALT_BAD" 2>&1); rc=$?
+assert_exit 1 "$rc" "strict + _internal/ on bad halt type -> exit 1"
+
+# ── Fixture: max_iterations without halt_conditions ─────────────
+# P1-c rule is enforced only by the strict variant. With the D1 (#461)
+# strict/lenient split and Kill Switch defaulting to OFF, the lenient
+# variant accepts the same input. Strict-mode coverage lives below.
 ITER_NO_HALT_SKILL="$WORK/iter-no-halt-skill.md"
 write_file "$ITER_NO_HALT_SKILL" '---
 name: iter-no-halt-skill
-description: SKILL.md declaring max_iterations but missing halt_conditions. Must be rejected by the P1-c conditional-required rule.
+description: SKILL.md declaring max_iterations but missing halt_conditions. Lenient accepts; strict + _internal/ path rejects.
 max_iterations: 5
 ---
 
@@ -320,16 +374,15 @@ content
 '
 
 echo ""
-echo "[case 10e: P1-c — max_iterations without halt_conditions rejected]"
+echo "[case 10e: lenient (default) accepts max_iterations without halt_conditions]"
 out=$(run_lint skill "$ITER_NO_HALT_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "max_iterations without halt_conditions -> exit 1"
-assert_output_contains "'halt_conditions' is a required property" "$out" "missing halt_conditions error"
+assert_exit 0 "$rc" "lenient mode -> exit 0"
 
-# ── Fixture: loop_safe true without halt_conditions (P1-c, #458) ─
+# ── Fixture: loop_safe true without halt_conditions ──────────────
 LOOP_NO_HALT_SKILL="$WORK/loop-no-halt-skill.md"
 write_file "$LOOP_NO_HALT_SKILL" '---
 name: loop-no-halt-skill
-description: SKILL.md declaring loop_safe true but missing halt_conditions. Must be rejected by the P1-c conditional-required rule.
+description: SKILL.md declaring loop_safe true but missing halt_conditions. Lenient accepts; strict + _internal/ path rejects.
 loop_safe: true
 ---
 
@@ -337,16 +390,15 @@ content
 '
 
 echo ""
-echo "[case 10f: P1-c — loop_safe: true without halt_conditions rejected]"
+echo "[case 10f: lenient (default) accepts loop_safe: true without halt_conditions]"
 out=$(run_lint skill "$LOOP_NO_HALT_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "loop_safe: true without halt_conditions -> exit 1"
-assert_output_contains "'halt_conditions' is a required property" "$out" "missing halt_conditions error"
+assert_exit 0 "$rc" "lenient mode -> exit 0"
 
 # ── Fixture: loop_safe false without halt_conditions (allowed) ───
 LOOP_FALSE_SKILL="$WORK/loop-false-skill.md"
 write_file "$LOOP_FALSE_SKILL" '---
 name: loop-false-skill
-description: SKILL.md with loop_safe false and no halt_conditions. P1-c rule does not apply when loop_safe is false.
+description: SKILL.md with loop_safe false and no halt_conditions. Always accepted (rule never applies).
 loop_safe: false
 ---
 
@@ -354,9 +406,51 @@ content
 '
 
 echo ""
-echo "[case 10g: P1-c — loop_safe: false without halt_conditions accepted]"
+echo "[case 10g: loop_safe: false without halt_conditions accepted (lenient and strict)]"
 out=$(run_lint skill "$LOOP_FALSE_SKILL" 2>&1); rc=$?
-assert_exit 0 "$rc" "loop_safe: false without halt_conditions -> exit 0"
+assert_exit 0 "$rc" "lenient mode -> exit 0"
+
+# ── P1-c strict-mode coverage (D1, #461) ────────────────────────
+# Place fixtures under a temporary global/skills/_internal/ tree so the
+# path-based dispatch resolves to the strict schema. STRICT_SCHEMA=1
+# overrides the Kill Switch default.
+INTERNAL_ROOT="$WORK/repo/global/skills/_internal"
+mkdir -p "$INTERNAL_ROOT/iter-strict" "$INTERNAL_ROOT/loop-strict"
+INTERNAL_ITER="$INTERNAL_ROOT/iter-strict/SKILL.md"
+INTERNAL_LOOP="$INTERNAL_ROOT/loop-strict/SKILL.md"
+write_file "$INTERNAL_ITER" '---
+name: iter-strict
+description: Strict-mode fixture (max_iterations declared, halt_conditions missing) under a simulated _internal/ path. P1-c must reject under STRICT_SCHEMA=1.
+max_iterations: 5
+---
+
+content
+'
+write_file "$INTERNAL_LOOP" '---
+name: loop-strict
+description: Strict-mode fixture (loop_safe true, halt_conditions missing) under a simulated _internal/ path. P1-c must reject under STRICT_SCHEMA=1.
+loop_safe: true
+---
+
+content
+'
+
+echo ""
+echo "[case 10h: strict + _internal/ rejects max_iterations without halt_conditions]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$INTERNAL_ITER" 2>&1); rc=$?
+assert_exit 1 "$rc" "strict + _internal/ on iter -> exit 1"
+assert_output_contains "'halt_conditions' is a required property" "$out" "P1-c rejection message"
+
+echo ""
+echo "[case 10i: strict + _internal/ rejects loop_safe true without halt_conditions]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$INTERNAL_LOOP" 2>&1); rc=$?
+assert_exit 1 "$rc" "strict + _internal/ on loop_safe -> exit 1"
+assert_output_contains "'halt_conditions' is a required property" "$out" "P1-c rejection message"
+
+echo ""
+echo "[case 10j: strict ON but path NOT in _internal/ -> dispatches to lenient]"
+out=$(STRICT_SCHEMA=1 run_lint skill "$ITER_NO_HALT_SKILL" 2>&1); rc=$?
+assert_exit 0 "$rc" "strict ON outside _internal/ -> still lenient -> exit 0"
 
 # ── Wrapper invocation ───────────────────────────────────────
 echo ""

--- a/tests/scripts/test-strict-lenient-dispatch.sh
+++ b/tests/scripts/test-strict-lenient-dispatch.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Test suite for P4-a strict/lenient skill schema dispatch (issue #461).
+# Verifies select_skill_schema_mode() honors both the Kill Switch toggle
+# and the global/skills/_internal/ path marker.
+# Run: bash tests/scripts/test-strict-lenient-dispatch.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+PYTHON=""
+for c in python3 python; do
+    if command -v "$c" >/dev/null 2>&1; then PYTHON="$c"; break; fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "SKIP: python3/python not in PATH" >&2
+    exit 0
+fi
+if ! "$PYTHON" -c "import yaml, jsonschema" >/dev/null 2>&1; then
+    echo "SKIP: missing PyYAML or jsonschema" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Helper: invoke select_skill_schema_mode with explicit path and strict_enabled
+run_select() {
+    # $1 = expected mode, $2 = label, $3 = path, $4 = strict_enabled (true/false)
+    local expected="$1" label="$2" path="$3" strict="$4"
+    local out
+    out=$("$PYTHON" -c "
+import sys
+from pathlib import Path
+sys.path.insert(0, r'$ROOT_DIR/scripts')
+from spec_lint import select_skill_schema_mode
+print(select_skill_schema_mode(Path(r'$path'), $strict))
+" 2>&1)
+    if [ "$out" = "$expected" ]; then
+        PASS=$((PASS+1))
+        echo "PASS: $label -> $out"
+    else
+        FAIL=$((FAIL+1))
+        ERRORS+=("FAIL: $label (expected $expected, got $out)")
+    fi
+}
+
+# Set up a fake repo layout so resolve() produces predictable paths
+mkdir -p "$WORK/repo/global/skills/_internal/sample"
+mkdir -p "$WORK/repo/global/skills/regular/sample"
+mkdir -p "$WORK/repo/plugin/skills/external"
+touch "$WORK/repo/global/skills/_internal/sample/SKILL.md"
+touch "$WORK/repo/global/skills/regular/sample/SKILL.md"
+touch "$WORK/repo/plugin/skills/external/SKILL.md"
+
+# Strict OFF -> always lenient (Kill Switch behavior)
+run_select "skill-lenient" "_internal/ path with strict OFF -> lenient" \
+    "$WORK/repo/global/skills/_internal/sample/SKILL.md" "False"
+run_select "skill-lenient" "regular global skill with strict OFF -> lenient" \
+    "$WORK/repo/global/skills/regular/sample/SKILL.md" "False"
+run_select "skill-lenient" "plugin skill with strict OFF -> lenient" \
+    "$WORK/repo/plugin/skills/external/SKILL.md" "False"
+
+# Strict ON -> path-based dispatch
+run_select "skill-strict" "_internal/ path with strict ON -> strict" \
+    "$WORK/repo/global/skills/_internal/sample/SKILL.md" "True"
+run_select "skill-lenient" "regular global skill with strict ON -> lenient" \
+    "$WORK/repo/global/skills/regular/sample/SKILL.md" "True"
+run_select "skill-lenient" "plugin skill with strict ON -> lenient" \
+    "$WORK/repo/plugin/skills/external/SKILL.md" "True"
+
+# Edge: nested path under _internal
+mkdir -p "$WORK/repo/global/skills/_internal/nested/deep/skill"
+touch "$WORK/repo/global/skills/_internal/nested/deep/skill/SKILL.md"
+run_select "skill-strict" "deeply nested _internal path with strict ON" \
+    "$WORK/repo/global/skills/_internal/nested/deep/skill/SKILL.md" "True"
+
+# Edge: path containing the literal substring elsewhere should NOT match
+# Test ensures the marker is anchored to the actual directory layout
+mkdir -p "$WORK/repo/docs/global/skills/_internal-fake"
+touch "$WORK/repo/docs/global/skills/_internal-fake/notes.md"
+# This path has "global/skills/_internal-" not "global/skills/_internal/", so lenient
+run_select "skill-lenient" "look-alike _internal-fake path with strict ON -> lenient" \
+    "$WORK/repo/docs/global/skills/_internal-fake/notes.md" "True"
+
+# Real repo file (should always be lenient until D2 creates _internal/ entries)
+run_select "skill-lenient" "real claude-config skill (no _internal/ yet) with strict ON" \
+    "$ROOT_DIR/global/skills/preflight/SKILL.md" "True"
+
+# Final report
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    printf '%s\n' "${ERRORS[@]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #461
Part of #454
Builds on #469 (Kill Switch infrastructure - merged)
Unblocks #462 (D2: relocate skills to _internal/)

## What

Splits scripts/schemas/skill-md.schema.json into strict and lenient variants and adds path-based dispatch in spec_lint.py. Strict toggle is OFF by default for the 7-day grace window mandated by EPIC #454.

Three schema files now coexist:

| File | Role | additionalProperties | P1-c halt_conditions rule |
|------|------|----------------------|---------------------------|
| skill-md.schema.strict.json | global/skills/_internal/ only | false | required for iterative |
| skill-md.schema.lenient.json | plugin/, plugin-lite/, external | true | omitted |
| skill-md.schema.json | DEPRECATED ALIAS - same as lenient | true | omitted |

Path-based dispatch logic (select_skill_schema_mode):

| Kill Switch | Path | Schema picked |
|-------------|------|---------------|
| OFF (default) | any | lenient |
| ON | global/skills/_internal/* | strict |
| ON | any other | lenient |

## Why

P4-a. The canonical schema mixed two audiences:
- claude-config-internal skills that benefit from strict contracts (P1-c, additionalProperties:false)
- External plugin/plugin-lite skills whose authors cannot afford install-time rejects when claude-config tightens a rule

Without the split, every rule we add becomes a public breaking change for external authors. The split lets claude-config tighten its own contracts without forcing the same on the ecosystem.

The 7-day grace window with default OFF lets us observe whether external authors hit unexpected lenient violations before strict goes live.

## Where

- scripts/schemas/skill-md.schema.strict.json - new
- scripts/schemas/skill-md.schema.lenient.json - new
- scripts/schemas/skill-md.schema.json - converted to deprecated alias matching lenient
- scripts/spec_lint.py - INTERNAL_SKILL_MARKER, select_skill_schema_mode(), strict_enabled threading through lint_files
- tests/scripts/test-strict-lenient-dispatch.sh - new (9 cases)
- tests/scripts/test-spec-lint.sh - reorganized 6 cases into lenient-accepts vs strict-rejects pairs (now 48 assertions)

## How

1. Strict variant copies the previous canonical schema verbatim and only changes its \$id and title.
2. Lenient variant drops the allOf/if-then P1-c rule, sets additionalProperties:true, and removes per-property strictness on halt_conditions array entries.
3. spec_lint.py reads the Kill Switch via read_p4_strict_schema_toggle() (landed in #469). When OFF, dispatch always returns lenient. When ON, paths matching INTERNAL_SKILL_MARKER (global/skills/_internal/) hit strict.
4. The legacy skill-md.schema.json file is preserved at the same \$id URL but its body now matches lenient. External plugin authors who reference the URL keep working.

## Verification

| Gate | Command | Result |
|------|---------|--------|
| G1 (existing skill compat) | bash scripts/validate_skills.sh | 258 pass / 0 fail / 12 warn - byte-identical pre/post-PR |
| G1 (spec_lint full repo) | python3 scripts/spec_lint.py --mode skill <21 SKILL.md> | 0 violations |
| G1 (strict ON sanity) | STRICT_SCHEMA=1 python3 scripts/spec_lint.py --mode skill <21 SKILL.md> | 0 violations (no _internal/ skills exist yet) |
| G2 (plugin smoke) | bash tests/plugin/smoke-test.sh | 38/38 pass |
| New: dispatch | bash tests/scripts/test-strict-lenient-dispatch.sh | 9/9 pass |
| Updated: spec_lint | bash tests/scripts/test-spec-lint.sh | 48/48 pass |
| Regression: killswitch | bash tests/scripts/test-killswitch.sh | 10/10 pass |
| Regression: severity | bash tests/scripts/test-severity-enum.sh | 22/22 pass |
| Regression: migrate | bash tests/scripts/test-migrate-halt-conditions.sh | 20/20 pass |
| Strict integration | manual fixture under global/skills/_internal/ with STRICT_SCHEMA=1 | iterative skill missing halt_conditions correctly rejected |

Total: 195/195 assertions pass.

## Pre-merge requirements (from issue body)

- [x] Kill Switch PR landed first (#469 merged at 977f301)
- [x] Strict toggle defaults to false for the first 7 days
- [x] Plugin smoke test (G2) confirms lenient path
- [ ] G5 install dry-run - install.sh has no --dry-run flag today (pre-existing infrastructure gap, separate follow-up)

## SemVer

suite: major (1.10.0 -> 2.0.0) - public schema split for strict consumers, even with toggle defaulting off, per EPIC #454.

## Sequence and follow-up

- W4. Strict OFF for 7 days. Operators can flip STRICT_SCHEMA=1 for early opt-in testing.
- D2 (#462) at W5: physically move claude-config-internal skills under global/skills/_internal/ to activate strict dispatch for them.
- 7-day observation window + 72h freeze before flipping default to true.
- Optional follow-up: add scripts/install.sh --dry-run for the G5 gate (currently absent).
