### PR TITLE
fix(hooks): avoid PowerShell read-only $home in p4 timeline hooks

### DIFF
--- a/global/hooks/p4-timeline-guard.ps1
+++ b/global/hooks/p4-timeline-guard.ps1
@@ -19,12 +19,15 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # Override: set CLAUDE_P4_OVERRIDE=1 in the environment with the reason
 # documented in COMPATIBILITY.md (incident response, RCA-required).
 
-# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json
+# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json.
+# NOTE: do NOT use $home — it is a read-only PowerShell automatic variable, and
+# under $ErrorActionPreference='Stop' (set above) any attempt to assign it
+# raises a terminating WriteError that kills the whole hook.
 $SettingsPath = $env:P4_SETTINGS_PATH
 if (-not $SettingsPath) {
-    $home = [Environment]::GetFolderPath('UserProfile')
-    if (-not $home) { $home = $env:HOME }
-    $SettingsPath = Join-Path $home '.claude' 'settings.json'
+    $userProfile = [Environment]::GetFolderPath('UserProfile')
+    if (-not $userProfile) { $userProfile = $env:HOME }
+    $SettingsPath = Join-Path $userProfile '.claude' 'settings.json'
 }
 
 # Override gate

--- a/global/hooks/p4-timeline-reminder.ps1
+++ b/global/hooks/p4-timeline-reminder.ps1
@@ -14,12 +14,15 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # much time remains. Silent when the rollout is fully complete (now() >=
 # p4_freeze_until) or when the relevant fields are absent.
 
-# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json
+# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json.
+# NOTE: do NOT use $home — it is a read-only PowerShell automatic variable, and
+# under $ErrorActionPreference='Stop' (set above) any attempt to assign it
+# raises a terminating WriteError that kills the whole hook.
 $SettingsPath = $env:P4_SETTINGS_PATH
 if (-not $SettingsPath) {
-    $home = [Environment]::GetFolderPath('UserProfile')
-    if (-not $home) { $home = $env:HOME }
-    $SettingsPath = Join-Path $home '.claude' 'settings.json'
+    $userProfile = [Environment]::GetFolderPath('UserProfile')
+    if (-not $userProfile) { $userProfile = $env:HOME }
+    $SettingsPath = Join-Path $userProfile '.claude' 'settings.json'
 }
 
 # Settings file may not exist on fresh installs - silent


### PR DESCRIPTION
## What

Rename the local variable from `$home` to `$userProfile` in the two P4 timeline PowerShell hooks so that `$ErrorActionPreference='Stop'` no longer kills the hook on Windows.

- `global/hooks/p4-timeline-guard.ps1`
- `global/hooks/p4-timeline-reminder.ps1`

## Why

PowerShell's `$home` is a read-only automatic variable. Both hooks set `$ErrorActionPreference='Stop'` near the top, which means any attempt to assign `$home` raises a terminating `WriteError` and the hook process exits before it ever reaches the settings-path resolution. The result on Windows: the P4 timeline guard/reminder hooks silently fail at startup.

## Where

Only the settings-path resolution block in the two hooks is modified. No behavior change to the override gate, freeze logic, or settings parsing.

## How

```powershell
# before
$home = [Environment]::GetFolderPath('UserProfile')
if (-not $home) { $home = $env:HOME }
$SettingsPath = Join-Path $home '.claude' 'settings.json'

# after
$userProfile = [Environment]::GetFolderPath('UserProfile')
if (-not $userProfile) { $userProfile = $env:HOME }
$SettingsPath = Join-Path $userProfile '.claude' 'settings.json'
```

A `NOTE` comment is added next to each renamed block to deter future regressions.

## Testing

- [x] PowerShell 5.1 / 7+ on Windows: hooks load without WriteError
- [x] Linux/macOS path unchanged (uses `$env:HOME` fallback when `UserProfile` is empty)