### PR TITLE
refactor(install): switch Claude Code CLI auto-install to native installer

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -55,7 +55,9 @@ function Test-Dependencies {
 # ── Ensure Claude Code CLI is installed ──────────────────────
 # version-check.ps1, batch-issue-work.ps1 등이 `claude --version` / `claude`
 # 명령을 호출하므로 미설치 시 silent failure가 발생한다. 본 함수는 부트스트랩
-# 시점에 사용자 동의 하에 npm 경로로 Claude Code CLI를 설치한다.
+# 시점에 사용자 동의 하에 Anthropic 공식 native installer로 Claude Code CLI를
+# 설치한다.
+# 참고: https://code.claude.com/docs/en/setup
 function Confirm-ClaudeCli {
     Write-Info "Claude Code CLI 확인 중..."
 
@@ -80,49 +82,49 @@ function Confirm-ClaudeCli {
     if ([string]::IsNullOrEmpty($installClaude)) { $installClaude = 'y' }
 
     if ($installClaude -ne 'y') {
-        Write-Warn "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        Write-Warn "Claude Code CLI 설치 건너뜀. 추후 수동 설치:"
+        Write-Host "    irm https://claude.ai/install.ps1 | iex"
         return
     }
 
-    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        Write-Warn "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
-        Write-Host "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
-        Write-Host "    npm install -g @anthropic-ai/claude-code"
-        Write-Host ""
-        Write-Host "  Node.js 설치 안내 (Windows):"
-        Write-Host "    winget install OpenJS.NodeJS.LTS"
-        Write-Host "    또는: choco install nodejs-lts"
-        return
-    }
-
-    Write-Info "npm install -g @anthropic-ai/claude-code 실행 중..."
+    # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
+    # 설치 경로: $env:USERPROFILE\.local\bin\claude.exe (Windows) /
+    #           ~/.local/bin/claude (macOS, Linux, WSL)
+    $installerUrl = 'https://claude.ai/install.ps1'
+    Write-Info "Native installer 실행 중: $installerUrl"
     try {
-        & npm install -g '@anthropic-ai/claude-code'
-        if ($LASTEXITCODE -eq 0) {
-            if (Get-Command claude -ErrorAction SilentlyContinue) {
-                try {
-                    $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
-                }
-                catch {
-                    $ccVersion = $null
-                }
-                if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
-                Write-Ok "Claude Code CLI 설치 완료: $ccVersion"
-            }
-            else {
-                Write-Warn "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
-                Write-Host "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+        $installerScript = Invoke-RestMethod -Uri $installerUrl -ErrorAction Stop
+        Invoke-Expression $installerScript
+
+        # PATH에 새로 추가된 ~/.local/bin이 아직 반영되지 않았을 수 있다.
+        $localBin = Join-Path $HOME '.local' 'bin'
+        if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+            if (Test-Path $localBin) {
+                $env:PATH = "$localBin$([System.IO.Path]::PathSeparator)$env:PATH"
             }
         }
+
+        if (Get-Command claude -ErrorAction SilentlyContinue) {
+            try {
+                $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+            }
+            catch {
+                $ccVersion = $null
+            }
+            if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+            Write-Ok "Claude Code CLI 설치 완료: $ccVersion"
+            $claudePath = (Get-Command claude -ErrorAction SilentlyContinue).Source
+            if ($claudePath) { Write-Host "  설치 위치: $claudePath" }
+        }
         else {
-            Write-Warn "Claude Code CLI 자동 설치 실패. (exit code: $LASTEXITCODE)"
-            Write-Host "  수동 설치를 시도하거나 권한 문제일 수 있습니다:"
-            Write-Host "    npm install -g @anthropic-ai/claude-code"
+            Write-Warn "Native installer는 종료되었으나 'claude'를 PATH에서 찾을 수 없습니다."
+            Write-Host "  새 PowerShell 세션을 시작하거나 PATH를 갱신하세요."
         }
     }
     catch {
-        Write-Warn "Claude Code CLI 자동 설치 중 예외 발생: $($_.Exception.Message)"
-        Write-Host "  수동 설치: npm install -g @anthropic-ai/claude-code"
+        Write-Warn "Claude Code CLI 자동 설치 실패: $($_.Exception.Message)"
+        Write-Host "  수동 설치: irm https://claude.ai/install.ps1 | iex"
+        Write-Host "  또는 Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
     }
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,7 +74,8 @@ check_dependencies() {
 # Claude Code CLI 설치 확인 및 자동 설치
 # version-check.sh, batch-issue-work.sh 등이 `claude --version` / `claude` 명령을
 # 호출하므로 미설치 시 silent failure가 발생한다. 본 함수는 부트스트랩 시점에
-# 사용자 동의 하에 npm 경로로 Claude Code CLI를 설치한다.
+# 사용자 동의 하에 Anthropic 공식 native installer로 Claude Code CLI를 설치한다.
+# 참고: https://code.claude.com/docs/en/setup
 ensure_claude_cli() {
     info "Claude Code CLI 확인 중..."
 
@@ -94,37 +95,47 @@ ensure_claude_cli() {
     INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
 
     if [ "$INSTALL_CLAUDE" != "y" ]; then
-        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치:"
+        echo "    curl -fsSL https://claude.ai/install.sh | bash"
         return 0
     fi
 
-    if ! command -v npm >/dev/null 2>&1; then
-        warning "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
-        echo "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
-        echo "    npm install -g @anthropic-ai/claude-code"
-        echo ""
-        echo "  Node.js 설치 안내:"
-        echo "    - macOS:        brew install node"
-        echo "    - Debian/Ubuntu: sudo apt-get install -y nodejs npm"
-        echo "    - RHEL/Fedora:  sudo dnf install -y nodejs npm"
-        return 0
+    # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
+    # 설치 경로: ~/.local/bin/claude → ~/.local/share/claude/versions/<ver>
+    # check_dependencies()에서 curl-or-wget 존재를 이미 보장하므로 둘 중 하나는 반드시 사용 가능.
+    local installer_url="https://claude.ai/install.sh"
+    local install_status=1
+    info "Native installer 실행 중: $installer_url"
+    if command -v curl >/dev/null 2>&1; then
+        if curl -fsSL "$installer_url" | bash; then
+            install_status=0
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if wget -qO- "$installer_url" | bash; then
+            install_status=0
+        fi
     fi
 
-    info "npm install -g @anthropic-ai/claude-code 실행 중..."
-    if npm install -g @anthropic-ai/claude-code; then
+    if [ $install_status -eq 0 ]; then
+        # 새로 만들어진 ~/.local/bin이 현재 셸 PATH에 없을 수 있으므로 일시 prepend.
+        if ! command -v claude >/dev/null 2>&1 && [ -x "$HOME/.local/bin/claude" ]; then
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
         if command -v claude >/dev/null 2>&1; then
             local cc_version
             cc_version="$(claude --version 2>/dev/null | head -n1)"
             success "Claude Code CLI 설치 완료: ${cc_version:-version unknown}"
+            echo "  설치 위치: $(command -v claude)"
         else
-            warning "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
-            echo "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+            warning "Native installer는 종료되었으나 'claude'를 PATH에서 찾을 수 없습니다."
+            echo "  새 셸을 열거나 ~/.local/bin을 PATH에 추가하세요:"
+            echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
         fi
     else
         warning "Claude Code CLI 자동 설치 실패."
-        echo "  수동 설치를 시도하거나 권한(sudo) 문제일 수 있습니다:"
-        echo "    npm install -g @anthropic-ai/claude-code"
-        echo "    또는: sudo npm install -g @anthropic-ai/claude-code"
+        echo "  수동 설치:"
+        echo "    curl -fsSL https://claude.ai/install.sh | bash"
+        echo "  또는 Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
     fi
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -139,6 +139,8 @@ function Test-Administrator {
 # Verify Claude Code CLI presence and offer interactive installation.
 # version-check.ps1 hook and batch-* scripts call `claude --version` / `claude`
 # directly; deploying configuration without the CLI causes silent failures.
+# Uses Anthropic's official native installer (recommended method).
+# Reference: https://code.claude.com/docs/en/setup
 function Confirm-ClaudeCli {
     Write-Info "Checking Claude Code CLI..."
 
@@ -163,49 +165,49 @@ function Confirm-ClaudeCli {
     if ([string]::IsNullOrEmpty($installClaude)) { $installClaude = 'y' }
 
     if ($installClaude -ne 'y') {
-        Write-Warn "Skipping Claude Code CLI install. Manual install: npm install -g @anthropic-ai/claude-code"
+        Write-Warn "Skipping Claude Code CLI install. Manual install:"
+        Write-Host "    irm https://claude.ai/install.ps1 | iex"
         return
     }
 
-    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        Write-Warn "npm is not installed; cannot auto-install."
-        Write-Host "  Install Node.js/npm first, then run:"
-        Write-Host "    npm install -g @anthropic-ai/claude-code"
-        Write-Host ""
-        Write-Host "  Node.js install hint (Windows):"
-        Write-Host "    winget install OpenJS.NodeJS.LTS"
-        Write-Host "    or:    choco install nodejs-lts"
-        return
-    }
-
-    Write-Info "Running: npm install -g @anthropic-ai/claude-code"
+    # Native installer is the official recommended method and supports background auto-update.
+    # Install path: $env:USERPROFILE\.local\bin\claude.exe (Windows) /
+    #               ~/.local/bin/claude (macOS, Linux, WSL)
+    $installerUrl = 'https://claude.ai/install.ps1'
+    Write-Info "Running native installer: $installerUrl"
     try {
-        & npm install -g '@anthropic-ai/claude-code'
-        if ($LASTEXITCODE -eq 0) {
-            if (Get-Command claude -ErrorAction SilentlyContinue) {
-                try {
-                    $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
-                }
-                catch {
-                    $ccVersion = $null
-                }
-                if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
-                Write-Success "Claude Code CLI installed: $ccVersion"
-            }
-            else {
-                Write-Warn "npm install succeeded but 'claude' is not on PATH."
-                Write-Host "  Verify npm global bin is on PATH: npm config get prefix"
+        $installerScript = Invoke-RestMethod -Uri $installerUrl -ErrorAction Stop
+        Invoke-Expression $installerScript
+
+        # The newly created ~/.local/bin may not yet be on PATH for this session.
+        $localBin = Join-Path $HOME '.local' 'bin'
+        if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+            if (Test-Path $localBin) {
+                $env:PATH = "$localBin$([System.IO.Path]::PathSeparator)$env:PATH"
             }
         }
+
+        if (Get-Command claude -ErrorAction SilentlyContinue) {
+            try {
+                $ccVersion = (& claude --version 2>$null | Select-Object -First 1)
+            }
+            catch {
+                $ccVersion = $null
+            }
+            if ([string]::IsNullOrWhiteSpace($ccVersion)) { $ccVersion = 'version unknown' }
+            Write-Success "Claude Code CLI installed: $ccVersion"
+            $claudePath = (Get-Command claude -ErrorAction SilentlyContinue).Source
+            if ($claudePath) { Write-Host "  Install location: $claudePath" }
+        }
         else {
-            Write-Warn "Claude Code CLI auto-install failed (exit code: $LASTEXITCODE)."
-            Write-Host "  Try manual install or check permissions:"
-            Write-Host "    npm install -g @anthropic-ai/claude-code"
+            Write-Warn "Native installer finished but 'claude' is not on PATH."
+            Write-Host "  Open a new PowerShell session or refresh your PATH."
         }
     }
     catch {
-        Write-Warn "Exception during Claude Code CLI install: $($_.Exception.Message)"
-        Write-Host "  Manual install: npm install -g @anthropic-ai/claude-code"
+        Write-Warn "Claude Code CLI auto-install failed: $($_.Exception.Message)"
+        Write-Host "  Manual install: irm https://claude.ai/install.ps1 | iex"
+        Write-Host "  Or follow the official guide: https://code.claude.com/docs/en/setup"
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,7 +73,9 @@ check_dependencies() {
 # 함수: Claude Code CLI 설치 확인 및 자동 설치
 # version-check.sh 등 hook 스크립트와 batch-issue-work.sh / batch-pr-work.sh가
 # `claude --version` / `claude` 명령을 직접 호출한다. 미설치 상태에서 설정만
-# 배포되면 silent failure가 발생하므로 설치 시점에 동의 기반 자동 설치를 제공한다.
+# 배포되면 silent failure가 발생하므로 설치 시점에 Anthropic 공식 native
+# installer를 통한 동의 기반 자동 설치를 제공한다.
+# 참고: https://code.claude.com/docs/en/setup
 ensure_claude_cli() {
     info "Claude Code CLI 확인 중..."
 
@@ -93,32 +95,50 @@ ensure_claude_cli() {
     INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
 
     if [ "$INSTALL_CLAUDE" != "y" ]; then
-        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치: npm install -g @anthropic-ai/claude-code"
+        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치:"
+        echo "    curl -fsSL https://claude.ai/install.sh | bash"
         return 0
     fi
 
-    if ! command -v npm >/dev/null 2>&1; then
-        warning "npm이 설치되어 있지 않아 자동 설치를 진행할 수 없습니다."
-        echo "  Node.js/npm 설치 후 다음 명령을 실행하세요:"
-        echo "    npm install -g @anthropic-ai/claude-code"
+    # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
+    # 설치 경로: ~/.local/bin/claude → ~/.local/share/claude/versions/<ver>
+    local installer_url="https://claude.ai/install.sh"
+    local install_status=1
+    info "Native installer 실행 중: $installer_url"
+    if command -v curl >/dev/null 2>&1; then
+        if curl -fsSL "$installer_url" | bash; then
+            install_status=0
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if wget -qO- "$installer_url" | bash; then
+            install_status=0
+        fi
+    else
+        warning "curl/wget이 모두 없어 자동 설치를 진행할 수 없습니다."
+        echo "  curl 설치 후 재시도하거나 수동으로 다음을 실행하세요:"
+        echo "    curl -fsSL https://claude.ai/install.sh | bash"
         return 0
     fi
 
-    info "npm install -g @anthropic-ai/claude-code 실행 중..."
-    if npm install -g @anthropic-ai/claude-code; then
+    if [ $install_status -eq 0 ]; then
+        if ! command -v claude >/dev/null 2>&1 && [ -x "$HOME/.local/bin/claude" ]; then
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
         if command -v claude >/dev/null 2>&1; then
             local cc_version
             cc_version="$(claude --version 2>/dev/null | head -n1)"
             success "Claude Code CLI 설치 완료: ${cc_version:-version unknown}"
+            echo "  설치 위치: $(command -v claude)"
         else
-            warning "npm 설치는 성공했으나 'claude' 명령을 찾을 수 없습니다."
-            echo "  npm 글로벌 bin이 PATH에 있는지 확인하세요: npm config get prefix"
+            warning "Native installer는 종료되었으나 'claude'를 PATH에서 찾을 수 없습니다."
+            echo "  새 셸을 열거나 ~/.local/bin을 PATH에 추가하세요:"
+            echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
         fi
     else
         warning "Claude Code CLI 자동 설치 실패."
-        echo "  수동 설치를 시도하거나 권한(sudo) 문제일 수 있습니다:"
-        echo "    npm install -g @anthropic-ai/claude-code"
-        echo "    또는: sudo npm install -g @anthropic-ai/claude-code"
+        echo "  수동 설치:"
+        echo "    curl -fsSL https://claude.ai/install.sh | bash"
+        echo "  또는 Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
     fi
 }
 


### PR DESCRIPTION
## What

### Summary
Switch the Claude Code CLI auto-install path in `bootstrap.sh`, `bootstrap.ps1`, `scripts/install.sh`, and `scripts/install.ps1` from npm to Anthropic's official **native installer**. The npm path was added in #496; this follow-up aligns the implementation with the recommended method documented at [code.claude.com/docs/en/setup](https://code.claude.com/docs/en/setup).

### Change Type
- [x] Refactor (no functional regression for the happy path; install path internals change)
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation

## Why

Anthropic's official setup documentation lists the native installer as the **Recommended** method. npm is relegated to "Advanced installation options" with explicit warnings about `sudo npm install -g`. Differences that matter for claude-config users:

| Property | npm install | Native installer (this PR) |
|----------|------------|----------------------------|
| Recommended position in docs | Advanced options | Default tab |
| Background auto-update | No | Yes |
| Node.js dependency | Required (18+) | None |
| Installed binary | Same native binary (via per-platform optional dep) | Same native binary directly |
| `sudo` permission pitfall | Documented warning | N/A |

Verified locally that the current container's claude is installed via the native installer (`~/.local/share/claude/versions/2.1.119`), confirming this is the path that real users will already be on.

## Where

| File | Function | Insertions / Deletions |
|------|----------|-----------------------|
| `bootstrap.sh` | `ensure_claude_cli` | +30 / -23 |
| `bootstrap.ps1` | `Confirm-ClaudeCli` | +35 / -33 |
| `scripts/install.sh` | `ensure_claude_cli` | +35 / -22 |
| `scripts/install.ps1` | `Confirm-ClaudeCli` | +32 / -19 |

Total: 4 files, +132 / -97. Function names, call sites, prompt UX, and fail-soft semantics are preserved from #496.

## How

### Implementation
- POSIX (`bootstrap.sh`, `scripts/install.sh`):
  - Installer URL: `https://claude.ai/install.sh`
  - Prefer `curl -fsSL ... | bash`, fall back to `wget -qO- ... | bash` (the existing `check_dependencies` already requires curl-or-wget)
- PowerShell (`bootstrap.ps1`, `scripts/install.ps1`):
  - Installer URL: `https://claude.ai/install.ps1`
  - Use `Invoke-RestMethod -Uri $url` followed by `Invoke-Expression` (the `irm | iex` pattern shown in the official docs)
- Post-install behavior shared by both shells:
  - Native installer creates `~/.local/bin/claude`, which may not be on PATH for the current shell
  - The function transiently prepends `~/.local/bin` to PATH so `claude --version` succeeds in the same session
  - Prints the resolved install path on success
- Failure modes:
  - Network/install failure → warning + manual command + link to the official setup doc
  - All errors are non-fatal (no `exit 1`) — same fail-soft contract as #496

### Unrelated npm uses (intentionally untouched)
The other npm calls in these scripts install statusline packages (`ccstatusline`, `claude-limitline`) that are only published on npm. Those calls are left as-is.

### Test Plan for Reviewers
1. On a system without the CLI: run `bash bootstrap.sh`, accept the prompt, confirm a native install is performed and `claude --version` works in the same shell.
2. On a system with the CLI already installed (e.g., via Homebrew or apt): run the bootstrap, confirm the function detects the existing install and skips the prompt.
3. On a system without `curl` but with `wget`: confirm the wget fallback path runs.
4. Repeat 1–3 with `pwsh -File bootstrap.ps1` on Windows.
5. Repeat 1–3 with `bash scripts/install.sh` and `pwsh -File scripts/install.ps1` (post-clone install path).

### Testing Done
- [x] `bash -n` syntax check passes on `bootstrap.sh` and `scripts/install.sh`
- [x] All four files reference `claude.ai/install` and contain no `@anthropic-ai/claude-code` references inside the CLI install function (verified via grep)
- [x] Cherry-picked the change cleanly onto current `develop` (no conflicts) — confirms #496's npm context and this PR's diff are compatible
- [ ] PowerShell parser check — `pwsh` not available locally; please verify on a Windows runner before merge

### Breaking Changes
None. Behavior changes only in three observable ways:
1. Successful install path now drops files under `~/.local/bin` and `~/.local/share/claude/` (Anthropic standard) instead of the npm prefix
2. Auto-update will now run in the background once installed (this is a benefit, but worth noting for air-gapped users — they can disable via `DISABLE_AUTOUPDATER=1` in `~/.claude/settings.json` per the upstream docs)
3. Manual install hint shown when the user declines the prompt now points to the native installer URL

### Rollback Plan
Revert this PR. The previous npm path remains intact in #496's merged commit and would be restored by a straightforward revert.

## Notes

- Follow-up to #496. No new external behavior surface; this is a pure swap of the install backend.
- CI policy: PR targets `develop`, so per `branching-strategy.md` CI does not run on this PR. CI verification will run on the eventual `develop` → `main` release PR.
