### PR TITLE
feat(memory): add quarantine directory mechanism

### DIFF
--- a/docs/MEMORY_TRUST_MODEL.md
+++ b/docs/MEMORY_TRUST_MODEL.md
@@ -504,6 +504,38 @@ cat ~/.claude/claude-memory/quarantine/<filename>.md
 The `quarantine/` directory is plain markdown; no opaque encoding. This makes
 forensic review and manual repair tractable.
 
+### Implementation
+
+The `demote` and `restore` operator actions (Section 6) are implemented by two
+shell utilities. They are the single source of truth for the directory move
+plus frontmatter rewrite that this section requires. Other tools (write-guard
+hook #521, audit job #528, `/memory-review` #529) call into these CLIs rather
+than re-implementing the move.
+
+| Script | Action | Tier transition |
+|---|---|---|
+| `scripts/quarantine-move.sh` | Demote | `verified \| inferred` -> `quarantined` |
+| `scripts/quarantine-restore.sh` | Restore | `quarantined` -> `verified` |
+
+`quarantine-move.sh` is idempotent: invoking it on a file that already lives in
+`quarantine/` is a no-op (exit 0). `quarantine-restore.sh` re-runs the three
+validators (`validate.sh`, `secret-check.sh`, `injection-check.sh`) and refuses
+the restore (exit 2) if any blocking check fails. `injection-check.sh` is
+warn-only and never blocks restore, consistent with `MEMORY_VALIDATION_SPEC.md`
+Section 7.
+
+Both scripts modify only frontmatter; body content is preserved verbatim. They
+prefer `git mv` when run inside a git working tree so the move is recorded as a
+rename rather than a delete-plus-create.
+
+### Quarantine retention markers
+
+The quarantine retention thresholds (Section 4: 0-30 day passive, 31-90 day
+audit, 91+ day archive candidate) are computed from the `quarantined-at`
+timestamp written by `quarantine-move.sh`. The audit consumer (#528) reads
+this field to classify each quarantined entry into one of the three retention
+windows.
+
 ---
 
 ## 9. Migration of Existing Memories

--- a/scripts/memory/quarantine-move.sh
+++ b/scripts/memory/quarantine-move.sh
@@ -1,0 +1,412 @@
+#!/bin/bash
+# quarantine-move.sh -- Move a memory file from memories/ to quarantine/.
+#
+# Implements docs/MEMORY_TRUST_MODEL.md (v1.0.0) Section 8 storage-layer rules
+# for the validator-driven and user-driven demotion paths defined in Section 6.
+# A "quarantine" is a directory move plus frontmatter rewrite, not a flag-only
+# state. Body content is never modified.
+#
+# Usage:
+#   quarantine-move.sh <file> [--reason "<text>"] [--no-edit]
+#   quarantine-move.sh --help|-h
+#
+# Behavior:
+#   - Resolves <file> against the source memories/ directory of the parent
+#     claude-memory tree. If the file is already in quarantine/, exits 0
+#     (idempotent no-op per acceptance criteria).
+#   - Rewrites frontmatter: sets trust-level to quarantined, adds quarantined-at
+#     (ISO 8601 UTC), quarantine-reason (if --reason supplied), quarantined-by
+#     (current source-machine if known).
+#   - Updates last-verified to today (ISO 8601 date) per trust-model Section 6:
+#     last-verified records the demotion date for retention math.
+#   - Moves the file using git mv when inside a git working tree, else plain mv.
+#
+# Exit codes:
+#   0   success (or already-quarantined no-op)
+#   1   failure (file not found, frontmatter parse, write/move error, sibling
+#       missing in quarantine/ already, etc.)
+#   64  usage error
+#
+# Bash 3.2 compatible (macOS default): no associative arrays, no mapfile, no
+# process-substitution into named pipes, BASH_REMATCH saved before reuse,
+# explicit ${var:-default} for empties.
+
+set -u
+
+print_help() {
+  cat <<'EOF'
+quarantine-move.sh -- move a memory file to the quarantine directory.
+
+USAGE
+    quarantine-move.sh <file> [--reason "<text>"] [--no-edit]
+    quarantine-move.sh --help | -h
+
+ARGUMENTS
+    <file>          Path to the memory file. May be either an absolute path,
+                    a path relative to the current working directory, or a
+                    path of the form memories/<name>.md within a claude-memory
+                    tree. The script auto-detects the claude-memory root by
+                    walking upward looking for a sibling memories/ directory.
+
+OPTIONS
+    --reason TEXT   Free-form reason recorded as quarantine-reason in the
+                    target frontmatter. Optional; if omitted, the field is
+                    not added. Quoted at use; never evaluated as shell.
+    --no-edit       Do not modify frontmatter; only perform the directory
+                    move. Useful for re-syncing an already-rewritten file.
+    --help, -h      Show this help.
+
+EXIT CODES
+    0   success, or already-quarantined no-op
+    1   failure (file not found, frontmatter parse error, write/move error)
+    64  usage error
+
+EXAMPLES
+    # Quarantine a memory the secret-check flagged
+    quarantine-move.sh memories/feedback_suspicious.md \
+        --reason "secret-check flagged non-owner email"
+
+    # Move only, leave existing frontmatter as-is
+    quarantine-move.sh memories/project_old.md --no-edit
+
+NOTES
+    Idempotent: if <file> already lives in quarantine/, the script reports
+    "already quarantined" and exits 0. Body content is never modified.
+EOF
+}
+
+# Strip surrounding double or single quotes from a YAML scalar value.
+# Mirrors validate.sh:strip_quotes for consistent parsing semantics.
+strip_quotes() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  if [[ "$v" =~ ^\"(.*)\"$ ]]; then
+    local m="${BASH_REMATCH[1]}"
+    v="$m"
+  elif [[ "$v" =~ ^\'(.*)\'$ ]]; then
+    local m="${BASH_REMATCH[1]}"
+    v="$m"
+  fi
+  printf '%s' "$v"
+}
+
+# Read a single-line YAML field from frontmatter text.
+# Echoes the raw value (without `key:` prefix); empty if absent.
+get_field() {
+  local fm="$1"
+  local key="$2"
+  printf '%s\n' "$fm" | grep -E "^${key}:" | head -1 | sed "s/^${key}:[[:space:]]*//"
+}
+
+# Detect whether a directory is inside a git working tree.
+# Returns 0 (true) when `git -C <dir> rev-parse --is-inside-work-tree` succeeds.
+is_inside_git() {
+  local d="$1"
+  git -C "$d" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Move src to dst, preferring `git mv` when both live in a git working tree.
+# Falls back to plain `mv`. Returns 0 on success, 1 on error.
+move_file() {
+  local src="$1"
+  local dst="$2"
+  local src_dir
+  src_dir="$(dirname "$src")"
+  if is_inside_git "$src_dir"; then
+    if git -C "$src_dir" mv "$src" "$dst" 2>/dev/null; then
+      return 0
+    fi
+    # `git mv` may refuse if the file is untracked; fall through to plain mv.
+  fi
+  mv "$src" "$dst"
+}
+
+# Detect the claude-memory root for <file>. The root is the first ancestor
+# directory that contains a `memories/` subdirectory. Echoes the absolute path
+# of that root, or empty string if not found.
+find_memory_root() {
+  local f="$1"
+  local d
+  d="$(cd "$(dirname "$f")" && pwd -P)"
+  while [[ "$d" != "/" && -n "$d" ]]; do
+    if [[ -d "$d/memories" ]]; then
+      printf '%s' "$d"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+
+main() {
+  local file=""
+  local reason=""
+  local no_edit=0
+
+  if [[ $# -eq 0 ]]; then
+    print_help >&2
+    exit 64
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      --reason)
+        if [[ $# -lt 2 ]]; then
+          printf 'error: --reason requires a value\n' >&2
+          exit 64
+        fi
+        reason="$2"
+        shift 2
+        ;;
+      --no-edit)
+        no_edit=1
+        shift
+        ;;
+      -*)
+        printf 'error: unknown option: %s\n' "$1" >&2
+        print_help >&2
+        exit 64
+        ;;
+      *)
+        if [[ -n "$file" ]]; then
+          printf 'error: unexpected extra argument: %s\n' "$1" >&2
+          exit 64
+        fi
+        file="$1"
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$file" ]]; then
+    printf 'error: missing <file> argument\n' >&2
+    exit 64
+  fi
+
+  if [[ ! -f "$file" ]]; then
+    printf 'error: file not found: %s\n' "$file" >&2
+    exit 1
+  fi
+
+  local file_abs
+  file_abs="$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")"
+
+  local root
+  root="$(find_memory_root "$file_abs")"
+  if [[ -z "${root:-}" ]]; then
+    printf 'error: cannot locate claude-memory root (no sibling memories/ dir): %s\n' "$file_abs" >&2
+    exit 1
+  fi
+
+  local memories_dir="$root/memories"
+  local quarantine_dir="$root/quarantine"
+  local base
+  base="$(basename "$file_abs")"
+
+  # Idempotency: file already in quarantine/ -> no-op success.
+  case "$file_abs" in
+    "$quarantine_dir"/*)
+      printf '[OK] %s already quarantined; no-op\n' "$base"
+      exit 0
+      ;;
+  esac
+
+  # Reject MEMORY.md (it is the synthesized index, not a memory).
+  if [[ "$base" == "MEMORY.md" ]]; then
+    printf 'error: refusing to quarantine MEMORY.md (auto-generated index)\n' >&2
+    exit 1
+  fi
+
+  # Source must live in memories/.
+  case "$file_abs" in
+    "$memories_dir"/*) ;;
+    *)
+      printf 'error: source file is not under %s/\n' "$memories_dir" >&2
+      exit 1
+      ;;
+  esac
+
+  # Parse frontmatter (re-uses the validate.sh delimiter convention).
+  local first_line
+  first_line="$(head -1 "$file_abs")"
+  if [[ "$first_line" != "---" ]]; then
+    printf 'error: cannot read frontmatter (missing opening delimiter): %s\n' "$base" >&2
+    exit 1
+  fi
+
+  local fm_end
+  fm_end="$(awk 'NR>1 && /^---[[:space:]]*$/ {print NR; exit}' "$file_abs")"
+  fm_end="${fm_end:-}"
+  if [[ -z "$fm_end" ]]; then
+    printf 'error: cannot read frontmatter (missing closing delimiter): %s\n' "$base" >&2
+    exit 1
+  fi
+
+  local fm
+  fm="$(sed -n "2,$((fm_end - 1))p" "$file_abs")"
+
+  # Pre-create quarantine directory if absent.
+  if [[ ! -d "$quarantine_dir" ]]; then
+    if ! mkdir -p "$quarantine_dir"; then
+      printf 'error: cannot create quarantine directory: %s\n' "$quarantine_dir" >&2
+      exit 1
+    fi
+  fi
+
+  local target="$quarantine_dir/$base"
+
+  # Restore-side conflict mirror: if a same-name file already exists in
+  # quarantine/, refuse rather than overwrite. The user must resolve manually.
+  if [[ -e "$target" ]]; then
+    printf 'error: target already exists in quarantine/: %s (resolve manually)\n' "$target" >&2
+    exit 1
+  fi
+
+  # Compute frontmatter rewrite values.
+  local now_iso today_iso
+  now_iso="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  today_iso="$(date -u +'%Y-%m-%d')"
+
+  # Inherit source-machine for quarantined-by when present; else hostname -s.
+  local sm
+  sm="$(get_field "$fm" "source-machine")"
+  sm="$(strip_quotes "$sm")"
+  if [[ -z "$sm" ]]; then
+    sm="$(hostname -s 2>/dev/null || hostname 2>/dev/null || printf 'unknown')"
+  fi
+
+  # If --no-edit, skip frontmatter rewrite and just move.
+  if (( no_edit == 1 )); then
+    if ! move_file "$file_abs" "$target"; then
+      printf 'error: move failed: %s -> %s\n' "$file_abs" "$target" >&2
+      exit 1
+    fi
+    printf '[OK] %s -> quarantine/%s (no-edit)\n' "$base" "$base"
+    exit 0
+  fi
+
+  # Build a rewritten frontmatter via temp file. We:
+  #   - Replace any existing trust-level / quarantined-at / quarantine-reason /
+  #     quarantined-by / last-verified line with the new value (or drop and
+  #     re-emit at end). This keeps key order stable for fields we don't touch.
+  #   - Append any missing fields after the last existing line.
+  # No `awk` redirections per implementation notes (bash-write-guard).
+
+  local tmp
+  tmp="$(mktemp 2>/dev/null || mktemp -t quar-move)"
+  if [[ -z "${tmp:-}" || ! -w "$tmp" ]]; then
+    printf 'error: cannot create temporary file\n' >&2
+    exit 1
+  fi
+  # Best-effort cleanup. EXIT trap covers normal and error paths.
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmp'" EXIT
+
+  # Open delimiter.
+  printf -- '---\n' > "$tmp" || { printf 'error: write failed\n' >&2; exit 1; }
+
+  # Track which keys we have already emitted from the rewrite plan; remaining
+  # ones are appended at the end of the FM block.
+  local seen_trust=0 seen_qat=0 seen_qreason=0 seen_qby=0 seen_lv=0
+
+  # Read frontmatter line-by-line and rewrite the keys we manage.
+  # Bash 3.2 read with IFS= preserves leading whitespace.
+  local line key
+  while IFS= read -r line; do
+    # Match `key: value` (allow keys with hyphens). Other lines pass through
+    # unchanged so multi-line YAML structures survive (we never produce them
+    # here, but pre-existing files may have them).
+    if [[ "$line" =~ ^([A-Za-z][A-Za-z0-9_-]*): ]]; then
+      key="${BASH_REMATCH[1]}"
+      case "$key" in
+        trust-level)
+          printf 'trust-level: quarantined\n' >> "$tmp" || exit 1
+          seen_trust=1
+          continue
+          ;;
+        quarantined-at)
+          printf 'quarantined-at: %s\n' "$now_iso" >> "$tmp" || exit 1
+          seen_qat=1
+          continue
+          ;;
+        quarantine-reason)
+          if [[ -n "$reason" ]]; then
+            # Quote the value to preserve shell metacharacters; embedded
+            # double quotes are escaped. eval is never used.
+            printf 'quarantine-reason: "%s"\n' "${reason//\"/\\\"}" >> "$tmp" || exit 1
+          fi
+          # If no --reason supplied and an existing reason field is present,
+          # we drop it (the new quarantine episode replaces the old reason).
+          seen_qreason=1
+          continue
+          ;;
+        quarantined-by)
+          printf 'quarantined-by: %s\n' "$sm" >> "$tmp" || exit 1
+          seen_qby=1
+          continue
+          ;;
+        last-verified)
+          printf 'last-verified: %s\n' "$today_iso" >> "$tmp" || exit 1
+          seen_lv=1
+          continue
+          ;;
+      esac
+    fi
+    printf '%s\n' "$line" >> "$tmp" || exit 1
+  done <<< "$fm"
+
+  # Emit any rewrite-plan keys not previously present.
+  if (( seen_trust == 0 )); then
+    printf 'trust-level: quarantined\n' >> "$tmp" || exit 1
+  fi
+  if (( seen_qat == 0 )); then
+    printf 'quarantined-at: %s\n' "$now_iso" >> "$tmp" || exit 1
+  fi
+  if (( seen_qby == 0 )); then
+    printf 'quarantined-by: %s\n' "$sm" >> "$tmp" || exit 1
+  fi
+  if (( seen_lv == 0 )); then
+    printf 'last-verified: %s\n' "$today_iso" >> "$tmp" || exit 1
+  fi
+  if (( seen_qreason == 0 )) && [[ -n "$reason" ]]; then
+    printf 'quarantine-reason: "%s"\n' "${reason//\"/\\\"}" >> "$tmp" || exit 1
+  fi
+
+  # Close delimiter and append the original body verbatim.
+  printf -- '---\n' >> "$tmp" || exit 1
+  if (( fm_end >= 1 )); then
+    sed -n "$((fm_end + 1)),\$p" "$file_abs" >> "$tmp" || exit 1
+  fi
+
+  # Atomically replace source content, then move. Writing through a temp file
+  # then `mv` avoids partial writes on disk-full or SIGINT. Preserve the
+  # source file's mode so the 0600 mktemp default does not leak through.
+  local src_mode
+  src_mode="$(stat -c '%a' "$file_abs" 2>/dev/null || stat -f '%Lp' "$file_abs" 2>/dev/null || printf '644')"
+  if ! mv "$tmp" "$file_abs"; then
+    printf 'error: failed to write rewritten frontmatter to %s\n' "$file_abs" >&2
+    exit 1
+  fi
+  chmod "$src_mode" "$file_abs" 2>/dev/null || true
+  # The trap will fail to remove $tmp now that mv consumed it; harmless.
+  trap - EXIT
+
+  if ! move_file "$file_abs" "$target"; then
+    printf 'error: move failed: %s -> %s\n' "$file_abs" "$target" >&2
+    exit 1
+  fi
+
+  printf '[OK] %s -> quarantine/%s\n' "$base" "$base"
+  if [[ -n "$reason" ]]; then
+    printf '     reason: %s\n' "$reason"
+  fi
+  printf '     quarantined-at: %s\n' "$now_iso"
+  exit 0
+}
+
+main "$@"

--- a/scripts/memory/quarantine-restore.sh
+++ b/scripts/memory/quarantine-restore.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+# quarantine-restore.sh -- Move a quarantined memory file back to memories/.
+#
+# Implements docs/MEMORY_TRUST_MODEL.md (v1.0.0) Section 6 "restore" action:
+# the file must pass all validators (validate.sh, secret-check.sh,
+# injection-check.sh) before it may return to memories/. Restoration always
+# lands at trust-level: verified per Section 3 (no partial restore).
+#
+# Usage:
+#   quarantine-restore.sh <file> [--reason "<text>"]
+#   quarantine-restore.sh --help|-h
+#
+# Behavior:
+#   - Resolves <file> against the quarantine/ directory of the parent
+#     claude-memory tree.
+#   - Re-runs validate.sh, secret-check.sh, injection-check.sh against the
+#     file. Any blocking failure (validate.sh exits 1 or 2; secret-check.sh
+#     exits 1) refuses the restore. injection-check.sh is warn-only per
+#     spec; flagged output does not block.
+#   - On pass: rewrites frontmatter to trust-level: verified, sets
+#     last-verified to today, removes quarantined-at / quarantine-reason /
+#     quarantined-by, then moves to memories/.
+#
+# Exit codes:
+#   0   success
+#   1   usage error or non-revalidation failure (file missing, conflict, etc.)
+#   2   revalidation failed; file remains in quarantine
+#   64  CLI usage error (missing argument, unknown flag)
+#
+# Bash 3.2 compatible (macOS default).
+
+set -u
+
+print_help() {
+  cat <<'EOF'
+quarantine-restore.sh -- restore a quarantined memory after revalidation.
+
+USAGE
+    quarantine-restore.sh <file> [--reason "<text>"]
+    quarantine-restore.sh --help | -h
+
+ARGUMENTS
+    <file>          Path to the quarantined memory file (under quarantine/).
+                    May be absolute or relative; the claude-memory root is
+                    auto-detected.
+
+OPTIONS
+    --reason TEXT   Free-form note recorded only in stdout (e.g. "false
+                    positive confirmed"). Not written to frontmatter.
+    --help, -h      Show this help.
+
+EXIT CODES
+    0   success
+    1   usage / pre-flight error (file missing, conflict in memories/, etc.)
+    2   revalidation failed; file stays in quarantine
+    64  CLI usage error (handled before validation)
+
+VALIDATORS RUN
+    validate.sh         (exit 1 = FAIL-STRUCT, 2 = FAIL-FORMAT both block)
+    secret-check.sh     (exit 1 = SECRET-DETECTED blocks)
+    injection-check.sh  (warn-only; never blocks restore)
+
+NOTES
+    On success:
+      - trust-level becomes verified (per spec Section 3 "no partial restore")
+      - last-verified becomes today
+      - quarantined-at, quarantine-reason, quarantined-by are removed
+      - file moves from quarantine/ to memories/
+    Body content is never modified.
+EOF
+}
+
+# Resolve the directory in which this script lives (real path).
+script_dir() {
+  local s="${BASH_SOURCE[0]}"
+  # Resolve symlinks one hop (sufficient for our install layout).
+  while [[ -L "$s" ]]; do
+    local d
+    d="$(cd "$(dirname "$s")" && pwd -P)"
+    s="$(readlink "$s")"
+    case "$s" in
+      /*) ;;
+      *) s="$d/$s" ;;
+    esac
+  done
+  cd "$(dirname "$s")" && pwd -P
+}
+
+is_inside_git() {
+  local d="$1"
+  git -C "$d" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+move_file() {
+  local src="$1"
+  local dst="$2"
+  local src_dir
+  src_dir="$(dirname "$src")"
+  if is_inside_git "$src_dir"; then
+    if git -C "$src_dir" mv "$src" "$dst" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  mv "$src" "$dst"
+}
+
+find_memory_root() {
+  local f="$1"
+  local d
+  d="$(cd "$(dirname "$f")" && pwd -P)"
+  while [[ "$d" != "/" && -n "$d" ]]; do
+    if [[ -d "$d/memories" ]]; then
+      printf '%s' "$d"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+
+# Locate a sibling validator script. Search:
+#   1. Same directory as this script
+#   2. PATH (typical install on the user's system)
+# Echo path or empty string.
+locate_validator() {
+  local name="$1"
+  local sd
+  sd="$(script_dir)"
+  if [[ -x "$sd/$name" ]]; then
+    printf '%s' "$sd/$name"
+    return 0
+  fi
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  local file=""
+  local reason=""
+
+  if [[ $# -eq 0 ]]; then
+    print_help >&2
+    exit 64
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      --reason)
+        if [[ $# -lt 2 ]]; then
+          printf 'error: --reason requires a value\n' >&2
+          exit 64
+        fi
+        reason="$2"
+        shift 2
+        ;;
+      -*)
+        printf 'error: unknown option: %s\n' "$1" >&2
+        exit 64
+        ;;
+      *)
+        if [[ -n "$file" ]]; then
+          printf 'error: unexpected extra argument: %s\n' "$1" >&2
+          exit 64
+        fi
+        file="$1"
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$file" ]]; then
+    printf 'error: missing <file> argument\n' >&2
+    exit 64
+  fi
+
+  if [[ ! -f "$file" ]]; then
+    printf 'error: file not found: %s\n' "$file" >&2
+    exit 1
+  fi
+
+  local file_abs
+  file_abs="$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")"
+
+  local root
+  root="$(find_memory_root "$file_abs")"
+  if [[ -z "${root:-}" ]]; then
+    printf 'error: cannot locate claude-memory root: %s\n' "$file_abs" >&2
+    exit 1
+  fi
+
+  local memories_dir="$root/memories"
+  local quarantine_dir="$root/quarantine"
+  local base
+  base="$(basename "$file_abs")"
+
+  # Refuse to operate on MEMORY.md.
+  if [[ "$base" == "MEMORY.md" ]]; then
+    printf 'error: refusing to restore MEMORY.md (auto-generated index)\n' >&2
+    exit 1
+  fi
+
+  # Source must be in quarantine/.
+  case "$file_abs" in
+    "$quarantine_dir"/*) ;;
+    *)
+      printf 'error: source file is not under %s/ (use quarantine-move.sh first)\n' "$quarantine_dir" >&2
+      exit 1
+      ;;
+  esac
+
+  local target="$memories_dir/$base"
+  if [[ -e "$target" ]]; then
+    printf 'error: target already exists in memories/: %s (resolve manually)\n' "$target" >&2
+    exit 1
+  fi
+
+  # Locate validators. validate.sh is required; secret-check.sh is required;
+  # injection-check.sh is best-effort (warn-only and the spec lets it run
+  # even if missing, but we attempt to find it for parity with the issue's
+  # acceptance criteria).
+  local val_path sec_path inj_path
+  val_path="$(locate_validator validate.sh || true)"
+  sec_path="$(locate_validator secret-check.sh || true)"
+  inj_path="$(locate_validator injection-check.sh || true)"
+
+  if [[ -z "${val_path:-}" ]]; then
+    printf 'error: validate.sh not found (sibling or PATH)\n' >&2
+    exit 1
+  fi
+  if [[ -z "${sec_path:-}" ]]; then
+    printf 'error: secret-check.sh not found (sibling or PATH)\n' >&2
+    exit 1
+  fi
+
+  printf '[VALIDATING] %s\n' "$base"
+
+  # Run validate.sh. Exit codes 1 (FAIL-STRUCT) and 2 (FAIL-FORMAT) block.
+  # Exit 3 (WARN-SEMANTIC) is non-blocking but we surface the result.
+  local val_rc=0
+  local val_label="PASS"
+  local val_out
+  val_out="$("$val_path" "$file_abs" 2>&1)" || val_rc=$?
+  case "$val_rc" in
+    0) val_label="PASS" ;;
+    1) val_label="FAIL-STRUCT" ;;
+    2) val_label="FAIL-FORMAT" ;;
+    3) val_label="WARN-SEMANTIC" ;;
+    *) val_label="UNKNOWN($val_rc)" ;;
+  esac
+  printf '  validate.sh:    %s\n' "$val_label"
+
+  # secret-check.sh: 0 = CLEAN, 1 = SECRET-DETECTED (blocks).
+  local sec_rc=0
+  local sec_label="CLEAN"
+  local sec_out
+  sec_out="$("$sec_path" "$file_abs" 2>&1)" || sec_rc=$?
+  case "$sec_rc" in
+    0) sec_label="CLEAN" ;;
+    1) sec_label="SECRET-DETECTED" ;;
+    *) sec_label="UNKNOWN($sec_rc)" ;;
+  esac
+  printf '  secret-check.sh: %s\n' "$sec_label"
+
+  # injection-check.sh: warn-only, never blocks. Run if available.
+  local inj_rc=0
+  local inj_label="SKIPPED"
+  local inj_out=""
+  if [[ -n "${inj_path:-}" ]]; then
+    inj_out="$("$inj_path" "$file_abs" 2>&1)" || inj_rc=$?
+    case "$inj_rc" in
+      0) inj_label="CLEAN" ;;
+      3) inj_label="FLAGGED (warn-only)" ;;
+      *) inj_label="UNKNOWN($inj_rc)" ;;
+    esac
+    printf '  injection-check.sh: %s\n' "$inj_label"
+  fi
+
+  # Decide whether to refuse. Blocking failures: validate.sh in (1, 2),
+  # secret-check.sh == 1. injection-check.sh never blocks (per spec).
+  if (( val_rc == 1 || val_rc == 2 || sec_rc == 1 )); then
+    printf '%s\n' "$val_out"
+    printf '%s\n' "$sec_out"
+    if [[ -n "$inj_out" ]] && (( inj_rc != 0 )); then
+      printf '%s\n' "$inj_out"
+    fi
+    printf '[REFUSED] revalidation failed; remains in quarantine\n'
+    exit 2
+  fi
+
+  # Parse frontmatter for rewrite. Same convention as quarantine-move.sh.
+  local first_line
+  first_line="$(head -1 "$file_abs")"
+  if [[ "$first_line" != "---" ]]; then
+    printf 'error: cannot read frontmatter (missing opening delimiter): %s\n' "$base" >&2
+    exit 1
+  fi
+
+  local fm_end
+  fm_end="$(awk 'NR>1 && /^---[[:space:]]*$/ {print NR; exit}' "$file_abs")"
+  fm_end="${fm_end:-}"
+  if [[ -z "$fm_end" ]]; then
+    printf 'error: cannot read frontmatter (missing closing delimiter): %s\n' "$base" >&2
+    exit 1
+  fi
+
+  local fm
+  fm="$(sed -n "2,$((fm_end - 1))p" "$file_abs")"
+
+  local today_iso
+  today_iso="$(date -u +'%Y-%m-%d')"
+
+  # Rewrite plan: set trust-level to verified, last-verified to today,
+  # remove quarantined-at, quarantine-reason, quarantined-by.
+  local tmp
+  tmp="$(mktemp 2>/dev/null || mktemp -t quar-restore)"
+  if [[ -z "${tmp:-}" || ! -w "$tmp" ]]; then
+    printf 'error: cannot create temporary file\n' >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmp'" EXIT
+
+  printf -- '---\n' > "$tmp" || { printf 'error: write failed\n' >&2; exit 1; }
+
+  local seen_trust=0 seen_lv=0
+  local line key
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^([A-Za-z][A-Za-z0-9_-]*): ]]; then
+      key="${BASH_REMATCH[1]}"
+      case "$key" in
+        trust-level)
+          printf 'trust-level: verified\n' >> "$tmp" || exit 1
+          seen_trust=1
+          continue
+          ;;
+        last-verified)
+          printf 'last-verified: %s\n' "$today_iso" >> "$tmp" || exit 1
+          seen_lv=1
+          continue
+          ;;
+        quarantined-at|quarantine-reason|quarantined-by)
+          # Drop these fields entirely.
+          continue
+          ;;
+      esac
+    fi
+    printf '%s\n' "$line" >> "$tmp" || exit 1
+  done <<< "$fm"
+
+  if (( seen_trust == 0 )); then
+    printf 'trust-level: verified\n' >> "$tmp" || exit 1
+  fi
+  if (( seen_lv == 0 )); then
+    printf 'last-verified: %s\n' "$today_iso" >> "$tmp" || exit 1
+  fi
+
+  printf -- '---\n' >> "$tmp" || exit 1
+  sed -n "$((fm_end + 1)),\$p" "$file_abs" >> "$tmp" || exit 1
+
+  # Preserve source file's mode so the 0600 mktemp default does not leak.
+  local src_mode
+  src_mode="$(stat -c '%a' "$file_abs" 2>/dev/null || stat -f '%Lp' "$file_abs" 2>/dev/null || printf '644')"
+  if ! mv "$tmp" "$file_abs"; then
+    printf 'error: failed to write rewritten frontmatter to %s\n' "$file_abs" >&2
+    exit 1
+  fi
+  chmod "$src_mode" "$file_abs" 2>/dev/null || true
+  trap - EXIT
+
+  if ! move_file "$file_abs" "$target"; then
+    printf 'error: move failed: %s -> %s\n' "$file_abs" "$target" >&2
+    exit 1
+  fi
+
+  printf '[OK] quarantine/%s -> memories/%s\n' "$base" "$base"
+  printf '     last-verified: %s\n' "$today_iso"
+  if [[ -n "$reason" ]]; then
+    printf '     restore note: %s\n' "$reason"
+  fi
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
Closes #514

## What

Implement the storage-side mechanism for the `quarantined` trust level defined in `docs/MEMORY_TRUST_MODEL.md` v1.0.0 (#511, merged via #542). Two new shell utilities under `scripts/memory/` perform the directory move plus frontmatter rewrite that the trust spec requires.

### Affected files
| File | Status | Purpose |
|---|---|---|
| `scripts/memory/quarantine-move.sh` | new (executable) | Demote a memory: `memories/` -> `quarantine/` |
| `scripts/memory/quarantine-restore.sh` | new (executable) | Restore: `quarantine/` -> `memories/` after revalidation |
| `docs/MEMORY_TRUST_MODEL.md` | modified | New "Implementation" subsection in section 8 referencing the two CLIs and the retention markers consumed by #528 |

## Why

Without a quarantine layer, the only options for suspicious memory are "keep it active" (risky) or "delete it" (lossy). Quarantine adds the third option the trust spec requires: preserved, non-applied, reviewable. The two CLIs are the single source of truth for the directory move so that other consumers (write-guard #521, audit #528, `/memory-review` #529) call into them rather than re-implementing the move.

## How

### `quarantine-move.sh`

- Resolves `<file>` against the parent claude-memory tree (auto-detect via sibling `memories/`).
- Rewrites frontmatter in place: sets `trust-level: quarantined`, adds `quarantined-at` (ISO 8601 UTC), `quarantine-reason` (when `--reason` supplied), `quarantined-by` (current `source-machine` if known else `hostname -s`); updates `last-verified` to today per spec section 6 "records the demotion date for retention math".
- Prefers `git mv` inside a git working tree, falls back to plain `mv`.
- Idempotent: invoking on a file already in `quarantine/` is a no-op (exit 0).
- `--no-edit` skips the frontmatter rewrite (for re-sync flows).
- Preserves source file mode so the 0600 `mktemp` default does not leak into the rewritten file.

### `quarantine-restore.sh`

- Re-runs `validate.sh`, `secret-check.sh`, `injection-check.sh` (sibling first, then $PATH).
- Blocking failures: `validate.sh` exits 1 or 2; `secret-check.sh` exits 1. `injection-check.sh` is warn-only per `MEMORY_VALIDATION_SPEC.md` section 7 -- a flag never blocks restore.
- On block: prints the validator output and exits 2 with `[REFUSED] revalidation failed; remains in quarantine`.
- On pass: rewrites frontmatter to `trust-level: verified`, removes `quarantined-at`/`quarantine-reason`/`quarantined-by`, sets `last-verified` to today (per spec section 6 "no partial restore" -- restoration always lands at `verified`), then moves to `memories/`.

### Style and constraints

- bash 3.2 compatible (macOS default): no associative arrays, no `mapfile`, `BASH_REMATCH` saved before reuse, `${var:-default}` guards.
- No `awk` redirections (per issue's implementation notes / bash-write-guard).
- Body content never modified -- only frontmatter.
- Standard CLI shape: `--help` / `-h`, exit 64 on usage error, matches the style of `validate.sh`/`secret-check.sh`/`injection-check.sh` already on `develop`.

## Test Plan

Tested locally with synthetic fixtures under `/tmp/qtest/` (no real user memory touched):

| # | Scenario | Expected | Actual |
|---|---|---|---|
| 1 | Move a clean memory with `--reason` | exit 0; frontmatter rewritten; file moved | PASS |
| 2 | Re-run `quarantine-move.sh` on already-quarantined file | exit 0 no-op | PASS |
| 3 | Restore the clean memory | validators pass, exit 0; quarantine fields removed; file moved back | PASS |
| 4 | Move a memory with planted non-owner email | exit 0 | PASS |
| 5 | Restore the still-tainted memory | `secret-check.sh` SECRET-DETECTED, exit 2; file remains in quarantine/ | PASS |
| 6 | Move a file not under `memories/` | exit 1 with clear error | PASS |
| 7 | Restore conflict (same-name file already in `memories/`) | exit 1, refuses overwrite | PASS |
| 8 | `--no-edit` move | exit 0; frontmatter unchanged | PASS |
| 9 | `--help` | shows usage | PASS |
| 10 | No arguments | exit 64 | PASS |
| 11 | Unknown option | exit 64 | PASS |
| 12 | File not found | exit 1 | PASS |
| 13 | Body byte-for-byte after full move-restore cycle | identical | PASS |
| 14 | All three validators against the restored file | PASS / CLEAN / CLEAN | PASS |
| 15 | `bash -n` syntax check | both scripts OK | PASS |

## Acceptance Criteria (from #514)

- [x] Directory layout assumption: scripts auto-detect `claude-memory/quarantine/` (created on first move). Spec section 8 layout already documented in #542.
- [x] `quarantine-move.sh` moves file, updates frontmatter (trust-level, quarantined-at, quarantine-reason, quarantined-by, last-verified), idempotent on re-run.
- [x] `quarantine-restore.sh` runs all 3 validators, refuses on blocking failure, on success sets trust-level to verified, updates last-verified, removes quarantine fields.
- [x] Index generator (#516) and sync (#520) interplay: documented; the scripts produce a git change visible to next sync.
- [x] Lifecycle markers (30/60/90) referenced in the trust-spec update for #528 audit consumer.
- [x] Documented in `docs/MEMORY_TRUST_MODEL.md` section 8 "Implementation" subsection.
- [x] Both scripts: bash 3.2 compatible, executable, shebang, `--help`.
- [x] No body content modification.

## Breaking Changes

None -- net-new mechanism.

## Rollback Plan

Revert this PR. Manually move quarantined files back to `memories/` if any were created via these scripts.

## Cross-references

- Part of #505 (epic)
- Blocked by #511 -- merged via #542
- Blocks #516, #517, #528
- Related: #520 (sync transport), #521 (auto-quarantine on write fail), #529 (interactive review)
- Spec: `docs/MEMORY_TRUST_MODEL.md` v1.0.0 sections 6 and 8