### PR TITLE
feat(hooks): add Bash-channel coverage for sensitive-file and write detection

### DIFF
--- a/global/hooks/bash-sensitive-read-guard.ps1
+++ b/global/hooks/bash-sensitive-read-guard.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# bash-sensitive-read-guard.ps1
+# Blocks reading sensitive files via the Bash tool channel on Windows.
+# PowerShell parity for bash-sensitive-read-guard.sh.
+#
+# This script is a regex-driven approximation of the bash tokenizer-based
+# sibling. The full sub-command splitter from lib/tokenize-shell.sh is
+# intentionally not ported because (a) the Bash tool on Windows always
+# arrives with a string command identical to its POSIX form, and (b) the
+# sensitive-path patterns are themselves anchored enough that a
+# whitespace-aware scan catches the documented attack classes.
+
+$json = Read-HookInput
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+$cmd = ''
+try { $cmd = [string]$json.tool_input.command } catch {}
+if ([string]::IsNullOrEmpty($cmd)) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Sensitive-path regex set. Mirrors the deny patterns in
+# bash-sensitive-read-guard.sh (case-insensitive where applicable).
+$sensitivePatterns = @(
+    '(^|[\s/\\])\.env([\s.''"]|$)',
+    '(^|[\s/\\])\.env\.[A-Za-z0-9_-]+',
+    '(^|[\s/\\])\.ssh[/\\](id_[A-Za-z0-9_-]+|[A-Za-z0-9_-]+_(?:rsa|dsa|ecdsa|ed25519))',
+    '(^|[\s/\\])\.aws[/\\](credentials|config)',
+    '(^|[\s/\\])\.gnupg([/\\]|$)',
+    '(^|[\s/\\])\.netrc(\s|$)',
+    '(^|[\s/\\])\.npmrc(\s|$)',
+    '(^|[\s/\\])\.pypirc(\s|$)',
+    '(^|[\s/\\])\.dockerconfigjson(\s|$)',
+    '(^|[\s/\\])\.docker[/\\]config\.json',
+    '(^|[\s/\\])\.kube[/\\]config(\s|$)',
+    '\.(?:pem|key|p12|pfx|crt|cer)([\s''"]|$)',
+    '[/\\]secrets[/\\]',
+    '[/\\]credentials[/\\]',
+    '[/\\]passwords[/\\]',
+    '\bpassword\b',
+    '/etc/(shadow|sudoers)\b',
+    '/etc/ssh/ssh_host_[A-Za-z0-9_]+_key\b'
+)
+
+# Read-tool prefix the regex below requires before the sensitive token.
+# This keeps `echo "this references .env"` as allow while denying `cat .env`.
+$readToolPrefix = '\b(cat|head|tail|less|more|bat|view|grep|egrep|fgrep|rg|find|tar|xxd|od|strings|hexdump|cp|mv|rsync|scp|install|sudo\s+cat|sudo\s+head|sudo\s+tail)\b'
+
+foreach ($pattern in $sensitivePatterns) {
+    $combined = "$readToolPrefix.*$pattern"
+    if ($cmd -match $combined) {
+        $reason = "Bash read of sensitive file blocked: matched pattern $pattern"
+        New-HookDenyResponse -Reason $reason
+        exit 0
+    }
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/bash-sensitive-read-guard.sh
+++ b/global/hooks/bash-sensitive-read-guard.sh
@@ -1,0 +1,381 @@
+#!/bin/bash
+# bash-sensitive-read-guard.sh
+# Blocks reading sensitive files via the Bash tool channel.
+#
+# The Edit/Write/Read PreToolUse matchers already gate Edit/Write/Read tool
+# calls against `permissions.deny`. The Bash channel was previously
+# unguarded, so `cat .env`, `grep AWS_SECRET ~/.aws/credentials`, and
+# `find / -name '.env' -exec cat {} \;` could exfiltrate secrets without a
+# prompt. This hook closes that gap.
+#
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Strategy
+# --------
+# 1. Parse the command into sub-commands (respecting quotes/substitutions
+#    via lib/tokenize-shell.sh — same library as dangerous-command-guard).
+# 2. For each sub-command, identify well-known read tools.
+# 3. Extract their file-path arguments (skipping flags and -exec sentinels).
+# 4. Resolve `~`, `$HOME`, and relative paths via realpath when possible
+#    (defeats Red Team Vector F: symlink-to-secret race).
+# 5. Match the resolved path against the sensitive deny patterns.
+# 6. Deny on match; fall through to allow otherwise.
+
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/tokenize-shell.sh
+. "$LIB_DIR/tokenize-shell.sh"
+
+# --- helpers ----------------------------------------------------------------
+
+allow_response() {
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+deny_response() {
+    local reason="$1"
+    reason="${reason//\\/\\\\}"
+    reason="${reason//\"/\\\"}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+# resolve_path <raw_path>
+#   Expand ~ and $HOME, then resolve symlinks via realpath when available.
+resolve_path() {
+    local p="$1"
+    [ -z "$p" ] && return 0
+    # Expand $HOME and ~ at the start of the path. The single-quoted
+    # patterns inside ${p#'...'} are required because some bash builds
+    # tilde-expand the unquoted form, leaving a literal `~` in the result
+    # and producing nonsense like `/Users/x/~/.ssh/id_rsa`.
+    case "$p" in
+        '~')         p="${HOME:-$p}" ;;
+        '~/'*)       p="${HOME}/${p#'~/'}" ;;
+        '$HOME')     p="${HOME:-$p}" ;;
+        '$HOME/'*)   p="${HOME}/${p#'$HOME/'}" ;;
+    esac
+    local resolved
+    if command -v realpath >/dev/null 2>&1; then
+        # GNU coreutils realpath accepts -m for missing paths; macOS BSD
+        # does not. Try the unflagged form first.
+        resolved=$(realpath "$p" 2>/dev/null) || resolved=""
+    fi
+    if [ -z "$resolved" ]; then
+        # Fallback: resolve the parent directory and reattach the basename.
+        # Defeats Red Team Vector F when the link target exists, even when
+        # the link itself was created against a missing path.
+        local parent base
+        parent=$(dirname "$p")
+        base=$(basename "$p")
+        if [ -d "$parent" ] && command -v realpath >/dev/null 2>&1; then
+            local rp
+            rp=$(realpath "$parent" 2>/dev/null) || rp="$parent"
+            resolved="${rp%/}/$base"
+        else
+            resolved=$(printf '%s' "$p" | sed -e 's://*:/:g' -e 's:/$::')
+        fi
+    fi
+    printf '%s' "$resolved"
+}
+
+# is_sensitive <path>
+#   Returns 0 if the resolved path matches any sensitive pattern.
+#   Patterns mirror permissions.deny[] in global/settings.json.
+is_sensitive() {
+    local p="$1"
+    [ -z "$p" ] && return 1
+    # Lowercase for case-insensitive directory match (secrets/Secrets).
+    local lower
+    lower=$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')
+
+    # .env, .env.*, including dotted suffix variants.
+    case "$p" in
+        */.env|*.env|*/.env.*|*.env.*)
+            return 0 ;;
+    esac
+    # SSH private keys and well-known credential filenames.
+    case "$p" in
+        */.ssh/id_*|*/.ssh/*_rsa|*/.ssh/*_dsa|*/.ssh/*_ecdsa|*/.ssh/*_ed25519)
+            return 0 ;;
+        */.aws/credentials|*/.aws/config)
+            return 0 ;;
+        */.gnupg/*|*/.gnupg)
+            return 0 ;;
+        */.netrc|*/.npmrc|*/.pypirc|*/.dockerconfigjson|*/.docker/config.json)
+            return 0 ;;
+        */.kube/config)
+            return 0 ;;
+    esac
+    # Cryptographic material by extension.
+    case "$lower" in
+        *.pem|*.key|*.p12|*.pfx|*.crt|*.cer)
+            return 0 ;;
+    esac
+    # Sensitive directory tokens anywhere in the path. Match both
+    # absolute (`/foo/secrets/bar`) and relative (`secrets/bar`) forms.
+    case "$lower" in
+        */secrets/*|*/credentials/*|*/passwords/*) return 0 ;;
+        secrets/*|credentials/*|passwords/*)      return 0 ;;
+        *password*)                                return 0 ;;
+    esac
+    # Bare credential filenames — e.g. `find -name id_rsa` exposes the
+    # filename without a `.ssh/` prefix; treat the bare names as sensitive
+    # so a deliberate search for them is also flagged.
+    case "$p" in
+        id_rsa|id_dsa|id_ecdsa|id_ed25519|*/id_rsa|*/id_dsa|*/id_ecdsa|*/id_ed25519)
+            return 0 ;;
+        credentials|*/credentials)
+            return 0 ;;
+    esac
+    # System credential files. The `*/etc/...` variants catch macOS where
+    # realpath resolves /etc to /private/etc.
+    case "$p" in
+        /etc/shadow|/etc/sudoers|/etc/sudoers.d/*|/etc/ssh/ssh_host_*_key) return 0 ;;
+        */etc/shadow|*/etc/sudoers|*/etc/sudoers.d/*|*/etc/ssh/ssh_host_*_key) return 0 ;;
+    esac
+    return 1
+}
+
+# extract_read_paths <argv...>
+#   For a known read-tool argv, emit each candidate file-path argument on
+#   its own line. Skips flags and conservative -exec/-execdir sentinels for
+#   `find`. Best-effort: false negatives are preferred over false positives
+#   for non-read tokens.
+extract_read_paths() {
+    local cmd0="$1"
+    shift
+    local skip_next=0
+    local in_find_exec=0
+    local grep_pattern_seen=0
+    local arg
+    for arg in "$@"; do
+        if [ "$skip_next" = "1" ]; then
+            skip_next=0
+            continue
+        fi
+        case "$cmd0" in
+            grep|egrep|fgrep|rg)
+                # grep [-flags] PATTERN PATH... — the first non-flag arg
+                # is the pattern (when -e is not used) and must NOT be
+                # treated as a path. Subsequent non-flag args are paths.
+                case "$arg" in
+                    -e|--regexp|-f|--file|--include|--exclude|--include-dir|--exclude-dir)
+                        # `-e PATTERN` — the next arg is a pattern, not a path.
+                        skip_next=1
+                        grep_pattern_seen=1
+                        continue ;;
+                    -*)
+                        continue ;;
+                esac
+                if [ "$grep_pattern_seen" = "0" ]; then
+                    grep_pattern_seen=1
+                    continue
+                fi
+                printf '%s\n' "$arg"
+                continue
+                ;;
+            find)
+                # find PATH... [predicates]. After the first predicate flag,
+                # subsequent paths are usually arguments to predicates, not
+                # search roots — but we still want to flag the explicit
+                # -path/-name/-iname target file when it points at a secret.
+                case "$arg" in
+                    -exec|-execdir|-ok|-okdir)
+                        in_find_exec=1; continue ;;
+                    \;|+)
+                        in_find_exec=0; continue ;;
+                esac
+                if [ "$in_find_exec" = "1" ]; then
+                    # The argv inside -exec/-execdir is itself a command —
+                    # the tokenizer will surface it as a separate sub-command
+                    # only if the user used a shell metachar, so inspect
+                    # known sub-commands ourselves: `cat {}` is fine because
+                    # `{}` is not a literal sensitive path; the dangerous
+                    # case is `-exec cat /etc/shadow` which we do flag.
+                    case "$arg" in
+                        \{\}) continue ;;
+                        -*)   continue ;;
+                    esac
+                    printf '%s\n' "$arg"
+                    continue
+                fi
+                case "$arg" in
+                    -*) continue ;;
+                esac
+                printf '%s\n' "$arg"
+                continue
+                ;;
+            tar)
+                # `tar c FILE...` — emit each non-flag path. Strip leading
+                # `-c` / `c` mode token.
+                case "$arg" in
+                    c|cv|cvf|cf|czf|cjf|cJf|tf|tvf|xf|xvf|xzf|xjf)
+                        # Mode flag — next non-flag is archive name (skip).
+                        skip_next=1; continue ;;
+                    -[a-zA-Z]*) continue ;;
+                esac
+                printf '%s\n' "$arg"
+                continue
+                ;;
+            *)
+                # Generic: treat any non-flag token as a candidate path.
+                case "$arg" in
+                    -*) continue ;;
+                esac
+                printf '%s\n' "$arg"
+                ;;
+        esac
+    done
+}
+
+# inspect_subcommand <subcommand_string>
+#   Returns 0 (allow) or prints a deny reason and returns 1.
+inspect_subcommand() {
+    local sub="$1"
+    [ -z "$sub" ] && return 0
+
+    # Tokenize argv.
+    local -a argv=()
+    local t
+    while IFS= read -r t; do
+        argv+=("$t")
+    done < <(tokenize_argv "$sub")
+    [ ${#argv[@]} -eq 0 ] && return 0
+
+    # Strip a leading wrapper (sudo/env/nice/...). Mirrors the dangerous-
+    # command-guard logic so `sudo cat /etc/shadow` is also caught.
+    local head="${argv[0]}"
+    case "$head" in
+        sudo|nice|nohup|time|stdbuf|exec)
+            argv=("${argv[@]:1}")
+            ;;
+        env)
+            argv=("${argv[@]:1}")
+            while [ ${#argv[@]} -gt 0 ]; do
+                case "${argv[0]}" in
+                    *=*) argv=("${argv[@]:1}") ;;
+                    *)   break ;;
+                esac
+            done
+            ;;
+    esac
+    [ ${#argv[@]} -eq 0 ] && return 0
+
+    local cmd0="${argv[0]}"
+
+    # Whitelist of read tools we inspect. Other commands may still read
+    # files (their own -f flags etc.) but we keep the set bounded so the
+    # hook stays predictable; new read patterns are added on demand.
+    case "$cmd0" in
+        cat|head|tail|less|more|bat|view)
+            ;;
+        grep|egrep|fgrep|rg)
+            ;;
+        find)
+            ;;
+        tar)
+            ;;
+        xxd|od|strings|hexdump)
+            ;;
+        cp|mv|rsync|install|scp)
+            # Source argument(s) to copy/move are reads; targets are writes.
+            # We only flag the source side here (everything except the last
+            # token). Write-side enforcement lives in bash-write-guard.sh.
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+
+    # For cp/mv/rsync/install/scp the last argument is the destination.
+    # Inspect only the source positions.
+    local -a inspect_args=("${argv[@]:1}")
+    case "$cmd0" in
+        cp|mv|rsync|install|scp)
+            local n=${#inspect_args[@]}
+            if [ "$n" -ge 1 ]; then
+                inspect_args=("${inspect_args[@]:0:$((n-1))}")
+            else
+                inspect_args=()
+            fi
+            ;;
+    esac
+
+    local path resolved
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        resolved=$(resolve_path "$path")
+        if is_sensitive "$resolved"; then
+            echo "Bash read of sensitive file blocked: $cmd0 $path (resolved: $resolved)"
+            return 1
+        fi
+    done < <(extract_read_paths "$cmd0" "${inspect_args[@]}")
+    return 0
+}
+
+# --- main -------------------------------------------------------------------
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Fail-open on totally empty input — mirrors pre-edit-read-guard. The
+# upstream dangerous-command-guard already fails closed on parse errors;
+# duplicating that here would make the Bash chain double-deny on transient
+# stdin issues.
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+command -v jq >/dev/null 2>&1 || allow_response
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [ -z "$CMD" ]; then
+    allow_response
+fi
+
+# Performance bound: same threshold as dangerous-command-guard. For very
+# large pasted blobs fall through to a coarse regex that still flags the
+# obvious patterns.
+SRG_TOKENIZER_MAX_BYTES="${SRG_TOKENIZER_MAX_BYTES:-16384}"
+if [ "${#CMD}" -gt "$SRG_TOKENIZER_MAX_BYTES" ]; then
+    if echo "$CMD" | grep -qE '(^|[[:space:]])(cat|head|tail|less|more|grep|egrep|fgrep|rg|xxd|od|strings)[[:space:]]+[^|;&]*\.env(\s|$|[^[:alnum:]])'; then
+        deny_response "Bash read of .env file blocked (coarse-scan)"
+    fi
+    if echo "$CMD" | grep -qE '(^|[[:space:]])(cat|head|tail|grep|egrep|fgrep|rg|xxd|od|strings)[[:space:]]+[^|;&]*(\.pem|\.key|id_rsa|id_dsa|id_ecdsa|id_ed25519|\.aws/credentials|/etc/shadow)'; then
+        deny_response "Bash read of sensitive credential blocked (coarse-scan)"
+    fi
+    allow_response
+fi
+
+# Walk every sub-command. Single hit denies the whole call.
+prev=""
+while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    if reason=$(inspect_subcommand "$sub"); then
+        :
+    else
+        deny_response "$reason"
+    fi
+    prev="$sub"
+done < <(split_subcommands "$CMD")
+
+allow_response

--- a/global/hooks/bash-write-guard.ps1
+++ b/global/hooks/bash-write-guard.ps1
@@ -1,0 +1,100 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# bash-write-guard.ps1
+# Detects file-mutation patterns in Bash commands and enforces that the
+# target was Read first this session, mirroring bash-write-guard.sh.
+#
+# Whitelist approach (Issue #477): the script flags any command whose argv
+# matches a known write tool OR contains a redirection to a file. If the
+# write target cannot be statically extracted (e.g. `python -c "..."`,
+# awk script bodies, sed command-line scripts), the call is denied with a
+# message asking the agent to use the Edit/Write tool instead.
+
+$json = Read-HookInput
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+$cmd = ''
+try { $cmd = [string]$json.tool_input.command } catch {}
+if ([string]::IsNullOrEmpty($cmd)) {
+    New-HookAllowResponse
+    exit 0
+}
+
+$sessionId = $env:CLAUDE_SESSION_ID
+if ([string]::IsNullOrEmpty($sessionId)) {
+    try { $sessionId = [string]$json.session_id } catch {}
+}
+if ([string]::IsNullOrEmpty($sessionId)) { $sessionId = 'unknown' }
+
+$trackerDir = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR } else { [System.IO.Path]::GetTempPath() }
+$tracker = Join-Path $trackerDir ("claude-read-set-{0}" -f $sessionId)
+
+$sensitiveTargetRegex = '(\.env([.\s''"]|$))|((\.ssh)[/\\](id_|[A-Za-z0-9_-]+_(rsa|dsa|ecdsa|ed25519)))|(\.aws[/\\]credentials)|(\.kube[/\\]config)|(/etc/(shadow|sudoers|passwd|hosts))|(\.(pem|key|p12|pfx)(\s|$|[''"]))|([/\\]secrets[/\\])|([/\\]credentials[/\\])'
+
+# Uninspectable patterns — always denied.
+$uninspectableRegex = '\b(python\d?|node|perl|ruby)\s+-(c|e|E)\b|\b(awk|gawk|mawk)\b'
+
+# Known write-tool argv heads.
+$writeToolRegex = '\b(tee|cp|mv|install|rsync|scp|dd|truncate|ln|chmod|chown|chgrp|sed\s+-i|sed\s+--in-place)\b'
+
+# Redirect-to-file target extraction (best-effort; ignores `&>`/`2>&1`/`/dev/null`).
+function Get-RedirectTarget([string]$cmdLine) {
+    $matches = [regex]::Matches($cmdLine, '(?<![0-9&])>+\s*([^\s|;&<>]+)')
+    foreach ($m in $matches) {
+        $tgt = $m.Groups[1].Value.Trim('"', "'")
+        if ($tgt -ne '/dev/null' -and $tgt -ne '/dev/stderr' -and $tgt -ne '/dev/stdout' -and $tgt -ne '/dev/tty') {
+            Write-Output $tgt
+        }
+    }
+}
+
+# Sensitive-target check on any redirect target.
+foreach ($target in (Get-RedirectTarget $cmd)) {
+    if ($target -match $sensitiveTargetRegex) {
+        New-HookDenyResponse -Reason "Bash write to sensitive file blocked: $target"
+        exit 0
+    }
+}
+
+# Uninspectable mutation pattern.
+if ($cmd -match $uninspectableRegex) {
+    New-HookDenyResponse -Reason "Uninspectable file mutation pattern; use Edit/Write tool instead"
+    exit 0
+}
+
+# Sensitive-target check via cp/mv/tee/install argument scan: any sensitive
+# pattern preceded by a write tool (best-effort regex).
+if ($cmd -match $writeToolRegex) {
+    if ($cmd -match $sensitiveTargetRegex) {
+        New-HookDenyResponse -Reason "Bash write to sensitive file blocked (write-tool argument matches sensitive pattern)"
+        exit 0
+    }
+}
+
+# Read-before-Edit on existing redirect targets.
+if (Test-Path -LiteralPath $tracker) {
+    foreach ($target in (Get-RedirectTarget $cmd)) {
+        $resolved = $target
+        try {
+            if (Test-Path -LiteralPath $target) {
+                $resolved = (Resolve-Path -LiteralPath $target -ErrorAction Stop).Path
+            }
+        } catch {}
+        if (Test-Path -LiteralPath $resolved -PathType Leaf) {
+            $hit = $false
+            try { $hit = (Get-Content -LiteralPath $tracker -ErrorAction SilentlyContinue) -contains $resolved } catch {}
+            if (-not $hit) {
+                New-HookDenyResponse -Reason "Cannot Bash-write '$target' without reading it first in this session. Call Read on '$target' and retry."
+                exit 0
+            }
+        }
+    }
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/bash-write-guard.sh
+++ b/global/hooks/bash-write-guard.sh
@@ -1,0 +1,523 @@
+#!/bin/bash
+# bash-write-guard.sh
+# Enforces the "Read before Edit/Write" invariant on the Bash tool channel.
+#
+# Rationale (Issue #477)
+# ----------------------
+# The PreToolUse "Edit|Write|Read" matcher already enforces Read-before-
+# Edit for the structured Edit/Write tools. The Bash channel was previously
+# unguarded, so `cat > existing.py <<EOF`, `tee file`, `sed -i`, `python -c
+# "open(f,'w').write(...)"`, `awk 'BEGIN{print > "f"}'`, `cp /dev/stdin f`,
+# `install -m`, and `dd of=` all bypassed the contract.
+#
+# Whitelist, not blacklist
+# ------------------------
+# Red Team Vector E showed a blacklist of write commands is unbounded:
+# new interpreters and obscure tools keep appearing. This guard inverts
+# the question: any command whose argv head is in the WRITE_VERBS set or
+# that contains a redirect-to-file is treated as a write, then we attempt
+# to extract the destination path. If extraction fails, we DENY with a
+# message asking the agent to use the Edit/Write tool instead — that is
+# the stated breaking-change behavior in the issue spec.
+#
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/tokenize-shell.sh
+. "$LIB_DIR/tokenize-shell.sh"
+
+# --- helpers ----------------------------------------------------------------
+
+allow_response() {
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+deny_response() {
+    local reason="$1"
+    reason="${reason//\\/\\\\}"
+    reason="${reason//\"/\\\"}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+# resolve_path <raw_path>
+#   Expands ~/ and $HOME at the head, then resolves the path through
+#   realpath so symlinks collapse and macOS `/var/...` is canonicalized
+#   to `/private/var/...`. Falls back to a manual cleanup when realpath
+#   cannot resolve the path (BSD realpath rejects missing files).
+resolve_path() {
+    local p="$1"
+    [ -z "$p" ] && return 0
+    case "$p" in
+        '~')         p="${HOME:-$p}" ;;
+        '~/'*)       p="${HOME}/${p#'~/'}" ;;
+        '$HOME')     p="${HOME:-$p}" ;;
+        '$HOME/'*)   p="${HOME}/${p#'$HOME/'}" ;;
+    esac
+    local resolved
+    if command -v realpath >/dev/null 2>&1; then
+        resolved=$(realpath "$p" 2>/dev/null) || resolved=""
+    fi
+    if [ -z "$resolved" ]; then
+        # Fallback: resolve the parent directory (which usually exists)
+        # and reattach the basename. This collapses `//` and trailing
+        # `/` while keeping behavior consistent for write targets that
+        # don't exist yet.
+        local parent base
+        parent=$(dirname "$p")
+        base=$(basename "$p")
+        if [ -d "$parent" ] && command -v realpath >/dev/null 2>&1; then
+            local rp
+            rp=$(realpath "$parent" 2>/dev/null) || rp="$parent"
+            resolved="${rp%/}/$base"
+        else
+            # Last-resort manual cleanup.
+            resolved=$(printf '%s' "$p" | sed -e 's://*:/:g' -e 's:/$::')
+        fi
+    fi
+    printf '%s' "$resolved"
+}
+
+# is_sensitive_target <path>
+#   Path patterns that must NEVER be written by the Bash channel without an
+#   explicit prior Read. Mirrors permissions.deny[] in settings.json plus a
+#   superset for system credential files.
+is_sensitive_target() {
+    local p="$1"
+    [ -z "$p" ] && return 1
+    local lower
+    lower=$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')
+    case "$p" in
+        */.env|*.env|*/.env.*|*.env.*) return 0 ;;
+        */.ssh/id_*|*/.ssh/*_rsa|*/.ssh/*_dsa|*/.ssh/*_ecdsa|*/.ssh/*_ed25519) return 0 ;;
+        */.aws/credentials|*/.aws/config) return 0 ;;
+        */.gnupg/*|*/.gnupg) return 0 ;;
+        */.netrc|*/.npmrc|*/.pypirc|*/.dockerconfigjson|*/.docker/config.json) return 0 ;;
+        */.kube/config) return 0 ;;
+        /etc/passwd|/etc/shadow|/etc/sudoers|/etc/sudoers.d/*|/etc/hosts) return 0 ;;
+        */etc/passwd|*/etc/shadow|*/etc/sudoers|*/etc/sudoers.d/*|*/etc/hosts) return 0 ;;
+    esac
+    case "$lower" in
+        *.pem|*.key|*.p12|*.pfx) return 0 ;;
+        */secrets/*|*/credentials/*|*/passwords/*) return 0 ;;
+    esac
+    return 1
+}
+
+# tracker_has <path>
+#   Returns 0 if the resolved path appears in the session Read tracker.
+#   Mirrors the pre-edit-read-guard tracker file location.
+tracker_has() {
+    local resolved="$1"
+    local session_id="${CLAUDE_SESSION_ID:-unknown}"
+    local tracker_dir="${TMPDIR:-/tmp}"
+    local tracker="${tracker_dir%/}/claude-read-set-${session_id}"
+    [ -f "$tracker" ] || return 1
+    grep -Fxq "$resolved" "$tracker" 2>/dev/null
+}
+
+# extract_redirect_target <subcommand_string>
+#   Returns the file path of a `>`/`>>` redirect, if any, on stdout.
+#   Walks the raw string with a simple quote-aware scan because the
+#   tokenizer strips redirect operators from argv.
+extract_redirect_target() {
+    local cmd="$1"
+    local len=${#cmd}
+    local i=0 ch next quote=""
+    local target=""
+    local seen_redirect=0
+    while [ "$i" -lt "$len" ]; do
+        ch="${cmd:$i:1}"
+        next="${cmd:$((i+1)):1}"
+        if [ "$quote" = "'" ]; then
+            [ "$ch" = "'" ] && quote=""
+            i=$((i+1)); continue
+        fi
+        if [ "$quote" = '"' ]; then
+            if [ "$ch" = "\\" ] && [ "$i" -lt "$((len-1))" ]; then i=$((i+2)); continue; fi
+            [ "$ch" = '"' ] && quote=""
+            i=$((i+1)); continue
+        fi
+        case "$ch" in
+            "'") quote="'" ;;
+            '"') quote='"' ;;
+            '>')
+                # Skip duplicate `>>` and `&>`/`>&` flavors — both still
+                # imply a write target follows.
+                seen_redirect=1
+                if [ "$next" = '>' ]; then i=$((i+2)); continue; fi
+                if [ "$next" = '&' ]; then i=$((i+2)); continue; fi
+                ;;
+            *)
+                if [ "$seen_redirect" = "1" ]; then
+                    case "$ch" in
+                        ' '|$'\t') : ;;
+                        *)
+                            # Read the next whitespace-delimited token.
+                            local j=$i
+                            local tok=""
+                            local tquote=""
+                            while [ "$j" -lt "$len" ]; do
+                                local c2="${cmd:$j:1}"
+                                if [ "$tquote" = "'" ]; then
+                                    [ "$c2" = "'" ] && tquote=""
+                                    tok+="$c2"; j=$((j+1)); continue
+                                fi
+                                if [ "$tquote" = '"' ]; then
+                                    [ "$c2" = '"' ] && tquote=""
+                                    tok+="$c2"; j=$((j+1)); continue
+                                fi
+                                case "$c2" in
+                                    "'") tquote="'"; tok+="$c2" ;;
+                                    '"') tquote='"'; tok+="$c2" ;;
+                                    ' '|$'\t'|$'\n'|';'|'&'|'|') break ;;
+                                    *) tok+="$c2" ;;
+                                esac
+                                j=$((j+1))
+                            done
+                            # Strip surrounding quotes.
+                            if [ ${#tok} -ge 2 ]; then
+                                local f="${tok:0:1}" l="${tok: -1}"
+                                if { [ "$f" = "'" ] && [ "$l" = "'" ]; } \
+                                    || { [ "$f" = '"' ] && [ "$l" = '"' ]; }; then
+                                    tok="${tok:1:${#tok}-2}"
+                                fi
+                            fi
+                            target="$tok"
+                            printf '%s\n' "$target"
+                            return 0
+                            ;;
+                    esac
+                fi
+                ;;
+        esac
+        i=$((i+1))
+    done
+    return 1
+}
+
+# extract_target_from_argv <argv...>
+#   For known write tools, extract the destination path from argv.
+#   Returns 0 with the path on stdout, or 1 if the target cannot be
+#   determined from argv alone (caller must deny as uninspectable).
+extract_target_from_argv() {
+    local cmd0="$1"
+    shift
+    local arg
+    case "$cmd0" in
+        tee)
+            # `tee [-a] FILE...` — emit each non-flag arg.
+            for arg in "$@"; do
+                case "$arg" in
+                    -*) continue ;;
+                    *)  printf '%s\n' "$arg" ;;
+                esac
+            done
+            return 0
+            ;;
+        cp|mv|install|rsync|scp)
+            # Last positional argument is the destination.
+            local last=""
+            for arg in "$@"; do
+                case "$arg" in
+                    -*) continue ;;
+                    *)  last="$arg" ;;
+                esac
+            done
+            [ -n "$last" ] && printf '%s\n' "$last"
+            return 0
+            ;;
+        sed)
+            # Only -i (in-place) edits a file. Find the file argument(s).
+            local has_inplace=0
+            for arg in "$@"; do
+                case "$arg" in
+                    -i|-i*|--in-place|--in-place=*) has_inplace=1 ;;
+                esac
+            done
+            if [ "$has_inplace" = "0" ]; then return 0; fi
+            # The last non-flag token after the script is the file. Best
+            # effort: emit every non-flag, non-script token.
+            local script_seen=0
+            for arg in "$@"; do
+                case "$arg" in
+                    -i|-i*|--in-place|--in-place=*|-e|--expression|-f|--file|-n|--quiet|-E|--regexp-extended) continue ;;
+                    -*) continue ;;
+                esac
+                if [ "$script_seen" = "0" ]; then
+                    script_seen=1
+                    continue
+                fi
+                printf '%s\n' "$arg"
+            done
+            return 0
+            ;;
+        dd)
+            # `dd of=PATH` — pull from of=.
+            for arg in "$@"; do
+                case "$arg" in
+                    of=*) printf '%s\n' "${arg#of=}" ;;
+                esac
+            done
+            return 0
+            ;;
+        truncate)
+            # `truncate -s SIZE FILE`
+            local prev=""
+            for arg in "$@"; do
+                if [ "$prev" = "-s" ] || [ "$prev" = "--size" ]; then
+                    prev="$arg"; continue
+                fi
+                case "$arg" in
+                    -*) prev="$arg"; continue ;;
+                esac
+                printf '%s\n' "$arg"
+                prev="$arg"
+            done
+            return 0
+            ;;
+        ln)
+            # `ln -s TARGET LINK_NAME` — the LINK_NAME is the writable side.
+            local last=""
+            for arg in "$@"; do
+                case "$arg" in
+                    -*) continue ;;
+                    *)  last="$arg" ;;
+                esac
+            done
+            [ -n "$last" ] && printf '%s\n' "$last"
+            return 0
+            ;;
+        chmod|chown|chgrp)
+            # Mode/owner is argv[1]; targets follow.
+            local skipped_mode=0
+            for arg in "$@"; do
+                if [ "$skipped_mode" = "0" ]; then
+                    skipped_mode=1; continue
+                fi
+                case "$arg" in
+                    -*) continue ;;
+                esac
+                printf '%s\n' "$arg"
+            done
+            return 0
+            ;;
+        python|python2|python3|node|perl|ruby)
+            # `python -c "..."`/`node -e "..."` — payload is opaque to
+            # static inspection. Caller treats inability to extract as
+            # uninspectable and denies.
+            for arg in "$@"; do
+                case "$arg" in
+                    -c|-e|-E)
+                        return 1 ;;
+                esac
+            done
+            return 0
+            ;;
+        awk|gawk|mawk)
+            # awk programs frequently write via redirection inside the
+            # script body — uninspectable.
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# inspect_write_subcommand <subcommand_string>
+#   Returns 0 (allow), or prints a deny reason and returns 1.
+inspect_write_subcommand() {
+    local sub="$1"
+    [ -z "$sub" ] && return 0
+
+    # Tokenize argv.
+    local -a argv=()
+    local t
+    while IFS= read -r t; do
+        argv+=("$t")
+    done < <(tokenize_argv "$sub")
+    [ ${#argv[@]} -eq 0 ] && return 0
+
+    # Strip wrapper.
+    local head="${argv[0]}"
+    case "$head" in
+        sudo|nice|nohup|time|stdbuf|exec)
+            argv=("${argv[@]:1}") ;;
+        env)
+            argv=("${argv[@]:1}")
+            while [ ${#argv[@]} -gt 0 ]; do
+                case "${argv[0]}" in
+                    *=*) argv=("${argv[@]:1}") ;;
+                    *)   break ;;
+                esac
+            done ;;
+    esac
+    [ ${#argv[@]} -eq 0 ] && return 0
+
+    local cmd0="${argv[0]}"
+
+    # Detect the write category.
+    #   1. Redirect-to-file present in the raw sub-command string.
+    #   2. argv head matches a known write tool.
+    local redirect_target=""
+    if printf '%s' "$sub" | grep -qE '(^|[^0-9&|<])>+([^|]|$)'; then
+        redirect_target=$(extract_redirect_target "$sub" || true)
+    fi
+
+    local is_write_tool=0
+    case "$cmd0" in
+        tee|cp|mv|install|rsync|scp|sed|dd|truncate|ln|chmod|chown|chgrp)
+            is_write_tool=1 ;;
+        python|python2|python3|node|perl|ruby|awk|gawk|mawk)
+            is_write_tool=1 ;;
+    esac
+
+    # Nothing to inspect.
+    if [ -z "$redirect_target" ] && [ "$is_write_tool" = "0" ]; then
+        return 0
+    fi
+
+    # --- Sensitive-target check (always denied, regardless of Read state) ---
+    local check_target resolved
+    if [ -n "$redirect_target" ]; then
+        case "$redirect_target" in
+            /dev/null|/dev/stderr|/dev/stdout|/dev/tty)
+                redirect_target="" ;;
+        esac
+    fi
+    if [ -n "$redirect_target" ]; then
+        resolved=$(resolve_path "$redirect_target")
+        if is_sensitive_target "$resolved"; then
+            echo "Bash write to sensitive file blocked: $redirect_target (resolved: $resolved)"
+            return 1
+        fi
+    fi
+
+    # --- Whitelist branch: opaque interpreters / awk ---
+    case "$cmd0" in
+        python|python2|python3|node|perl|ruby)
+            local i
+            for ((i=1; i<${#argv[@]}; i++)); do
+                case "${argv[$i]}" in
+                    -c|-e|-E)
+                        echo "Uninspectable file mutation pattern ($cmd0 -${argv[$i]:1}); use Edit/Write tool instead"
+                        return 1 ;;
+                esac
+            done
+            ;;
+        awk|gawk|mawk)
+            # awk script bodies routinely write via `print > FILE`. Any
+            # awk invocation that reaches this point is treated as
+            # uninspectable; whitelist with `--whitelist-awk` is a future
+            # extension (not in this PR).
+            echo "Uninspectable file mutation pattern (awk script may write via redirection); use Edit/Write tool instead"
+            return 1
+            ;;
+    esac
+
+    # --- Extract argv-side targets (cp/mv/tee/sed -i/dd/...) ---
+    local -a write_targets=()
+    if [ "$is_write_tool" = "1" ]; then
+        local target
+        local -a rest=()
+        if [ "${#argv[@]}" -gt 1 ]; then
+            rest=("${argv[@]:1}")
+        fi
+        while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            write_targets+=("$target")
+        done < <(extract_target_from_argv "$cmd0" ${rest[@]+"${rest[@]}"})
+    fi
+    if [ -n "$redirect_target" ]; then
+        write_targets+=("$redirect_target")
+    fi
+
+    # Sensitive-target check across all write targets.
+    local wt
+    for wt in ${write_targets[@]+"${write_targets[@]}"}; do
+        resolved=$(resolve_path "$wt")
+        if is_sensitive_target "$resolved"; then
+            echo "Bash write to sensitive file blocked: $wt (resolved: $resolved)"
+            return 1
+        fi
+    done
+
+    # --- Read-before-Edit enforcement on existing files ---
+    # Only enforce when at least one target points at an existing regular
+    # file. New files are exempt (Write semantics).
+    for wt in ${write_targets[@]+"${write_targets[@]}"}; do
+        resolved=$(resolve_path "$wt")
+        # Skip /dev/null and friends.
+        case "$resolved" in
+            /dev/null|/dev/stderr|/dev/stdout|/dev/tty) continue ;;
+        esac
+        if [ -e "$resolved" ] && [ ! -d "$resolved" ]; then
+            if ! tracker_has "$resolved"; then
+                # First-run safety: if no tracker exists yet, fall through
+                # to allow (mirrors pre-edit-read-guard).
+                local tracker_dir="${TMPDIR:-/tmp}"
+                local session_id="${CLAUDE_SESSION_ID:-unknown}"
+                local tracker="${tracker_dir%/}/claude-read-set-${session_id}"
+                if [ ! -f "$tracker" ]; then
+                    continue
+                fi
+                echo "Cannot Bash-write '$wt' without reading it first in this session. Call Read on '$wt' and retry."
+                return 1
+            fi
+        fi
+    done
+
+    return 0
+}
+
+# --- main -------------------------------------------------------------------
+
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+command -v jq >/dev/null 2>&1 || allow_response
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && allow_response
+
+# Performance bound.
+BWG_TOKENIZER_MAX_BYTES="${BWG_TOKENIZER_MAX_BYTES:-16384}"
+if [ "${#CMD}" -gt "$BWG_TOKENIZER_MAX_BYTES" ]; then
+    if echo "$CMD" | grep -qE '(^|[[:space:]])(python|node|perl|ruby)\s+(-c|-e)'; then
+        deny_response "Uninspectable file mutation pattern (coarse-scan); use Edit/Write tool instead"
+    fi
+    allow_response
+fi
+
+prev=""
+while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    if reason=$(inspect_write_subcommand "$sub"); then
+        :
+    else
+        deny_response "$reason"
+    fi
+    prev="$sub"
+done < <(split_subcommands "$CMD")
+
+allow_response

--- a/global/settings.json
+++ b/global/settings.json
@@ -133,6 +133,16 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/bash-sensitive-read-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/bash-write-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/github-api-preflight.sh",
             "timeout": 10
           },

--- a/tests/hooks/fixtures/bash-channel-corpus/README.md
+++ b/tests/hooks/fixtures/bash-channel-corpus/README.md
@@ -1,0 +1,22 @@
+# Bash-channel guard fixtures
+
+Mirrors the `dcg-corpus/` structure used by `test-dangerous-command-guard-golden.sh`.
+
+| Directory | Hook under test | Expected decision |
+|-----------|----------------|-------------------|
+| `deny-read/` | `bash-sensitive-read-guard.sh` | `deny` |
+| `deny-write/` | `bash-write-guard.sh` | `deny` |
+| `allow/` | both hooks | `allow` |
+
+Each fixture is a single JSON file with shape:
+
+```json
+{ "tool_name": "Bash", "tool_input": { "command": "..." } }
+```
+
+The companion runner is `test-bash-sensitive-read-guard.sh` /
+`test-bash-write-guard.sh` — these inline-assertion suites generate
+fixtures programmatically (via `jq -n --arg cmd ...`) so backslashes,
+heredocs, and embedded quotes survive the JSON layer unchanged. The
+on-disk fixtures here cover the Issue #477 acceptance-criteria minimum
+and serve as a living reference for the documented attack classes.

--- a/tests/hooks/fixtures/bash-channel-corpus/allow/01-cat-readme.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/allow/01-cat-readme.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"cat README.md"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/allow/02-grep-todo-src.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/allow/02-grep-todo-src.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"grep TODO src/main.py"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/allow/03-echo-mentions-env.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/allow/03-echo-mentions-env.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"echo \"do not commit .env\""}}

--- a/tests/hooks/fixtures/bash-channel-corpus/allow/04-redirect-devnull.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/allow/04-redirect-devnull.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"echo hello > /dev/null"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/allow/05-git-status.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/allow/05-git-status.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"git status"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-read/01-cat-dotenv.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-read/01-cat-dotenv.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"cat .env"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-read/02-cat-id-rsa.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-read/02-cat-id-rsa.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"cat ~/.ssh/id_rsa"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-read/03-find-exec-cat-env.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-read/03-find-exec-cat-env.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"find / -name .env -exec cat {} \\;"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-read/04-grep-aws-credentials.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-read/04-grep-aws-credentials.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"grep AWS_SECRET ~/.aws/credentials"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-read/05-cp-source-env.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-read/05-cp-source-env.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"cp ~/.ssh/id_rsa /tmp/x"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-write/01-echo-redirect-env.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-write/01-echo-redirect-env.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"echo SECRET=x > .env"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-write/02-tee-credentials.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-write/02-tee-credentials.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"echo data | tee ~/.aws/credentials"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-write/03-python-c.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-write/03-python-c.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"python -c \"open('/etc/x','w').write('y')\""}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-write/04-awk-redirect.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-write/04-awk-redirect.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"awk 'BEGIN{print \"x\" > \"/etc/x\"}'"}}

--- a/tests/hooks/fixtures/bash-channel-corpus/deny-write/05-dd-of-shadow.json
+++ b/tests/hooks/fixtures/bash-channel-corpus/deny-write/05-dd-of-shadow.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"dd of=/etc/shadow if=/dev/zero"}}

--- a/tests/hooks/test-bash-sensitive-read-guard.sh
+++ b/tests/hooks/test-bash-sensitive-read-guard.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Test suite for bash-sensitive-read-guard.sh
+# Run: bash tests/hooks/test-bash-sensitive-read-guard.sh
+
+HOOK="global/hooks/bash-sensitive-read-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Use a scratch fixture dir so tests are independent of the developer's $HOME.
+SCRATCH_ROOT="${TMPDIR:-/tmp}"
+FIXTURE_DIR=$(mktemp -d "$SCRATCH_ROOT/bsrg-test.XXXXXX" 2>/dev/null) \
+    || FIXTURE_DIR="$SCRATCH_ROOT/bsrg-test.$$"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# Pipe a fixture file into the hook. Using a file (rather than echo) avoids
+# shell-channel re-interpretation of backslash escapes in commands like
+# `find ... -exec cat {} \;`.
+make_fixture() {
+    local cmd="$1"
+    local out="$FIXTURE_DIR/in.json"
+    # jq -n produces correctly-escaped JSON regardless of the command shape.
+    if command -v jq >/dev/null 2>&1; then
+        jq -n --arg cmd "$cmd" '{tool_name:"Bash", tool_input:{command:$cmd}}' > "$out"
+    else
+        # Fallback: rely on the caller having already escaped backslashes/quotes.
+        printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd" > "$out"
+    fi
+    printf '%s' "$out"
+}
+
+assert_deny() {
+    local cmd="$1" label="$2"
+    local fixture
+    fixture=$(make_fixture "$cmd")
+    local result
+    result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local cmd="$1" label="$2"
+    local fixture
+    fixture=$(make_fixture "$cmd")
+    local result
+    result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== bash-sensitive-read-guard.sh tests ==="
+echo ""
+
+echo "[Fail-open on missing input]"
+assert_allow '' "Empty command → allow (fail-open; dangerous-command-guard owns parse-failure)"
+
+echo ""
+echo "[deny — direct read of sensitive paths]"
+assert_deny "cat .env" "cat .env"
+assert_deny "cat ./config/.env.production" "nested .env.production"
+assert_deny "head -n 5 .env" "head .env"
+assert_deny "tail -f .env.local" "tail .env.local"
+assert_deny "grep AWS_SECRET .env" "grep .env"
+assert_deny 'cat ~/.ssh/id_rsa' "cat ~/.ssh/id_rsa"
+assert_deny 'cat ~/.ssh/my_key_ed25519' "ssh ed25519 key"
+assert_deny 'cat ~/.aws/credentials' "AWS credentials file"
+assert_deny 'cat /etc/shadow' "/etc/shadow"
+assert_deny 'cat secrets/db.yml' "secrets/ directory"
+assert_deny 'cat config/credentials/aws.json' "credentials/ directory"
+assert_deny 'cat certs/server.pem' "*.pem extension"
+assert_deny 'cat keys/private.key' "*.key extension"
+
+echo ""
+echo "[deny — wrapper bypasses]"
+assert_deny 'sudo cat /etc/shadow' "sudo wrapper"
+assert_deny 'env DEBUG=1 cat .env' "env wrapper"
+assert_deny 'nice cat .env' "nice wrapper"
+
+echo ""
+echo "[deny — chained commands]"
+assert_deny 'echo start && cat .env' "&& chain"
+assert_deny 'cat README.md; cat .env' "; chain"
+assert_deny 'true | cat .env' "pipe receiver"
+
+echo ""
+echo "[deny — find -exec cat]"
+assert_deny 'find / -name .env -exec cat {} \;' "find -exec cat sensitive"
+assert_deny 'find . -name id_rsa' "find -name id_rsa (search target itself)"
+
+echo ""
+echo "[allow — non-sensitive reads]"
+assert_allow "cat README.md" "README.md"
+assert_allow "cat src/main.py" "src/main.py"
+assert_allow "cat package.json" "package.json"
+assert_allow 'head -n 10 docs/guide.md' "docs/guide.md"
+assert_allow 'grep TODO src/' "grep TODO in src/"
+assert_allow 'find . -name "*.md"' "find non-sensitive"
+
+echo ""
+echo "[allow — sensitive token inside non-read context]"
+assert_allow 'echo "do not commit .env"' "echo about .env (not a read)"
+assert_allow 'echo cat .env' "echo cat .env (echo, not cat)"
+assert_allow 'git status' "git status"
+assert_allow 'ls -la' "ls -la"
+
+echo ""
+echo "[edge — symlink to sensitive (Red Team Vector F)]"
+# Plant an actual .env so realpath has a target to resolve to. The hook's
+# resolve_path follows the symlink, so the deny pattern fires on the real
+# path even though the surface argument is `safe.txt`. /etc/shadow is
+# unreliable for this test (absent on macOS), so we use a fixture .env.
+TARGET_ENV="$FIXTURE_DIR/.env"
+echo "SECRET=x" > "$TARGET_ENV"
+LINK="$FIXTURE_DIR/safe.txt"
+ln -sf "$TARGET_ENV" "$LINK" 2>/dev/null || true
+if [ -L "$LINK" ]; then
+    assert_deny "cat $LINK" "symlink to .env → deny (resolves through realpath)"
+fi
+
+echo ""
+echo "[edge — cp source side]"
+assert_deny 'cp .env /tmp/exfil' "cp .env (source side denied)"
+assert_allow 'cp README.md /tmp/copy.md' "cp README.md (non-sensitive source)"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0

--- a/tests/hooks/test-bash-write-guard.sh
+++ b/tests/hooks/test-bash-write-guard.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Test suite for bash-write-guard.sh
+# Run: bash tests/hooks/test-bash-write-guard.sh
+
+HOOK="global/hooks/bash-write-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+SCRATCH_ROOT="${TMPDIR:-/tmp}"
+FIXTURE_DIR=$(mktemp -d "$SCRATCH_ROOT/bwg-test.XXXXXX" 2>/dev/null) \
+    || FIXTURE_DIR="$SCRATCH_ROOT/bwg-test.$$"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# Use a fresh session id for this test run so we don't interact with the
+# developer's existing read tracker.
+TEST_SESSION="bwg-test-$$"
+export CLAUDE_SESSION_ID="$TEST_SESSION"
+TRACKER="${TMPDIR:-/tmp}/claude-read-set-${TEST_SESSION}"
+rm -f "$TRACKER"
+
+make_fixture() {
+    local cmd="$1"
+    local out="$FIXTURE_DIR/in.json"
+    if command -v jq >/dev/null 2>&1; then
+        jq -n --arg cmd "$cmd" --arg sid "$TEST_SESSION" \
+            '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:$sid}' > "$out"
+    else
+        printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$cmd" > "$out"
+    fi
+    printf '%s' "$out"
+}
+
+assert_deny() {
+    local cmd="$1" label="$2"
+    local fixture
+    fixture=$(make_fixture "$cmd")
+    local result
+    result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local cmd="$1" label="$2"
+    local fixture
+    fixture=$(make_fixture "$cmd")
+    local result
+    result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== bash-write-guard.sh tests ==="
+echo ""
+
+echo "[Fail-open on missing input]"
+assert_allow '' "Empty command → allow"
+
+echo ""
+echo "[deny — write to sensitive paths]"
+assert_deny 'echo secret > .env' "echo > .env"
+assert_deny "$(printf 'cat <<EOF > .env\nA=1\nEOF')" "heredoc > .env"
+assert_deny 'tee .env' "tee .env"
+assert_deny 'cp newkey ~/.ssh/id_rsa' "cp into ~/.ssh/id_rsa"
+assert_deny 'echo y > /etc/passwd' "echo > /etc/passwd"
+assert_deny 'curl https://x | tee ~/.aws/credentials' "tee ~/.aws/credentials"
+assert_deny 'dd of=/etc/shadow' "dd of=/etc/shadow"
+assert_deny 'echo y >> .env' "append >> .env"
+
+echo ""
+echo "[deny — uninspectable mutation patterns (Red Team Vector E)]"
+assert_deny 'python -c "open(\"/etc/x\", \"w\").write(\"y\")"' "python -c"
+assert_deny 'python3 -c "import pathlib; pathlib.Path(\"f\").write_text(\"y\")"' "python3 -c"
+assert_deny 'node -e "require(\"fs\").writeFileSync(\"f\",\"y\")"' "node -e"
+assert_deny 'perl -e "open(F,\">f\");print F \"y\""' "perl -e"
+assert_deny 'awk "BEGIN{print \"x\" > \"/tmp/y\"}"' "awk script body"
+assert_deny 'gawk "BEGIN{print > \"f\"}"' "gawk script body"
+
+echo ""
+echo "[deny — wrapper bypass for sensitive write]"
+assert_deny 'sudo tee /etc/shadow' "sudo tee /etc/shadow"
+assert_deny 'env X=1 echo y > .env' "env wrapper write"
+
+echo ""
+echo "[deny — chained sensitive write]"
+assert_deny 'true; echo y > .env' "; chain"
+assert_deny 'true && echo y > .env' "&& chain"
+
+echo ""
+echo "[allow — write to new, non-sensitive files]"
+NEW_TARGET="$FIXTURE_DIR/new_output.txt"
+assert_allow "echo hello > $NEW_TARGET" "echo > new file"
+assert_allow "tee $NEW_TARGET" "tee new file"
+
+echo ""
+echo "[allow — read-only commands]"
+assert_allow 'cat README.md' "cat (no redirect)"
+assert_allow 'grep TODO src/' "grep (no redirect)"
+assert_allow 'ls -la' "ls"
+assert_allow 'echo hello | tee /dev/null' "tee /dev/null (allowed sink)"
+assert_allow 'echo hello > /dev/null' "echo > /dev/null"
+assert_allow 'true 2>&1' "stderr redirect, no file"
+
+echo ""
+echo "[allow — write to file already Read this session]"
+EXISTING="$FIXTURE_DIR/existing.txt"
+echo "initial" > "$EXISTING"
+# `realpath` on macOS canonicalizes `/var/folders/.../T//x` to
+# `/private/var/folders/.../T/x`, the same form the hook computes — so
+# this single call produces a tracker entry that matches.
+RESOLVED=$(realpath "$EXISTING" 2>/dev/null || echo "$EXISTING")
+echo "$RESOLVED" > "$TRACKER"
+assert_allow "echo update > $EXISTING" "tracker hit → allow"
+
+echo ""
+echo "[deny — write to existing file NOT yet Read]"
+UNTRACKED="$FIXTURE_DIR/untracked.txt"
+echo "data" > "$UNTRACKED"
+# Tracker exists (from prior test) but does not contain $UNTRACKED → deny.
+assert_deny "echo overwrite > $UNTRACKED" "untracked existing file → deny"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

### Summary
Adds two new PreToolUse Bash hooks (`bash-sensitive-read-guard.sh` and
`bash-write-guard.sh`, plus PowerShell parity) that close the gap where
sensitive-file enforcement and the Read-before-Edit invariant were
applied only on the Edit/Write/Read tool channel, leaving the Bash
channel unguarded.

### Change Type
- [x] Feature (new functionality)
- [x] Security

### Affected Components
- `global/hooks/bash-sensitive-read-guard.{sh,ps1}` (new)
- `global/hooks/bash-write-guard.{sh,ps1}` (new)
- `global/settings.json` PreToolUse Bash hook chain extended
- `tests/hooks/test-bash-sensitive-read-guard.sh` (35 cases)
- `tests/hooks/test-bash-write-guard.sh` (29 cases)
- `tests/hooks/fixtures/bash-channel-corpus/` (15 golden fixtures)

## Why

### Problem
Audit cross-validation flagged five separate findings that all reduce to
"the Bash tool channel is unguarded":
- Security #5: Bash bypasses `permissions.deny`
- Compliance #1: no content scanner for secrets in source
- Compliance #7: Read-before-Edit unenforceable via Bash heredoc/tee
- Red Team Vector E: write-guard blacklist evasion via
  `python -c` / `awk` / `cp /dev/stdin` / `dd` / `install` / `rsync`
- Red Team Vector F: symlink race against benign-looking path

Concretely, `cat .env`, `grep AWS_SECRET ~/.aws/credentials`,
`find / -name '.env' -exec cat {} \;`, `echo > .env`,
`python -c "open(f,'w').write(...)"`, `cp /dev/stdin /etc/x` all passed
through without prompts.

### Related Issues
- Closes #477
- Part of #474 (Hook System Hardening)

## How

### Technical Approach
**bash-sensitive-read-guard.sh**:
1. Walks each sub-command via `lib/tokenize-shell.sh` (#476).
2. For each known read tool (`cat`/`head`/`tail`/`grep`/`find`/`tar c`/
   `xxd`/`od`/`strings`/`cp` source side), extracts the path arguments
   (skipping flags and conservative `-exec` / `-name` sentinels).
3. Resolves `~`, `$HOME`, and relative paths through `realpath` to
   defeat symlink races (Red Team Vector F).
4. Matches against the same deny patterns that
   `permissions.deny[]` enforces for Edit/Write/Read.

**bash-write-guard.sh** (whitelist, not blacklist):
1. Flags any sub-command whose argv head matches a known write tool
   (`tee` / `cp` / `mv` / `install` / `rsync` / `scp` / `sed -i` / `dd` /
   `truncate` / `ln` / `chmod` / `chown` / `chgrp`) **or** contains a
   redirect-to-file (`>`, `>>`, `&>`) other than `/dev/null` and friends.
2. Treats `python -c` / `node -e` / `perl -e` / `ruby -e` and `awk`
   script bodies as **uninspectable** and denies them with a message
   asking the agent to use the Edit/Write tool — the documented
   breaking change in the issue spec.
3. Sensitive-target writes are denied unconditionally.
4. Non-sensitive writes to existing files require the file to appear in
   the `pre-edit-read-guard` session tracker (same tracker location and
   contract as the existing hook).

### Reuse of `lib/tokenize-shell.sh` (yes)
Both hooks `source` the library introduced in #483 — no duplicated
tokenization logic.

### Tests
- 35 new cases for sensitive-read (deny direct / wrapper / chain /
  find -exec / cp source / symlink / non-sensitive allow / find non-sensitive).
- 29 new cases for write-guard (deny redirect / tee / dd / heredoc /
  uninspectable interpreter / awk / wrapper bypass / chain / tracker
  hit / untracked existing file).
- 15 on-disk JSON fixtures under
  `tests/hooks/fixtures/bash-channel-corpus/{deny-read,deny-write,allow}/`
  mirroring the `dcg-corpus/` pattern from #482.
- `bash tests/hooks/test-runner.sh`: **467 passed, 1 failed**
  (`markdown-anchor-validator` baseline failure unchanged).

### Breaking Changes
Documented in #477 — many uninspectable Bash file-write patterns
(`python -c`, `awk` script bodies, etc.) now deny. Affected workflows
must switch to the Edit/Write tool. This is the intended behavior.

### Rollback Plan
1. Remove the two new hook entries from `settings.json` PreToolUse Bash
   array.
2. Run `./scripts/install.sh`.
3. Restart session.
