### PR TITLE
feat(hooks): P4 rollout timeline safeguards via Claude-native hooks

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -118,7 +118,11 @@ reference: [`code.claude.com/docs/en/settings`](https://code.claude.com/docs/en/
 | `skipDangerousModePermissionPrompt` | Stable | 2.0.0+ | Ignored in project settings (security). |
 | `showTurnDuration` | **Misplaced** | 2.1.0+ | Officially belongs in `~/.claude.json`, not `settings.json`. May trigger schema validation warning in future CC versions. Consider moving. |
 | `teammateMode` | **Misplaced** | 2.1.0+ | Same as above — belongs in `~/.claude.json`. Valid values: `auto`, `in-process`, `tmux`. |
-| `harness_policies.p4_strict_schema` | Undocumented | — | claude-config Kill Switch for P4 strict-schema dispatch (EPIC #454). Default `false`. **Bypass:** set `STRICT_SCHEMA=0` env var (env wins over settings) to force lenient schema validation across all skills. Until D1 (#461) merges, the toggle is read but unused. |
+| `harness_policies.p4_strict_schema` | Undocumented | — | claude-config Kill Switch for P4 strict-schema dispatch (EPIC #454). Default `false`. **Bypass:** set `STRICT_SCHEMA=0` env var (env wins over settings) to force lenient schema validation across all skills. |
+| `harness_policies.p4_d1_merged_at` | Undocumented | — | ISO-8601 anchor for the D1 (#461) merge. Read by p4-timeline-guard.sh and p4-timeline-reminder.sh. |
+| `harness_policies.p4_grace_until` | Undocumented | — | ISO-8601 deadline for the lenient-only grace window. PRs touching `global/skills/_internal/` are blocked by p4-timeline-guard.sh until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
+| `harness_policies.p4_observation_until` | Undocumented | — | ISO-8601 deadline for the observation window. Edits flipping `p4_strict_schema` to `true` are blocked until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
+| `harness_policies.p4_freeze_until` | Undocumented | — | ISO-8601 deadline for the post-D2 72h freeze. SessionStart banner remains active until now() >= this timestamp. |
 
 ### env fields in settings.json
 

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -16,4 +16,4 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.13.0
+settings-schema: 1.13.1

--- a/global/hooks/p4-timeline-guard.sh
+++ b/global/hooks/p4-timeline-guard.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# p4-timeline-guard.sh
+# Blocks Claude-initiated actions that violate the EPIC #454 P4 rollout timeline.
+# Hook Type: PreToolUse (Bash | Edit | Write)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName + permissionDecision
+#
+# Two protected actions:
+#   1. gh pr merge of a PR whose diff touches global/skills/_internal/
+#      -> blocked until p4_grace_until passes
+#   2. Edit/Write to settings.json that flips harness_policies.p4_strict_schema
+#      from false to true
+#      -> blocked until p4_observation_until passes
+#
+# Override: set CLAUDE_P4_OVERRIDE=1 in the environment with the reason
+# documented in COMPATIBILITY.md (incident response, RCA-required).
+
+SETTINGS_PATH="${P4_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
+
+deny_response() {
+    local reason="$1"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+allow_response() {
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+# Override gate
+if [ "${CLAUDE_P4_OVERRIDE:-}" = "1" ]; then
+    allow_response
+fi
+
+# Read input from stdin (Claude Code passes JSON via stdin)
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+# Required deps - if jq missing, fail-open (other guards already enforce policy)
+if ! command -v jq >/dev/null 2>&1; then
+    allow_response
+fi
+
+# Settings file may not exist on fresh installs - allow
+if [ ! -f "$SETTINGS_PATH" ]; then
+    allow_response
+fi
+
+# Helper: read ISO timestamp field from settings.json, output epoch seconds (or empty)
+read_iso_epoch() {
+    local field="$1"
+    local iso
+    iso=$(jq -r ".harness_policies.${field} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    [ -z "$iso" ] && return 0
+    if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null; then
+        return 0
+    fi
+    date -u -d "$iso" +%s 2>/dev/null || true
+}
+
+NOW_EPOCH=$(date -u +%s)
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# ── Branch 1: Bash matcher ──────────────────────────────────────
+if [ "$TOOL" = "Bash" ]; then
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    case "$CMD" in
+        *"gh pr merge"*)
+            GRACE_EPOCH=$(read_iso_epoch p4_grace_until)
+            if [ -z "$GRACE_EPOCH" ]; then
+                allow_response
+            fi
+            if [ "$NOW_EPOCH" -ge "$GRACE_EPOCH" ]; then
+                allow_response
+            fi
+            # Extract PR number; if missing, allow (cannot evaluate)
+            PR_NUM=$(echo "$CMD" | grep -oE 'gh pr merge[[:space:]]+([0-9]+)' | grep -oE '[0-9]+' | head -1)
+            if [ -z "$PR_NUM" ]; then
+                allow_response
+            fi
+            REPO_FLAG=$(echo "$CMD" | grep -oE -- '--repo[[:space:]]+[^[:space:]]+' | awk '{print $2}')
+            REPO_ARG=""
+            [ -n "$REPO_FLAG" ] && REPO_ARG="--repo $REPO_FLAG"
+            # If gh unavailable or call fails, allow (cannot evaluate diff)
+            if ! command -v gh >/dev/null 2>&1; then
+                allow_response
+            fi
+            DIFF_FILES=$(gh pr diff $REPO_ARG "$PR_NUM" --name-only 2>/dev/null || true)
+            if echo "$DIFF_FILES" | grep -q "^global/skills/_internal/"; then
+                REMAIN=$((GRACE_EPOCH - NOW_EPOCH))
+                DAYS=$((REMAIN / 86400))
+                HOURS=$(((REMAIN % 86400) / 3600))
+                deny_response "P4 grace window not closed (${DAYS}d ${HOURS}h remaining). PR #${PR_NUM} touches global/skills/_internal/ which requires the 7-day grace window to pass first per EPIC #454. Override with CLAUDE_P4_OVERRIDE=1 (RCA required)."
+            fi
+            allow_response
+            ;;
+    esac
+fi
+
+# ── Branch 2: Edit/Write matcher (settings.json toggle flip) ────
+if [ "$TOOL" = "Edit" ] || [ "$TOOL" = "Write" ]; then
+    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+    case "$FILE_PATH" in
+        *settings.json|*settings.windows.json)
+            OBS_EPOCH=$(read_iso_epoch p4_observation_until)
+            if [ -z "$OBS_EPOCH" ] || [ "$NOW_EPOCH" -ge "$OBS_EPOCH" ]; then
+                allow_response
+            fi
+            # Detect a flip: new content sets p4_strict_schema true while
+            # current settings have it false.
+            CURRENT=$(jq -r '.harness_policies.p4_strict_schema // empty' "$SETTINGS_PATH" 2>/dev/null)
+            [ "$CURRENT" = "true" ] && allow_response
+            NEW_BLOB=""
+            if [ "$TOOL" = "Write" ]; then
+                NEW_BLOB=$(echo "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
+            else
+                NEW_BLOB=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+            fi
+            # Match the JSON form `"p4_strict_schema": true` (whitespace-tolerant)
+            if echo "$NEW_BLOB" | grep -qE '"p4_strict_schema"[[:space:]]*:[[:space:]]*true'; then
+                REMAIN=$((OBS_EPOCH - NOW_EPOCH))
+                DAYS=$((REMAIN / 86400))
+                HOURS=$(((REMAIN % 86400) / 3600))
+                deny_response "P4 observation window not closed (${DAYS}d ${HOURS}h remaining). harness_policies.p4_strict_schema cannot be flipped to true until the 14-day observation window passes per EPIC #454. Override with CLAUDE_P4_OVERRIDE=1 (RCA required)."
+            fi
+            ;;
+    esac
+fi
+
+allow_response

--- a/global/hooks/p4-timeline-reminder.sh
+++ b/global/hooks/p4-timeline-reminder.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# p4-timeline-reminder.sh
+# SessionStart banner that surfaces the active P4 rollout window.
+# Hook Type: SessionStart
+# Exit codes: 0 (always - lifecycle event)
+# Response format: none (writes to stderr; visible in terminal)
+#
+# Reads harness_policies timestamps from ~/.claude/settings.json and prints
+# a colored banner on stderr indicating which window is currently active and
+# how much time remains. Silent when the rollout is fully complete (now() >=
+# p4_freeze_until) or when the relevant fields are absent.
+
+SETTINGS_PATH="${P4_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
+
+[ -f "$SETTINGS_PATH" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+read_iso_epoch() {
+    local field="$1"
+    local iso
+    iso=$(jq -r ".harness_policies.${field} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    [ -z "$iso" ] && return 0
+    if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null; then
+        return 0
+    fi
+    date -u -d "$iso" +%s 2>/dev/null || true
+}
+
+GRACE_EPOCH=$(read_iso_epoch p4_grace_until)
+OBS_EPOCH=$(read_iso_epoch p4_observation_until)
+FREEZE_EPOCH=$(read_iso_epoch p4_freeze_until)
+
+# Silent when no timeline is configured at all
+if [ -z "$GRACE_EPOCH" ] && [ -z "$OBS_EPOCH" ] && [ -z "$FREEZE_EPOCH" ]; then
+    exit 0
+fi
+
+NOW_EPOCH=$(date -u +%s)
+
+# Silent when the rollout is fully complete
+if [ -n "$FREEZE_EPOCH" ] && [ "$NOW_EPOCH" -ge "$FREEZE_EPOCH" ]; then
+    exit 0
+fi
+
+# Color helpers - disabled when stderr is not a TTY
+if [ -t 2 ]; then
+    YELLOW='\033[1;33m'
+    CYAN='\033[1;36m'
+    GREEN='\033[1;32m'
+    RESET='\033[0m'
+else
+    YELLOW=''
+    CYAN=''
+    GREEN=''
+    RESET=''
+fi
+
+format_remaining() {
+    local target="$1"
+    local remain=$((target - NOW_EPOCH))
+    if [ "$remain" -le 0 ]; then
+        echo "ended"
+        return
+    fi
+    local days=$((remain / 86400))
+    local hours=$(((remain % 86400) / 3600))
+    echo "${days}d ${hours}h remaining"
+}
+
+format_iso() {
+    local epoch="$1"
+    date -u -r "$epoch" "+%Y-%m-%d %H:%M UTC" 2>/dev/null || \
+        date -u -d "@$epoch" "+%Y-%m-%d %H:%M UTC" 2>/dev/null
+}
+
+WINDOW=""
+DEADLINE_EPOCH=""
+NEXT_ACTION=""
+
+if [ -n "$GRACE_EPOCH" ] && [ "$NOW_EPOCH" -lt "$GRACE_EPOCH" ]; then
+    WINDOW="GRACE (lenient only)"
+    DEADLINE_EPOCH="$GRACE_EPOCH"
+    NEXT_ACTION="D2 (#462) merge eligible after grace ends"
+elif [ -n "$OBS_EPOCH" ] && [ "$NOW_EPOCH" -lt "$OBS_EPOCH" ]; then
+    WINDOW="OBSERVATION (collecting metrics)"
+    DEADLINE_EPOCH="$OBS_EPOCH"
+    NEXT_ACTION="p4_strict_schema flip eligible after observation ends"
+elif [ -n "$FREEZE_EPOCH" ] && [ "$NOW_EPOCH" -lt "$FREEZE_EPOCH" ]; then
+    WINDOW="FREEZE (72h post-D2)"
+    DEADLINE_EPOCH="$FREEZE_EPOCH"
+    NEXT_ACTION="Default toggle flip eligible after freeze ends"
+else
+    exit 0
+fi
+
+REMAINING=$(format_remaining "$DEADLINE_EPOCH")
+DEADLINE_ISO=$(format_iso "$DEADLINE_EPOCH")
+
+printf "%b" "${YELLOW}P4 Rollout Active${RESET}\n" >&2
+printf "  Window:   ${CYAN}%s${RESET}\n" "$WINDOW" >&2
+printf "  Ends:     %s (%s)\n" "$DEADLINE_ISO" "$REMAINING" >&2
+printf "  Next:     ${GREEN}%s${RESET}\n" "$NEXT_ACTION" >&2
+printf "  Override: CLAUDE_P4_OVERRIDE=1 (RCA required; see COMPATIBILITY.md)\n" >&2
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -115,6 +115,11 @@
             "type": "command",
             "command": "~/.claude/hooks/pre-edit-read-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/p4-timeline-guard.sh",
+            "timeout": 5
           }
         ]
       },
@@ -165,6 +170,11 @@
             "type": "command",
             "command": "~/.claude/hooks/attribution-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/p4-timeline-guard.sh",
+            "timeout": 10
           }
         ]
       },
@@ -192,6 +202,11 @@
             "command": "~/.claude/hooks/version-check.sh",
             "timeout": 10,
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/p4-timeline-reminder.sh",
+            "timeout": 5
           }
         ]
       }
@@ -438,10 +453,14 @@
   "skipDangerousModePermissionPrompt": true,
   "includeGitInstructions": false,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "showTurnDuration": true,
   "teammateMode": "in-process",
   "harness_policies": {
-    "p4_strict_schema": false
+    "p4_strict_schema": false,
+    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
+    "p4_grace_until": "2026-05-03T22:15:57Z",
+    "p4_observation_until": "2026-05-17T22:15:57Z",
+    "p4_freeze_until": "2026-05-20T22:15:57Z"
   }
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.13.0",
+  "version": "1.13.1",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -50,7 +50,11 @@
   "alwaysThinkingEnabled": true,
   "teammateMode": "in-process",
   "harness_policies": {
-    "p4_strict_schema": false
+    "p4_strict_schema": false,
+    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
+    "p4_grace_until": "2026-05-03T22:15:57Z",
+    "p4_observation_until": "2026-05-17T22:15:57Z",
+    "p4_freeze_until": "2026-05-20T22:15:57Z"
   },
 
   "autoUpdatesChannel": "latest",

--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -114,6 +114,26 @@
         "p4_strict_schema": {
           "type": "boolean",
           "description": "Kill Switch for P4 strict-schema dispatch. When false, even _internal/ skills validate against the lenient schema. Settings precedence: STRICT_SCHEMA env var > this field > default false."
+        },
+        "p4_d1_merged_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 timestamp of the D1 (#461) merge commit. Anchor for grace/observation/freeze window calculations. Set by claude-config maintainers; do not edit ad-hoc."
+        },
+        "p4_grace_until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 deadline for the lenient-only grace window. D2 (#462) and any change to global/skills/_internal/ must wait until now() >= this timestamp."
+        },
+        "p4_observation_until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 deadline for the observation window. p4_strict_schema must not be flipped to true until now() >= this timestamp."
+        },
+        "p4_freeze_until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 deadline for the post-D2 72h freeze. Default behavior changes (e.g., flipping p4_strict_schema true by default) must wait until now() >= this timestamp."
         }
       }
     }

--- a/tests/hooks/test-p4-timeline-guard.sh
+++ b/tests/hooks/test-p4-timeline-guard.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Test suite for p4-timeline-guard.sh and p4-timeline-reminder.sh (#472).
+# Run: bash tests/hooks/test-p4-timeline-guard.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+GUARD="$ROOT_DIR/global/hooks/p4-timeline-guard.sh"
+REMINDER="$ROOT_DIR/global/hooks/p4-timeline-reminder.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not in PATH" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a settings.json fixture with the given grace/observation timestamps
+write_settings() {
+    local file="$1" grace="$2" obs="$3" freeze="$4"
+    cat > "$file" <<EOF
+{
+  "harness_policies": {
+    "p4_strict_schema": false,
+    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
+    "p4_grace_until": "$grace",
+    "p4_observation_until": "$obs",
+    "p4_freeze_until": "$freeze"
+  }
+}
+EOF
+}
+
+# Run guard with given input + settings, capture decision
+guard_decision() {
+    local settings="$1" input="$2"
+    P4_SETTINGS_PATH="$settings" CLAUDE_P4_OVERRIDE="" bash "$GUARD" <<<"$input" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // "missing"'
+}
+
+# Run reminder with given settings, capture stderr
+reminder_stderr() {
+    local settings="$1"
+    P4_SETTINGS_PATH="$settings" bash "$REMINDER" 2>&1 >/dev/null
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS+1))
+        echo "PASS: $label"
+    else
+        FAIL=$((FAIL+1))
+        ERRORS+=("FAIL: $label (expected '$expected', got '$actual')")
+    fi
+}
+
+# ── Future deadlines (windows still open) ────────────────────────
+FUTURE_SETTINGS="$WORK/future.json"
+write_settings "$FUTURE_SETTINGS" "2099-01-01T00:00:00Z" "2099-02-01T00:00:00Z" "2099-03-01T00:00:00Z"
+
+# 1. settings.json edit flipping p4_strict_schema to true -> deny
+INPUT_FLIP='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.json","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+assert_eq "deny" "$(guard_decision "$FUTURE_SETTINGS" "$INPUT_FLIP")" \
+    "Edit flipping p4_strict_schema to true within observation -> deny"
+
+# 2. Write new settings with toggle true -> deny
+INPUT_WRITE='{"tool_name":"Write","tool_input":{"file_path":"/x/settings.json","content":"{\"harness_policies\":{\"p4_strict_schema\":true}}"}}'
+assert_eq "deny" "$(guard_decision "$FUTURE_SETTINGS" "$INPUT_WRITE")" \
+    "Write setting toggle true within observation -> deny"
+
+# 3. Edit unrelated setting -> allow
+INPUT_OTHER='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.json","old_string":"a","new_string":"\"unrelated\": true"}}'
+assert_eq "allow" "$(guard_decision "$FUTURE_SETTINGS" "$INPUT_OTHER")" \
+    "Edit unrelated settings field -> allow"
+
+# 4. Edit non-settings file mentioning p4_strict_schema true -> allow (path not matched)
+INPUT_DOC='{"tool_name":"Edit","tool_input":{"file_path":"/x/docs.md","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+assert_eq "allow" "$(guard_decision "$FUTURE_SETTINGS" "$INPUT_DOC")" \
+    "Edit non-settings file mentioning toggle -> allow"
+
+# 5. Bash gh pr list -> allow
+INPUT_LIST='{"tool_name":"Bash","tool_input":{"command":"gh pr list --repo foo/bar"}}'
+assert_eq "allow" "$(guard_decision "$FUTURE_SETTINGS" "$INPUT_LIST")" \
+    "Bash gh pr list -> allow"
+
+# 6. Override env -> always allow
+INPUT_FLIP_OVERRIDE='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.json","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+ACT=$(P4_SETTINGS_PATH="$FUTURE_SETTINGS" CLAUDE_P4_OVERRIDE=1 bash "$GUARD" <<<"$INPUT_FLIP_OVERRIDE" 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecision // "missing"')
+assert_eq "allow" "$ACT" "Override env -> allow even on toggle flip"
+
+# ── Past deadlines (windows already closed) ───────────────────────
+PAST_SETTINGS="$WORK/past.json"
+write_settings "$PAST_SETTINGS" "2000-01-01T00:00:00Z" "2000-02-01T00:00:00Z" "2000-03-01T00:00:00Z"
+
+# 7. Toggle flip after observation closed -> allow
+assert_eq "allow" "$(guard_decision "$PAST_SETTINGS" "$INPUT_FLIP")" \
+    "Toggle flip after observation closed -> allow"
+
+# ── Missing settings.json -> allow (fail-open per other guards) ───
+NOFILE="$WORK/does-not-exist.json"
+assert_eq "allow" "$(guard_decision "$NOFILE" "$INPUT_FLIP")" \
+    "Missing settings.json -> allow (fail-open)"
+
+# ── Reminder banner output ─────────────────────────────────────────
+# Future window -> banner emitted
+OUT=$(reminder_stderr "$FUTURE_SETTINGS")
+if echo "$OUT" | grep -q "P4 Rollout Active"; then
+    PASS=$((PASS+1)); echo "PASS: reminder emits banner inside grace"
+else
+    FAIL=$((FAIL+1)); ERRORS+=("FAIL: reminder did not emit banner inside grace")
+fi
+if echo "$OUT" | grep -q "GRACE"; then
+    PASS=$((PASS+1)); echo "PASS: reminder marks GRACE window"
+else
+    FAIL=$((FAIL+1)); ERRORS+=("FAIL: reminder missing GRACE label")
+fi
+
+# Past window -> silent
+OUT_PAST=$(reminder_stderr "$PAST_SETTINGS")
+if [ -z "$OUT_PAST" ]; then
+    PASS=$((PASS+1)); echo "PASS: reminder silent after rollout complete"
+else
+    FAIL=$((FAIL+1)); ERRORS+=("FAIL: reminder should be silent after rollout: $OUT_PAST")
+fi
+
+# Settings without timeline fields -> silent
+NO_TIMELINE="$WORK/no-timeline.json"
+echo '{"harness_policies":{"p4_strict_schema":false}}' > "$NO_TIMELINE"
+OUT_NONE=$(reminder_stderr "$NO_TIMELINE")
+if [ -z "$OUT_NONE" ]; then
+    PASS=$((PASS+1)); echo "PASS: reminder silent when timeline fields absent"
+else
+    FAIL=$((FAIL+1)); ERRORS+=("FAIL: reminder should be silent without timeline: $OUT_NONE")
+fi
+
+# ── Summary ────────────────────────────────────────────────────────
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    printf '%s\n' "${ERRORS[@]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #472
Part of #454
Reinforces #461 (D1 grace), #462 (D2 obs), and the post-D2 toggle flip

## What

Native hook safeguards for the EPIC #454 P4 rollout timeline. Three layers:

1. settings.json timeline anchors under harness_policies (single source of truth)
2. PreToolUse hook (p4-timeline-guard.sh) blocking premature actions
3. SessionStart hook (p4-timeline-reminder.sh) surfacing the active window every session

No GitHub Actions, no external cron. Uses the same hook infrastructure that already
enforces commit messages, attribution, branch protection, and dangerous commands.

## Why

Before this PR the only enforcement of the 7-day grace + 14-day observation + 72h freeze
windows was human memory: the issue body checklist and PR comments. A maintainer could
merge D2 (#462) too early, flip p4_strict_schema to true before observation completed,
or simply forget the windows if the next session was days later.

The hook layer makes those mistakes impossible without an explicit override
(CLAUDE_P4_OVERRIDE=1, RCA-required), and the SessionStart banner guarantees the
maintainer sees the current window and remaining time on every session start.

## Where

| File | Change |
|------|--------|
| global/settings.json + .windows.json | timeline fields under harness_policies, version 1.13.0 -> 1.13.1 |
| scripts/schemas/settings-json.schema.json | declare four new ISO-8601 fields with format:date-time |
| global/hooks/p4-timeline-guard.sh | new PreToolUse gate (Edit\|Write\|Read + Bash) |
| global/hooks/p4-timeline-reminder.sh | new SessionStart banner |
| global/settings.json hooks block | register both hooks |
| COMPATIBILITY.md | five new rows documenting fields + override |
| VERSION_MAP.yml | settings-schema 1.13.0 -> 1.13.1 |
| tests/hooks/test-p4-timeline-guard.sh | 12-case coverage |

## How

Two-branch logic in p4-timeline-guard.sh:

| Branch | Trigger | Decision |
|--------|---------|----------|
| Bash | command matches gh pr merge | gh pr diff inspected; if any file under global/skills/_internal/ AND now() < p4_grace_until -> deny |
| Edit/Write | file path ends in settings.json | if new content sets p4_strict_schema true AND current value is false AND now() < p4_observation_until -> deny |

Override: CLAUDE_P4_OVERRIDE=1 short-circuits to allow at the top of the hook.

p4-timeline-reminder.sh classifies the current moment into GRACE / OBSERVATION /
FREEZE / DONE based on the four anchor timestamps and prints a colored banner on
stderr (color suppressed on non-TTY).

P4_SETTINGS_PATH env override exists for tests; production reads from
~/.claude/settings.json.

## Verification (full sweep)

| Suite | Result |
|-------|--------|
| tests/hooks/test-p4-timeline-guard.sh | 12/12 pass (new) |
| python3 scripts/spec_lint.py --mode settings | 0 violations |
| bash scripts/validate_skills.sh | 258 pass / 0 fail / 12 warn (byte-identical pre/post-PR) |
| Live banner check on repo settings.json | "GRACE (lenient only) - Ends 2026-05-03 22:15 UTC (6d 23h remaining)" |
| Live guard check (Edit flipping toggle) | deny with "20d 23h remaining" message |
| Regression: test-killswitch.sh | 10/10 |
| Regression: test-strict-lenient-dispatch.sh | 9/9 |
| Regression: test-spec-lint.sh | 48/48 |

## Pre-merge requirements

- [x] Hooks pass test-p4-timeline-guard.sh (12/12)
- [x] Override mechanism documented in COMPATIBILITY.md
- [x] validate_skills.sh remains 258 pass / 0 fail / 12 warn
- [x] Banner output sane on non-color terminals (TTY check)

## SemVer

- suite: minor (additive guardrails)
- settings-schema: 1.13.0 -> 1.13.1 (new optional fields with format:date-time)

## Follow-up (intentionally out of scope)

- PowerShell ports of both hooks for global/settings.windows.json (tracked separately).
  Windows variant carries the timeline fields but does not register hooks yet.
- Optional durable cron registration via CronCreate(durable:true). Hook layer is
  primary; cron would be a session-active accelerator.
- scripts/install.sh --dry-run flag for the G5 gate (pre-existing infrastructure gap).

## Sequence

W4. Lands inside the active grace window so users start receiving the banner immediately.
