### PR TITLE
feat(hooks): restore PowerShell parity for p4-timeline hooks

### DIFF
--- a/.github/workflows/validate-hooks-doc.yml
+++ b/.github/workflows/validate-hooks-doc.yml
@@ -39,3 +39,42 @@ jobs:
             diff <(printf '%s\n' "$first") <(printf '%s\n' "$second") >&2 || true
             exit 1
           fi
+
+  parity:
+    # Parity audit per #489: every bash hook in global/hooks/*.sh must have a
+    # PowerShell counterpart of the same basename, and vice versa. Fails the
+    # PR if counts diverge so the COMPATIBILITY.md ratio cannot drift silently.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Audit .sh / .ps1 parity
+        run: |
+          missing=0
+          sh_count=0
+          ps_count=0
+          for sh in global/hooks/*.sh; do
+            sh_count=$((sh_count + 1))
+            base=$(basename "$sh" .sh)
+            ps="global/hooks/${base}.ps1"
+            if [ ! -f "$ps" ]; then
+              echo "MISSING PowerShell counterpart for $sh -> $ps" >&2
+              missing=$((missing + 1))
+            fi
+          done
+          for ps in global/hooks/*.ps1; do
+            ps_count=$((ps_count + 1))
+            base=$(basename "$ps" .ps1)
+            sh="global/hooks/${base}.sh"
+            if [ ! -f "$sh" ]; then
+              echo "MISSING bash counterpart for $ps -> $sh" >&2
+              missing=$((missing + 1))
+            fi
+          done
+          echo "Bash hooks: $sh_count, PowerShell hooks: $ps_count"
+          if [ "$sh_count" -ne "$ps_count" ] || [ "$missing" -ne 0 ]; then
+            echo "Parity audit FAILED: counts diverge or counterparts missing" >&2
+            exit 1
+          fi
+          echo "Parity audit PASSED: $sh_count/$sh_count counterparts present"

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -206,16 +206,11 @@ The README v1.7.0 changelog originally claimed "All 42 bash scripts now have Pow
 
 | Surface | Bash count | PowerShell count | Coverage |
 |---|---:|---:|---:|
-| `global/hooks/*.sh` | 32 | 30 | 30/32 (94%) |
+| `global/hooks/*.sh` | 32 | 32 | 32/32 (100%) |
 
-Bash hooks **without** a `.ps1` counterpart (tracked for restoration in a follow-up issue):
+The previous gap (`p4-timeline-guard.sh` and `p4-timeline-reminder.sh`) was closed in #489: both bash hooks now have `.ps1` counterparts wired into `global/settings.windows.json`. A bash/PowerShell parity test (`tests/hooks/test-p4-timeline-guard-parity.sh`) confirms the two implementations return identical decisions across every fixture; the parity audit job in `.github/workflows/validate-hooks-doc.yml` fails the PR if `*.sh` and `*.ps1` counts diverge.
 
-- `global/hooks/p4-timeline-guard.sh` — P4 rollout timeline enforcement (EPIC #454).
-- `global/hooks/p4-timeline-reminder.sh` — SessionStart banner for the active P4 window.
-
-Both are tied to a transient EPIC-#454 rollout window and are scheduled to be ported (or sunset together with the rollout) before the next minor release. Windows users in the rollout window currently get the same enforcement via the bash hooks under WSL or Git Bash; native PowerShell users are reminded by `bootstrap.ps1` if the EPIC is active.
-
-The script that produces the live count: `bash -c 'b=$(ls global/hooks/*.sh | wc -l); p=$(ls global/hooks/*.ps1 | wc -l); echo "$p/$b"'`. CI can extend `validate-hooks-doc.yml` to fail when this row drifts from the filesystem; tracked in the PowerShell-parity follow-up issue.
+The script that produces the live count: `bash -c 'b=$(ls global/hooks/*.sh | wc -l); p=$(ls global/hooks/*.ps1 | wc -l); echo "$p/$b"'`.
 
 #### Cross-platform `timeout` fallback (`global/hooks/lib/timeout-wrapper.sh`)
 

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1014,8 +1014,8 @@ this catalog for the canonical hook inventory.
 | [`instructions-loaded-reinforcer.sh`](#instructions-loaded-reinforcer) | InstructionsLoaded (sync) | yes |
 | [`markdown-anchor-validator.sh`](#markdown-anchor-validator) | PreToolUse (Bash) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
-| [`p4-timeline-guard.sh`](#p4-timeline-guard) | PreToolUse (Bash | Edit | Write) | no |
-| [`p4-timeline-reminder.sh`](#p4-timeline-reminder) | SessionStart | no |
+| [`p4-timeline-guard.sh`](#p4-timeline-guard) | PreToolUse (Bash | Edit | Write) | yes |
+| [`p4-timeline-reminder.sh`](#p4-timeline-reminder) | SessionStart | yes |
 | [`post-compact-restore.sh`](#post-compact-restore) | PostCompact (sync) | yes |
 | [`post-task-checkpoint.sh`](#post-task-checkpoint) | PostToolUse | yes |
 | [`pr-language-guard.sh`](#pr-language-guard) | PreToolUse (Bash) | yes |
@@ -1034,7 +1034,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 32 bash hooks, 30 with PowerShell counterparts._
+_Total: 32 bash hooks, 32 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1246,7 +1246,7 @@ Blocks Claude-initiated actions that violate the EPIC #454 P4 rollout timeline.
 | Trigger / Matcher | Bash | Edit | Write |
 | Exit codes | 0 (always - decision is in JSON) |
 | Response format | hookSpecificOutput with hookEventName + permissionDecision |
-| PowerShell counterpart | absent |
+| PowerShell counterpart | present (`p4-timeline-guard.ps1`) |
 | Source | `global/hooks/p4-timeline-guard.sh` |
 
 ### p4-timeline-reminder.sh
@@ -1261,7 +1261,7 @@ SessionStart banner that surfaces the active P4 rollout window.
 | Trigger / Matcher | — |
 | Exit codes | 0 (always - lifecycle event) |
 | Response format | none (writes to stderr; visible in terminal) |
-| PowerShell counterpart | absent |
+| PowerShell counterpart | present (`p4-timeline-reminder.ps1`) |
 | Source | `global/hooks/p4-timeline-reminder.sh` |
 
 ### post-compact-restore.sh

--- a/global/hooks/p4-timeline-guard.ps1
+++ b/global/hooks/p4-timeline-guard.ps1
@@ -1,0 +1,178 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# p4-timeline-guard.ps1
+# Blocks Claude-initiated actions that violate the EPIC #454 P4 rollout timeline.
+# PowerShell counterpart of p4-timeline-guard.sh.
+# Hook Type: PreToolUse (Bash | Edit | Write)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName + permissionDecision
+#
+# Two protected actions:
+#   1. gh pr merge of a PR whose diff touches global/skills/_internal/
+#      -> blocked until p4_grace_until passes
+#   2. Edit/Write to settings.json (or settings.windows.json) that flips
+#      harness_policies.p4_strict_schema from false to true
+#      -> blocked until p4_observation_until passes
+#
+# Override: set CLAUDE_P4_OVERRIDE=1 in the environment with the reason
+# documented in COMPATIBILITY.md (incident response, RCA-required).
+
+# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json
+$SettingsPath = $env:P4_SETTINGS_PATH
+if (-not $SettingsPath) {
+    $home = [Environment]::GetFolderPath('UserProfile')
+    if (-not $home) { $home = $env:HOME }
+    $SettingsPath = Join-Path $home '.claude' 'settings.json'
+}
+
+# Override gate
+if ($env:CLAUDE_P4_OVERRIDE -eq '1') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Read input from stdin
+$json = Read-HookInput
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Settings file may not exist on fresh installs - allow (fail-open)
+if (-not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Parse settings.json once
+$settings = $null
+try {
+    $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+}
+catch {
+    # Malformed settings -> allow (other guards already enforce policy)
+    New-HookAllowResponse
+    exit 0
+}
+
+# Helper: read ISO-8601 timestamp field from harness_policies and return epoch seconds.
+# Returns $null when the field is missing or unparseable.
+function Get-IsoEpoch {
+    param([Parameter(Mandatory)][string]$Field)
+    $iso = $null
+    try {
+        $iso = $settings.harness_policies.$Field
+    } catch { return $null }
+    if (-not $iso) { return $null }
+    try {
+        $dto = [System.DateTimeOffset]::Parse(
+            $iso,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+        )
+        return [int64]$dto.ToUnixTimeSeconds()
+    } catch {
+        return $null
+    }
+}
+
+$NowEpoch = [int64][System.DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# Extract tool name
+$Tool = $null
+try { $Tool = $json.tool_name } catch {}
+
+# ── Branch 1: Bash matcher ──────────────────────────────────────
+if ($Tool -eq 'Bash') {
+    $cmd = $null
+    try { $cmd = $json.tool_input.command } catch {}
+    if ($cmd -and $cmd -match 'gh pr merge') {
+        $graceEpoch = Get-IsoEpoch -Field 'p4_grace_until'
+        if ($null -eq $graceEpoch) {
+            New-HookAllowResponse
+            exit 0
+        }
+        if ($NowEpoch -ge $graceEpoch) {
+            New-HookAllowResponse
+            exit 0
+        }
+        # Extract PR number; if missing, allow (cannot evaluate)
+        $prNum = $null
+        $prMatch = [regex]::Match($cmd, 'gh pr merge\s+(\d+)')
+        if ($prMatch.Success) { $prNum = $prMatch.Groups[1].Value }
+        if (-not $prNum) {
+            New-HookAllowResponse
+            exit 0
+        }
+        # Optional --repo flag
+        $repoArg = @()
+        $repoMatch = [regex]::Match($cmd, '--repo\s+(\S+)')
+        if ($repoMatch.Success) {
+            $repoArg = @('--repo', $repoMatch.Groups[1].Value)
+        }
+        # If gh unavailable or call fails, allow (cannot evaluate diff)
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+            New-HookAllowResponse
+            exit 0
+        }
+        $diffFiles = $null
+        try {
+            $diffFiles = & gh pr diff @repoArg $prNum --name-only 2>$null
+        } catch {
+            New-HookAllowResponse
+            exit 0
+        }
+        if ($LASTEXITCODE -ne 0) {
+            New-HookAllowResponse
+            exit 0
+        }
+        if ($diffFiles -and ($diffFiles | Where-Object { $_ -match '^global/skills/_internal/' })) {
+            $remain = $graceEpoch - $NowEpoch
+            $days = [math]::Floor($remain / 86400)
+            $hours = [math]::Floor(($remain % 86400) / 3600)
+            New-HookDenyResponse -Reason ("P4 grace window not closed (${days}d ${hours}h remaining). PR #${prNum} touches global/skills/_internal/ which requires the 7-day grace window to pass first per EPIC #454. Override with CLAUDE_P4_OVERRIDE=1 (RCA required).")
+            exit 0
+        }
+        New-HookAllowResponse
+        exit 0
+    }
+}
+
+# ── Branch 2: Edit/Write matcher (settings.json toggle flip) ────
+if ($Tool -eq 'Edit' -or $Tool -eq 'Write') {
+    $filePath = $null
+    try { $filePath = $json.tool_input.file_path } catch {}
+    if ($filePath -and ($filePath -match 'settings\.json$' -or $filePath -match 'settings\.windows\.json$')) {
+        $obsEpoch = Get-IsoEpoch -Field 'p4_observation_until'
+        if ($null -eq $obsEpoch -or $NowEpoch -ge $obsEpoch) {
+            New-HookAllowResponse
+            exit 0
+        }
+        # If current toggle is already true, nothing to flip -> allow
+        $current = $null
+        try { $current = $settings.harness_policies.p4_strict_schema } catch {}
+        if ($current -eq $true) {
+            New-HookAllowResponse
+            exit 0
+        }
+        # Detect a flip: new content sets p4_strict_schema true.
+        $newBlob = ''
+        if ($Tool -eq 'Write') {
+            try { $newBlob = $json.tool_input.content } catch {}
+        } else {
+            try { $newBlob = $json.tool_input.new_string } catch {}
+        }
+        if ($newBlob -and ($newBlob -match '"p4_strict_schema"\s*:\s*true')) {
+            $remain = $obsEpoch - $NowEpoch
+            $days = [math]::Floor($remain / 86400)
+            $hours = [math]::Floor(($remain % 86400) / 3600)
+            New-HookDenyResponse -Reason ("P4 observation window not closed (${days}d ${hours}h remaining). harness_policies.p4_strict_schema cannot be flipped to true until the 14-day observation window passes per EPIC #454. Override with CLAUDE_P4_OVERRIDE=1 (RCA required).")
+            exit 0
+        }
+    }
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/p4-timeline-reminder.ps1
+++ b/global/hooks/p4-timeline-reminder.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# p4-timeline-reminder.ps1
+# SessionStart banner that surfaces the active P4 rollout window.
+# PowerShell counterpart of p4-timeline-reminder.sh.
+# Hook Type: SessionStart
+# Exit codes: 0 (always - lifecycle event)
+# Response format: none (writes to stderr; visible in terminal)
+#
+# Reads harness_policies timestamps from ~/.claude/settings.json and prints
+# a banner on stderr indicating which window is currently active and how
+# much time remains. Silent when the rollout is fully complete (now() >=
+# p4_freeze_until) or when the relevant fields are absent.
+
+# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json
+$SettingsPath = $env:P4_SETTINGS_PATH
+if (-not $SettingsPath) {
+    $home = [Environment]::GetFolderPath('UserProfile')
+    if (-not $home) { $home = $env:HOME }
+    $SettingsPath = Join-Path $home '.claude' 'settings.json'
+}
+
+# Settings file may not exist on fresh installs - silent
+if (-not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+    exit 0
+}
+
+# Parse settings.json
+$settings = $null
+try {
+    $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+}
+catch {
+    exit 0
+}
+
+function Get-IsoEpoch {
+    param([Parameter(Mandatory)][string]$Field)
+    $iso = $null
+    try {
+        $iso = $settings.harness_policies.$Field
+    } catch { return $null }
+    if (-not $iso) { return $null }
+    try {
+        $dto = [System.DateTimeOffset]::Parse(
+            $iso,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+        )
+        return [int64]$dto.ToUnixTimeSeconds()
+    } catch {
+        return $null
+    }
+}
+
+$GraceEpoch  = Get-IsoEpoch -Field 'p4_grace_until'
+$ObsEpoch    = Get-IsoEpoch -Field 'p4_observation_until'
+$FreezeEpoch = Get-IsoEpoch -Field 'p4_freeze_until'
+
+# Silent when no timeline is configured at all
+if ($null -eq $GraceEpoch -and $null -eq $ObsEpoch -and $null -eq $FreezeEpoch) {
+    exit 0
+}
+
+$NowEpoch = [int64][System.DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# Silent when the rollout is fully complete
+if ($null -ne $FreezeEpoch -and $NowEpoch -ge $FreezeEpoch) {
+    exit 0
+}
+
+# Determine active window
+$Window = $null
+$Deadline = $null
+$NextAction = $null
+
+if ($null -ne $GraceEpoch -and $NowEpoch -lt $GraceEpoch) {
+    $Window = 'GRACE (lenient only)'
+    $Deadline = $GraceEpoch
+    $NextAction = 'D2 (#462) merge eligible after grace ends'
+}
+elseif ($null -ne $ObsEpoch -and $NowEpoch -lt $ObsEpoch) {
+    $Window = 'OBSERVATION (collecting metrics)'
+    $Deadline = $ObsEpoch
+    $NextAction = 'p4_strict_schema flip eligible after observation ends'
+}
+elseif ($null -ne $FreezeEpoch -and $NowEpoch -lt $FreezeEpoch) {
+    $Window = 'FREEZE (72h post-D2)'
+    $Deadline = $FreezeEpoch
+    $NextAction = 'Default toggle flip eligible after freeze ends'
+}
+else {
+    exit 0
+}
+
+# Format remaining time
+$remain = $Deadline - $NowEpoch
+if ($remain -le 0) {
+    $remaining = 'ended'
+} else {
+    $days = [math]::Floor($remain / 86400)
+    $hours = [math]::Floor(($remain % 86400) / 3600)
+    $remaining = "${days}d ${hours}h remaining"
+}
+
+# Format ISO deadline (UTC)
+$deadlineIso = [System.DateTimeOffset]::FromUnixTimeSeconds($Deadline).UtcDateTime.ToString('yyyy-MM-dd HH:mm') + ' UTC'
+
+# Emit banner to stderr. Use Write-Host with -ForegroundColor when stderr is a TTY;
+# fall back to plain [Console]::Error.WriteLine() for non-interactive sessions.
+$isTty = -not [Console]::IsErrorRedirected
+
+if ($isTty) {
+    [Console]::Error.WriteLine('')
+    Write-Host 'P4 Rollout Active' -ForegroundColor Yellow
+    Write-Host '  Window:   ' -NoNewline
+    Write-Host $Window -ForegroundColor Cyan
+    [Console]::Error.WriteLine("  Ends:     $deadlineIso ($remaining)")
+    Write-Host '  Next:     ' -NoNewline
+    Write-Host $NextAction -ForegroundColor Green
+    [Console]::Error.WriteLine('  Override: CLAUDE_P4_OVERRIDE=1 (RCA required; see COMPATIBILITY.md)')
+} else {
+    [Console]::Error.WriteLine('P4 Rollout Active')
+    [Console]::Error.WriteLine("  Window:   $Window")
+    [Console]::Error.WriteLine("  Ends:     $deadlineIso ($remaining)")
+    [Console]::Error.WriteLine("  Next:     $NextAction")
+    [Console]::Error.WriteLine('  Override: CLAUDE_P4_OVERRIDE=1 (RCA required; see COMPATIBILITY.md)')
+}
+
+exit 0

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -77,6 +77,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/p4-timeline-guard.ps1",
+            "timeout": 5
           }
         ]
       },
@@ -127,6 +132,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/attribution-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/p4-timeline-guard.ps1",
+            "timeout": 10
           }
         ]
       },
@@ -154,6 +164,11 @@
             "command": "pwsh -NoProfile -File ~/.claude/hooks/version-check.ps1",
             "timeout": 10,
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/p4-timeline-reminder.ps1",
+            "timeout": 5
           }
         ]
       }

--- a/tests/hooks/test-p4-timeline-guard-parity.sh
+++ b/tests/hooks/test-p4-timeline-guard-parity.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Parity test for p4-timeline-guard.sh and p4-timeline-guard.ps1 (#489).
+# For every fixture, the bash decision and the PowerShell decision MUST agree.
+# Skips silently when pwsh or jq is unavailable.
+#
+# Run: bash tests/hooks/test-p4-timeline-guard-parity.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+GUARD_SH="$ROOT_DIR/global/hooks/p4-timeline-guard.sh"
+GUARD_PS="$ROOT_DIR/global/hooks/p4-timeline-guard.ps1"
+REMINDER_SH="$ROOT_DIR/global/hooks/p4-timeline-reminder.sh"
+REMINDER_PS="$ROOT_DIR/global/hooks/p4-timeline-reminder.ps1"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not in PATH" >&2
+    exit 0
+fi
+
+if ! command -v pwsh >/dev/null 2>&1; then
+    echo "SKIP: pwsh not in PATH (parity audit requires PowerShell 7+)" >&2
+    exit 0
+fi
+
+if [ ! -f "$GUARD_PS" ]; then
+    echo "FAIL: $GUARD_PS missing — PowerShell counterpart required for parity" >&2
+    exit 1
+fi
+if [ ! -f "$REMINDER_PS" ]; then
+    echo "FAIL: $REMINDER_PS missing — PowerShell counterpart required for parity" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+write_settings() {
+    local file="$1" grace="$2" obs="$3" freeze="$4"
+    cat > "$file" <<EOF
+{
+  "harness_policies": {
+    "p4_strict_schema": false,
+    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
+    "p4_grace_until": "$grace",
+    "p4_observation_until": "$obs",
+    "p4_freeze_until": "$freeze"
+  }
+}
+EOF
+}
+
+# Run guard (bash) and capture decision
+sh_decision() {
+    local settings="$1" input="$2"
+    P4_SETTINGS_PATH="$settings" CLAUDE_P4_OVERRIDE="" bash "$GUARD_SH" <<<"$input" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // "missing"'
+}
+
+# Run guard (pwsh) and capture decision
+ps_decision() {
+    local settings="$1" input="$2"
+    P4_SETTINGS_PATH="$settings" CLAUDE_P4_OVERRIDE="" pwsh -NoProfile -File "$GUARD_PS" <<<"$input" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // "missing"'
+}
+
+# Run guard (pwsh) with override env set
+ps_decision_override() {
+    local settings="$1" input="$2"
+    P4_SETTINGS_PATH="$settings" CLAUDE_P4_OVERRIDE=1 pwsh -NoProfile -File "$GUARD_PS" <<<"$input" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // "missing"'
+}
+
+# Run guard (bash) with override env set
+sh_decision_override() {
+    local settings="$1" input="$2"
+    P4_SETTINGS_PATH="$settings" CLAUDE_P4_OVERRIDE=1 bash "$GUARD_SH" <<<"$input" 2>/dev/null \
+        | jq -r '.hookSpecificOutput.permissionDecision // "missing"'
+}
+
+assert_parity() {
+    local label="$1" sh="$2" ps="$3"
+    if [ "$sh" = "$ps" ]; then
+        PASS=$((PASS+1))
+        echo "PASS: $label (both -> $sh)"
+    else
+        FAIL=$((FAIL+1))
+        ERRORS+=("FAIL: $label (sh='$sh' vs ps='$ps')")
+    fi
+}
+
+# ── Fixture set 1: future deadlines (windows still open) ────────────
+FUTURE_SETTINGS="$WORK/future.json"
+write_settings "$FUTURE_SETTINGS" "2099-01-01T00:00:00Z" "2099-02-01T00:00:00Z" "2099-03-01T00:00:00Z"
+
+INPUT_FLIP_EDIT='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.json","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+INPUT_FLIP_WRITE='{"tool_name":"Write","tool_input":{"file_path":"/x/settings.json","content":"{\"harness_policies\":{\"p4_strict_schema\":true}}"}}'
+INPUT_OTHER='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.json","old_string":"a","new_string":"\"unrelated\": true"}}'
+INPUT_DOC='{"tool_name":"Edit","tool_input":{"file_path":"/x/docs.md","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+INPUT_LIST='{"tool_name":"Bash","tool_input":{"command":"gh pr list --repo foo/bar"}}'
+INPUT_WINDOWS_FLIP='{"tool_name":"Edit","tool_input":{"file_path":"/x/settings.windows.json","old_string":"a","new_string":"\"p4_strict_schema\": true"}}'
+
+assert_parity "future: Edit flip toggle (settings.json)" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_FLIP_EDIT")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_FLIP_EDIT")"
+
+assert_parity "future: Write flip toggle (settings.json)" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_FLIP_WRITE")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_FLIP_WRITE")"
+
+assert_parity "future: Edit unrelated field" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_OTHER")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_OTHER")"
+
+assert_parity "future: Edit non-settings doc mentioning toggle" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_DOC")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_DOC")"
+
+assert_parity "future: Bash gh pr list" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_LIST")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_LIST")"
+
+assert_parity "future: Edit flip toggle (settings.windows.json)" \
+    "$(sh_decision "$FUTURE_SETTINGS" "$INPUT_WINDOWS_FLIP")" \
+    "$(ps_decision "$FUTURE_SETTINGS" "$INPUT_WINDOWS_FLIP")"
+
+# Override env -> always allow on both implementations
+assert_parity "future: override env on flip" \
+    "$(sh_decision_override "$FUTURE_SETTINGS" "$INPUT_FLIP_EDIT")" \
+    "$(ps_decision_override "$FUTURE_SETTINGS" "$INPUT_FLIP_EDIT")"
+
+# ── Fixture set 2: past deadlines (windows closed) ──────────────────
+PAST_SETTINGS="$WORK/past.json"
+write_settings "$PAST_SETTINGS" "2000-01-01T00:00:00Z" "2000-02-01T00:00:00Z" "2000-03-01T00:00:00Z"
+
+assert_parity "past: flip after observation closed" \
+    "$(sh_decision "$PAST_SETTINGS" "$INPUT_FLIP_EDIT")" \
+    "$(ps_decision "$PAST_SETTINGS" "$INPUT_FLIP_EDIT")"
+
+assert_parity "past: Bash gh pr list (grace closed)" \
+    "$(sh_decision "$PAST_SETTINGS" "$INPUT_LIST")" \
+    "$(ps_decision "$PAST_SETTINGS" "$INPUT_LIST")"
+
+# ── Fixture set 3: missing settings.json -> fail-open (allow) ───────
+NOFILE="$WORK/does-not-exist.json"
+assert_parity "missing settings.json -> fail-open" \
+    "$(sh_decision "$NOFILE" "$INPUT_FLIP_EDIT")" \
+    "$(ps_decision "$NOFILE" "$INPUT_FLIP_EDIT")"
+
+# ── Fixture set 4: empty stdin -> allow ─────────────────────────────
+EMPTY_SH=$(P4_SETTINGS_PATH="$FUTURE_SETTINGS" bash "$GUARD_SH" </dev/null 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecision // "missing"')
+EMPTY_PS=$(P4_SETTINGS_PATH="$FUTURE_SETTINGS" pwsh -NoProfile -File "$GUARD_PS" </dev/null 2>/dev/null \
+    | jq -r '.hookSpecificOutput.permissionDecision // "missing"')
+assert_parity "empty stdin -> allow" "$EMPTY_SH" "$EMPTY_PS"
+
+# ── Fixture set 5: reminder banner parity ───────────────────────────
+# Reminder writes to stderr. We compare presence/absence of the banner header
+# rather than exact byte equality (color codes, formatting may differ slightly).
+
+reminder_emits_banner_sh() {
+    local settings="$1"
+    P4_SETTINGS_PATH="$settings" bash "$REMINDER_SH" 2>&1 >/dev/null \
+        | grep -q "P4 Rollout Active" && echo "yes" || echo "no"
+}
+reminder_emits_banner_ps() {
+    local settings="$1"
+    P4_SETTINGS_PATH="$settings" pwsh -NoProfile -File "$REMINDER_PS" 2>&1 >/dev/null \
+        | grep -q "P4 Rollout Active" && echo "yes" || echo "no"
+}
+
+assert_parity "reminder: banner inside grace window" \
+    "$(reminder_emits_banner_sh "$FUTURE_SETTINGS")" \
+    "$(reminder_emits_banner_ps "$FUTURE_SETTINGS")"
+
+assert_parity "reminder: silent after rollout complete" \
+    "$(reminder_emits_banner_sh "$PAST_SETTINGS")" \
+    "$(reminder_emits_banner_ps "$PAST_SETTINGS")"
+
+NO_TIMELINE="$WORK/no-timeline.json"
+echo '{"harness_policies":{"p4_strict_schema":false}}' > "$NO_TIMELINE"
+assert_parity "reminder: silent without timeline fields" \
+    "$(reminder_emits_banner_sh "$NO_TIMELINE")" \
+    "$(reminder_emits_banner_ps "$NO_TIMELINE")"
+
+# ── Summary ─────────────────────────────────────────────────────────
+echo ""
+echo "=== Parity Test Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    printf '%s\n' "${ERRORS[@]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

### Summary
Port the two missing bash-only hooks (`p4-timeline-guard.sh`, `p4-timeline-reminder.sh`) to PowerShell so `global/hooks/` reaches 32/32 `.sh`/`.ps1` parity. Wire the new `.ps1` hooks into `global/settings.windows.json`, add a bash/PS parity test, and add a CI parity audit that fails the PR if counts diverge.

### Change Type
- [x] Feature (PowerShell counterparts of existing bash hooks)
- [ ] Bugfix
- [ ] Refactor

### Affected Components
- `global/hooks/p4-timeline-guard.ps1` (new)
- `global/hooks/p4-timeline-reminder.ps1` (new)
- `global/settings.windows.json` (3 wiring entries added)
- `tests/hooks/test-p4-timeline-guard-parity.sh` (new)
- `.github/workflows/validate-hooks-doc.yml` (parity job added)
- `COMPATIBILITY.md` (30/32 -> 32/32)
- `HOOKS.md` (regenerated)

## Why

### Problem Solved
Two bash hooks lacked PowerShell counterparts, leaving Windows users without P4 rollout enforcement (`p4_freeze_until` is still ~3 weeks away — the rollout is active). `COMPATIBILITY.md` documented the gap as 30/32 (94%) and tracked restoration in this issue.

### Related Issues
- Closes #489
- Relates to #454 (P4 rollout EPIC)

### Alternative Approaches Considered
Sunset the hooks together with the rollout. Rejected: `p4_freeze_until = 2026-05-20` is still active, so Windows users in the rollout window need enforcement now.

## Who

### Reviewers
- @kcenon

### Stakeholders
- Windows users on the P4 rollout path

## When

### Urgency
- [x] Normal — non-blocking parity restoration before next minor release
- [ ] High Priority
- [ ] Hotfix

### Target Release
Next minor release (P4 rollout still active until 2026-05-20).

## Where

### Files Changed
| File | Change |
|---|---|
| `global/hooks/p4-timeline-guard.ps1` | New — ports the bash decision logic |
| `global/hooks/p4-timeline-reminder.ps1` | New — ports the SessionStart banner |
| `global/settings.windows.json` | Wire both hooks (Edit/Write/Read + Bash + SessionStart) |
| `tests/hooks/test-p4-timeline-guard-parity.sh` | New — bash/PS decision parity check |
| `.github/workflows/validate-hooks-doc.yml` | Add `parity` job |
| `COMPATIBILITY.md` | 30/32 (94%) -> 32/32 (100%) |
| `HOOKS.md` | Regenerated to reflect new `.ps1` counterparts |

### API/Database Changes
None.

## How

### Implementation Details
- `p4-timeline-guard.ps1` mirrors `p4-timeline-guard.sh` exactly: reads `harness_policies` ISO timestamps from `settings.json` (or `P4_SETTINGS_PATH` override), parses them via `[DateTimeOffset]::Parse` with `AssumeUniversal | AdjustToUniversal`, then applies the same two decision branches: gh pr merge touching `global/skills/_internal/` during grace -> deny; Edit/Write flipping `p4_strict_schema` to true during observation -> deny. `CLAUDE_P4_OVERRIDE=1` short-circuits both.
- `p4-timeline-reminder.ps1` emits the same banner shape as the bash version on stderr (`P4 Rollout Active`, `Window:`, `Ends:`, `Next:`, `Override:`). Silent when fields absent or rollout complete.
- Both rely on the existing `CommonHelpers.psm1` module (`Read-HookInput`, `New-HookAllowResponse`, `New-HookDenyResponse`).

### Testing Done
- `bash tests/hooks/test-p4-timeline-guard.sh` -> 12/12 passed (existing baseline preserved)
- `bash tests/hooks/test-p4-timeline-guard-parity.sh` -> skips cleanly when pwsh absent (local sandbox); intended to run on Windows / pwsh-equipped runners
- JSON validators: `global/settings.windows.json`, `global/settings.json` parse cleanly
- `bash scripts/gen-hooks-md.sh --check` -> exit 0 (HOOKS.md is in sync)
- File counts: `ls global/hooks/*.sh | wc -l` = 32; `ls global/hooks/*.ps1 | wc -l` = 32

### Test Plan for Reviewers
1. `bash tests/hooks/test-p4-timeline-guard.sh` — bash-only baseline still green
2. `bash scripts/gen-hooks-md.sh --check` — HOOKS.md drift check passes
3. Confirm parity job in `validate-hooks-doc.yml` fails when a `.sh` is removed without its `.ps1` (or vice versa)

### Breaking Changes
None.

### Rollback Plan
Revert this PR. The bash hooks remain unchanged, so POSIX behavior is unaffected even if the PS ports are reverted.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added (parity test) and existing tests pass
- [x] Documentation updated (COMPATIBILITY.md, HOOKS.md regenerated)
- [x] No sensitive data exposed
- [x] Commit is atomic and well-described
- [x] Issue linked with closing keyword (Closes #489)