### PR TITLE
chore(memory): enforce SSH commit signing across machines

### DIFF
--- a/docs/SSH_COMMIT_SIGNING.md
+++ b/docs/SSH_COMMIT_SIGNING.md
@@ -1,0 +1,210 @@
+# SSH Commit Signing for claude-memory
+
+> **Status**: Active
+> **Audience**: Operators of any machine that pushes to `kcenon/claude-memory`
+> **Tracker**: kcenon/claude-config#518
+> **Related**: kcenon/claude-config#534 (rotation/compromise procedures in `docs/MEMORY_SYNC.md`)
+
+Every machine that pushes commits to `kcenon/claude-memory` **must sign those
+commits with an SSH key**. Branch protection on `main` enforces this; unsigned
+commits are rejected at the server. This document is the per-machine setup
+runbook.
+
+## Why SSH signing (not GPG)
+
+- The user already has SSH keys configured for `git push`. Setting `gpg.format=ssh`
+  lets the same key authenticate the push **and** sign the commit. No new keys
+  to manage.
+- GPG keyrings, agent forwarding, and trust webs are out of proportion for a
+  single-user memory store.
+- GitHub natively recognizes SSH signing keys (since 2022) and renders the
+  "Verified" badge on the web UI.
+
+## Per-machine setup (one-shot)
+
+There are two paths: the **automated helper** (recommended) or **manual steps**.
+
+### Automated path
+
+```bash
+cd /path/to/kcenon/claude-config
+./scripts/memory/setup-ssh-signing.sh
+```
+
+The script:
+
+1. Verifies `git >= 2.34`
+2. Locates an existing SSH public key in `~/.ssh/` (preferring `id_ed25519`)
+3. Backs up `~/.gitconfig` to `~/.gitconfig.bak.<timestamp>`
+4. Sets `gpg.format=ssh`, `user.signingkey`, `commit.gpgsign=true`,
+   `tag.gpgsign=true`
+5. Writes `~/.config/git/allowed_signers` and configures
+   `gpg.ssh.allowedSignersFile`
+6. Prints the next manual steps (key registration on GitHub, signed-commit test)
+
+The script is **idempotent** (safe to re-run) and **non-destructive** (it does
+not generate keys unless given `--generate-key`, and never uploads keys to
+GitHub).
+
+Useful flags:
+
+| Flag | Effect |
+|------|--------|
+| `--key <path>` | Use a specific public key file instead of auto-detect |
+| `--generate-key` | Generate `~/.ssh/id_ed25519` if no key exists |
+| `--dry-run` | Print intended changes without writing |
+| `--help` | Show usage |
+
+### Manual path
+
+If you prefer to run each step yourself:
+
+```bash
+# 1. Verify git version
+git --version  # must be >= 2.34
+
+# 2. Generate an SSH key if you do not have one
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
+
+# 3. Configure git
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+
+# 4. Set up allowed_signers for local verification
+mkdir -p ~/.config/git
+EMAIL="$(git config --global user.email)"
+KEY="$(awk '{print $1, $2}' ~/.ssh/id_ed25519.pub)"
+echo "${EMAIL} ${KEY}" >> ~/.config/git/allowed_signers
+git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+```
+
+## Register the key on GitHub (manual)
+
+The setup helper does **not** upload keys for you. After running it:
+
+1. Open `https://github.com/settings/ssh/new`
+2. Paste the contents of your public key
+3. **Set Key type = Signing Key** (this is critical; auth keys are separate)
+4. Save
+
+Alternatively, with `gh` CLI (still requires your explicit consent):
+
+```bash
+gh ssh-key add ~/.ssh/id_ed25519.pub --type signing --title "$(hostname -s)"
+```
+
+## Verification
+
+From any local clone of `claude-memory`:
+
+```bash
+git commit -S --allow-empty -m "test signed commit"
+git log --show-signature -1
+```
+
+Expected output:
+
+```
+commit ...
+Signature made ... using SSH key SHA256:...
+Good "ssh" signature for you@example.com with ED25519 key SHA256:...
+```
+
+`git verify-commit HEAD` should also report `Good signature`.
+
+If you see `Could not verify signature`, your `allowed_signers` file is missing
+the email/key entry. Re-run `setup-ssh-signing.sh` or check the file by hand.
+
+## Branch protection (repository owner only)
+
+This is run **once per repository**, not per machine.
+
+```bash
+gh api repos/kcenon/claude-memory/branches/main/protection \
+  --method PUT \
+  -f required_signatures.enabled=true \
+  -f required_pull_request_reviews=null \
+  -f restrictions=null \
+  -f enforce_admins=true
+```
+
+After this, the server enforces:
+
+- Unsigned commits to `main` are rejected
+- Force-push to `main` is rejected
+- Branch deletion is rejected
+- `enforce_admins=true` means even the owner cannot bypass the rule
+
+The same can be configured via `Settings -> Branches -> Branch protection rules`
+in the GitHub web UI; check **Require signed commits**, **Include administrators**,
+and uncheck force-push and deletion.
+
+To temporarily disable (e.g., for emergency rollback):
+
+```bash
+gh api repos/kcenon/claude-memory/branches/main/protection \
+  --method PUT \
+  -f required_signatures.enabled=false
+```
+
+## Multi-machine workflow
+
+Each machine has its own SSH signing key. Do **not** copy private keys between
+machines; the threat model treats key compromise as a per-machine event.
+
+The shared `allowed_signers` file accumulates one line per (email, key) pair:
+
+```
+you@example.com ssh-ed25519 AAAA...machine1
+you@example.com ssh-ed25519 AAAA...machine2
+you@example.com ssh-ed25519 AAAA...machine3
+```
+
+If you sync this file across machines (via `claude-memory` itself or
+`stow(1)`), every machine can locally verify commits made by any other.
+
+`setup-ssh-signing.sh` appends a new line on each unique (email, key) pair and
+skips duplicates.
+
+## Rotation (planned key replacement)
+
+Detailed steps live in `docs/MEMORY_SYNC.md` (kcenon/claude-config#534). Quick
+summary:
+
+1. On the affected machine: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_v2`
+2. `git config --global user.signingkey ~/.ssh/id_ed25519_v2.pub`
+3. Add the new public key on GitHub as a signing key
+4. Append the new entry to `~/.config/git/allowed_signers`
+5. Test a signed commit
+6. After a grace period, remove the old key from GitHub
+
+## Compromise (urgent)
+
+If a private key may have leaked:
+
+1. Immediately remove the compromised key from GitHub
+   (`https://github.com/settings/keys`)
+2. Audit recent commits on `claude-memory main` for unauthorized changes
+3. Generate a new key, register it, update `allowed_signers`
+4. Document the incident in your local notes (and in the next memory sync)
+
+The detailed compromise procedure is tracked in
+kcenon/claude-config#534.
+
+## Edge cases
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `gpg failed to sign the data` | SSH agent not running | `eval "$(ssh-agent -s)" && ssh-add` |
+| `error: bad signature` after pull | Remote `allowed_signers` missing | Append the remote committer's key entry |
+| Existing `gpg.format=openpgp` | Previously used GPG | Helper backs up `~/.gitconfig` before changing |
+| Multiple SSH keys present | Helper picks first match | Pass `--key <path>` to override |
+| `git --version` < 2.34 | Distro git too old | Install newer git (Homebrew, deb backports, etc.) |
+
+## References
+
+- Git SSH signing config: <https://git-scm.com/docs/git-config#Documentation/git-config.txt-gpgssh>
+- GitHub signed commit verification: <https://docs.github.com/en/authentication/managing-commit-signature-verification>
+- `ssh-keygen` ALLOWED SIGNERS format: `man ssh-keygen` (search `ALLOWED SIGNERS`)

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -19,6 +19,7 @@ Global settings applied every session. Routing index only — procedural detail 
 
 - **Sandbox, TLS, `gh` caveat**: `docs/SANDBOX_TLS.md`
 - **Branching strategy**: `docs/branching-strategy.md`
+- **SSH commit signing (claude-memory)**: `docs/SSH_COMMIT_SIGNING.md`
 - **Lifecycle skills**: `global/skills/_internal/issue-work`, `pr-work`, `release`, `branch-cleanup`
 - **Build verification**: `global/skills/_internal/pr-work/reference/build-verification.md`
 - **Skill authoring**: `global/skills/_policy.md`, `global/skills/_internal/_shared/invariants.md`

--- a/scripts/memory/setup-ssh-signing.sh
+++ b/scripts/memory/setup-ssh-signing.sh
@@ -1,0 +1,372 @@
+#!/bin/bash
+# setup-ssh-signing.sh -- Configure git to sign commits with an SSH key.
+#
+# Per issue #518: every machine that pushes to claude-memory must sign commits
+# with an SSH key, so a committed memory file's authorship is cryptographically
+# verifiable. This helper configures git on the current machine and prints the
+# next steps the operator must perform manually (key registration on GitHub).
+#
+# Non-destructive by default:
+#   - Detects existing SSH keys; never generates one without --generate-key
+#   - Backs up ~/.gitconfig before modifying it
+#   - Never uploads keys to GitHub (operator does this with explicit consent)
+#
+# Exit codes:
+#   0   success (configured, or already configured -- idempotent)
+#   1   pre-flight failed (git too old, no SSH key, etc.)
+#   64  usage error
+#
+# Bash 3.2 compatible (macOS default). macOS and Linux both supported.
+#
+# Usage:
+#   setup-ssh-signing.sh                    auto-detect key, configure git
+#   setup-ssh-signing.sh --key <pubkey>     use a specific public key file
+#   setup-ssh-signing.sh --generate-key     create id_ed25519 if none exists
+#   setup-ssh-signing.sh --dry-run          show what would change, do not write
+#   setup-ssh-signing.sh --help|-h          show this help
+#
+# Environment overrides (all optional):
+#   OWNER_EMAIL   email to register in allowed_signers (default: from git config user.email)
+
+set -u
+
+DEFAULT_OWNER_EMAIL=""
+
+# Required minimum git version for SSH signing.
+GIT_MIN_MAJOR=2
+GIT_MIN_MINOR=34
+
+# Standard SSH public key locations, in preference order (ed25519 > ecdsa > rsa).
+SSH_KEY_CANDIDATES=(
+  "$HOME/.ssh/id_ed25519.pub"
+  "$HOME/.ssh/id_ecdsa.pub"
+  "$HOME/.ssh/id_rsa.pub"
+)
+
+usage() {
+  cat <<EOF
+setup-ssh-signing.sh -- configure git for SSH commit signing
+
+Usage:
+  $(basename "$0")                    auto-detect SSH key and configure
+  $(basename "$0") --key <pubkey>     use a specific .pub file
+  $(basename "$0") --generate-key     create ~/.ssh/id_ed25519 if missing
+  $(basename "$0") --dry-run          print intended changes, do not apply
+  $(basename "$0") --help|-h          show this help
+
+What it does:
+  1. Verifies git >= ${GIT_MIN_MAJOR}.${GIT_MIN_MINOR}
+  2. Locates an SSH public key (or generates one with --generate-key)
+  3. Backs up ~/.gitconfig to ~/.gitconfig.bak.<timestamp>
+  4. Sets gpg.format=ssh, user.signingkey, commit.gpgsign=true, tag.gpgsign=true
+  5. Writes ~/.config/git/allowed_signers and configures gpg.ssh.allowedSignersFile
+  6. Prints next-step instructions for registering the key on GitHub
+
+What it does NOT do (you must do these manually):
+  - Generate keys (unless --generate-key is passed)
+  - Upload keys to GitHub
+  - Modify branch protection rules
+
+Exit codes: 0=success, 1=pre-flight failed, 64=usage error.
+
+Environment overrides:
+  OWNER_EMAIL   override email registered in allowed_signers
+                (default: git config --global user.email)
+EOF
+}
+
+# log_info / log_ok / log_warn / log_error -- consistent prefixed output.
+log_info()  { printf '[..] %s\n' "$*"; }
+log_ok()    { printf '[OK] %s\n' "$*"; }
+log_warn()  { printf '[WARN] %s\n' "$*" >&2; }
+log_error() { printf '[ERROR] %s\n' "$*" >&2; }
+
+# check_git_version -- verify git is installed and >= 2.34.
+check_git_version() {
+  if ! command -v git >/dev/null 2>&1; then
+    log_error "git not found in PATH"
+    return 1
+  fi
+  local v major minor
+  v="$(git --version 2>/dev/null | awk '{print $3}')"
+  major="${v%%.*}"
+  minor="${v#*.}"
+  minor="${minor%%.*}"
+  if [[ -z "$major" ]] || [[ -z "$minor" ]]; then
+    log_error "could not parse git version: $v"
+    return 1
+  fi
+  if (( major < GIT_MIN_MAJOR )) || { (( major == GIT_MIN_MAJOR )) && (( minor < GIT_MIN_MINOR )); }; then
+    log_error "git ${v} is too old; SSH signing requires >= ${GIT_MIN_MAJOR}.${GIT_MIN_MINOR}"
+    return 1
+  fi
+  log_ok "git version: $v"
+  return 0
+}
+
+# find_ssh_key -- echo the first existing public key path. Returns 0 if found.
+find_ssh_key() {
+  local candidate
+  for candidate in "${SSH_KEY_CANDIDATES[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# generate_ed25519_key -- create ~/.ssh/id_ed25519 with default options.
+# Caller must have already confirmed it does not exist.
+generate_ed25519_key() {
+  local key_path="$HOME/.ssh/id_ed25519"
+  log_info "generating ${key_path} (ed25519)..."
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  if ! ssh-keygen -t ed25519 -f "$key_path" -N ""; then
+    log_error "ssh-keygen failed"
+    return 1
+  fi
+  log_ok "generated $key_path"
+  printf '%s.pub\n' "$key_path"
+  return 0
+}
+
+# resolve_owner_email -- echo the email to use in allowed_signers.
+# Order: $OWNER_EMAIL env > git config --global user.email > empty (error).
+resolve_owner_email() {
+  if [[ -n "${OWNER_EMAIL:-$DEFAULT_OWNER_EMAIL}" ]]; then
+    printf '%s\n' "${OWNER_EMAIL:-$DEFAULT_OWNER_EMAIL}"
+    return 0
+  fi
+  local e
+  e="$(git config --global user.email 2>/dev/null || true)"
+  if [[ -n "$e" ]]; then
+    printf '%s\n' "$e"
+    return 0
+  fi
+  return 1
+}
+
+# backup_gitconfig -- copy ~/.gitconfig to a timestamped backup. Idempotent
+# (returns 0 even if no existing config). Echoes the backup path on success.
+backup_gitconfig() {
+  local src="$HOME/.gitconfig"
+  if [[ ! -f "$src" ]]; then
+    return 0
+  fi
+  local stamp
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  local dst="${src}.bak.${stamp}"
+  if cp "$src" "$dst"; then
+    printf '%s\n' "$dst"
+    return 0
+  fi
+  return 1
+}
+
+# write_allowed_signers -- create or update ~/.config/git/allowed_signers with
+# one line per (email, key) pair. Appends if email/key combo not present.
+write_allowed_signers() {
+  local email="$1"
+  local pubkey_path="$2"
+  local signers_dir="$HOME/.config/git"
+  local signers_file="$signers_dir/allowed_signers"
+
+  mkdir -p "$signers_dir"
+
+  # Read the public-key body (everything except the optional trailing comment).
+  local key_content
+  key_content="$(awk '{print $1, $2}' "$pubkey_path" 2>/dev/null)"
+  if [[ -z "$key_content" ]]; then
+    log_error "could not read public key: $pubkey_path"
+    return 1
+  fi
+
+  local entry="${email} ${key_content}"
+
+  # If the exact entry already exists, do nothing.
+  if [[ -f "$signers_file" ]] && grep -Fxq "$entry" "$signers_file"; then
+    log_ok "allowed_signers already contains this entry"
+    return 0
+  fi
+
+  # Append the new entry. Preserve any existing entries (multi-machine).
+  printf '%s\n' "$entry" >> "$signers_file"
+  chmod 644 "$signers_file"
+  log_ok "wrote $signers_file"
+  return 0
+}
+
+# apply_git_config -- set the global git config keys for SSH signing.
+apply_git_config() {
+  local pubkey_path="$1"
+  local signers_file="$HOME/.config/git/allowed_signers"
+
+  git config --global gpg.format ssh
+  git config --global user.signingkey "$pubkey_path"
+  git config --global commit.gpgsign true
+  git config --global tag.gpgsign true
+  git config --global gpg.ssh.allowedSignersFile "$signers_file"
+}
+
+# print_next_steps -- post-configuration instructions. Operator-driven.
+print_next_steps() {
+  local pubkey_path="$1"
+  cat <<EOF
+
+Next steps (operator action required):
+
+  1. Open https://github.com/settings/ssh/new
+  2. Paste the public key shown below; set Key type = Signing Key
+       cat "$pubkey_path"
+  3. From any local clone of claude-memory, verify a signed commit:
+       git commit -S --allow-empty -m "test signed commit"
+       git log --show-signature -1
+     Expected:
+       Good "ssh" signature for <email> with ED25519 key SHA256:...
+  4. (Repository owner only) Enable required-signed-commit branch protection:
+       gh api repos/kcenon/claude-memory/branches/main/protection \\
+         --method PUT \\
+         -f required_signatures.enabled=true \\
+         -f required_pull_request_reviews=null \\
+         -f restrictions=null \\
+         -f enforce_admins=true
+
+After step 4, unsigned commits to claude-memory main will be rejected.
+EOF
+}
+
+# print_dry_run -- show what would change without writing anything.
+print_dry_run() {
+  local pubkey_path="$1"
+  local email="$2"
+  cat <<EOF
+
+[DRY RUN] No changes written. Intended changes:
+
+  Backup:
+    ~/.gitconfig -> ~/.gitconfig.bak.<timestamp> (if ~/.gitconfig exists)
+
+  git config --global:
+    gpg.format = ssh
+    user.signingkey = ${pubkey_path}
+    commit.gpgsign = true
+    tag.gpgsign = true
+    gpg.ssh.allowedSignersFile = \$HOME/.config/git/allowed_signers
+
+  ~/.config/git/allowed_signers (append):
+    ${email} <key body from ${pubkey_path}>
+
+Re-run without --dry-run to apply.
+EOF
+}
+
+main() {
+  local pubkey_path=""
+  local generate_key=0
+  local dry_run=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --key)
+        if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
+          log_error "--key requires a path argument"
+          usage >&2
+          exit 64
+        fi
+        pubkey_path="$2"
+        shift 2
+        ;;
+      --generate-key)
+        generate_key=1
+        shift
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      *)
+        log_error "unknown argument: $1"
+        usage >&2
+        exit 64
+        ;;
+    esac
+  done
+
+  # 1. Pre-flight: git version.
+  if ! check_git_version; then
+    return 1
+  fi
+
+  # 2. Locate or generate SSH key.
+  if [[ -n "$pubkey_path" ]]; then
+    if [[ ! -f "$pubkey_path" ]]; then
+      log_error "public key not found: $pubkey_path"
+      return 1
+    fi
+    log_ok "using specified key: $pubkey_path"
+  else
+    if pubkey_path="$(find_ssh_key)"; then
+      log_ok "found SSH key: $pubkey_path"
+    else
+      if (( generate_key == 1 )); then
+        if ! pubkey_path="$(generate_ed25519_key)"; then
+          return 1
+        fi
+      else
+        log_error "no SSH key found in ~/.ssh/"
+        log_error "generate one with:"
+        log_error "    ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519"
+        log_error "or re-run this script with --generate-key"
+        return 1
+      fi
+    fi
+  fi
+
+  # 3. Resolve owner email.
+  local email
+  if ! email="$(resolve_owner_email)"; then
+    log_error "could not determine owner email"
+    log_error "set it with: git config --global user.email <you@example.com>"
+    log_error "or pass via: OWNER_EMAIL=you@example.com $(basename "$0")"
+    return 1
+  fi
+  log_ok "owner email: $email"
+
+  # 4. Dry run mode -- print intended changes and exit.
+  if (( dry_run == 1 )); then
+    print_dry_run "$pubkey_path" "$email"
+    return 0
+  fi
+
+  # 5. Backup existing ~/.gitconfig.
+  local backup
+  if backup="$(backup_gitconfig)"; then
+    if [[ -n "$backup" ]]; then
+      log_ok "backed up ~/.gitconfig to $backup"
+    fi
+  else
+    log_warn "could not back up ~/.gitconfig; continuing"
+  fi
+
+  # 6. Write allowed_signers.
+  if ! write_allowed_signers "$email" "$pubkey_path"; then
+    return 1
+  fi
+
+  # 7. Apply git config.
+  apply_git_config "$pubkey_path"
+  log_ok "configured git for SSH signing"
+
+  # 8. Print next steps.
+  print_next_steps "$pubkey_path"
+  return 0
+}
+
+main "$@"
+exit $?


### PR DESCRIPTION
## What

### Summary

Adds per-machine SSH commit signing setup for `kcenon/claude-memory` so every committed memory file's authorship is cryptographically verifiable.

### Change Type

- [x] Chore (maintenance task)
- [x] Documentation (operator runbook)

### Affected Components

- `scripts/memory/setup-ssh-signing.sh` -- new helper script
- `docs/SSH_COMMIT_SIGNING.md` -- per-machine setup runbook
- `global/CLAUDE.md` -- routing entry pointing to the new doc

## Why

### Problem Solved

Without enforced signing, a future bad actor (or future-me with a bad day) could push memory files that influence Claude's behavior across all synced machines without verifiable authorship. SSH signing closes that gap with a per-machine key whose loss affects only one machine (R3 mitigation per the epic body).

SSH signing is preferred over GPG because the user already has SSH keys configured for `git push`; setting `gpg.format=ssh` lets the same key authenticate the push and sign the commit.

### Related Issues

- Closes #518
- BlockedBy: #515 (already CLOSED)
- Blocks: #532 (onboarding new machine documents key registration)
- Related: #534 (rotation/compromise docs in `docs/MEMORY_SYNC.md`)
- Part of: #505

## Who

- **Implementer**: @kcenon
- **Reviewer**: @kcenon

## When

- Priority: medium
- Target: feeds into #532 (second-machine onboarding)

## Where

- `scripts/memory/setup-ssh-signing.sh` (new, +318 LOC)
- `docs/SSH_COMMIT_SIGNING.md` (new, +193 LOC)
- `global/CLAUDE.md` (+1 LOC routing entry)

Branch protection on `kcenon/claude-memory` main is a repo-owner step; the runbook documents the exact `gh api` command. The `gh ssh-key add --type signing` step is also operator-driven (the helper script never uploads keys without explicit consent).

## How

### Implementation Highlights

`setup-ssh-signing.sh` is the per-machine driver:

1. Verifies `git >= 2.34`
2. Locates an existing SSH public key in standard paths (`~/.ssh/id_ed25519.pub`, `id_ecdsa.pub`, `id_rsa.pub`); refuses to proceed if none unless `--generate-key` is passed
3. Backs up `~/.gitconfig` to `~/.gitconfig.bak.<timestamp>`
4. Sets `gpg.format=ssh`, `user.signingkey`, `commit.gpgsign=true`, `tag.gpgsign=true`
5. Writes `~/.config/git/allowed_signers` (one line per (email, key) pair; skips duplicates so multi-machine adds are append-only)
6. Configures `gpg.ssh.allowedSignersFile`
7. Prints next-step instructions (GitHub key registration URL + verification commands + branch-protection command)

Non-destructive guarantees:

- Never generates keys without `--generate-key`
- Never uploads keys to GitHub (operator does this manually)
- Idempotent (re-run is safe; backup taken every time, allowed_signers entry deduplicated)
- Bash 3.2 compatible (macOS default)

The runbook (`docs/SSH_COMMIT_SIGNING.md`) covers both automated and manual setup paths, multi-machine `allowed_signers` usage, branch protection enable/disable commands, edge cases, and pointers to the rotation/compromise procedures (which live in `docs/MEMORY_SYNC.md` per #534).

### Testing Done

Verified locally with isolated `$HOME` directories and synthetic SSH public keys (real `ssh-keygen` not available in the working container, so a synthetic ed25519-formatted public key was used):

- `--help` -- prints usage, exit 0
- `--dry-run` (no key) -- fails gracefully with [ERROR] and exit 1
- `--dry-run --key <pub>` -- prints intended changes, no writes, exit 0
- `--key <pub>` (fresh `$HOME`) -- writes config, allowed_signers, prints next steps, exit 0
- Re-run on already-configured `$HOME` -- backs up `.gitconfig`, detects existing allowed_signers entry, no duplicate appended, exit 0
- Append second machine key -- two distinct entries in allowed_signers, no duplicates
- Unknown argument -- prints usage to stderr, exit 64
- Non-existent `--key` path -- [ERROR] exit 1

`bash -n` syntax check passes.

### Test Plan for Reviewers

1. Read `docs/SSH_COMMIT_SIGNING.md` end-to-end
2. On a real machine: `./scripts/memory/setup-ssh-signing.sh --dry-run` -- verify intended changes match your existing config
3. Re-run without `--dry-run` -- verify `~/.gitconfig` and `~/.config/git/allowed_signers` are written as printed
4. Register the public key on GitHub as a Signing Key
5. From a `claude-memory` clone: `git commit -S --allow-empty -m test && git log --show-signature -1` -- expect `Good "ssh" signature`

### Breaking Changes

None for this PR's diff. After branch protection is enabled (separate operator step), unsigned commits to `claude-memory` main will be rejected.

### Rollback

- Disable branch protection: `gh api repos/kcenon/claude-memory/branches/main/protection --method PUT -f required_signatures.enabled=false`
- Revert this PR (existing signed commits remain valid)

## Checklist

- [x] Code follows project style (matches existing `scripts/memory/*.sh` conventions)
- [x] Self-review completed
- [x] Tests done (manual, with isolated `$HOME`)
- [x] Documentation added (runbook + routing entry)
- [x] No sensitive data (no real keys committed)
- [x] Commits are atomic and well-described
- [x] Issue linked with closing keyword