### PR TITLE
refactor(hooks): narrow gh api allowlist + GraphQL mutation guard + write-verb scope

### DIFF
--- a/global/hooks/gh-write-verb-guard.ps1
+++ b/global/hooks/gh-write-verb-guard.ps1
@@ -1,0 +1,140 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# gh-write-verb-guard.ps1
+# PowerShell parity for gh-write-verb-guard.sh.
+#
+# Approximation note (Issue #478): this script implements the same policy
+# (block `gh api` write methods unless allow-listed; block GraphQL
+# mutations/subscriptions; deny cross-repo state-change subcommands; warn
+# via additionalContext on in-scope state changes) but uses regex over
+# the raw command string instead of the bash tokenizer. Substitution-aware
+# splitting is therefore weaker on Windows. The bash variant is canonical.
+
+$json = Read-HookInput
+if (-not $json) { New-HookAllowResponse; exit 0 }
+
+$cmd = ''
+try { $cmd = [string]$json.tool_input.command } catch {}
+if ([string]::IsNullOrEmpty($cmd)) { New-HookAllowResponse; exit 0 }
+
+# Quick filter.
+if ($cmd -notmatch '(^|[\s`(])gh\s') {
+    New-HookAllowResponse; exit 0
+}
+
+$auditOnly = ($env:GH_WRITE_VERB_GUARD_AUDIT_ONLY -eq '1')
+
+function Deny([string]$reason) {
+    if ($auditOnly) {
+        [Console]::Error.WriteLine("gh-write-verb-guard (audit-only) would deny: $reason")
+        New-HookAllowResponse
+        exit 0
+    }
+    New-HookDenyResponse -Reason $reason
+    exit 0
+}
+
+function AllowWithContext([string]$context) {
+    $payload = @{
+        hookSpecificOutput = @{
+            hookEventName = 'PreToolUse'
+            permissionDecision = 'allow'
+            additionalContext = "gh-write-verb-guard: $context"
+        }
+    }
+    $payload | ConvertTo-Json -Depth 6 -Compress
+    exit 0
+}
+
+# Split sub-commands on shell separators. This is intentionally simpler
+# than the bash splitter: it does not respect quotes. Treat each segment
+# as a candidate gh invocation.
+$segments = [regex]::Split($cmd, '\s*(?:&&|\|\||;|\||&)\s*')
+
+# --- GraphQL mutation scan (across the whole command string for safety) ---
+if ($cmd -match 'gh\s+api\s+graphql\b') {
+    $queryMatches = [regex]::Matches($cmd, '-(?:f|F|-field|-raw-field)(?:=|\s+)([^''"\s][^\s]*|''[^'']*''|"[^"]*")')
+    foreach ($m in $queryMatches) {
+        $payload = $m.Groups[1].Value.Trim('"', "'")
+        if ($payload -match '^query=(.*)$') {
+            $doc = $Matches[1]
+            if ($doc -match '^@') {
+                Deny "GraphQL opaque-file-reference blocked: payload references @$doc — cannot statically inspect for mutation/subscription operations."
+            }
+            $stripped = ($doc -replace '#[^\n]*','')
+            if ($stripped -match '(^|[^A-Za-z0-9_])(mutation|subscription)([\s][A-Za-z_][A-Za-z0-9_]*)?\s*[\{(]') {
+                Deny "GraphQL graphql-mutation-or-subscription blocked: gh api graphql may not carry mutating or subscription operations. Use a specific gh subcommand or restrict the document to a query."
+            }
+        }
+    }
+    # Explicit non-GET/POST methods on graphql.
+    if ($cmd -match 'gh\s+api\s+graphql\b.*?(?:-X|--method)(?:\s+|=)(PATCH|PUT|DELETE)') {
+        $m = $Matches[1]
+        Deny "gh api graphql -X $m blocked: GraphQL endpoint only accepts GET/POST."
+    }
+    # Other gh api segments still need method checking below.
+}
+
+# --- gh api method gate (non-graphql) ---
+$apiSegments = $segments | Where-Object { $_ -match 'gh\s+api\b' -and $_ -notmatch 'gh\s+api\s+graphql\b' }
+foreach ($seg in $apiSegments) {
+    $method = 'GET'
+    if ($seg -match '(?:-X|--method)(?:\s+|=)(\w+)') {
+        $method = $Matches[1].ToUpper()
+    } elseif ($seg -match '(?:-f|-F|--field|--raw-field|--input)\b') {
+        $method = 'POST'
+    }
+    if ($method -in @('GET','HEAD')) { continue }
+
+    # Allowlist endpoints from $env:GH_API_WRITE_ALLOW (':' or newline separated).
+    $endpoint = $null
+    if ($seg -match 'gh\s+api(?:\s+-\S+(?:\s+\S+)?)*\s+([^\s-][^\s]*)') {
+        $endpoint = $Matches[1]
+    }
+    $allowGlobs = @()
+    if ($env:GH_API_WRITE_ALLOW) {
+        $allowGlobs = $env:GH_API_WRITE_ALLOW -split '[:`r`n]' | Where-Object { $_ }
+    }
+    $allowed = $false
+    foreach ($g in $allowGlobs) {
+        if ($endpoint -and $endpoint -like $g) { $allowed = $true; break }
+    }
+    if (-not $allowed) {
+        $ep = if ($endpoint) { $endpoint } else { '<no-endpoint>' }
+        Deny "gh api -X $method $ep blocked: write methods require an explicit endpoint on the GH_API_WRITE_ALLOW allowlist. Use a dedicated gh subcommand."
+    }
+}
+
+# --- gh state-change subcommands ---
+$stateChangePattern = 'gh\s+(issue\s+(comment|edit|close|reopen|delete|develop|lock|unlock|pin|unpin|transfer)|pr\s+(comment|edit|close|reopen|review|merge|ready|lock|unlock)|workflow\s+(run|enable|disable)|secret\s+(set|delete|remove)|variable\s+(set|delete|remove)|ssh-key\s+(add|delete)|gpg-key\s+(add|delete)|gist\s+(create|edit|delete|clone)|release\s+(create|edit|upload|delete)|repo\s+(create|delete|edit|fork|rename|archive|unarchive)|cache\s+delete|label\s+(create|edit|delete|clone))'
+
+$stateLabels = @()
+foreach ($seg in $segments) {
+    if ($seg -match $stateChangePattern) {
+        $label = $Matches[1] -replace '\s+',' '
+        # Cross-repo write check.
+        if ($seg -match '(?:--repo(?:\s+|=)|\s-R\s+)(\S+)') {
+            $targetRepo = $Matches[1].Trim('"', "'")
+            $currentRepo = $null
+            try {
+                $url = (& git remote get-url origin 2>$null).Trim()
+                if ($url -match 'github\.com[:/](.+?)(?:\.git)?$') {
+                    $currentRepo = $Matches[1]
+                }
+            } catch {}
+            if ($currentRepo -and $targetRepo -ne $currentRepo) {
+                Deny "gh $label --repo $targetRepo blocked: cross-repo write does not match working tree origin ($currentRepo)."
+            }
+        }
+        $stateLabels += $label
+    }
+}
+
+if ($stateLabels.Count -gt 0) {
+    AllowWithContext "state-changing gh operation(s) detected: $($stateLabels -join '; ')"
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/gh-write-verb-guard.sh
+++ b/global/hooks/gh-write-verb-guard.sh
@@ -1,0 +1,545 @@
+#!/bin/bash
+# gh-write-verb-guard.sh
+# Narrows the `gh` CLI surface on the Bash channel:
+#
+#   1. `gh api -X PATCH|PUT|DELETE|POST <endpoint>` — denied unless the
+#      endpoint sits on a small explicit allowlist. Implicit GET (no `-X`)
+#      and explicit `-X GET` pass.
+#   2. `gh api graphql ... query=...` — payloads containing the literal
+#      tokens `mutation` or `subscription` (outside of strings) are denied.
+#      Read-only `query { ... }` payloads pass.
+#   3. State-changing `gh` subcommands not routed through `gh api`
+#      (issue comment/edit/close/reopen/delete, pr comment/edit/close/
+#      reopen/review, workflow run/enable/disable, secret *, ssh-key *,
+#      gist create/edit/delete, release create/edit/upload/delete) — by
+#      default allowed with an `additionalContext` warning so the model is
+#      reminded to scope the operation. When `--repo OTHER_ORG/REPO` is
+#      passed, the call is denied because the audit found cross-repo
+#      writes are the highest-risk subset (Issue #478, Vector I).
+#
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+#
+# Reuses lib/tokenize-shell.sh so quote/substitution-aware sub-command
+# splitting matches the rest of the Bash hook chain (PR #483 / #484).
+#
+# Audit-only mode: set GH_WRITE_VERB_GUARD_AUDIT_ONLY=1 to downgrade every
+# `deny` decision to `allow` while still emitting the diagnostic to
+# stderr. This supports the issue's "1-week telemetry" rollout step
+# without requiring code changes.
+
+set -uo pipefail
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+# shellcheck source=lib/tokenize-shell.sh
+. "$LIB_DIR/tokenize-shell.sh"
+
+LOG_DIR="${CLAUDE_LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/gh-write-verb-guard.log"
+
+log_decision() {
+    local decision="$1"
+    local reason="$2"
+    local cmd="$3"
+    mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg ts "$ts" \
+            --arg d "$decision" \
+            --arg r "$reason" \
+            --arg c "$cmd" \
+            '{ts:$ts, decision:$d, reason:$r, command:$c}' \
+            >>"$LOG_FILE" 2>/dev/null || true
+    fi
+}
+
+allow_response() {
+    local reason="${1:-}"
+    log_decision "allow" "${reason:-no-write-pattern}" "${CMD:-}"
+    cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    exit 0
+}
+
+allow_with_context() {
+    local context="$1"
+    log_decision "allow_with_context" "$context" "${CMD:-}"
+    local esc
+    esc="${context//\\/\\\\}"
+    esc="${esc//\"/\\\"}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "additionalContext": "gh-write-verb-guard: $esc"
+  }
+}
+EOF
+    exit 0
+}
+
+deny_response() {
+    local reason="$1"
+    if [ "${GH_WRITE_VERB_GUARD_AUDIT_ONLY:-0}" = "1" ]; then
+        echo "gh-write-verb-guard (audit-only) would deny: $reason" >&2
+        log_decision "audit_allow" "$reason" "${CMD:-}"
+        cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+        exit 0
+    fi
+    log_decision "deny" "$reason" "${CMD:-}"
+    local esc
+    esc="${reason//\\/\\\\}"
+    esc="${esc//\"/\\\"}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$esc"
+  }
+}
+EOF
+    exit 0
+}
+
+# --- Read input ---
+INPUT=$(cat 2>/dev/null || true)
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+command -v jq >/dev/null 2>&1 || allow_response
+
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && allow_response
+
+# Performance bound — defer to coarse regex on giant inputs.
+GHWVG_TOKENIZER_MAX_BYTES="${GHWVG_TOKENIZER_MAX_BYTES:-16384}"
+
+# Quick pre-filter: if `gh ` does not appear at all, skip work entirely.
+if ! echo "$CMD" | grep -qE '(^|[[:space:]`(])gh[[:space:]]'; then
+    allow_response "no-gh-invocation"
+fi
+
+# --- Endpoint allowlist for write-method `gh api` calls -----------------
+#
+# Each entry is a glob applied to the *endpoint argument* of
+# `gh api <method> <endpoint> ...`. The endpoint is the first non-flag
+# positional argument after `api`. Empty by default — the issue treats
+# every write method against an arbitrary endpoint as denied. Operators
+# can override at deploy time via $GH_API_WRITE_ALLOW (newline- or
+# colon-separated globs).
+gh_api_write_allow_globs() {
+    local raw="${GH_API_WRITE_ALLOW:-}"
+    [ -z "$raw" ] && return 0
+    # Normalize : separators to newlines.
+    printf '%s\n' "${raw//:/$'\n'}"
+}
+
+endpoint_on_write_allowlist() {
+    local endpoint="$1"
+    [ -z "$endpoint" ] && return 1
+    local glob
+    while IFS= read -r glob; do
+        [ -z "$glob" ] && continue
+        # shellcheck disable=SC2254
+        case "$endpoint" in
+            $glob) return 0 ;;
+        esac
+    done < <(gh_api_write_allow_globs)
+    return 1
+}
+
+# --- Helpers ------------------------------------------------------------
+
+# argv_to_array <subcommand> — populates the named array via printf-eval.
+# Bash 3.2 (macOS) lacks namerefs, so callers iterate the helper directly.
+read_argv() {
+    local sub="$1"
+    tokenize_argv "$sub"
+}
+
+# extract_repo_flag <argv...> — emit the value of -R / --repo if present.
+extract_repo_flag() {
+    local prev=""
+    local arg
+    for arg in "$@"; do
+        if [ "$prev" = "-R" ] || [ "$prev" = "--repo" ]; then
+            printf '%s' "$arg"
+            return 0
+        fi
+        case "$arg" in
+            --repo=*) printf '%s' "${arg#--repo=}"; return 0 ;;
+        esac
+        prev="$arg"
+    done
+    return 1
+}
+
+# extract_api_method <argv...> — emit the HTTP method for a gh api call.
+# argv[0] is expected to be `gh`, argv[1] is `api`. Defaults follow gh's
+# CLI semantics: GET when no `-X`/`--method` is present and no body flag
+# (`-f`/`-F`/`--field`/`--raw-field`/`--input`) is present; POST when a
+# body flag is present without `-X`. We intentionally treat the implicit
+# POST conservatively because a body flag with no method is the same
+# write-class request as `-X POST`.
+extract_api_method() {
+    local prev=""
+    local method=""
+    local has_body=0
+    local arg
+    for arg in "$@"; do
+        if [ "$prev" = "-X" ] || [ "$prev" = "--method" ]; then
+            method="$arg"
+            prev=""
+            continue
+        fi
+        case "$arg" in
+            --method=*) method="${arg#--method=}" ;;
+            -X|--method) prev="$arg"; continue ;;
+            -f|--field|-F|--raw-field|--input) has_body=1 ;;
+            -f=*|--field=*|-F=*|--raw-field=*|--input=*) has_body=1 ;;
+        esac
+        prev="$arg"
+    done
+    if [ -n "$method" ]; then
+        # Normalize to upper-case.
+        printf '%s' "$method" | tr '[:lower:]' '[:upper:]'
+        return 0
+    fi
+    if [ "$has_body" = "1" ]; then
+        printf 'POST'
+        return 0
+    fi
+    printf 'GET'
+}
+
+# extract_api_endpoint <argv...> — first non-flag positional argument
+# after `api`. Skips known flag forms; treats `-H NAME:VAL`, `-X METHOD`,
+# `-f KEY=VAL`, `-F KEY=VAL`, `--input FILE`, `--method M` as flag pairs.
+extract_api_endpoint() {
+    local prev=""
+    local arg
+    # argv passed in is the full argv from `gh` onward; skip the first
+    # two tokens (`gh api`).
+    local skipped=0
+    for arg in "$@"; do
+        if [ "$skipped" -lt 2 ]; then
+            skipped=$((skipped + 1))
+            continue
+        fi
+        if [ "$prev" = "-X" ] || [ "$prev" = "--method" ] \
+            || [ "$prev" = "-H" ] || [ "$prev" = "--header" ] \
+            || [ "$prev" = "-f" ] || [ "$prev" = "--field" ] \
+            || [ "$prev" = "-F" ] || [ "$prev" = "--raw-field" ] \
+            || [ "$prev" = "--input" ] || [ "$prev" = "-q" ] \
+            || [ "$prev" = "--jq" ] || [ "$prev" = "--template" ] \
+            || [ "$prev" = "-t" ] || [ "$prev" = "--hostname" ] \
+            || [ "$prev" = "--cache" ] || [ "$prev" = "--paginate-method" ]; then
+            prev=""
+            continue
+        fi
+        case "$arg" in
+            --*=*|-*=*) prev=""; continue ;;
+            -*) prev="$arg"; continue ;;
+        esac
+        printf '%s' "$arg"
+        return 0
+    done
+    return 1
+}
+
+# scan_graphql_for_mutation <argv...> — returns 0 if a `-f query=` or
+# `-F query=` argument carries a `mutation` or `subscription` operation.
+# The check looks for the literal keyword followed by `{`, `(`, or
+# whitespace (the GraphQL operation prefix). Anonymous mutations like
+# `mutation { ... }` and named ones like `mutation Foo { ... }` both
+# match. `query` is left alone.
+scan_graphql_for_mutation() {
+    local prev=""
+    local arg
+    for arg in "$@"; do
+        local payload=""
+        if [ "$prev" = "-f" ] || [ "$prev" = "--field" ] \
+            || [ "$prev" = "-F" ] || [ "$prev" = "--raw-field" ]; then
+            payload="$arg"
+            prev=""
+        else
+            case "$arg" in
+                -f=*|--field=*|-F=*|--raw-field=*)
+                    payload="${arg#*=}" ;;
+                *) prev="$arg"; continue ;;
+            esac
+        fi
+        # The payload form is `key=value`; we only care about `query=...`
+        # (the GraphQL document) and ignore `variables=...` JSON.
+        case "$payload" in
+            query=*)
+                local doc="${payload#query=}"
+                # `@file` reads from disk — we cannot statically inspect.
+                # Conservatively flag as a mutation candidate so the
+                # operator is forced to be explicit.
+                case "$doc" in
+                    @*)
+                        printf 'opaque-file-reference: %s' "$doc"
+                        return 0
+                        ;;
+                esac
+                # Strip line comments (#...) before scanning so a quoted
+                # `# mutation` in a comment does not trigger.
+                local stripped
+                stripped=$(printf '%s' "$doc" | sed -E 's/#[^\n]*//g')
+                if printf '%s' "$stripped" | grep -qE '(^|[^A-Za-z0-9_])(mutation|subscription)([[:space:]]+[A-Za-z_][A-Za-z0-9_]*)?[[:space:]]*[\{(]'; then
+                    printf 'graphql-mutation-or-subscription'
+                    return 0
+                fi
+                ;;
+        esac
+    done
+    return 1
+}
+
+# is_state_change_subcommand <argv...> — argv[0]=gh. Returns 0 with an
+# emitted "<noun> <verb>" label if the call is a state-changing
+# non-`api` subcommand.
+is_state_change_subcommand() {
+    [ "$#" -lt 3 ] && return 1
+    local noun="$2"
+    local verb="$3"
+    case "$noun" in
+        issue)
+            case "$verb" in
+                comment|edit|close|reopen|delete|develop|lock|unlock|pin|unpin|transfer)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        pr)
+            case "$verb" in
+                comment|edit|close|reopen|review|merge|ready|lock|unlock)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        workflow)
+            case "$verb" in
+                run|enable|disable)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        secret|variable|ssh-key|gpg-key)
+            case "$verb" in
+                set|delete|remove|add)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        gist)
+            case "$verb" in
+                create|edit|delete|clone)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        release)
+            case "$verb" in
+                create|edit|upload|delete)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        repo)
+            case "$verb" in
+                create|delete|edit|fork|rename|archive|unarchive|deploy-key|set-default)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        cache)
+            case "$verb" in
+                delete) printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+        label)
+            case "$verb" in
+                create|edit|delete|clone)
+                    printf '%s %s' "$noun" "$verb"; return 0 ;;
+            esac ;;
+    esac
+    return 1
+}
+
+# current_repo_slug — best-effort `<owner>/<repo>` for the working
+# directory's `origin` remote. Empty on failure (we only use this for the
+# cross-repo write check, which fails open).
+current_repo_slug() {
+    local url
+    url=$(git -C "$(pwd)" remote get-url origin 2>/dev/null) || return 0
+    # https://github.com/foo/bar.git or git@github.com:foo/bar.git
+    case "$url" in
+        *github.com[:/]*)
+            url="${url#*github.com[:/]}"
+            url="${url%.git}"
+            printf '%s' "$url"
+            ;;
+    esac
+}
+
+# --- Main inspection ----------------------------------------------------
+
+# Walk every sub-command (split by `;`, `&&`, `||`, pipes, substitutions)
+# so chained gh invocations inside compound shells are individually
+# checked.
+inspect_subcommand() {
+    local sub="$1"
+
+    # Tokenize argv.
+    local -a argv=()
+    local t
+    while IFS= read -r t; do
+        argv+=("$t")
+    done < <(read_argv "$sub")
+    [ ${#argv[@]} -eq 0 ] && return 0
+
+    # Strip a single benign wrapper.
+    local head="${argv[0]}"
+    case "$head" in
+        sudo|nice|nohup|time|stdbuf|exec)
+            argv=("${argv[@]:1}") ;;
+        env)
+            argv=("${argv[@]:1}")
+            while [ ${#argv[@]} -gt 0 ]; do
+                case "${argv[0]}" in
+                    *=*) argv=("${argv[@]:1}") ;;
+                    *)   break ;;
+                esac
+            done ;;
+    esac
+    [ ${#argv[@]} -eq 0 ] && return 0
+    [ "${argv[0]}" = "gh" ] || return 0
+    [ "${#argv[@]}" -lt 2 ] && return 0
+
+    local subcmd="${argv[1]}"
+
+    # --- gh api ---------------------------------------------------------
+    if [ "$subcmd" = "api" ]; then
+        local third="${argv[2]:-}"
+
+        # GraphQL is a special case: the gh CLI sends `-f query=...` as
+        # a POST regardless, so the HTTP-method check would always trip.
+        # Instead we rely on a textual mutation scan: if the document
+        # contains `mutation`/`subscription`, deny — otherwise allow.
+        # Explicit `-X PATCH|PUT|DELETE` against graphql is still denied.
+        if [ "$third" = "graphql" ]; then
+            local why
+            if why=$(scan_graphql_for_mutation "${argv[@]:2}"); then
+                echo "GraphQL ${why} blocked: gh api graphql may not carry mutating or subscription operations. Use a specific gh subcommand (e.g. gh issue edit, gh pr merge) or restrict the document to a query."
+                return 1
+            fi
+            local gql_method
+            gql_method=$(extract_api_method "${argv[@]}")
+            case "$gql_method" in
+                PATCH|PUT|DELETE)
+                    echo "gh api graphql -X ${gql_method} blocked: GraphQL endpoint only accepts GET/POST; explicit write verbs are not a legitimate use."
+                    return 1
+                    ;;
+            esac
+            return 0
+        fi
+
+        local method endpoint
+        method=$(extract_api_method "${argv[@]}")
+        endpoint=$(extract_api_endpoint "${argv[@]}" || true)
+
+        case "$method" in
+            GET|HEAD)
+                # Read methods always allowed.
+                return 0
+                ;;
+            POST|PATCH|PUT|DELETE)
+                if endpoint_on_write_allowlist "$endpoint"; then
+                    return 0
+                fi
+                echo "gh api -X ${method} ${endpoint:-<no-endpoint>} blocked: write methods require an explicit endpoint on the GH_API_WRITE_ALLOW allowlist. Use a dedicated gh subcommand (gh issue/pr/release/...) where possible."
+                return 1
+                ;;
+            *)
+                # Unknown method: deny conservatively.
+                echo "gh api -X ${method} blocked: unrecognized HTTP method (only GET/HEAD pass without an allowlist match)."
+                return 1
+                ;;
+        esac
+    fi
+
+    # --- gh <noun> <verb> (non-api state changes) ----------------------
+    if [ "${#argv[@]}" -ge 3 ]; then
+        local label
+        if label=$(is_state_change_subcommand "${argv[@]}"); then
+            # Cross-repo write: deny when --repo points outside the
+            # current working tree's origin slug.
+            local target_repo
+            target_repo=$(extract_repo_flag "${argv[@]:2}" || true)
+            if [ -n "$target_repo" ]; then
+                local current
+                current=$(current_repo_slug || true)
+                if [ -n "$current" ] && [ "$target_repo" != "$current" ]; then
+                    echo "gh ${label} --repo ${target_repo} blocked: cross-repo write does not match working tree origin (${current}). Re-run inside the target checkout or pass GH_WRITE_VERB_GUARD_AUDIT_ONLY=1 if intentional."
+                    return 1
+                fi
+            fi
+            # In-scope state change: allow with a context warning so the
+            # model is reminded the operation mutates remote state.
+            printf '__CONTEXT__%s' "$label"
+            return 2
+        fi
+    fi
+
+    return 0
+}
+
+# --- Drive every sub-command ------------------------------------------
+
+if [ "${#CMD}" -gt "$GHWVG_TOKENIZER_MAX_BYTES" ]; then
+    # Coarse regex pass for over-budget inputs: catch the two highest-
+    # impact cases and otherwise fall through.
+    if echo "$CMD" | grep -qE 'gh[[:space:]]+api[[:space:]]+graphql\b'; then
+        if echo "$CMD" | grep -qE '(^|[^A-Za-z0-9_])(mutation|subscription)([[:space:]]+[A-Za-z_][A-Za-z0-9_]*)?[[:space:]]*[\{(]'; then
+            deny_response "GraphQL mutation/subscription blocked (coarse-scan): gh api graphql payload exceeded the tokenizer budget but contained a mutating operation."
+        fi
+    fi
+    if echo "$CMD" | grep -qE 'gh[[:space:]]+api[[:space:]]+(-[A-Za-z]+[[:space:]]+)*(-X|--method)[[:space:]]+(POST|PUT|PATCH|DELETE)\b'; then
+        deny_response "gh api write-method blocked (coarse-scan): input exceeded tokenizer budget; rerun with a smaller payload to enable structured inspection."
+    fi
+    allow_response "coarse-scan-clear"
+fi
+
+context_messages=""
+while IFS= read -r sub; do
+    [ -z "$sub" ] && continue
+    reason=""
+    if reason=$(inspect_subcommand "$sub"); then
+        :
+    else
+        rc=$?
+        if [ "$rc" = "2" ]; then
+            # Allow-with-context channel: the helper printed a
+            # __CONTEXT__<label> marker.
+            label="${reason#__CONTEXT__}"
+            if [ -n "$context_messages" ]; then
+                context_messages="$context_messages; $label"
+            else
+                context_messages="$label"
+            fi
+            continue
+        fi
+        deny_response "$reason"
+    fi
+done < <(split_subcommands "$CMD")
+
+if [ -n "$context_messages" ]; then
+    allow_with_context "state-changing gh operation(s) detected: $context_messages"
+fi
+
+allow_response

--- a/global/hooks/merge-gate-guard.sh
+++ b/global/hooks/merge-gate-guard.sh
@@ -76,6 +76,14 @@ if ! echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge'; then
     allow_response
 fi
 
+# --- Squash-only enforcement (Issue #478) ---
+# The branching strategy mandates squash merges to develop/main. Reject
+# `--merge` and `--rebase` flags so the gh CLI cannot bypass that policy
+# even when the model is convinced "this one time" is fine.
+if echo "$CMD" | grep -qE -- '(^|[[:space:]])--(merge|rebase)([[:space:]]|=|$)'; then
+    deny_response "gh pr merge --merge/--rebase blocked: branching strategy requires squash merges (use --squash). See workflow/branching-strategy.md."
+fi
+
 # --- Extract PR number ---
 # Supports: gh pr merge 123, gh pr merge 123 --squash, gh pr merge --squash 123,
 #           gh pr merge https://github.com/owner/repo/pull/123

--- a/global/settings.json
+++ b/global/settings.json
@@ -30,7 +30,8 @@
       "Bash(git describe:*)",
       "Bash(git for-each-ref:*)",
       "Bash(git worktree list:*)",
-      "Bash(git fetch:*)",
+      "Bash(git fetch origin:*)",
+      "Bash(git fetch upstream:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr diff:*)",
@@ -77,7 +78,14 @@
       "Bash(gh release delete:*)",
       "Bash(gh release upload:*)",
       "Bash(gh auth status:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api -X GET:*)",
+      "Bash(gh api -H *:*)",
+      "Bash(gh api repos/*:*)",
+      "Bash(gh api orgs/*:*)",
+      "Bash(gh api users/*:*)",
+      "Bash(gh api user:*)",
+      "Bash(gh api rate_limit:*)",
+      "Bash(gh api graphql:*)"
     ],
     "deny": [
       "Read(.env)",
@@ -139,6 +147,11 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/bash-write-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/gh-write-verb-guard.sh",
             "timeout": 5
           },
           {

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/01-gh-api-implicit-get.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/01-gh-api-implicit-get.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api repos/owner/repo --jq .name"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/02-gh-api-explicit-get.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/02-gh-api-explicit-get.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X GET repos/owner/repo/pulls"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/03-graphql-query.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/03-graphql-query.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='query { viewer { login } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/04-graphql-named-query.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/04-graphql-named-query.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='query GetViewer { viewer { login id } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/05-non-gh-command.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/05-non-gh-command.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "ls -la"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/06-gh-pr-view.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/06-gh-pr-view.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh pr view 478"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/07-gh-issue-comment-in-scope.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/07-gh-issue-comment-in-scope.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh issue comment 478 --body 'Implementation update'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/allow/08-gh-workflow-run-in-scope.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/allow/08-gh-workflow-run-in-scope.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh workflow run deploy.yml"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/01-gh-api-delete-repo.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/01-gh-api-delete-repo.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X DELETE repos/owner/repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/02-gh-api-put-collaborator.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/02-gh-api-put-collaborator.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X PUT repos/owner/repo/collaborators/attacker"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/03-gh-api-patch.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/03-gh-api-patch.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api --method PATCH repos/owner/repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/04-gh-api-post-with-body.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/04-gh-api-post-with-body.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api repos/owner/repo/issues -f title=hi -f body=test"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/05-graphql-mutation.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/05-graphql-mutation.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='mutation { deleteRepository(input: {repositoryId: \"x\"}) { clientMutationId } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/06-graphql-named-mutation.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/06-graphql-named-mutation.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='mutation DeleteThing { deleteRepository(input: {}) { clientMutationId } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/07-graphql-subscription.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/07-graphql-subscription.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='subscription { repositoryUpdates { id } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/08-graphql-file-payload.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/08-graphql-file-payload.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -F query=@./payload.graphql"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/09-graphql-explicit-delete.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/09-graphql-explicit-delete.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -X DELETE -f query='query{viewer{login}}'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/10-cross-repo-secret-set.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/10-cross-repo-secret-set.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh secret set TOKEN --body abc --repo other-org/other-repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/11-cross-repo-issue-edit.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/11-cross-repo-issue-edit.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh issue edit 1 --repo other-org/other-repo --title hijacked"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/deny/12-chained-delete-after-allow.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/deny/12-chained-delete-after-allow.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh pr view 478 && gh api -X DELETE repos/owner/repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/01-mutation-keyword-in-comment.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/01-mutation-keyword-in-comment.expect.json
@@ -1,0 +1,3 @@
+{
+  "expect_decision": "allow"
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/01-mutation-keyword-in-comment.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/01-mutation-keyword-in-comment.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='# this is not a mutation\nquery { viewer { login } }'"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/02-graphql-with-variables.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/02-graphql-with-variables.expect.json
@@ -1,0 +1,3 @@
+{
+  "expect_decision": "allow"
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/02-graphql-with-variables.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/02-graphql-with-variables.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api graphql -f query='query($n: String!) { repository(name: $n, owner: \"o\") { id } }' -f n=foo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/03-sudo-prefix-delete.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/03-sudo-prefix-delete.expect.json
@@ -1,0 +1,3 @@
+{
+  "expect_decision": "deny"
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/03-sudo-prefix-delete.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/03-sudo-prefix-delete.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "sudo gh api -X DELETE repos/owner/repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/04-allowlist-override.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/04-allowlist-override.expect.json
@@ -1,0 +1,6 @@
+{
+  "expect_decision": "allow",
+  "env": {
+    "GH_API_WRITE_ALLOW": "repos/*/issues/*/comments"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/04-allowlist-override.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/04-allowlist-override.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X POST repos/kcenon/claude-config/issues/478/comments -f body=hi"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/05-audit-only-mode.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/05-audit-only-mode.expect.json
@@ -1,0 +1,6 @@
+{
+  "expect_decision": "allow",
+  "env": {
+    "GH_WRITE_VERB_GUARD_AUDIT_ONLY": "1"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/05-audit-only-mode.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/05-audit-only-mode.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api -X DELETE repos/owner/repo"
+  }
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/06-rate-limit-endpoint.expect.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/06-rate-limit-endpoint.expect.json
@@ -1,0 +1,3 @@
+{
+  "expect_decision": "allow"
+}

--- a/tests/hooks/fixtures/ghwvg-corpus/edge/06-rate-limit-endpoint.json
+++ b/tests/hooks/fixtures/ghwvg-corpus/edge/06-rate-limit-endpoint.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "gh api rate_limit"
+  }
+}

--- a/tests/hooks/test-gh-write-verb-guard.sh
+++ b/tests/hooks/test-gh-write-verb-guard.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Test suite: gh-write-verb-guard.sh — golden corpus runner
+# Run: bash tests/hooks/test-gh-write-verb-guard.sh
+#
+# Iterates over JSON fixtures under tests/hooks/fixtures/ghwvg-corpus/{deny,allow,edge}
+# and asserts that each one produces the expected permission decision.
+#
+# Outcome is encoded by directory:
+#   deny/  → must yield "permissionDecision": "deny"
+#   allow/ → must yield "permissionDecision": "allow"
+#   edge/  → expected decision in <name>.expect.json (default: allow);
+#            optional `env` map to set environment variables before running.
+
+HOOK="global/hooks/gh-write-verb-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+CORPUS_ROOT="tests/hooks/fixtures/ghwvg-corpus"
+
+# Use a scratch log dir so assertions don't touch ~/.claude/logs.
+SCRATCH_ROOT="${TMPDIR:-/tmp}"
+TEST_LOG_DIR=$(mktemp -d "$SCRATCH_ROOT/ghwvg-golden.XXXXXX" 2>/dev/null) \
+    || TEST_LOG_DIR="$SCRATCH_ROOT/ghwvg-golden.$$"
+mkdir -p "$TEST_LOG_DIR"
+export CLAUDE_LOG_DIR="$TEST_LOG_DIR"
+trap 'rm -rf "$TEST_LOG_DIR"' EXIT
+
+expect_for_edge() {
+    local fixture="$1"
+    local expect_file="${fixture%.json}.expect.json"
+    if [ -f "$expect_file" ] && command -v jq >/dev/null 2>&1; then
+        jq -r '.expect_decision // "allow"' "$expect_file" 2>/dev/null
+    else
+        echo "allow"
+    fi
+}
+
+# Read environment map from .expect.json and apply it inline. Returns
+# the env-var pairs as `KEY=VALUE` lines on stdout.
+expect_env_pairs() {
+    local fixture="$1"
+    local expect_file="${fixture%.json}.expect.json"
+    if [ -f "$expect_file" ] && command -v jq >/dev/null 2>&1; then
+        jq -r '(.env // {}) | to_entries[] | "\(.key)=\(.value)"' "$expect_file" 2>/dev/null
+    fi
+}
+
+assert_decision() {
+    local expected="$1"
+    local fixture="$2"
+    local label
+    label=$(basename "$fixture" .json)
+
+    local result
+    local -a env_pairs=()
+    while IFS= read -r pair; do
+        [ -n "$pair" ] && env_pairs+=("$pair")
+    done < <(expect_env_pairs "$fixture")
+
+    if [ "${#env_pairs[@]}" -gt 0 ]; then
+        result=$(env "${env_pairs[@]}" bash "$HOOK" < "$fixture" 2>/dev/null)
+    else
+        result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    fi
+
+    if echo "$result" | grep -q "\"$expected\""; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected $expected, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== gh-write-verb-guard golden corpus ==="
+echo ""
+
+# --- deny corpus ---
+deny_count=$(ls "$CORPUS_ROOT"/deny/*.json 2>/dev/null | wc -l | tr -d ' ')
+echo "[deny — $deny_count fixtures]"
+for f in "$CORPUS_ROOT"/deny/*.json; do
+    [ -f "$f" ] || continue
+    assert_decision "deny" "$f"
+done
+
+echo ""
+allow_count=$(ls "$CORPUS_ROOT"/allow/*.json 2>/dev/null | wc -l | tr -d ' ')
+echo "[allow — $allow_count fixtures]"
+for f in "$CORPUS_ROOT"/allow/*.json; do
+    [ -f "$f" ] || continue
+    assert_decision "allow" "$f"
+done
+
+echo ""
+edge_count=0
+for f in "$CORPUS_ROOT"/edge/*.json; do
+    [ -f "$f" ] || continue
+    case "$(basename "$f")" in
+        *.expect.json) continue ;;
+    esac
+    edge_count=$((edge_count + 1))
+done
+echo "[edge — $edge_count fixtures]"
+for f in "$CORPUS_ROOT"/edge/*.json; do
+    [ -f "$f" ] || continue
+    case "$(basename "$f")" in
+        *.expect.json) continue ;;
+    esac
+    expected=$(expect_for_edge "$f")
+    assert_decision "$expected" "$f"
+done
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0

--- a/tests/hooks/test-merge-gate-squash-only.sh
+++ b/tests/hooks/test-merge-gate-squash-only.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Test suite: merge-gate-guard.sh — squash-only enforcement (Issue #478)
+# Run: bash tests/hooks/test-merge-gate-squash-only.sh
+#
+# Validates that --merge / --rebase flags are rejected before the hook
+# ever calls `gh pr checks`. The squash-only check is a pre-CI gate so we
+# do not need a stubbed gh binary for these cases.
+
+HOOK="global/hooks/merge-gate-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+assert_deny() {
+    local cmd="$1" label="$2" needle="$3"
+    local fixture
+    fixture=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}')
+    local result
+    result=$(printf '%s' "$fixture" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"' && echo "$result" | grep -q "$needle"; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected deny mentioning '$needle', got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_passthrough() {
+    local cmd="$1" label="$2"
+    local fixture
+    fixture=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}')
+    # We do not assert allow/deny here — only that the squash-only branch
+    # did NOT fire. The CI-checks branch may legitimately allow or deny
+    # based on the (absent) gh CLI, so we just verify the response does
+    # not mention "branching strategy requires squash".
+    local result
+    result=$(printf '%s' "$fixture" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q "branching strategy requires squash"; then
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — squash-only branch unexpectedly fired: $result")
+        echo "  FAIL: $label"
+    else
+        ((PASS++))
+        echo "  PASS: $label"
+    fi
+}
+
+echo "=== merge-gate-guard squash-only tests ==="
+echo ""
+
+echo "[deny — non-squash flags]"
+assert_deny 'gh pr merge 1 --merge'   "long-form --merge"   "branching strategy requires squash"
+assert_deny 'gh pr merge --merge 1'   "--merge before PR#"  "branching strategy requires squash"
+assert_deny 'gh pr merge 1 --rebase'  "long-form --rebase"  "branching strategy requires squash"
+assert_deny 'gh pr merge --rebase 7'  "--rebase before PR#" "branching strategy requires squash"
+
+echo ""
+echo "[allow-pass-through — squash and unrelated commands]"
+assert_passthrough 'gh pr merge 1 --squash --delete-branch'      "--squash"
+assert_passthrough 'gh pr view 1'                                 "non-merge gh"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

### Summary
Replaces the broad `Bash(gh api:*)` permission with a narrow allowlist and adds three runtime guards so destructive `gh` operations require explicit confirmation again.

### Change Type
- [x] Security / refactor

### Affected Components
- `global/settings.json` — narrowed `gh api:*` and `git fetch:*` allowlists; registered new hook
- `global/hooks/gh-write-verb-guard.{sh,ps1}` — new hook (Bash channel)
- `global/hooks/merge-gate-guard.sh` — extended with squash-only enforcement
- `tests/hooks/fixtures/ghwvg-corpus/` — new golden corpus (12 deny / 8 allow / 6 edge)
- `tests/hooks/test-gh-write-verb-guard.sh` — new corpus runner
- `tests/hooks/test-merge-gate-squash-only.sh` — new focused test

## Why

### Problem Solved
Issue #478: a single `Bash(gh api:*)` line was functionally "all GitHub admin operations pre-approved" — any tool call that produced `gh api -X DELETE /repos/X/Y` resulted in silent repo deletion. GraphQL mutations via `gh api graphql` had no scrutiny at all. State-changing non-`api` subcommands (issue/pr/secret/release/...) were also unguarded by the merge-gate path.

### Related Issues
- Closes #478
- Part of #474 (Hook System Hardening)

## How

### Implementation Highlights

**1. `gh api` HTTP method gate**
- `extract_api_method` derives the HTTP verb from `-X`/`--method`, defaulting to `GET` and inferring `POST` when `-f`/`-F`/`--input` is present (mirrors gh CLI semantics).
- `GET`/`HEAD` always allowed.
- `POST`/`PATCH`/`PUT`/`DELETE` denied unless the endpoint matches a glob in `GH_API_WRITE_ALLOW` (operator-controlled).

**2. GraphQL mutation/subscription scan**
- `gh api graphql -f query=...` payloads are scanned for the literal tokens `mutation` or `subscription` followed by `{`/`(` (anonymous and named operations).
- `query{...}` documents pass; `mutation{...}` and `subscription{...}` are denied.
- `-F query=@file.graphql` is conservatively denied as opaque — the hook cannot statically inspect a disk-loaded payload.
- Line comments (`#...`) are stripped before scanning so a literal `# mutation` annotation doesn't false-positive.
- Explicit `-X PATCH|PUT|DELETE` against the graphql endpoint is rejected on principle (GitHub's GraphQL only accepts GET/POST).

**3. State-changing non-`api` subcommands**
- `gh issue|pr|workflow|secret|variable|ssh-key|gpg-key|gist|release|repo|cache|label <verb>` is detected against a verb whitelist.
- Default action: **allow with `additionalContext`** so the model is reminded the operation mutates remote state. This matches the issue's "audit-only first, tighten later" guidance.
- Cross-repo writes (`--repo other-org/...` differing from the working tree's `origin`) are **denied** because the audit identified that subset as the highest-risk vector (Vector I).

**4. `merge-gate-guard.sh` squash-only**
- `gh pr merge --merge`/`--rebase` is denied before the hook reaches the CI check path. Branching strategy already mandates squash via `pr-target-guard.sh` for the create path; this closes the merge path symmetrically.

### Reuse and Style
Sources `lib/tokenize-shell.sh` (PR #483) for quote- and substitution-aware splitting, mirroring `bash-write-guard.sh` (PR #484). PowerShell parity uses regex with a documented approximation note.

### Audit-only fallback
Set `GH_WRITE_VERB_GUARD_AUDIT_ONLY=1` to downgrade every deny to allow while still logging the diagnostic to stderr — supports the issue's "1-week telemetry" rollout without code changes.

### Testing Done
- New golden corpus: **26 fixtures** (12 deny + 8 allow + 6 edge), all passing
- New squash-only suite: 6 cases passing
- Full `tests/hooks/test-runner.sh`: **485 passed / 15 failed**, where the 15 failures are the pre-existing baseline (commit-msg, markdown-anchor-validator, p4-timeline-guard). Up from 453 passed pre-PR — no regressions, +32 new tests.
- Performance: 100 KB DELETE payload completes in ~50 ms.

### Acceptance Criteria (from #478)
- [x] `gh api repos/owner/repo --json name` (implicit GET) → allow
- [x] `gh api -X DELETE repos/owner/repo` → deny
- [x] `gh api -X PUT repos/owner/repo/collaborators/X` → deny
- [x] `gh api graphql -f query='query{viewer{login}}'` → allow
- [x] `gh api graphql -f query='mutation{deleteRepository(...)}'` → deny
- [x] `gh pr merge 1 --merge` → deny ("squash required")
- [x] `gh pr merge 1 --squash` → allow (subject to CI gate)
- [x] `gh issue comment 1 --body "test"` → allow + additionalContext
- [x] `gh workflow run deploy.yml` → allow + additionalContext
- [x] `git fetch evil-remote refs/*:refs/*` → no longer in allowlist (now `git fetch origin:*` and `git fetch upstream:*` only)
- [x] `git fetch origin develop` → allow

### Breaking Changes
- Any user script using `gh api -X DELETE/PUT/POST/PATCH` against an arbitrary endpoint will now fail. Override per-deployment via `export GH_API_WRITE_ALLOW='repos/*/issues/*/comments:repos/*/pulls/*/comments'` or temporary audit-only mode.
- `gh pr merge --merge` / `--rebase` will fail — must use `--squash`.
- `git fetch <random-remote>` no longer pre-approved — only `origin` and `upstream`.

### Rollback Plan
1. Restore `Bash(gh api:*)` and `Bash(git fetch:*)` in `settings.json`
2. Remove the `gh-write-verb-guard.sh` entry from `hooks.PreToolUse[Bash]`
3. Revert `merge-gate-guard.sh` squash-only block
4. `./scripts/install.sh` and restart

Closes #478
