### PR TITLE
docs(claude-md): add Skill Aliases dispatch table for relocated _internal skills

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -22,6 +22,29 @@ Global settings applied every session. Routing index only — procedural detail 
 - **Lifecycle skills**: `global/skills/_internal/issue-work`, `pr-work`, `release`, `branch-cleanup`
 - **Build verification**: `global/skills/_internal/pr-work/reference/build-verification.md`
 - **Skill authoring**: `global/skills/_policy.md`, `global/skills/_internal/_shared/invariants.md`
+- **Skill aliases**: see "Skill Aliases" section below
+
+## Skill Aliases (post-D2 relocation, see #491, #492)
+
+When the user types one of the keywords below as a leading command (with or without arguments, with or without a leading `/`), treat it as an explicit invocation of the corresponding `SKILL.md` under `~/.claude/skills/_internal/`. Read the SKILL.md, parse arguments per its `argument-hint`, and execute its body honoring `halt_conditions` and `max_iterations`. Do not ask for confirmation; the keyword is the invocation. This preserves `disable-model-invocation: true` semantics because the user's keyword is an explicit user invocation, not autonomous model triggering.
+
+| Keyword                | Skill path                                                  |
+|------------------------|-------------------------------------------------------------|
+| `issue-work`           | `~/.claude/skills/_internal/issue-work/SKILL.md`            |
+| `pr-work`              | `~/.claude/skills/_internal/pr-work/SKILL.md`               |
+| `release`              | `~/.claude/skills/_internal/release/SKILL.md`               |
+| `branch-cleanup`       | `~/.claude/skills/_internal/branch-cleanup/SKILL.md`        |
+| `ci-fix`               | `~/.claude/skills/_internal/ci-fix/SKILL.md`                |
+| `harness`              | `~/.claude/skills/_internal/harness/SKILL.md`               |
+| `research`             | `~/.claude/skills/_internal/research/SKILL.md`              |
+| `doc-review`           | `~/.claude/skills/_internal/doc-review/SKILL.md`            |
+| `doc-index`            | `~/.claude/skills/_internal/doc-index/SKILL.md`             |
+| `preflight`            | `~/.claude/skills/_internal/preflight/SKILL.md`             |
+| `issue-create`         | `~/.claude/skills/_internal/issue-create/SKILL.md`          |
+| `implement-all-levels` | `~/.claude/skills/_internal/implement-all-levels/SKILL.md`  |
+| `fleet-orchestrator`   | `~/.claude/skills/_internal/fleet-orchestrator/SKILL.md`    |
+
+Ambiguity rule: if a keyword appears mid-sentence (not as a leading command) or inside quotes, ask whether the user meant the skill or a literal mention before invoking.
 
 ## Updating
 
@@ -29,4 +52,4 @@ Edit the linked files and restart the session.
 
 ---
 
-*Version: 3.2.0 | Last updated: 2026-04-23*
+*Version: 3.3.0 | Last updated: 2026-04-27*


### PR DESCRIPTION
## What

### Summary
Adds a **Skill Aliases dispatch table** to `global/CLAUDE.md` so the 13 workflow skills relocated under `global/skills/_internal/` in PR #491 remain reachable through short keyword commands (e.g. `issue-work`, `pr-work`, `release`) without requiring per-session priming.

### Change Type
- [x] Documentation
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Test
- [ ] Chore

### Affected Components
- `global/CLAUDE.md` — single file changed (+24/-1)

## Why

### Problem solved
After #491 moved 13 SKILL.md files (`branch-cleanup`, `ci-fix`, `doc-index`, `doc-review`, `fleet-orchestrator`, `harness`, `implement-all-levels`, `issue-create`, `issue-work`, `pr-work`, `preflight`, `release`, `research`) under `_internal/`, Claude Code's user-invocable skill discovery treats the `_`-prefixed directory as hidden and no longer surfaces them in the available-skills catalog. Slash commands like `/issue-work` silently disappeared from daily workflows even though each SKILL.md still declares `user-invocable: true`.

### Related Issues
- Closes #492
- Related to #491 (D2 relocation), EPIC #454 (P4-b strict-schema dispatch)

### Alternatives considered
| Alternative | Rejected because |
|---|---|
| Move skills back out of `_internal/` | Conflicts with #491 / EPIC #454 strict-schema dispatch design |
| Create 13 forwarding files in `~/.claude/commands/` | Bypasses strict-schema dispatch intent; 13-file maintenance burden |
| Free-form alias (Pattern 2) | Requires per-session priming, brittle |
| Full-path invocation (Pattern 1) | Verbose; hostile UX for daily work |

## Who

### Reviewers
- @kcenon — repo owner
- Anyone touching `_internal/` skills going forward

### Required approvals
- [ ] Maintainer review

## When

### Urgency
- [x] Normal — UX restoration; not a security issue
- [ ] High Priority
- [ ] Hotfix

### Target
Next merge into `develop`. No release coupling required.

### Dependencies
- Depends on: #491 (already merged into develop / 3b3f513).
- Blocks: nothing.

## Where

### Files Changed
| Path | Change |
|---|---|
| `global/CLAUDE.md` | +24 / -1 (new section + version footer bump) |

### Architecture impact
None. The alias table is interpretive guidance loaded into Claude's session context via the existing CLAUDE.md auto-load mechanism. No directory layout changes, no new files in `commands/` or `skills/`, no schema changes.

### `disable-model-invocation: true` interaction
Preserved. The alias table fires only on explicit user keyword input (which is itself a user invocation), not autonomous model triggering. Mid-sentence or quoted occurrences are gated by the explicit "Ambiguity rule" in the new section.

## How

### Implementation
1. Added a "Skill Aliases (post-D2 relocation)" section after the Routing block listing 13 keyword → `~/.claude/skills/_internal/<name>/SKILL.md` mappings.
2. Section spec: leading-command match, optional `/` prefix, ambiguity rule for mid-sentence keywords, explicit instruction to honor each SKILL.md's `argument-hint`, `halt_conditions`, `max_iterations`.
3. Added a one-line cross-reference under the Routing list.
4. Bumped version footer `3.2.0` → `3.3.0`, date `2026-04-23` → `2026-04-27`.

### Testing done
- [x] `spec_lint.sh` clean: `mode=skill files=32 violations=0`, `mode=plugin files=2 violations=0`, `mode=settings files=3 violations=0`.
- [x] All 13 listed paths exist on disk: `for s in issue-work pr-work release branch-cleanup ci-fix harness research doc-review doc-index preflight issue-create implement-all-levels fleet-orchestrator; do test -f ~/.claude/skills/_internal/$s/SKILL.md && echo OK $s; done` → 13/13 OK.
- [x] All 13 SKILL.md files declare `user-invocable: true` (3 with `disable-model-invocation: false`, 10 with `true` — alias table is compatible with both since it triggers on explicit user input).
- [x] Diff is ASCII-only on the changed lines (line 3 em-dash predates this PR and is outside the diff).
- [x] Markdown table renders with 13 rows, single header, aligned columns.
- [x] Live deploy verified: copied to `~/.claude/CLAUDE.md`, `.install-manifest.json` SHA refreshed to `8c62f56d…7bbb`.

### Test plan for reviewers
1. Pull this branch, inspect `global/CLAUDE.md` diff (should be +24/-1).
2. Run `bash scripts/spec_lint.sh` — expect 0 violations.
3. After merge + `bootstrap.sh`, in a fresh Claude Code session type `issue-work` as a leading command — Claude should read `~/.claude/skills/_internal/issue-work/SKILL.md` and ask for arguments per its `argument-hint`.
4. Confirm a quoted mention like `"the issue-work pattern"` does NOT auto-invoke (ambiguity rule).

### Breaking changes
None. Removing the section reverts behavior to the post-#491 state.

### Rollback
Revert this single commit. No artifacts outside `global/CLAUDE.md`.
