### PR TITLE
fix(hooks): cross-platform timeout fallback for merge-gate-guard

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -200,6 +200,18 @@ When upgrading Claude Code itself:
 - Use `install.ps1` on Windows instead of `install.sh`
 - PowerShell 7+ (`pwsh`) is required for Windows support
 
+#### Cross-platform `timeout` fallback (`global/hooks/lib/timeout-wrapper.sh`)
+
+`merge-gate-guard.sh` bounds its `gh pr checks` call via `_run_with_timeout`. The
+wrapper resolves to the first available implementation, in this order:
+
+1. **GNU `timeout`** — present on Linux (coreutils) and BSD distros that ship coreutils.
+2. **`gtimeout`** — installed by `brew install coreutils` on macOS.
+3. **`perl alarm`** — universal fallback. macOS ships `/usr/bin/perl` by default, so vanilla machines without Homebrew coreutils still get a bounded call.
+4. **Pure-bash `wait`/`kill`** — last-resort fallback for minimal images (e.g. busybox) that lack perl.
+
+All branches normalize to GNU-timeout exit semantics (exit 124 on budget exceeded). The PowerShell guard uses `Start-Job` + `Wait-Job -Timeout` for the same contract. Override the budget with `GH_CHECKS_TIMEOUT_SEC` (default `10`).
+
 ---
 
 *Last updated: 2026-04-17 | claude-config v1.6.0*

--- a/global/hooks/lib/timeout-wrapper.sh
+++ b/global/hooks/lib/timeout-wrapper.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# timeout-wrapper.sh
+# Cross-platform timeout helper for hook scripts.
+#
+# Resolution order:
+#   1. GNU timeout (Linux, BSD with coreutils)
+#   2. gtimeout    (macOS Homebrew coreutils)
+#   3. perl alarm  (universal fallback — perl ships with macOS by default)
+#
+# Exit-code contract matches GNU timeout:
+#   - 124 when the wall-clock budget is exceeded
+#   - otherwise the wrapped command's exit code
+#
+# Usage:
+#   . "$LIB_DIR/timeout-wrapper.sh"
+#   if OUTPUT=$(_run_with_timeout 10 gh pr checks "$PR_NUM" --json bucket); then
+#       ...
+#   else
+#       rc=$?
+#       [ "$rc" = "124" ] && handle_timeout || handle_gh_error "$rc"
+#   fi
+
+_run_with_timeout() {
+    local secs="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${secs}" "$@"
+        return $?
+    fi
+
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "${secs}" "$@"
+        return $?
+    fi
+
+    if command -v perl >/dev/null 2>&1; then
+        # perl alarm fallback. The child runs in its own process group so a
+        # single negative-pid kill cleans up grandchildren too — `gh` shells
+        # out and `sleep`s, and SIGTERM to the immediate child alone leaves
+        # those grandchildren running, which would block waitpid for the full
+        # original duration. Exit 124 matches GNU timeout semantics.
+        perl -e '
+            use POSIX qw(setpgid);
+            my $s = shift;
+            my $pid = fork();
+            if (!defined $pid) { exit 125; }
+            if ($pid == 0) {
+                setpgid(0, 0);
+                exec @ARGV;
+                exit 127;
+            }
+            setpgid($pid, $pid);
+            local $SIG{ALRM} = sub {
+                kill "-TERM", $pid;
+                select(undef, undef, undef, 0.5);
+                kill "-KILL", $pid;
+                waitpid($pid, 0);
+                exit 124;
+            };
+            alarm $s;
+            waitpid $pid, 0;
+            my $rc = $? >> 8;
+            exit $rc;
+        ' "${secs}" "$@"
+        return $?
+    fi
+
+    # Last-resort pure-bash fallback. Less precise than perl alarm because
+    # `wait` does not honour signal-driven exit codes uniformly across shells,
+    # but keeps the hook functional on minimal containers (busybox-style).
+    "$@" &
+    local cmd_pid=$!
+    (
+        sleep "${secs}"
+        kill -TERM "$cmd_pid" 2>/dev/null
+        sleep 1
+        kill -KILL "$cmd_pid" 2>/dev/null
+    ) &
+    local timer_pid=$!
+    if wait "$cmd_pid" 2>/dev/null; then
+        local rc=0
+    else
+        local rc=$?
+    fi
+    kill -TERM "$timer_pid" 2>/dev/null
+    wait "$timer_pid" 2>/dev/null
+    # Bash sets rc=143 (128+SIGTERM) when the child was killed. Normalize to
+    # 124 so callers can branch on a single sentinel value.
+    [ "$rc" = "143" ] || [ "$rc" = "137" ] && rc=124
+    return "$rc"
+}

--- a/global/hooks/merge-gate-guard.ps1
+++ b/global/hooks/merge-gate-guard.ps1
@@ -92,15 +92,44 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     exit 0
 }
 
-# --- Call gh pr checks ---
+# --- Call gh pr checks (bounded by Start-Job/Wait-Job timeout) ---
+# Wall-clock budget for a single `gh pr checks` invocation. Mirrors the
+# Bash GH_CHECKS_TIMEOUT_SEC contract.
+$timeoutSec = if ($env:GH_CHECKS_TIMEOUT_SEC) { [int]$env:GH_CHECKS_TIMEOUT_SEC } else { 10 }
+
 $ghArgs = @('pr', 'checks', $prNum, '--json', 'bucket,name,state')
 if ($repo) { $ghArgs += @('-R', $repo) }
 
+$checksRaw = $null
+$ghExit = 0
+$timedOut = $false
+
 try {
-    $checksRaw = & gh @ghArgs 2>&1
-    $ghExit = $LASTEXITCODE
+    $job = Start-Job -ScriptBlock {
+        param($ghArgs)
+        $out = & gh @ghArgs 2>&1
+        [pscustomobject]@{ Output = $out; ExitCode = $LASTEXITCODE }
+    } -ArgumentList (,$ghArgs)
+
+    if (Wait-Job $job -Timeout $timeoutSec) {
+        $result = Receive-Job $job
+        if ($result) {
+            $checksRaw = $result.Output
+            $ghExit = $result.ExitCode
+        }
+    } else {
+        Stop-Job $job | Out-Null
+        $timedOut = $true
+    }
+    Remove-Job $job -Force | Out-Null
 } catch {
     Write-Diag "gh invocation threw: $_"
+    New-HookAllowResponse
+    exit 0
+}
+
+if ($timedOut) {
+    Write-Diag "gh pr checks timed out after ${timeoutSec}s, allowing merge (fail-open)"
     New-HookAllowResponse
     exit 0
 }

--- a/global/hooks/merge-gate-guard.sh
+++ b/global/hooks/merge-gate-guard.sh
@@ -23,6 +23,17 @@
 
 set -uo pipefail
 
+# --- Resolve script dir + load shared helpers ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/timeout-wrapper.sh
+. "$SCRIPT_DIR/lib/timeout-wrapper.sh"
+
+# Wall-clock budget for any single `gh pr checks` invocation. Slow networks
+# and GitHub degradation can otherwise pin the entire PreToolUse chain on
+# the gh internal default (~30 s). 10 s is short enough to keep merge UX
+# snappy and long enough to ride out typical jitter.
+GH_CHECKS_TIMEOUT_SEC="${GH_CHECKS_TIMEOUT_SEC:-10}"
+
 # --- Response helpers ---
 deny_response() {
     local reason="$1"
@@ -122,13 +133,22 @@ if ! command -v gh >/dev/null 2>&1; then
     allow_response
 fi
 
-# --- Call gh pr checks ---
+# --- Call gh pr checks (bounded by cross-platform timeout wrapper) ---
 if [ -n "$REPO" ]; then
-    CHECKS_JSON=$(gh pr checks "$PR_NUM" -R "$REPO" --json bucket,name,state 2>&1)
+    CHECKS_JSON=$(_run_with_timeout "$GH_CHECKS_TIMEOUT_SEC" gh pr checks "$PR_NUM" -R "$REPO" --json bucket,name,state 2>&1)
 else
-    CHECKS_JSON=$(gh pr checks "$PR_NUM" --json bucket,name,state 2>&1)
+    CHECKS_JSON=$(_run_with_timeout "$GH_CHECKS_TIMEOUT_SEC" gh pr checks "$PR_NUM" --json bucket,name,state 2>&1)
 fi
 GH_RC=$?
+
+# 124 is the GNU-timeout sentinel; the wrapper normalizes perl/bash fallbacks
+# to the same code so a single branch covers all platforms. Fail-open per
+# the guard's stated policy — server-side branch protection remains the
+# authoritative gate.
+if [ $GH_RC -eq 124 ]; then
+    log_diag "gh pr checks timed out after ${GH_CHECKS_TIMEOUT_SEC}s, allowing merge (fail-open)"
+    allow_response
+fi
 
 if [ $GH_RC -ne 0 ]; then
     log_diag "gh pr checks failed (exit $GH_RC), allowing merge (fail-open): ${CHECKS_JSON}"

--- a/tests/hooks/test-merge-gate-guard-timeout.sh
+++ b/tests/hooks/test-merge-gate-guard-timeout.sh
@@ -4,8 +4,8 @@
 #
 # Validates how merge-gate-guard.sh reacts when the upstream `gh` CLI behaves
 # unusually (slow, hanging, failing). Uses a stub `gh` binary on PATH so we
-# never call real GitHub. The 5 cases below match the issue acceptance
-# criteria (merge-gate-guard timeout, 5 cases).
+# never call real GitHub. Cases below match the issue #479 acceptance
+# criteria.
 
 HOOK="global/hooks/merge-gate-guard.sh"
 PASS=0
@@ -33,17 +33,16 @@ case "${MOCK_MODE:-}" in
         ;;
     slow2)
         # 2-second simulated slow response — exercises the "long but not hung"
-        # path without slowing CI. The hook has no internal timeout, so this
-        # is bounded only by real CI patience; the test wraps the call in a
-        # host-level timeout.
+        # path. With a default 10 s timeout the hook still returns allow; the
+        # perl-fallback case below uses a tighter budget to fire the timeout.
         sleep 2
         echo '[{"bucket":"pass","name":"build","state":"COMPLETED"}]'
         exit 0
         ;;
     hang)
-        # Long sleep simulating an unresponsive gh process. The test wraps
-        # the hook in a 3-second host timeout to prove the process can be
-        # interrupted without producing a stale "allow" response.
+        # Long sleep simulating an unresponsive gh process. The hook's
+        # internal timeout should kill this and fall through to fail-open
+        # allow without waiting the full 30 s.
         sleep 30
         ;;
     fail)
@@ -73,29 +72,25 @@ fi
 
 INPUT_PR='{"tool_input":{"command":"gh pr merge 42 --squash --delete-branch"}}'
 
-run_hook_with_timeout() {
-    local timeout_sec="$1"
-    local mode="$2"
-    if command -v timeout >/dev/null 2>&1; then
-        MOCK_MODE="$mode" timeout "${timeout_sec}s" bash "$HOOK" <<<"$INPUT_PR" 2>/dev/null
-    elif command -v gtimeout >/dev/null 2>&1; then
-        MOCK_MODE="$mode" gtimeout "${timeout_sec}s" bash "$HOOK" <<<"$INPUT_PR" 2>/dev/null
-    else
-        # Fallback: spawn the hook in a subshell and kill it after `timeout_sec`.
-        # We use bash background + sleep rather than depending on `timeout(1)`
-        # because macOS does not ship coreutils' timeout by default.
-        (
-            MOCK_MODE="$mode" bash "$HOOK" <<<"$INPUT_PR" 2>/dev/null &
-            local pid=$!
-            (
-                sleep "$timeout_sec"
-                kill -KILL "$pid" 2>/dev/null
-            ) &
-            local killer=$!
-            wait "$pid" 2>/dev/null
-            kill -KILL "$killer" 2>/dev/null
-        )
-    fi
+# Run the hook with the test stub on PATH. The hook itself is responsible for
+# bounding the gh call — these tests no longer wrap the hook in a host-level
+# timeout because the contract under test is "hook returns within budget".
+run_hook() {
+    local mode="$1"
+    local timeout_sec="${2:-10}"
+    GH_CHECKS_TIMEOUT_SEC="$timeout_sec" MOCK_MODE="$mode" \
+        bash "$HOOK" <<<"$INPUT_PR" 2>/dev/null
+}
+
+# Run the hook with a deliberately stripped PATH that excludes any
+# coreutils binaries, forcing the timeout-wrapper down to the perl fallback.
+# Keeps stub gh + system perl/jq reachable via absolute paths.
+run_hook_no_coreutils() {
+    local mode="$1"
+    local timeout_sec="${2:-10}"
+    local minimal_path="$STUB_DIR:/usr/bin:/bin"
+    PATH="$minimal_path" GH_CHECKS_TIMEOUT_SEC="$timeout_sec" MOCK_MODE="$mode" \
+        bash "$HOOK" <<<"$INPUT_PR" 2>/dev/null
 }
 
 assert_decision() {
@@ -104,12 +99,22 @@ assert_decision() {
     local result="$3"
 
     if echo "$result" | grep -q "\"$expected\""; then
-        ((PASS++))
+        PASS=$((PASS + 1))
         echo "  PASS: $label"
     else
-        ((FAIL++))
+        FAIL=$((FAIL + 1))
         ERRORS+=("FAIL: $label — expected $expected, got: $result")
         echo "  FAIL: $label"
+    fi
+}
+
+now_ms() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import time; print(int(time.time()*1000))'
+    elif command -v perl >/dev/null 2>&1; then
+        perl -MTime::HiRes=time -e 'printf("%d\n", int(time()*1000))'
+    else
+        echo 0
     fi
 }
 
@@ -118,34 +123,36 @@ echo ""
 
 # Case 1: fast pass — gh returns immediately with all-pass checks → allow.
 echo "[1] fast pass — all checks green, immediate response"
-result=$(run_hook_with_timeout 5 fast)
+result=$(run_hook fast)
 assert_decision "fast pass → allow" "allow" "$result"
 
-# Case 2: slow gh (2 s) — the hook has no internal timeout, so it blocks until
-# the stub responds. The host wraps it in a 6 s ceiling; result must still be
-# allow because the stub returns all-pass once it eventually responds.
+# Case 2: slow gh (2 s) within budget — hook waits for the response and
+# allows. Default 10 s budget comfortably covers this.
 echo ""
-echo "[2] slow gh (2 s) — eventually returns all-pass"
-start_ms=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)
-result=$(run_hook_with_timeout 6 slow2)
-end_ms=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo 0)
+echo "[2] slow gh (2 s) within 10 s budget — eventually returns all-pass"
+start_ms=$(now_ms)
+result=$(run_hook slow2)
+end_ms=$(now_ms)
 elapsed=$((end_ms - start_ms))
 assert_decision "slow gh → allow (eventual)" "allow" "$result"
 echo "    info: hook returned in ${elapsed}ms"
 
-# Case 3: hung gh — 3-second host-level timeout kills the hook. We expect
-# either a SIGKILL (empty result) or the host's timeout exit. Either way the
-# hook should NOT have emitted a stale "allow" response.
+# Case 3: hung gh (>30 s sleep) with a 2 s budget — hook's internal timeout
+# wrapper fires, we expect a fail-open allow within ~3 s, not the full 30 s.
 echo ""
-echo "[3] hung gh — host-level 3 s timeout"
-result=$(run_hook_with_timeout 3 hang || true)
-if echo "$result" | grep -q '"permissionDecision"'; then
-    ((FAIL++))
-    ERRORS+=("FAIL: hung gh produced a decision, expected truncation: $result")
-    echo "  FAIL: hung gh produced a decision (should have been killed)"
+echo "[3] hung gh — hook internal 2 s timeout fires, fail-open allow"
+start_ms=$(now_ms)
+result=$(run_hook hang 2)
+end_ms=$(now_ms)
+elapsed=$((end_ms - start_ms))
+assert_decision "hung gh → allow (timeout fail-open)" "allow" "$result"
+if [ "$elapsed" -gt 5000 ]; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: hung gh exceeded 5 s wall time (${elapsed}ms) — timeout did not fire")
+    echo "  FAIL: timeout did not bound wall time (${elapsed}ms > 5000ms)"
 else
-    ((PASS++))
-    echo "  PASS: hung gh — no decision emitted (process killed before response)"
+    PASS=$((PASS + 1))
+    echo "  PASS: wall time bounded (${elapsed}ms)"
 fi
 
 # Case 4: gh exits non-zero — fail-open per merge-gate-guard policy. The
@@ -153,15 +160,40 @@ fi
 # still allow the merge and let server-side branch protection be the gate.
 echo ""
 echo "[4] gh exits non-zero — fail-open policy"
-result=$(run_hook_with_timeout 5 fail)
+result=$(run_hook fail)
 assert_decision "gh fail → allow (fail-open)" "allow" "$result"
 
 # Case 5: non-passing checks — gh succeeds but reports a failing bucket,
 # guard must deny.
 echo ""
 echo "[5] non-passing check — guard denies merge"
-result=$(run_hook_with_timeout 5 nonpassing)
+result=$(run_hook nonpassing)
 assert_decision "non-passing checks → deny" "deny" "$result"
+
+# Case 6: cross-platform timeout fallback — strip coreutils from PATH so the
+# wrapper must use perl alarm. Fast stub still resolves; allow is expected.
+echo ""
+echo "[6] perl fallback — PATH without timeout/gtimeout, fast stub"
+result=$(run_hook_no_coreutils fast)
+assert_decision "perl fallback fast → allow" "allow" "$result"
+
+# Case 7: cross-platform timeout fires via perl fallback — same stripped
+# PATH, hung stub, 2 s budget. Wall time must be bounded by the budget.
+echo ""
+echo "[7] perl fallback — hung stub, internal timeout fires"
+start_ms=$(now_ms)
+result=$(run_hook_no_coreutils hang 2)
+end_ms=$(now_ms)
+elapsed=$((end_ms - start_ms))
+assert_decision "perl fallback hang → allow (timeout)" "allow" "$result"
+if [ "$elapsed" -gt 5000 ]; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: perl fallback exceeded 5 s wall time (${elapsed}ms)")
+    echo "  FAIL: perl fallback did not bound wall time (${elapsed}ms > 5000ms)"
+else
+    PASS=$((PASS + 1))
+    echo "  PASS: perl fallback bounded wall time (${elapsed}ms)"
+fi
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## What

Wrap the synchronous `gh pr checks` calls in `merge-gate-guard` with a wall-clock budget that resolves across `timeout` (GNU coreutils) → `gtimeout` (macOS Homebrew coreutils) → `perl alarm` → pure-bash `wait`/`kill`. The hook now bounds its own latency instead of relying on the `gh` CLI's ~30 s internal default.

### Change Type
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

### Affected Components
- `global/hooks/lib/timeout-wrapper.sh` (new)
- `global/hooks/merge-gate-guard.sh` (sources wrapper, handles rc=124)
- `global/hooks/merge-gate-guard.ps1` (Start-Job/Wait-Job parity)
- `tests/hooks/test-merge-gate-guard-timeout.sh` (rewritten: 9 cases, 9 pass)
- `COMPATIBILITY.md` (Cross-Platform Notes section)

## Why

Closes: part of #474. Implements #479.

On macOS without Homebrew coreutils — the audit author's machine has neither `timeout` nor `gtimeout` — naively wrapping `gh pr checks` in `timeout 10` would crash every `gh pr merge` with `command not found`. Without any wrapper, every `gh pr merge` invocation pins the entire 9-hook PreToolUse chain on the gh internal default (~30 s) whenever the network is slow or GitHub is degraded. This change bounds that path to a configurable 10 s on every supported platform.

## How

### Resolution order (timeout-wrapper.sh)
1. GNU `timeout` (Linux + BSDs with coreutils)
2. `gtimeout` (macOS + Homebrew coreutils)
3. `perl -e 'alarm ...'` (universal — `/usr/bin/perl` ships with macOS)
4. Pure-bash `wait`/`kill` (last resort for minimal containers)

All branches normalize the wall-clock-exceeded exit code to **124**, matching GNU-timeout semantics. The Bash hook keys on `GH_RC -eq 124` to take the existing fail-open path with a distinct \"timed out\" log line.

### Perl-fallback subtlety

`gh` shells out internally and may sleep in a grandchild. SIGTERM to the immediate child alone leaves the grandchild waiting, which would block `waitpid` for the original duration even after `alarm` fires. The wrapper calls `setpgid` so the child runs in its own process group and the timeout sends `kill -TERM`/`kill -KILL` to the negative pid (whole group). Verified: a 30 s stub in a 2 s budget returns within ~2.6 s.

### PowerShell parity

`merge-gate-guard.ps1` uses `Start-Job` + `Wait-Job -Timeout`, with `Stop-Job` on miss. Same `GH_CHECKS_TIMEOUT_SEC` env override.

## Acceptance Criteria

- [x] Mock `gh` returning success in <1 s → allow, total wall time < 1 s
- [x] Mock `gh` returning success at 2 s → allow, within budget (2.1 s)
- [x] Mock `gh` hanging > 30 s → allow (fail-open), total wall time ~2.6 s, log entry contains \"timed out\"
- [x] Mock `gh` returning failure → deny (existing behavior preserved — non-passing case unchanged)
- [x] `PATH=stub:/usr/bin:/bin` (no timeout/gtimeout) + mock fast `gh` → allow via perl fallback
- [x] Same scenarios on the perl-fallback path with hung stub → bounded wall time
- [x] `COMPATIBILITY.md` updated with timeout fallback documentation
- [ ] PowerShell parity exercised on Windows — not run locally; logic mirrors the Bash side and uses `Start-Job`/`Wait-Job -Timeout` per the issue spec

## Test Plan

```
bash tests/hooks/test-merge-gate-guard-timeout.sh
# 9 passed, 0 failed
bash tests/hooks/test-runner.sh
# Total: 503 passed, 1 failed (markdown-anchor-validator — baseline on develop)
```

## Breaking Changes

None. Fail-open on timeout matches the existing fail-open contract on gh CLI errors. New env var `GH_CHECKS_TIMEOUT_SEC` defaults to 10 — unset behavior is unchanged from the issue spec.

## Rollback Plan

`git revert <merge-sha>` then `./scripts/install.sh`. New file `global/hooks/lib/timeout-wrapper.sh` is sourced only by `merge-gate-guard.sh`; its absence after revert is safe because the source line is also removed.

Closes: part of #474