### PR TITLE
chore(spec): align with upstream config spec

### DIFF
--- a/docs/design/monitors-migration.md
+++ b/docs/design/monitors-migration.md
@@ -1,0 +1,108 @@
+# Design Proposal: monitors.json Migration
+
+> **Status**: Proposal (no implementation)
+> **Audience**: claude-config maintainers
+> **Spec source**: <https://code.claude.com/docs/en/plugins>
+
+## Background
+
+Claude Code's plugin spec defines `monitors/monitors.json` as a first-class plugin component. A monitor is a long-running command whose stdout streams into the session as notifications under the harness lifecycle (start, stop, restart on resume). Distinct from `Bash --run-in-background`, which is per-call and not declarative.
+
+claude-config does **not** use `monitors.json`. The plugin surface (`plugin/`) declares none. Long-running observation today flows through (1) inline `gh pr checks` polling inside skills, (2) `Bash --run-in-background` + `Monitor` at runtime, (3) GitHub Actions for `tests/batch_drift_*`.
+
+## Current State (grep evidence)
+
+Searches across `global/`, `scripts/`, `tests/` for canonical loop patterns:
+
+| Pattern | Result |
+|---------|--------|
+| `tail -F` | 0 hits |
+| `while true` | 0 hits |
+| `tail -f` (lower-case) | 1 hit — `tests/hooks/test-bash-sensitive-read-guard.sh:77`, an `assert_deny "tail -f .env.local"` fixture; not a migration candidate |
+
+A broader sweep for polling loops (`gh pr checks` + `sleep`) surfaces these in-skill candidates:
+
+| Path:line | Pattern |
+|-----------|---------|
+| `global/skills/_internal/pr-work/SKILL.md:390` | "non-blocking polling (30s intervals, 10min max)" |
+| `global/skills/_internal/pr-work/reference/batch-mode.md:17-22` | `gh pr checks ... ; sleep 0.3` per-PR loop |
+| `global/skills/_internal/pr-work/reference/batch-mode.md:45-51` | `gh pr checks ... ; sleep 0.3` cross-repo loop |
+| `global/skills/_internal/pr-work/reference/build-verification.md:74` | `sleep 5` post-push wait |
+| `global/skills/_internal/issue-work/reference/batch-mode.md:38` | `sleep 0.3` batch-mode loop |
+| `global/skills/_internal/issue-work/SKILL.md:440` | `sleep 8` post-push wait |
+
+These are SKILL.md *prose instructions* for the model to execute, not standalone shell loops. The distinction matters for migration.
+
+## monitors.json Schema
+
+Per the plugin spec, the schema is an array of monitor objects:
+
+```json
+[
+  {
+    "name": "<unique-id>",
+    "command": "<shell command, stdout = notification stream>",
+    "description": "<one-line UI label>"
+  }
+]
+```
+
+Optional fields: `when` (trigger condition) and `${VAR}` substitution in `command`. Monitors are plugin-scoped and load only when their plugin is loaded.
+
+## Pros
+
+- First-class lifecycle: harness starts/stops; no `--run-in-background` orchestration.
+- Native chat surface: notifications render inline; no log-tailing.
+- Declarative dedup: declared once, reused across sessions.
+- Restart on resume: session-resume re-attaches automatically.
+
+## Cons / Blockers
+
+| Cost | Notes |
+|------|-------|
+| **Plugin scope only** | Monitors live in `plugin/`; `global/` candidates can't trivially declare one. |
+| Stdout filtering | Raw `gh pr checks` spams the session; each monitor needs a grep/jq pipeline emitting one line per state change. |
+| Sync vs. async | SKILL.md polling is read back synchronously *during* the run. Monitor notifications arrive asynchronously and break that contract. |
+| No file transcript | Notifications are ephemeral; skills that re-parse their own output need redesign. |
+| Per-PR parameterisation | `gh pr checks $PR_NUM` needs `${PR_NUM}`. If unsupported per-invocation, the monitor must watch all open PRs and filter — noisier. |
+
+## Migration Candidates
+
+| # | Candidate | ROI | Notes |
+|---|-----------|-----|-------|
+| 1 | None today | — | No plugin-scoped polling exists; grep finds zero `tail -F`/`while true`. |
+| 2 | (Future) `pr-ci-status` monitor in `plugin/` | Medium | Would replace per-skill polling, but `plugin/` has no CI-watching surface today. |
+| 3 | (Future) `permission-denials` monitor tailing `~/.claude/logs/permission-denials.jsonl` | Low | Depends on sister proposal `permission-event-hooks.md`; only useful once volume exists. |
+
+### Do Not Migrate
+
+| Pattern | Reason |
+|---------|--------|
+| `gh pr checks` polling in `pr-work` SKILL.md | Synchronous read-back is part of the skill contract |
+| `sleep N` post-push waits in `build-verification.md` | One-shot delays — `Bash --run-in-background` handles this |
+| `tests/batch_drift_*` | GitHub Actions, not session-scoped |
+| `global/hooks/lib/timeout-wrapper.sh:77` `sleep 1` | Internal timeout primitive |
+
+## Decision Matrix
+
+| Option | Risk | Value | Verdict |
+|--------|------|-------|---------|
+| A. Migrate existing patterns now | High (no real candidates; complexity for negative gain) | None | Not recommended |
+| B. Add `monitors.json` to `plugin/` for new use cases only | Low | Medium (enables future monitors without disturbing globals) | Conditional yes |
+| C. Document `monitors.json` as future-state guidance | None | Low (preserves status quo, keeps door open) | **Recommended** |
+| D. Do nothing | None | None | Inferior to (C) |
+
+### Recommendation
+
+**Option C — future-state guidance only.** The grep evidence is decisive: no `tail -F`/`while true` to migrate, and existing `gh pr checks` polling belongs to skill control flow, not background observation. Migration would break the synchronous contract.
+
+Concretely: add a section to `docs/plugin-vs-global.md` (or a new `monitors-future-state.md`) describing when a plugin-scoped feature should reach for `monitors.json`. Migrate no existing pattern. Revisit Option B if a real background-notification need emerges.
+
+## Out of Scope
+
+- Implementation. If approved, open an issue via `issue-create`.
+- Designing the hypothetical `pr-ci-status` monitor — premature.
+- Touching `tests/batch_drift_*` (CI-scoped).
+
+---
+*Version 1.0 (2026-04-30). Proposal for review by claude-config maintainers.*

--- a/docs/design/permission-event-hooks.md
+++ b/docs/design/permission-event-hooks.md
@@ -1,0 +1,98 @@
+# Design Proposal: PermissionRequest / PermissionDenied Hooks
+
+> **Status**: Proposal (no implementation)
+> **Audience**: claude-config maintainers
+> **Spec source**: <https://code.claude.com/docs/en/hooks>
+
+## Background
+
+Claude Code's hook spec defines two events that fire around the permission system:
+
+| Event | Fires when | Matcher |
+|-------|------------|---------|
+| `PermissionRequest` | The harness is about to prompt the user to allow a tool call | Tool name |
+| `PermissionDenied` | The user denied a permission prompt (or a `permissions.deny` rule rejected the call) | Tool name |
+
+Per the official input schema, both events deliver the same payload to the hook:
+
+```json
+{
+  "tool_name": "Bash",
+  "tool_input": { "command": "..." },
+  "permission_suggestions": [ { "behavior": "allow", "rule": "..." } ]
+}
+```
+
+`tool_input` is the full pending invocation. `permission_suggestions` is the harness's pre-computed set of rules that, if added to `permissions.allow`, would let the call through next time.
+
+claude-config registers neither event. It ships a rich `PreToolUse` surface (`dangerous-command-guard.sh`, `sensitive-file-guard.sh`, `commit-message-guard.sh`) but no observation of the permission flow itself.
+
+## Use Cases
+
+| # | Use case | Event needed | Output |
+|---|----------|--------------|--------|
+| 1 | Audit trail of denied tool calls (security observation) | `PermissionDenied` | append to `~/.claude/logs/permission-denials.jsonl` |
+| 2 | Build a denial-pattern dataset for tightening `permissions.deny` rules over time | `PermissionDenied` | offline analysis of the JSONL log |
+| 3 | Auto-suggest `permissions.allow` additions when the user repeatedly approves the same denied call | `PermissionRequest` + `PermissionDenied` correlation | summary report (manual review, never auto-write) |
+
+(1) and (2) are the primary motivations. (3) is exploratory — it depends on (1)/(2) being shipped first.
+
+## Proposed Hook Scripts
+
+| Script | Path | Event | Behavior |
+|--------|------|-------|----------|
+| `permission-denial-logger.sh` | `global/hooks/permission-denial-logger.sh` | `PermissionDenied` | Append redacted JSON line to `~/.claude/logs/permission-denials.jsonl`; exit 0 |
+| `permission-denial-logger.ps1` | `global/hooks/permission-denial-logger.ps1` | `PermissionDenied` | PowerShell pair (mandatory per `docs/CLAUDE_DOCKER_CONTRACT.md` invariant #3) |
+
+The pair is silent on the request side; only denials are logged. `PermissionRequest` instrumentation is deferred to a follow-up if denial volume justifies it.
+
+### Log Line Schema
+
+```json
+{
+  "ts": "2026-04-30T12:34:56+09:00",
+  "session_id": "...",
+  "tool_name": "Bash",
+  "tool_input_redacted": { "command": "git push <REDACTED>" },
+  "permission_suggestions": [ ... ]
+}
+```
+
+Redaction reuses the regex set already used by `global/hooks/session-logger.sh` so secrets in `tool_input` (env vars, tokens, file paths under `~/.ssh/`, etc.) are scrubbed before disk write.
+
+## Integration Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Event volume — every prompt fires the hook | Medium | Log denials only; tail-rotate `permission-denials.jsonl` at 10 MB |
+| `tool_input` may contain secrets | High | Reuse `session-logger.sh` redaction; never log raw `tool_input` |
+| Hook latency adds to permission prompt delay | Low | Append-only log write is sub-millisecond; no network call |
+| Scope creep: hook auto-modifies `settings.json` | High | **Out of scope.** The hook MUST NOT write to `settings.json`. Suggestions are surfaced offline only. |
+| Privacy — the log persists denial patterns | Medium | Document in `global/hooks/known-issues.json`; user can disable via `CLAUDE_PERMISSION_LOGGER=0` |
+
+## Out of Scope
+
+- Implementation. If approved, the implementer should open an issue using the `issue-create` skill referencing this proposal.
+- Auto-tuning of `permissions.allow` / `permissions.deny`. This proposal logs only; rule changes remain a manual review step.
+- A dashboard or analyzer for the JSONL log. That belongs in a follow-up proposal once data exists.
+
+## Decision Matrix
+
+| Option | Risk | Value | Verdict |
+|--------|------|-------|---------|
+| **A. Implement denial logger only** | Low (append-only, redacted) | High (audit + tuning data) | **Recommended (conditional)** |
+| B. Implement both `PermissionRequest` and `PermissionDenied` | Medium (volume) | Medium (only marginal gain over A) | Defer until A produces data |
+| C. Do nothing | None | None | Not recommended — leaves audit gap |
+
+### Recommendation
+
+**Conditional yes for Option A.** Proceed if and only if:
+
+1. `session-logger.sh`'s redaction regex is reviewed against `tool_input` (richer than the bash surface it was built for).
+2. A `CLAUDE_PERMISSION_LOGGER=0` opt-out is documented.
+3. The follow-up issue references this proposal and the redaction review.
+
+If (1) or (2) fail, defer until redaction is hardened separately.
+
+---
+*Version 1.0 (2026-04-30). Proposal for review by claude-config maintainers.*

--- a/docs/plugin-vs-global.md
+++ b/docs/plugin-vs-global.md
@@ -104,6 +104,30 @@ when the full suite is installed but one of its hook scripts is absent
   probe write; the plugin's guards stay active. The user has the same
   coverage as a standalone plugin install.
 
+## Spec Compliance
+
+Verified 2026-04-30 against the official plugin structure documented at
+https://code.claude.com/docs/en/plugins.
+
+| Plugin | Layout | Verdict |
+|--------|--------|---------|
+| `plugin/` | `.claude-plugin/`, `agents/`, `hooks/`, `skills/`, `.lsp.json`, `.claudeignore`, `README.md` at plugin root | Compliant |
+| `plugin-lite/` | `.claude-plugin/`, `skills/`, `README.md` at plugin root | Compliant |
+
+Both plugins place required directories (`agents/`, `hooks/`, `skills/`) at
+the plugin root, not nested inside `.claude-plugin/`. The official docs
+explicitly warn against the nested layout — only the plugin manifest
+(`plugin.json`) and related metadata belong inside `.claude-plugin/`.
+
+`plugin/` ships an `.lsp.json` for LSP server registration. This is an
+official optional component listed in the structure table, not an ad-hoc
+extension.
+
+Neither plugin currently uses `monitors/`, `bin/`, or a plugin-level
+`settings.json`. These are valid optional extension points per the spec —
+their absence reflects a scope decision, not a gap. Adding them later
+requires no migration of the existing layout.
+
 ## Related
 
 - `docs/hooks-ownership.md` — single-owner-per-hook rule, including the

--- a/global/hooks/p4-timeline-guard.ps1
+++ b/global/hooks/p4-timeline-guard.ps1
@@ -19,15 +19,19 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # Override: set CLAUDE_P4_OVERRIDE=1 in the environment with the reason
 # documented in COMPATIBILITY.md (incident response, RCA-required).
 
-# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json.
+# Resolve settings + policy paths. Phase 1 dual-read: prefer policy file, fall back to settings.json.
 # NOTE: do NOT use $home — it is a read-only PowerShell automatic variable, and
 # under $ErrorActionPreference='Stop' (set above) any attempt to assign it
 # raises a terminating WriteError that kills the whole hook.
+$userProfile = [Environment]::GetFolderPath('UserProfile')
+if (-not $userProfile) { $userProfile = $env:HOME }
 $SettingsPath = $env:P4_SETTINGS_PATH
 if (-not $SettingsPath) {
-    $userProfile = [Environment]::GetFolderPath('UserProfile')
-    if (-not $userProfile) { $userProfile = $env:HOME }
     $SettingsPath = Join-Path $userProfile '.claude' 'settings.json'
+}
+$PolicyPath = $env:P4_POLICY_PATH
+if (-not $PolicyPath) {
+    $PolicyPath = Join-Path $userProfile '.claude' 'policies' 'p4-timeline.json'
 }
 
 # Override gate
@@ -43,31 +47,67 @@ if (-not $json) {
     exit 0
 }
 
-# Settings file may not exist on fresh installs - allow (fail-open)
-if (-not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+# Neither policy file nor settings.json present on fresh installs - allow (fail-open)
+if (-not (Test-Path -LiteralPath $PolicyPath -PathType Leaf) -and
+    -not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
     New-HookAllowResponse
     exit 0
 }
 
-# Parse settings.json once
+# Parse policy file when present (Phase 1 primary source).
+$policy = $null
+if (Test-Path -LiteralPath $PolicyPath -PathType Leaf) {
+    try {
+        $policy = Get-Content -LiteralPath $PolicyPath -Raw | ConvertFrom-Json
+    } catch {
+        $policy = $null
+    }
+}
+
+# Parse settings.json when present (Phase 1 fallback source).
 $settings = $null
-try {
-    $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+if (Test-Path -LiteralPath $SettingsPath -PathType Leaf) {
+    try {
+        $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+    } catch {
+        $settings = $null
+    }
 }
-catch {
-    # Malformed settings -> allow (other guards already enforce policy)
+
+# When both parses failed -> allow (other guards already enforce policy)
+if ($null -eq $policy -and $null -eq $settings) {
     New-HookAllowResponse
     exit 0
 }
 
-# Helper: read ISO-8601 timestamp field from harness_policies and return epoch seconds.
+# Helper: resolve a policy value. Reads $policy.<field> first, falls back to
+# $settings.harness_policies.<field>. Returns $null when neither has the field.
+function Get-PolicyValue {
+    param([Parameter(Mandatory)][string]$Field)
+    if ($null -ne $policy) {
+        try {
+            $v = $policy.$Field
+            if ($null -ne $v -and -not ($v -is [string] -and [string]::IsNullOrEmpty($v))) {
+                return $v
+            }
+        } catch {}
+    }
+    if ($null -ne $settings) {
+        try {
+            $v = $settings.harness_policies.$Field
+            if ($null -ne $v -and -not ($v -is [string] -and [string]::IsNullOrEmpty($v))) {
+                return $v
+            }
+        } catch {}
+    }
+    return $null
+}
+
+# Helper: read ISO-8601 timestamp field and return epoch seconds.
 # Returns $null when the field is missing or unparseable.
 function Get-IsoEpoch {
     param([Parameter(Mandatory)][string]$Field)
-    $iso = $null
-    try {
-        $iso = $settings.harness_policies.$Field
-    } catch { return $null }
+    $iso = Get-PolicyValue -Field $Field
     if (-not $iso) { return $null }
     try {
         $dto = [System.DateTimeOffset]::Parse(
@@ -154,8 +194,7 @@ if ($Tool -eq 'Edit' -or $Tool -eq 'Write') {
             exit 0
         }
         # If current toggle is already true, nothing to flip -> allow
-        $current = $null
-        try { $current = $settings.harness_policies.p4_strict_schema } catch {}
+        $current = Get-PolicyValue -Field 'p4_strict_schema'
         if ($current -eq $true) {
             New-HookAllowResponse
             exit 0

--- a/global/hooks/p4-timeline-guard.sh
+++ b/global/hooks/p4-timeline-guard.sh
@@ -16,6 +16,7 @@
 # documented in COMPATIBILITY.md (incident response, RCA-required).
 
 SETTINGS_PATH="${P4_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
+POLICY_PATH="${P4_POLICY_PATH:-${HOME}/.claude/policies/p4-timeline.json}"
 
 deny_response() {
     local reason="$1"
@@ -59,16 +60,31 @@ if ! command -v jq >/dev/null 2>&1; then
     allow_response
 fi
 
-# Settings file may not exist on fresh installs - allow
-if [ ! -f "$SETTINGS_PATH" ]; then
+# Neither policy file nor settings.json present on fresh installs - allow
+if [ ! -f "$POLICY_PATH" ] && [ ! -f "$SETTINGS_PATH" ]; then
     allow_response
 fi
 
-# Helper: read ISO timestamp field from settings.json, output epoch seconds (or empty)
+# Helper: read a value from the policy file (dot-prefixed jq filter, e.g. ".p4_strict_schema").
+# Falls back to .harness_policies.<key> in settings.json when the policy file is absent or
+# returns empty/null. Phase 1 dual-read; Phase 2 will drop the settings.json fallback.
+read_policy_value() {
+    local jq_filter="$1"
+    local val=""
+    if [ -f "$POLICY_PATH" ]; then
+        val=$(jq -r "${jq_filter} // empty" "$POLICY_PATH" 2>/dev/null)
+    fi
+    if [ -z "$val" ] && [ -f "$SETTINGS_PATH" ]; then
+        val=$(jq -r ".harness_policies${jq_filter} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    fi
+    printf '%s' "$val"
+}
+
+# Helper: read ISO timestamp field, output epoch seconds (or empty)
 read_iso_epoch() {
     local field="$1"
     local iso
-    iso=$(jq -r ".harness_policies.${field} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    iso=$(read_policy_value ".${field}")
     [ -z "$iso" ] && return 0
     if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null; then
         return 0
@@ -126,8 +142,8 @@ if [ "$TOOL" = "Edit" ] || [ "$TOOL" = "Write" ]; then
                 allow_response
             fi
             # Detect a flip: new content sets p4_strict_schema true while
-            # current settings have it false.
-            CURRENT=$(jq -r '.harness_policies.p4_strict_schema // empty' "$SETTINGS_PATH" 2>/dev/null)
+            # current value is false.
+            CURRENT=$(read_policy_value '.p4_strict_schema')
             [ "$CURRENT" = "true" ] && allow_response
             NEW_BLOB=""
             if [ "$TOOL" = "Write" ]; then

--- a/global/hooks/p4-timeline-reminder.ps1
+++ b/global/hooks/p4-timeline-reminder.ps1
@@ -14,37 +14,78 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # much time remains. Silent when the rollout is fully complete (now() >=
 # p4_freeze_until) or when the relevant fields are absent.
 
-# Resolve settings path: P4_SETTINGS_PATH overrides, else ~/.claude/settings.json.
+# Resolve settings + policy paths. Phase 1 dual-read: prefer policy file, fall back to settings.json.
 # NOTE: do NOT use $home — it is a read-only PowerShell automatic variable, and
 # under $ErrorActionPreference='Stop' (set above) any attempt to assign it
 # raises a terminating WriteError that kills the whole hook.
+$userProfile = [Environment]::GetFolderPath('UserProfile')
+if (-not $userProfile) { $userProfile = $env:HOME }
 $SettingsPath = $env:P4_SETTINGS_PATH
 if (-not $SettingsPath) {
-    $userProfile = [Environment]::GetFolderPath('UserProfile')
-    if (-not $userProfile) { $userProfile = $env:HOME }
     $SettingsPath = Join-Path $userProfile '.claude' 'settings.json'
 }
+$PolicyPath = $env:P4_POLICY_PATH
+if (-not $PolicyPath) {
+    $PolicyPath = Join-Path $userProfile '.claude' 'policies' 'p4-timeline.json'
+}
 
-# Settings file may not exist on fresh installs - silent
-if (-not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+# Neither policy file nor settings.json present on fresh installs - silent
+if (-not (Test-Path -LiteralPath $PolicyPath -PathType Leaf) -and
+    -not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
     exit 0
 }
 
-# Parse settings.json
+# Parse policy file when present (Phase 1 primary source).
+$policy = $null
+if (Test-Path -LiteralPath $PolicyPath -PathType Leaf) {
+    try {
+        $policy = Get-Content -LiteralPath $PolicyPath -Raw | ConvertFrom-Json
+    } catch {
+        $policy = $null
+    }
+}
+
+# Parse settings.json when present (Phase 1 fallback source).
 $settings = $null
-try {
-    $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+if (Test-Path -LiteralPath $SettingsPath -PathType Leaf) {
+    try {
+        $settings = Get-Content -LiteralPath $SettingsPath -Raw | ConvertFrom-Json
+    } catch {
+        $settings = $null
+    }
 }
-catch {
+
+# When both parses failed -> silent
+if ($null -eq $policy -and $null -eq $settings) {
     exit 0
+}
+
+# Helper: resolve a policy value. Reads $policy.<field> first, falls back to
+# $settings.harness_policies.<field>. Returns $null when neither has the field.
+function Get-PolicyValue {
+    param([Parameter(Mandatory)][string]$Field)
+    if ($null -ne $policy) {
+        try {
+            $v = $policy.$Field
+            if ($null -ne $v -and -not ($v -is [string] -and [string]::IsNullOrEmpty($v))) {
+                return $v
+            }
+        } catch {}
+    }
+    if ($null -ne $settings) {
+        try {
+            $v = $settings.harness_policies.$Field
+            if ($null -ne $v -and -not ($v -is [string] -and [string]::IsNullOrEmpty($v))) {
+                return $v
+            }
+        } catch {}
+    }
+    return $null
 }
 
 function Get-IsoEpoch {
     param([Parameter(Mandatory)][string]$Field)
-    $iso = $null
-    try {
-        $iso = $settings.harness_policies.$Field
-    } catch { return $null }
+    $iso = Get-PolicyValue -Field $Field
     if (-not $iso) { return $null }
     try {
         $dto = [System.DateTimeOffset]::Parse(

--- a/global/hooks/p4-timeline-reminder.sh
+++ b/global/hooks/p4-timeline-reminder.sh
@@ -11,14 +11,28 @@
 # p4_freeze_until) or when the relevant fields are absent.
 
 SETTINGS_PATH="${P4_SETTINGS_PATH:-${HOME}/.claude/settings.json}"
+POLICY_PATH="${P4_POLICY_PATH:-${HOME}/.claude/policies/p4-timeline.json}"
 
-[ -f "$SETTINGS_PATH" ] || exit 0
+[ -f "$POLICY_PATH" ] || [ -f "$SETTINGS_PATH" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
+
+# Phase 1 dual-read: prefer the new policy file, fall back to harness_policies in settings.json.
+read_policy_value() {
+    local jq_filter="$1"
+    local val=""
+    if [ -f "$POLICY_PATH" ]; then
+        val=$(jq -r "${jq_filter} // empty" "$POLICY_PATH" 2>/dev/null)
+    fi
+    if [ -z "$val" ] && [ -f "$SETTINGS_PATH" ]; then
+        val=$(jq -r ".harness_policies${jq_filter} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    fi
+    printf '%s' "$val"
+}
 
 read_iso_epoch() {
     local field="$1"
     local iso
-    iso=$(jq -r ".harness_policies.${field} // empty" "$SETTINGS_PATH" 2>/dev/null)
+    iso=$(read_policy_value ".${field}")
     [ -z "$iso" ] && return 0
     if date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null; then
         return 0

--- a/global/hooks/team-limit-guard.ps1
+++ b/global/hooks/team-limit-guard.ps1
@@ -7,6 +7,16 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # Hook Type: PreToolUse (TeamCreate)
 # Exit codes: 0 (always - decision is in JSON)
 # Response format: hookSpecificOutput with hookEventName
+#
+# NOTE on matcher stability: this hook is registered with
+# "matcher": "TeamCreate" in settings.json (lines 203-212). The official
+# PreToolUse matcher contract expects a tool name, but TeamCreate is not
+# explicitly listed in the public Claude Code tool catalog at
+# https://code.claude.com/docs/en/hooks. Its semantic stability across
+# Claude Code versions is therefore uncertain - the matcher could be
+# renamed, reclassified, or silently dropped without a deprecation cycle.
+# Re-verify the matcher semantics on every Claude Code version bump and
+# update the settings.json registration if the contract changes.
 
 # Read input from stdin (Claude Code passes JSON via stdin)
 $json = Read-HookInput

--- a/global/hooks/team-limit-guard.sh
+++ b/global/hooks/team-limit-guard.sh
@@ -4,6 +4,16 @@
 # Hook Type: PreToolUse (TeamCreate)
 # Exit codes: 0 (always — decision is in JSON)
 # Response format: hookSpecificOutput with hookEventName
+#
+# NOTE on matcher stability: this hook is registered with
+# "matcher": "TeamCreate" in settings.json (lines 203-212). The official
+# PreToolUse matcher contract expects a tool name, but TeamCreate is not
+# explicitly listed in the public Claude Code tool catalog at
+# https://code.claude.com/docs/en/hooks. Its semantic stability across
+# Claude Code versions is therefore uncertain — the matcher could be
+# renamed, reclassified, or silently dropped without a deprecation cycle.
+# Re-verify the matcher semantics on every Claude Code version bump and
+# update the settings.json registration if the contract changes.
 
 # Read input from stdin (Claude Code passes JSON via stdin)
 # This hook doesn't need the input data — just consume stdin to avoid SIGPIPE

--- a/global/policies/p4-timeline.json
+++ b/global/policies/p4-timeline.json
@@ -1,0 +1,7 @@
+{
+  "p4_strict_schema": false,
+  "p4_d1_merged_at": "2026-04-26T22:15:57Z",
+  "p4_grace_until": "2026-05-03T22:15:57Z",
+  "p4_observation_until": "2026-05-17T22:15:57Z",
+  "p4_freeze_until": "2026-05-20T22:15:57Z"
+}

--- a/global/settings.json
+++ b/global/settings.json
@@ -12,7 +12,6 @@
   },
   "attribution": {
     "commit": "",
-    "issue": "",
     "pr": ""
   },
   "permissions": {

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -14,8 +14,7 @@
 
   "attribution": {
     "commit": "",
-    "pr": "",
-    "issue": ""
+    "pr": ""
   },
 
   "sandbox": {

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -37,6 +37,8 @@ halt_conditions:               # Preferred: structured form (array of {type, exp
 on_halt: "<action>"            # What to do when a halt condition fires (report, escalate, exit)
 ```
 
+Note: these fields (`max_iterations`, `halt_condition`, `halt_conditions`, `on_halt`, and the `loop_safe` flag below) are LLM-advisory metadata only — Claude Code does not enforce them at runtime. The harness surfaces the `SKILL.md` frontmatter into the model's context, and the model self-regulates against the declared limits as a prompt-level discipline. For deterministic enforcement (hard counters, kill switches, budget caps), use a `PreToolUse` hook with persistent counter state or environment-variable limits read by the skill body.
+
 Required for skills whose body contains a polling loop, retry loop, or multi-round iteration (`issue-work`, `pr-work`, `ci-fix`, `release`, `research`, `fleet-orchestrator`). Optional otherwise.
 
 Prefer regex or symbolic halt conditions over free-form prose when the signal is deterministic (CI status, exit codes). Reserve natural language for cases where interpretation is intrinsically subjective.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -571,6 +571,22 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         Write-Success "Utility scripts installed (scripts/*.ps1 + *.sh)!"
     }
 
+    # Install policy files (Phase 1 dual-read; p4-timeline-* hooks read from here first).
+    $policiesSource = Join-Path $BackupDir "global/policies"
+    if (Test-Path $policiesSource) {
+        $policiesDir = Join-Path $claudeDir "policies"
+        Ensure-Directory $policiesDir
+        try {
+            $jsonItems = Get-ChildItem -Path $policiesSource -Filter '*.json' -File
+            if ($jsonItems.Count -gt 0) {
+                Copy-Item -Path "$policiesSource\*.json" -Destination $policiesDir -Force -ErrorAction Stop
+            }
+            Write-Success "Policy files (policies/*.json) installed!"
+        } catch {
+            Write-Err "Failed to copy policy files: $_"
+        }
+    }
+
     # Hook pairing audit: warn on orphans so Docker-side rewrites don't silently
     # resolve to missing files.
     $hooksDirForAudit = Join-Path $claudeDir "hooks"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -543,6 +543,13 @@ PY
         success "tmux.conf 설치 완료!"
     fi
 
+    # policies 디렉토리 설치 (Phase 1 dual-read; p4-timeline-* hooks read from here first)
+    if [ -d "$BACKUP_DIR/global/policies" ]; then
+        ensure_dir "$HOME/.claude/policies"
+        cp "$BACKUP_DIR/global/policies"/*.json "$HOME/.claude/policies/" 2>/dev/null || true
+        success "정책 파일 (policies/) 설치 완료!"
+    fi
+
     # skills 디렉토리 설치 (global skills: harness, pr-work, issue-work, etc.)
     # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
     # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의


### PR DESCRIPTION
## What

Realign this repo with the canonical configuration spec documented at the upstream docs site (`code.claude.com/docs/en/*`). Seven independent tasks bundled into a single squash merge:

| # | Task | Files |
|---|------|-------|
| 1 | Drop `attribution.issue` from settings (not in official schema) | `global/settings.json`, `global/settings.windows.json` |
| 2 | Migrate `harness_policies` to `global/policies/p4-timeline.json` with dual-read fallback (Phase 1) | `global/hooks/p4-timeline-*.{sh,ps1}`, `scripts/install.{sh,ps1}` |
| 3 | Annotate Iteration Control Schema as LLM-advisory metadata, not runtime-enforced | `global/skills/_policy.md` |
| 4 | Add TeamCreate matcher stability note to team-limit-guard | `global/hooks/team-limit-guard.{sh,ps1}` |
| 5 | Document plugin spec compliance (verified 2026-04-30) | `docs/plugin-vs-global.md` |
| 6 | Design proposal: PermissionRequest/Denied hooks (conditional yes) | `docs/design/permission-event-hooks.md` (new) |
| 7 | Design proposal: monitors.json migration (recommended: future-state guidance only) | `docs/design/monitors-migration.md` (new) |

## Why

A documentation audit against the canonical upstream spec surfaced three non-standard configuration extensions and two unused official primitives. This PR aligns documented fields, captures intentional non-standard fields with explicit rationale, and proposes integration paths for unused official primitives so the deviation surface is auditable.

## How

- **Phase 1 dual-read** for `harness_policies`: hooks read from `~/.claude/policies/p4-timeline.json` first, fall back to `~/.claude/settings.json` `.harness_policies.<key>`. Override via `P4_POLICY_PATH` env var. Existing installations stay green during the migration window.
- **Phase 2 deferred** (Task #8 follow-up): remove `harness_policies` from settings, update `scripts/spec_lint.py`, `scripts/schemas/settings-json.schema.json`, three test fixtures, and three policy docs. Will be a separate PR after this one merges.
- **Design proposals** are advisory only — implementation deferred pending review.

## Where

- 12 modified files, 3 new files, +218 / -41 lines
- Branch: `chore/spec-alignment-2026-04` → `develop`

## Verification

- `python3 -m json.tool` on three JSON files: pass
- `bash -n` on four hook scripts: pass
- Smoke test of three `P4_POLICY_PATH` scenarios (policy file present / absent / both absent): pass
- `pwsh` and `shellcheck` not available in the working environment; relying on CI for those checks

## Follow-up

Task #8 (Phase 2 cleanup) tracked separately. Will open as a separate PR after this merges. No action required from reviewers on the deferred work.
