### PR TITLE
fix(install): mirror global skills install drift and clarify invocation modes

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -171,18 +171,16 @@ See `README.md` for detailed information:
 
 ### Try a skill
 
+> **Two invocation modes.** `/git-status`, `/code-quality`, `/security-audit`, `/performance-review`, `/pr-review` are slash-catalog skills — Claude Code's `/`-autocomplete will suggest them. The workflow-automation set (`issue-work`, `pr-work`, `release`, `issue-create`, `branch-cleanup`, `harness`, `doc-index`, `doc-review`, `implement-all-levels`) is intentionally hidden under `~/.claude/skills/_internal/` and resolved by the **Skill Aliases** table in `global/CLAUDE.md`. Type the keyword as the leading command — the leading `/` is optional, but `/`-autocomplete will not suggest these. See [README → Skills](README.md#skills--what-you-can-do).
+
 ````bash
-# Check your repo status
-/git-status
+# Slash-catalog skills (autocompleted)
+/git-status                              # Check repo status
+/code-quality src/                       # Review code quality
 
-# Review code quality of a file or directory
-/code-quality src/
-
-# Create a well-structured GitHub issue
-/issue-create my-project --type feature
-
-# Automate an issue from start to PR
-/issue-work my-project 42
+# Keyword-aliased skills (no autocomplete; alias table resolves them)
+issue-create my-project --type feature   # leading slash optional
+issue-work my-project 42                 # automate an issue from start to PR
 ````
 
 ### Choose your path

--- a/README.ko.md
+++ b/README.ko.md
@@ -523,9 +523,16 @@ paths:
 
 ## 스킬 — 무엇을 할 수 있나요
 
-Claude Code에서 명령어를 입력하여 스킬을 실행할 수 있습니다.
+스킬 호출 방식은 두 가지입니다.
+
+1. **슬래시 카탈로그 스킬** (`/code-quality`, `/security-audit`, `/performance-review`, `/pr-review`, `/git-status` 및 아래의 `plugin/` 스킬들) — `~/.claude/skills/<name>/SKILL.md` 1단계 폴더로 위치하며 Claude Code의 `/` 자동완성 카탈로그에 노출됩니다. 명령어를 입력하면 하네스가 디스패치합니다.
+2. **키워드 별칭(alias) 스킬** (`/issue-work`, `/pr-work`, `/release`, `/issue-create`, `/branch-cleanup`, `/harness`, `/doc-index`, `/doc-review`, `/implement-all-levels`) — 의도적으로 `~/.claude/skills/_internal/` 하위에 격리되고 frontmatter에 `disable-model-invocation: true`가 적용되어 **`/` 자동완성 카탈로그에 노출되지 않습니다**. 메시지를 키워드로 시작하면 `global/CLAUDE.md`의 **Skill Aliases** 표가 매핑하여 실행합니다 (앞의 `/`는 선택사항). `issue-work`, `/issue-work` 둘 다 동작하지만 탭 자동완성은 제안되지 않습니다.
+
+아래 표에 각 명령의 호출 모드를 표시합니다.
 
 ### 워크플로우 자동화
+
+이 그룹의 모든 명령은 **키워드 별칭** 호출입니다 (슬래시 자동완성 없음, alias 표가 처리).
 
 | 명령어 | 기능 |
 |--------|------|
@@ -546,13 +553,15 @@ Claude Code에서 명령어를 입력하여 스킬을 실행할 수 있습니다
 
 ### 설계 및 문서화
 
-| 명령어 | 기능 |
-|--------|------|
-| `/harness` | Agent team 설계 및 모든 도메인에 대한 스킬 생성 |
-| `/doc-index` | 문서 인덱스 파일 생성 (manifest, bundles, graph, router) |
-| `/doc-review` | 정확성, 앵커, 상호 참조에 대한 마크다운 문서 리뷰 |
-| `/git-status` | 실행 가능한 인사이트가 포함된 저장소 상태 |
-| `/implement-all-levels` | 계층형 기능의 모든 티어에 대한 완전한 구현 강제 |
+`/git-status`는 슬래시 카탈로그 스킬, 나머지는 키워드 별칭입니다.
+
+| 명령어 | 모드 | 기능 |
+|--------|------|------|
+| `/harness` | keyword | Agent team 설계 및 모든 도메인에 대한 스킬 생성 |
+| `/doc-index` | keyword | 문서 인덱스 파일 생성 (manifest, bundles, graph, router) |
+| `/doc-review` | keyword | 정확성, 앵커, 상호 참조에 대한 마크다운 문서 리뷰 |
+| `/git-status` | slash | 실행 가능한 인사이트가 포함된 저장소 상태 |
+| `/implement-all-levels` | keyword | 계층형 기능의 모든 티어에 대한 완전한 구현 강제 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -565,9 +565,16 @@ When you work on files matching these patterns, the rule is automatically loaded
 
 ## Skills — What You Can Do
 
-Invoke any skill by typing its command in Claude Code.
+Skills come in two invocation modes:
+
+1. **Slash-catalog skills** (`/code-quality`, `/security-audit`, `/performance-review`, `/pr-review`, `/git-status` and the `plugin/` skills below) live as one-level folders in `~/.claude/skills/` and appear in Claude Code's `/`-autocomplete. Type the command and the harness dispatches it.
+2. **Keyword-aliased skills** (`/issue-work`, `/pr-work`, `/release`, `/issue-create`, `/branch-cleanup`, `/harness`, `/doc-index`, `/doc-review`, `/implement-all-levels`) are intentionally hidden under `~/.claude/skills/_internal/` with `disable-model-invocation: true`. They are **not** in Claude Code's `/`-autocomplete. The model resolves them via the **Skill Aliases** table in `global/CLAUDE.md` when you start your message with the keyword (the leading `/` is optional). Both `issue-work` and `/issue-work` work; tab-completion will not suggest them.
+
+The tables below mark each command's mode.
 
 ### Workflow Automation
+
+All commands in this group are **keyword-aliased** (no slash-autocomplete; resolved by the alias table).
 
 | Command | What it does |
 |---------|-------------|
@@ -588,13 +595,15 @@ Invoke any skill by typing its command in Claude Code.
 
 ### Design and Documentation
 
-| Command | What it does |
-|---------|-------------|
-| `/harness` | Design agent teams and generate skills for any domain |
-| `/doc-index` | Generate documentation index files (manifest, bundles, graph, router) |
-| `/doc-review` | Review markdown documents for accuracy, anchors, cross-references |
-| `/git-status` | Repository status with actionable insights |
-| `/implement-all-levels` | Enforce complete implementation of all tiers for tiered features |
+`/git-status` is a slash-catalog skill; the rest in this table are keyword-aliased.
+
+| Command | Mode | What it does |
+|---------|------|-------------|
+| `/harness` | keyword | Design agent teams and generate skills for any domain |
+| `/doc-index` | keyword | Generate documentation index files (manifest, bundles, graph, router) |
+| `/doc-review` | keyword | Review markdown documents for accuracy, anchors, cross-references |
+| `/git-status` | slash | Repository status with actionable insights |
+| `/implement-all-levels` | keyword | Enforce complete implementation of all tiers for tiered features |
 
 ---
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -161,6 +161,30 @@ function Install-GlobalSettings {
     # Legacy settings.json migration warning (informational only).
     $null = Show-LegacySettingsWarning -SettingsPath (Join-Path $HOME '.claude/settings.json') -NewSelection $contentLanguage
 
+    # Install global skills and commands.
+    # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
+    # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의
+    # "Skill Aliases" 표에 따라 leading keyword 호출로만 실행된다.
+    $globalSkillsSrc = Join-Path $InstallDir 'global' 'skills'
+    if (Test-Path -LiteralPath $globalSkillsSrc -PathType Container) {
+        $globalSkillsDst = Join-Path $ClaudeDir 'skills'
+        if (-not (Test-Path $globalSkillsDst)) {
+            New-Item -ItemType Directory -Path $globalSkillsDst -Force | Out-Null
+        }
+        Copy-Item -Path "$globalSkillsSrc\*" -Destination $globalSkillsDst -Recurse -Force
+        $skillCount = (Get-ChildItem -Path $globalSkillsDst -Filter SKILL.md -Recurse -ErrorAction SilentlyContinue).Count
+        Write-Ok "글로벌 skills 설치 완료 ($skillCount 개)"
+    }
+    $globalCommandsSrc = Join-Path $InstallDir 'global' 'commands'
+    if (Test-Path -LiteralPath $globalCommandsSrc -PathType Container) {
+        $globalCommandsDst = Join-Path $ClaudeDir 'commands'
+        if (-not (Test-Path $globalCommandsDst)) {
+            New-Item -ItemType Directory -Path $globalCommandsDst -Force | Out-Null
+        }
+        Copy-Item -Path "$globalCommandsSrc\*" -Destination $globalCommandsDst -Recurse -Force
+        Write-Ok "글로벌 commands 설치 완료"
+    }
+
     # tmux config installation
     $tmuxConf = Join-Path $InstallDir 'global' 'tmux.conf'
     if (Test-Path -LiteralPath $tmuxConf) {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -165,6 +165,22 @@ install_global() {
         fi
     fi
 
+    # 글로벌 skills 및 commands 설치
+    # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
+    # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의
+    # "Skill Aliases" 표에 따라 leading keyword 호출로만 실행된다.
+    if [ -d "$INSTALL_DIR/global/skills" ]; then
+        mkdir -p "$CLAUDE_DIR/skills"
+        cp -r "$INSTALL_DIR/global/skills"/. "$CLAUDE_DIR/skills/"
+        skill_count=$(find "$CLAUDE_DIR/skills" -name "SKILL.md" | wc -l | tr -d ' ')
+        success "글로벌 skills 설치 완료 (${skill_count}개)"
+    fi
+    if [ -d "$INSTALL_DIR/global/commands" ]; then
+        mkdir -p "$CLAUDE_DIR/commands"
+        cp -r "$INSTALL_DIR/global/commands"/. "$CLAUDE_DIR/commands/"
+        success "글로벌 commands 설치 완료"
+    fi
+
     # tmux 설정 설치
     if [ -f "$INSTALL_DIR/global/tmux.conf" ]; then
         cp "$INSTALL_DIR/global/tmux.conf" "$HOME/.tmux.conf"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -510,6 +510,37 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         }
     }
 
+    # Install global skills (mirrors install.sh:473-484).
+    # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
+    # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의
+    # "Skill Aliases" 표에 따라 leading keyword 호출로만 실행된다.
+    # `Copy-Item -Path "$src\*"` 패턴으로 _policy.md 같은 루트 레벨 파일까지 복사한다.
+    $skillsSource = Join-Path $BackupDir "global/skills"
+    if (Test-Path $skillsSource) {
+        $skillsDir = Join-Path $claudeDir "skills"
+        Ensure-Directory $skillsDir
+        try {
+            Copy-Item -Path "$skillsSource\*" -Destination $skillsDir -Recurse -Force -ErrorAction Stop
+            $skillCount = (Get-ChildItem -Path $skillsDir -Filter SKILL.md -Recurse -ErrorAction SilentlyContinue).Count
+            Write-Success "Global Skills ($skillCount) installed!"
+        } catch {
+            Write-Err "Failed to copy global skills: $_"
+        }
+    }
+
+    # Install global commands (mirrors install.sh:485-489).
+    $commandsSource = Join-Path $BackupDir "global/commands"
+    if (Test-Path $commandsSource) {
+        $commandsDir = Join-Path $claudeDir "commands"
+        Ensure-Directory $commandsDir
+        try {
+            Copy-Item -Path "$commandsSource\*" -Destination $commandsDir -Recurse -Force -ErrorAction Stop
+            Write-Success "Global Commands installed!"
+        } catch {
+            Write-Err "Failed to copy global commands: $_"
+        }
+    }
+
     # Install ccstatusline settings (~/.config/ccstatusline/ — ccstatusline default settings path)
     $ccstatuslineSource = Join-Path $BackupDir "global/ccstatusline"
     if (Test-Path $ccstatuslineSource) {
@@ -675,6 +706,12 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
     Write-Host "    - ~/.claude/settings.json (Hook settings - Windows)"
     Write-Host "    - ~/.claude/hooks/ (PowerShell + bash hook scripts, lib/, data)"
     Write-Host "    - ~/.claude/scripts/ (PowerShell + bash utility scripts)"
+    if (Test-Path (Join-Path $HOME ".claude/skills")) {
+        Write-Host "    - ~/.claude/skills/ (Global skills — keyword-invoked via CLAUDE.md alias table)"
+    }
+    if (Test-Path (Join-Path $HOME ".claude/commands")) {
+        Write-Host "    - ~/.claude/commands/ (Global commands)"
+    }
     Write-Host "    - ~/.config/ccstatusline/ (ccstatusline settings)"
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -471,13 +471,13 @@ PY
     fi
 
     # skills 디렉토리 설치 (global skills: harness, pr-work, issue-work, etc.)
+    # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
+    # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의
+    # "Skill Aliases" 표에 따라 leading keyword 호출로만 실행된다.
+    # `cp -r src/. dst/` 점 트릭으로 _policy.md 같은 루트 레벨 파일까지 복사한다.
     if [ -d "$BACKUP_DIR/global/skills" ]; then
         mkdir -p "$HOME/.claude/skills"
-        for skill_dir in "$BACKUP_DIR/global/skills"/*/; do
-            if [ -d "$skill_dir" ]; then
-                cp -r "$skill_dir" "$HOME/.claude/skills/"
-            fi
-        done
+        cp -r "$BACKUP_DIR/global/skills"/. "$HOME/.claude/skills/"
         skill_count=$(find "$HOME/.claude/skills" -name "SKILL.md" | wc -l | tr -d ' ')
         success "Global Skills (${skill_count}개) 설치 완료!"
     fi


### PR DESCRIPTION
## What

### Summary
Two-part fix for the keyword-aliased global skills (`issue-work`, `pr-work`, `release`, `branch-cleanup`, `harness`, `doc-index`, `doc-review`, `issue-create`, `implement-all-levels`, `ci-fix`, `research`, `preflight`, `fleet-orchestrator`):

1. **Install scripts** — `install.ps1`, `bootstrap.ps1`, and `bootstrap.sh` had no global skills/commands install block at all, and `install.sh`'s `*/` glob was missing root-level files like `_policy.md`. PowerShell-only installs left `~/.claude/skills/` empty, so the **Skill Aliases** table in `global/CLAUDE.md` had no `SKILL.md` files to dispatch to.
2. **Documentation** — `README.md` / `README.ko.md` / `QUICKSTART.md` listed every skill the same way, suggesting all of them appear in Claude Code's `/`-autocomplete. The `_internal/`-isolated set with `disable-model-invocation: true` does not, by design — but the docs never said so.

### Change Type
- [x] Bugfix (install drift)
- [x] Documentation (invocation modes)
- [ ] Feature
- [ ] Refactor

### Affected Components
- `scripts/install.ps1`, `scripts/install.sh`
- `bootstrap.ps1`, `bootstrap.sh`
- `README.md`, `README.ko.md`, `QUICKSTART.md`

## Why

### Problem Solved
A user reported that `/issue-work` and the other workflow-automation skills did not appear in `/`-autocomplete after running `install.ps1`. Two separate causes were uncovered:

- The Windows installers never copied `global/skills/` into `~/.claude/skills/` (drift between `install.sh` and `install.ps1`/`bootstrap.*`). With no SKILL.md on disk, the alias table cannot resolve anything.
- Even when the skills are present, they are intentionally placed under `~/.claude/skills/_internal/` with `disable-model-invocation: true`, so Claude Code's slash-catalog scanner skips them. The docs did not communicate this design, so users assumed `/issue-work` was broken.

### Related Issues
No tracking issue was filed before the fix. This PR documents the root cause directly in the commit messages and PR body. (Repo follows a 5W1H rule — flagging this as a deviation worth resolving by retro-filing if maintainers prefer.)

### Alternative Approaches Considered
1. **Move skills out of `_internal/` into `~/.claude/skills/<name>/`** — would expose them in `/`-autocomplete but defeats the original isolation intent (`disable-model-invocation: true` + `_internal/` was a deliberate "user-only invocation" design, see #491/#492). Rejected.
2. **Drop `disable-model-invocation` and keep `_internal/`** — would not help, since Claude Code's slash-catalog scanner ignores `_`-prefixed top-level dirs regardless of frontmatter. Rejected.
3. **Patch only `install.ps1`** — leaves `bootstrap.ps1`/`bootstrap.sh` and the `install.sh` `_policy.md` gap untouched. Rejected; we mirror everywhere.

## Who

### Reviewers
Repo maintainers — install scripts and CLAUDE.md alias table are sensitive surfaces.

### Required Approvals
- [ ] Code owner approval (install scripts)

## When

### Urgency
- [x] Normal — not blocking a release

### Target Release
Next minor release of `claude-config`.

### Deployment Notes
None. Idempotent: running `install.ps1` after merge will populate `~/.claude/skills/` and `~/.claude/commands/` if they are missing; existing files are overwritten with `Copy-Item -Force`.

## Where

### Files Changed

| File | Type of Change |
|------|----------------|
| `scripts/install.ps1` | Add global skills + commands copy block; extend post-install summary |
| `scripts/install.sh` | Replace `*/` glob with `cp -r src/. dst/` so `_policy.md` is included |
| `bootstrap.ps1` | Add global skills + commands install block in `Install-GlobalSettings` |
| `bootstrap.sh` | Same block in `install_global` |
| `README.md` | Skills section header documents two invocation modes; tables annotated |
| `README.ko.md` | Mirror of README.md changes (Korean) |
| `QUICKSTART.md` | Try-a-skill block split into slash-catalog vs keyword-aliased examples |

### API/Database Changes
None.

## How

### Implementation Details
- Copy semantics unified: `Copy-Item -Path "$src\*" -Recurse -Force` (PowerShell) and `cp -r "$src"/. "$dst/"` (bash) both pull every entry — directories and root-level files — into the destination.
- The `install.ps1` block sits between the hooks pairing audit and the ccstatusline copy, mirroring `install.sh`'s ordering. Both `bootstrap.*` blocks land just before tmux setup.
- Each new block carries an inline comment explaining the `_internal/` isolation intent and pointing at the alias table, so a future drop-by edit cannot silently re-introduce the drift.
- Documentation reuses the existing skill tables; only the section header and a per-table mode annotation were added. The `global/CLAUDE.md` Skill Aliases table itself is unchanged.

### Testing Done
- [x] Manual: ran the patched `install.ps1` block logic against `D:/Sources/claude-config/global/skills/` — `Copy-Item -Path "$src\*" -Recurse -Force` produces `~/.claude/skills/_internal/<name>/SKILL.md` and `~/.claude/skills/_policy.md` matching the source layout.
- [x] Manual: confirmed `cp -r src/. dst/` form for `install.sh`/`bootstrap.sh` includes `_policy.md`.
- [x] Lint: commit-msg hook passes for both commits (`fix(install)`, `docs(skills)`).
- [ ] CI on PR — to be observed.

### Test Plan for Reviewers
1. Run `pwsh ./scripts/install.ps1` (option 1, Global only) on a fresh `~/.claude/`.
2. Confirm `~/.claude/skills/_internal/<name>/SKILL.md` exists for all 13 keyword-aliased skills, plus `~/.claude/skills/_policy.md`.
3. Confirm `~/.claude/commands/_policy.md` exists.
4. In Claude Code, type `issue-work` (no slash) or `/issue-work` as the leading command and confirm the alias table dispatches the SKILL.md.
5. Type `/` and confirm the slash-autocomplete does **not** suggest `/issue-work` (this is the intended design).

### Breaking Changes
None.

### Rollback Plan
Revert this PR. Existing `~/.claude/skills/` content is preserved; users only need to re-run `install.ps1` to get back to the previous (broken) state — there is no destructive operation to undo.

## Checklist

- [x] Code follows project style guidelines (Conventional Commits, no AI attribution)
- [x] Self-review completed
- [x] Tests added/updated — manual verification documented in Test Plan
- [x] Documentation updated (README.md, README.ko.md, QUICKSTART.md)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (`fix(install)` + `docs(skills)`)
- [ ] Related issue(s) linked — no pre-existing issue; root cause documented in PR body
