### PR TITLE
feat(install): auto-install Claude Code CLI in bootstrap and install scripts

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -52,6 +52,80 @@ function Test-Dependencies {
     Write-Ok "의존성 확인 완료"
 }
 
+# ── Ensure Claude Code CLI is installed ──────────────────────
+# version-check.ps1, batch-issue-work.ps1 등이 `claude --version` / `claude`
+# 명령을 호출하므로 미설치 시 silent failure가 발생한다. 본 함수는 부트스트랩
+# 시점에 사용자 동의 하에 npm 경로로 Claude Code CLI를 설치한다.
+function Confirm-ClaudeCli {
+    Write-Info "Claude Code CLI 확인 중..."
+
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        try {
+            $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+        }
+        catch {
+            $ccVersion = $null
+        }
+        if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+        Write-Ok "Claude Code CLI 이미 설치됨: $ccVersion"
+        return
+    }
+
+    Write-Warn "Claude Code CLI가 설치되어 있지 않습니다."
+    Write-Host "  Claude Code CLI는 hooks(version-check), batch scripts(issue-work, pr-work) 등이"
+    Write-Host "  의존하는 핵심 도구입니다. 미설치 상태에서는 일부 기능이 동작하지 않습니다."
+    Write-Host ""
+
+    $installClaude = Read-Host "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]"
+    if ([string]::IsNullOrEmpty($installClaude)) { $installClaude = 'y' }
+
+    if ($installClaude -ne 'y') {
+        Write-Warn "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        return
+    }
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Warn "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
+        Write-Host "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
+        Write-Host "    npm install -g @anthropic-ai/claude-code"
+        Write-Host ""
+        Write-Host "  Node.js 설치 안내 (Windows):"
+        Write-Host "    winget install OpenJS.NodeJS.LTS"
+        Write-Host "    또는: choco install nodejs-lts"
+        return
+    }
+
+    Write-Info "npm install -g @anthropic-ai/claude-code 실행 중..."
+    try {
+        & npm install -g '@anthropic-ai/claude-code'
+        if ($LASTEXITCODE -eq 0) {
+            if (Get-Command claude -ErrorAction SilentlyContinue) {
+                try {
+                    $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+                }
+                catch {
+                    $ccVersion = $null
+                }
+                if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+                Write-Ok "Claude Code CLI 설치 완료: $ccVersion"
+            }
+            else {
+                Write-Warn "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
+                Write-Host "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+            }
+        }
+        else {
+            Write-Warn "Claude Code CLI 자동 설치 실패. (exit code: $LASTEXITCODE)"
+            Write-Host "  수동 설치를 시도하거나 권한 문제일 수 있습니다:"
+            Write-Host "    npm install -g @anthropic-ai/claude-code"
+        }
+    }
+    catch {
+        Write-Warn "Claude Code CLI 자동 설치 중 예외 발생: $($_.Exception.Message)"
+        Write-Host "  수동 설치: npm install -g @anthropic-ai/claude-code"
+    }
+}
+
 # ── Clone repository ─────────────────────────────────────────
 
 function Invoke-CloneRepository {
@@ -365,6 +439,7 @@ function Install-ProjectSettings {
 
 function Invoke-Main {
     Test-Dependencies
+    Confirm-ClaudeCli
     Invoke-CloneRepository
 
     $installType = Select-InstallType

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,6 +71,63 @@ check_dependencies() {
     success "의존성 확인 완료"
 }
 
+# Claude Code CLI 설치 확인 및 자동 설치
+# version-check.sh, batch-issue-work.sh 등이 `claude --version` / `claude` 명령을
+# 호출하므로 미설치 시 silent failure가 발생한다. 본 함수는 부트스트랩 시점에
+# 사용자 동의 하에 npm 경로로 Claude Code CLI를 설치한다.
+ensure_claude_cli() {
+    info "Claude Code CLI 확인 중..."
+
+    if command -v claude >/dev/null 2>&1; then
+        local cc_version
+        cc_version="$(claude --version 2>/dev/null | head -n1)"
+        success "Claude Code CLI 이미 설치됨: ${cc_version:-version unknown}"
+        return 0
+    fi
+
+    warning "Claude Code CLI가 설치되어 있지 않습니다."
+    echo "  Claude Code CLI는 hooks(version-check), batch scripts(issue-work, pr-work) 등이"
+    echo "  의존하는 핵심 도구입니다. 미설치 상태에서는 일부 기능이 동작하지 않습니다."
+    echo ""
+
+    read -p "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]: " INSTALL_CLAUDE
+    INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
+
+    if [ "$INSTALL_CLAUDE" != "y" ]; then
+        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        return 0
+    fi
+
+    if ! command -v npm >/dev/null 2>&1; then
+        warning "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
+        echo "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
+        echo "    npm install -g @anthropic-ai/claude-code"
+        echo ""
+        echo "  Node.js 설치 안내:"
+        echo "    - macOS:        brew install node"
+        echo "    - Debian/Ubuntu: sudo apt-get install -y nodejs npm"
+        echo "    - RHEL/Fedora:  sudo dnf install -y nodejs npm"
+        return 0
+    fi
+
+    info "npm install -g @anthropic-ai/claude-code 실행 중..."
+    if npm install -g @anthropic-ai/claude-code; then
+        if command -v claude >/dev/null 2>&1; then
+            local cc_version
+            cc_version="$(claude --version 2>/dev/null | head -n1)"
+            success "Claude Code CLI 설치 완료: ${cc_version:-version unknown}"
+        else
+            warning "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
+            echo "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+        fi
+    else
+        warning "Claude Code CLI 자동 설치 실패."
+        echo "  수동 설치를 시도하거나 권한(sudo) 문제일 수 있습니다:"
+        echo "    npm install -g @anthropic-ai/claude-code"
+        echo "    또는: sudo npm install -g @anthropic-ai/claude-code"
+    fi
+}
+
 # 저장소 클론
 clone_repository() {
     info "저장소 클론 중..."
@@ -277,6 +334,7 @@ install_project() {
 # 메인 실행
 main() {
     check_dependencies
+    ensure_claude_cli
     clone_repository
     select_install_type
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -136,6 +136,79 @@ function Test-Administrator {
     }
 }
 
+# Verify Claude Code CLI presence and offer interactive installation.
+# version-check.ps1 hook and batch-* scripts call `claude --version` / `claude`
+# directly; deploying configuration without the CLI causes silent failures.
+function Confirm-ClaudeCli {
+    Write-Info "Checking Claude Code CLI..."
+
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        try {
+            $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+        }
+        catch {
+            $ccVersion = $null
+        }
+        if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+        Write-Success "Claude Code CLI already installed: $ccVersion"
+        return
+    }
+
+    Write-Warn "Claude Code CLI is not installed."
+    Write-Host "  Hooks (version-check) and batch scripts (issue-work, pr-work) call the"
+    Write-Host "  'claude' command directly. Some features will not work without it."
+    Write-Host ""
+
+    $installClaude = Read-Host "Install Claude Code CLI now? (y/n) [default: y]"
+    if ([string]::IsNullOrEmpty($installClaude)) { $installClaude = 'y' }
+
+    if ($installClaude -ne 'y') {
+        Write-Warn "Skipping Claude Code CLI install. Manual install: npm install -g @anthropic-ai/claude-code"
+        return
+    }
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Warn "npm is not installed; cannot auto-install."
+        Write-Host "  Install Node.js/npm first, then run:"
+        Write-Host "    npm install -g @anthropic-ai/claude-code"
+        Write-Host ""
+        Write-Host "  Node.js install hint (Windows):"
+        Write-Host "    winget install OpenJS.NodeJS.LTS"
+        Write-Host "    or:    choco install nodejs-lts"
+        return
+    }
+
+    Write-Info "Running: npm install -g @anthropic-ai/claude-code"
+    try {
+        & npm install -g '@anthropic-ai/claude-code'
+        if ($LASTEXITCODE -eq 0) {
+            if (Get-Command claude -ErrorAction SilentlyContinue) {
+                try {
+                    $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+                }
+                catch {
+                    $ccVersion = $null
+                }
+                if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+                Write-Success "Claude Code CLI installed: $ccVersion"
+            }
+            else {
+                Write-Warn "npm install succeeded but 'claude' is not on PATH."
+                Write-Host "  Verify npm global bin is on PATH: npm config get prefix"
+            }
+        }
+        else {
+            Write-Warn "Claude Code CLI auto-install failed (exit code: $LASTEXITCODE)."
+            Write-Host "  Try manual install or check permissions:"
+            Write-Host "    npm install -g @anthropic-ai/claude-code"
+        }
+    }
+    catch {
+        Write-Warn "Exception during Claude Code CLI install: $($_.Exception.Message)"
+        Write-Host "  Manual install: npm install -g @anthropic-ai/claude-code"
+    }
+}
+
 # ── Enterprise installation ──────────────────────────────────
 
 function Install-Enterprise {
@@ -230,6 +303,10 @@ Write-Host "    (PowerShell Edition)                            " -ForegroundCol
 Write-Host "                                                    " -ForegroundColor Blue
 Write-Host "==================================================" -ForegroundColor Blue
 Write-Host ""
+
+# ── Claude Code CLI presence check ────────────────────────────
+
+Confirm-ClaudeCli
 
 # ── Installation type selection ───────────────────────────────
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,6 +70,58 @@ check_dependencies() {
     fi
 }
 
+# 함수: Claude Code CLI 설치 확인 및 자동 설치
+# version-check.sh 등 hook 스크립트와 batch-issue-work.sh / batch-pr-work.sh가
+# `claude --version` / `claude` 명령을 직접 호출한다. 미설치 상태에서 설정만
+# 배포되면 silent failure가 발생하므로 설치 시점에 동의 기반 자동 설치를 제공한다.
+ensure_claude_cli() {
+    info "Claude Code CLI 확인 중..."
+
+    if command -v claude >/dev/null 2>&1; then
+        local cc_version
+        cc_version="$(claude --version 2>/dev/null | head -n1)"
+        success "Claude Code CLI 이미 설치됨: ${cc_version:-version unknown}"
+        return 0
+    fi
+
+    warning "Claude Code CLI가 설치되어 있지 않습니다."
+    echo "  설치된 hook(version-check) 및 batch 스크립트가 'claude' 명령을 호출하므로,"
+    echo "  미설치 상태에서는 일부 기능이 정상 동작하지 않습니다."
+    echo ""
+
+    read -p "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]: " INSTALL_CLAUDE
+    INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
+
+    if [ "$INSTALL_CLAUDE" != "y" ]; then
+        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        return 0
+    fi
+
+    if ! command -v npm >/dev/null 2>&1; then
+        warning "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
+        echo "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
+        echo "    npm install -g @anthropic-ai/claude-code"
+        return 0
+    fi
+
+    info "npm install -g @anthropic-ai/claude-code 실행 중..."
+    if npm install -g @anthropic-ai/claude-code; then
+        if command -v claude >/dev/null 2>&1; then
+            local cc_version
+            cc_version="$(claude --version 2>/dev/null | head -n1)"
+            success "Claude Code CLI 설치 완료: ${cc_version:-version unknown}"
+        else
+            warning "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
+            echo "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+        fi
+    else
+        warning "Claude Code CLI 자동 설치 실패."
+        echo "  수동 설치를 시도하거나 권한(sudo) 문제일 수 있습니다:"
+        echo "    npm install -g @anthropic-ai/claude-code"
+        echo "    또는: sudo npm install -g @anthropic-ai/claude-code"
+    fi
+}
+
 # 함수: CLAUDE.local.md 생성
 create_local_claude() {
     local project_dir="$1"
@@ -245,6 +297,7 @@ install_enterprise() {
 
 # 의존성 확인
 check_dependencies
+ensure_claude_cli
 
 # 설치 타입 선택
 echo ""


### PR DESCRIPTION
## What

### Summary
Bootstrap (`bootstrap.sh`, `bootstrap.ps1`) and install (`scripts/install.sh`, `scripts/install.ps1`) entry points now detect missing Claude Code CLI and offer an interactive npm-based auto-install. Existing CLI installs are detected and skipped.

### Change Type
- [x] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation

### Affected Components
- `bootstrap.sh` — `ensure_claude_cli()` added, called from `main()` after `check_dependencies`
- `bootstrap.ps1` — `Confirm-ClaudeCli` added, called from `Invoke-Main` after `Test-Dependencies`
- `scripts/install.sh` — `ensure_claude_cli()` added, called after `check_dependencies`
- `scripts/install.ps1` — `Confirm-ClaudeCli` added, called after the banner, before install-type selection

## Why

Several hooks and batch scripts call `claude --version` or `claude` directly:

- `global/hooks/version-check.sh` / `version-check.ps1`
- `scripts/batch-issue-work.sh` / `batch-issue-work.ps1`
- `scripts/batch-pr-work.sh` / `batch-pr-work.ps1`

Deploying the configuration without the CLI installed causes silent failures at runtime (`PREREQUISITES.md` lists `git`, `jq`, `gh`, `perl`, `bash` but not the CLI itself). Detecting and offering installation at bootstrap/install time closes that gap.

## Where

| File | Insertions |
|------|-----------:|
| `bootstrap.sh` | +58 |
| `bootstrap.ps1` | +75 |
| `scripts/install.sh` | +53 |
| `scripts/install.ps1` | +77 |

Total: 4 files changed, 263 insertions(+).

## How

### Implementation
- Detection: `command -v claude` (POSIX) / `Get-Command claude -ErrorAction SilentlyContinue` (PowerShell)
- If installed: print `claude --version | head -n1` and return early
- If missing:
  1. Prompt for consent (default: `y`)
  2. If `npm` is available: run `npm install -g @anthropic-ai/claude-code`
  3. If `npm` is missing: print OS-specific Node.js install hints (`brew` / `apt` / `dnf`, `winget` / `choco`)
- Post-install verification: re-check `command -v claude` and print version
- Failure mode: fail-soft — emit a warning but never abort the rest of the install

### Test Plan for Reviewers
1. Run `bash bootstrap.sh` on a system without `claude` on PATH — verify the prompt appears and `npm install -g @anthropic-ai/claude-code` runs
2. Run `bash bootstrap.sh` on a system with `claude` already installed — verify the function prints the version and skips the prompt
3. Run `bash bootstrap.sh` on a system without `npm` — verify the warning includes Node.js install hints
4. Repeat 1–3 with `pwsh -File bootstrap.ps1` on Windows
5. Repeat 1–3 with `bash scripts/install.sh` and `pwsh -File scripts/install.ps1` (post-clone install path)

### Testing Done
- [x] `bash -n` syntax check passes on `bootstrap.sh` and `scripts/install.sh`
- [x] Function definition + invocation locations verified across all four files
- [ ] PowerShell parser check — `pwsh` was not available on the local runner; please verify on a Windows runner before merge

### Breaking Changes
None. Existing users with the CLI installed see only one extra `success` line. Non-interactive runs piping `n` (or any non-`y` answer) preserve the previous behavior with an informational warning.

### Rollback Plan
Revert this PR. The added functions are isolated and have no callers outside the entry points.

## Notes

- No linked issue: filing this as a direct enhancement to close an observed gap between hook/script expectations and the documented prerequisites. Happy to retroactively add an issue link if reviewers prefer.
- CI policy: per `branching-strategy.md`, CI runs only on `main`-targeted PRs, so this PR (targeting `develop`) does not trigger the workflow suite. CI verification will run on the eventual `develop` → `main` release PR.
