### PR TITLE
feat(memory): add memory-notify.sh centralized alert helper

### DIFF
--- a/scripts/memory-notify.sh
+++ b/scripts/memory-notify.sh
@@ -1,0 +1,560 @@
+#!/bin/bash
+# memory-notify.sh -- Centralized notification helper for memory-* scripts.
+#
+# Used by memory-sync.sh (#520), memory-write-guard.sh (#521), and the
+# SessionStart memory-integrity-check.sh (#522) to surface failures to the
+# user without burying them in logs. Routes alerts to OS notification
+# channels (macOS terminal-notifier / osascript; Linux notify-send) and a
+# persistent log read by the integrity-check hook on session start.
+#
+# Operations:
+#   emit (default)   memory-notify.sh <severity> <message>
+#   dismiss          memory-notify.sh --dismiss [<id>]
+#   list             memory-notify.sh --list [--all|--unread]
+#   help             memory-notify.sh --help|-h
+#
+# Severity (per issue #524):
+#   info       informational (e.g., audit completed clean)
+#   warn       needs attention (e.g., sync delayed)
+#   critical   needs immediate attention (e.g., merge conflict)
+#   high       alias for critical (kept for memory-sync.sh #520 callers)
+#
+# Exit codes:
+#   0   emit succeeded (regardless of OS-channel success)
+#   1   invalid severity
+#   2   message empty
+#   64  usage error
+#
+# Best-effort by design: OS-notification failures and log-write failures do
+# not propagate to the caller. The script always exits 0 on a well-formed
+# emit so upstream scripts (sync, write-guard) are never broken by missing
+# notification dependencies.
+#
+# Bash 3.2 compatible (macOS default): no associative arrays, no mapfile,
+# explicit ${var:-default} guards.
+
+set -u
+
+# ----- defaults -----
+
+DEFAULT_LOG_FILE="$HOME/.claude/logs/memory-alerts.log"
+DEFAULT_READ_MARK="$HOME/.claude/.memory-alerts-read-mark"
+DEDUP_WINDOW_SECONDS=3600
+DEDUP_SCAN_LINES=200
+
+# ----- runtime configuration (mutated by parse_args) -----
+
+LOG_FILE=""
+READ_MARK=""
+
+# ----- usage -----
+
+print_help() {
+  cat <<'EOF'
+memory-notify.sh -- centralized notification helper for memory-* scripts.
+
+USAGE
+    memory-notify.sh <severity> <message>            emit an alert
+    memory-notify.sh --dismiss [<id>]                mark unread alerts as read
+    memory-notify.sh --list [--all|--unread]         list alerts (default unread)
+    memory-notify.sh --help | -h                     show this help
+
+SEVERITY
+    info        informational (e.g., audit completed clean)
+    warn        needs attention but not urgent (e.g., sync delayed)
+    critical    needs immediate attention (e.g., merge conflict)
+    high        alias for critical (memory-sync.sh #520 caller compatibility)
+
+OPTIONS
+    --log-file PATH      override ~/.claude/logs/memory-alerts.log
+    --read-mark PATH     override ~/.claude/.memory-alerts-read-mark
+
+EXIT CODES
+     0  emit succeeded (regardless of OS-channel success)
+     1  invalid severity
+     2  message empty
+    64  usage error
+
+NOTES
+    Dedup: a `<severity, message>` pair re-emitted within 1 hour is silently
+    suppressed (no log append, no OS notification).
+
+    OS notification is best-effort: macOS uses terminal-notifier when
+    installed, otherwise falls back to osascript. Linux uses notify-send.
+    Neither channel failing affects the exit code.
+
+    The persistent log lives at ~/.claude/logs/memory-alerts.log and is
+    appended one line per alert in the form:
+
+      <ISO timestamp> <severity> <hash12> <message>
+
+    The SessionStart integrity-check hook (#522) reads this log to surface
+    "you missed N alerts" on the next session start.
+EOF
+}
+
+# ----- helpers -----
+
+# epoch_now -- print current Unix epoch.
+epoch_now() {
+  date +%s
+}
+
+# iso_now -- print current time in ISO 8601 UTC.
+iso_now() {
+  date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
+# iso_to_epoch <iso8601-utc> -- convert ISO 8601 (UTC, ending in Z) to epoch.
+# Tries GNU date first, falls back to BSD date.
+iso_to_epoch() {
+  local iso="$1"
+  local epoch=""
+  # GNU date.
+  epoch="$(date -u -d "$iso" +%s 2>/dev/null || true)"
+  if [[ -n "$epoch" ]]; then
+    printf '%s' "$epoch"
+    return 0
+  fi
+  # BSD date (macOS): strip trailing Z and parse with explicit format.
+  local stripped="${iso%Z}"
+  epoch="$(date -u -j -f '%Y-%m-%dT%H:%M:%S' "$stripped" +%s 2>/dev/null || true)"
+  if [[ -n "$epoch" ]]; then
+    printf '%s' "$epoch"
+    return 0
+  fi
+  printf '0'
+}
+
+# sha12 <text> -- print first 12 hex chars of SHA-256 of <text>.
+sha12() {
+  local text="$1"
+  local hash=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash="$(printf '%s' "$text" | sha256sum 2>/dev/null | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    hash="$(printf '%s' "$text" | shasum -a 256 2>/dev/null | awk '{print $1}')"
+  else
+    # Last-resort fallback: not cryptographic, but enough for dedup ids.
+    hash="$(printf '%s' "$text" | cksum 2>/dev/null | awk '{printf "%012x", $1}')"
+  fi
+  printf '%s' "${hash:0:12}"
+}
+
+# normalize_severity <input> -- map case-insensitive severity to canonical
+# form. Returns 0 with canonical severity on stdout, 1 if invalid.
+# Canonical levels are info|warn|critical. The alias `high` maps to
+# critical so existing memory-sync.sh #520 callers continue to work.
+normalize_severity() {
+  local raw="$1"
+  local lower
+  lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    info|warn|critical)
+      printf '%s' "$lower"
+      return 0
+      ;;
+    high)
+      printf 'critical'
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# escape_message <message> -- collapse newlines/CR to spaces so log entries
+# stay single-line. Trims surrounding whitespace.
+escape_message() {
+  local msg="$1"
+  msg="${msg//$'\r'/ }"
+  msg="${msg//$'\n'/ }"
+  msg="${msg//$'\t'/ }"
+  # Trim leading/trailing spaces (bash 3.2 compatible).
+  while [[ "$msg" == ' '* ]]; do msg="${msg# }"; done
+  while [[ "$msg" == *' ' ]]; do msg="${msg% }"; done
+  printf '%s' "$msg"
+}
+
+# log_dir -- ensure log directory exists; best-effort.
+ensure_log_dir() {
+  local dir
+  dir="$(dirname "$LOG_FILE")"
+  [[ -d "$dir" ]] && return 0
+  mkdir -p "$dir" 2>/dev/null || true
+}
+
+# is_dup <severity> <hash> -- exit 0 if same severity+hash appears in the
+# trailing DEDUP_SCAN_LINES of the log within DEDUP_WINDOW_SECONDS, else 1.
+is_dup() {
+  local severity="$1"
+  local hash="$2"
+  [[ -f "$LOG_FILE" ]] || return 1
+  local now
+  now="$(epoch_now)"
+  local line ts iso line_severity line_hash line_epoch
+  # Read the tail. tail returns nothing on empty file -- no error.
+  local tail_out
+  tail_out="$(tail -n "$DEDUP_SCAN_LINES" "$LOG_FILE" 2>/dev/null || true)"
+  [[ -z "$tail_out" ]] && return 1
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # Format: <ISO> <severity> <hash12> <message>
+    ts="${line%% *}"
+    local rest="${line#* }"
+    line_severity="${rest%% *}"
+    rest="${rest#* }"
+    line_hash="${rest%% *}"
+    if [[ "$line_severity" == "$severity" && "$line_hash" == "$hash" ]]; then
+      line_epoch="$(iso_to_epoch "$ts")"
+      if (( line_epoch > 0 )) && (( now - line_epoch < DEDUP_WINDOW_SECONDS )); then
+        return 0
+      fi
+    fi
+  done <<< "$tail_out"
+  return 1
+}
+
+# os_notify <severity> <message> -- best-effort OS-channel notification.
+# All errors swallowed; never affects exit status.
+os_notify() {
+  local severity="$1"
+  local message="$2"
+  local title="Claude Memory"
+  local subtitle="$severity"
+
+  # Detect macOS first (Darwin).
+  if [[ "$(uname 2>/dev/null || printf '')" == "Darwin" ]]; then
+    if command -v terminal-notifier >/dev/null 2>&1; then
+      terminal-notifier -title "$title" -subtitle "$subtitle" -message "$message" >/dev/null 2>&1 || true
+      return 0
+    fi
+    if command -v osascript >/dev/null 2>&1; then
+      # Escape double quotes and backslashes for AppleScript string literals.
+      local esc_msg esc_subtitle
+      esc_msg="${message//\\/\\\\}"
+      esc_msg="${esc_msg//\"/\\\"}"
+      esc_subtitle="${subtitle//\\/\\\\}"
+      esc_subtitle="${esc_subtitle//\"/\\\"}"
+      osascript -e "display notification \"$esc_msg\" with title \"$title\" subtitle \"$esc_subtitle\"" >/dev/null 2>&1 || true
+      return 0
+    fi
+    return 0
+  fi
+
+  # Linux: notify-send if available and a session bus is reachable.
+  if command -v notify-send >/dev/null 2>&1; then
+    local urgency="normal"
+    case "$severity" in
+      info)     urgency="low" ;;
+      warn)     urgency="normal" ;;
+      critical) urgency="critical" ;;
+    esac
+    notify-send --urgency="$urgency" "$title: $severity" "$message" >/dev/null 2>&1 || true
+    return 0
+  fi
+  return 0
+}
+
+# ----- emit -----
+
+emit_alert() {
+  local severity_raw="$1"
+  local message_raw="$2"
+
+  local severity
+  severity="$(normalize_severity "$severity_raw" || true)"
+  if [[ -z "$severity" ]]; then
+    printf 'error: invalid severity: %s (expected info|warn|critical)\n' "$severity_raw" >&2
+    return 1
+  fi
+
+  local message
+  message="$(escape_message "$message_raw")"
+  if [[ -z "$message" ]]; then
+    printf 'error: message empty\n' >&2
+    return 2
+  fi
+
+  local hash
+  hash="$(sha12 "${severity}:${message}")"
+
+  ensure_log_dir
+
+  if is_dup "$severity" "$hash"; then
+    # Silent dedup; honour Caller-Friendly contract.
+    return 0
+  fi
+
+  local ts
+  ts="$(iso_now)"
+  local line="${ts} ${severity} ${hash} ${message}"
+
+  # Append to log (best-effort). Append is line-atomic for messages
+  # smaller than PIPE_BUF on POSIX.
+  if [[ -n "$LOG_FILE" ]]; then
+    if ! printf '%s\n' "$line" >> "$LOG_FILE" 2>/dev/null; then
+      printf '%s\n' "$line" >&2
+    fi
+  fi
+
+  os_notify "$severity" "$message"
+  return 0
+}
+
+# ----- dismiss -----
+
+dismiss_alerts() {
+  local id="${1:-}"
+  ensure_log_dir
+  local mark_dir
+  mark_dir="$(dirname "$READ_MARK")"
+  mkdir -p "$mark_dir" 2>/dev/null || true
+
+  if [[ -z "$id" ]]; then
+    # Mark everything currently in the log as read.
+    local count=0
+    if [[ -f "$LOG_FILE" ]]; then
+      count="$(unread_count_internal)"
+    fi
+    # Atomic write via temp file + mv.
+    local tmp="${READ_MARK}.tmp.$$"
+    if printf '%s\n' "$(iso_now)" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$READ_MARK" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    fi
+    printf 'Dismissed %s unread alert(s).\n' "$count"
+    return 0
+  fi
+
+  # Per-id dismiss: append the id to the read-mark side-file so list
+  # filtering can skip it. Format: one id per line under a separate file
+  # to avoid clobbering the all-dismiss timestamp.
+  local id_file="${READ_MARK}.ids"
+  if [[ -f "$id_file" ]] && grep -Fxq "$id" "$id_file" 2>/dev/null; then
+    printf 'Alert %s already dismissed.\n' "$id"
+    return 0
+  fi
+  if printf '%s\n' "$id" >> "$id_file" 2>/dev/null; then
+    printf 'Dismissed alert %s.\n' "$id"
+  else
+    printf 'error: could not write read-mark id file: %s\n' "$id_file" >&2
+  fi
+  return 0
+}
+
+# unread_count_internal -- count alerts in the log not yet dismissed.
+# Used by dismiss-all to report a count, and by --list --unread to filter.
+unread_count_internal() {
+  [[ -f "$LOG_FILE" ]] || { printf '0'; return 0; }
+  local mark_epoch=0
+  if [[ -s "$READ_MARK" ]]; then
+    local mark_iso
+    mark_iso="$(head -1 "$READ_MARK" 2>/dev/null || printf '')"
+    mark_epoch="$(iso_to_epoch "$mark_iso")"
+    mark_epoch="${mark_epoch:-0}"
+  fi
+  local id_file="${READ_MARK}.ids"
+  local n=0
+  local line ts hash entry_epoch
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    ts="${line%% *}"
+    local rest="${line#* * }"
+    hash="${rest%% *}"
+    entry_epoch="$(iso_to_epoch "$ts")"
+    entry_epoch="${entry_epoch:-0}"
+    if (( entry_epoch <= mark_epoch )); then
+      continue
+    fi
+    if [[ -f "$id_file" ]] && grep -Fxq "$hash" "$id_file" 2>/dev/null; then
+      continue
+    fi
+    n=$((n + 1))
+  done < "$LOG_FILE"
+  printf '%s' "$n"
+}
+
+# ----- list -----
+
+# time_ago_from_epoch <epoch> -- human-friendly relative time.
+time_ago_from_epoch() {
+  local epoch="$1"
+  [[ -z "$epoch" || "$epoch" == "0" ]] && { printf 'unknown'; return; }
+  local now diff
+  now="$(epoch_now)"
+  diff=$((now - epoch))
+  if (( diff < 0 )); then diff=0; fi
+  if (( diff < 60 )); then
+    printf '%ss ago' "$diff"
+  elif (( diff < 3600 )); then
+    printf '%s min ago' "$((diff / 60))"
+  elif (( diff < 86400 )); then
+    printf '%s hr ago' "$((diff / 3600))"
+  else
+    printf '%s day ago' "$((diff / 86400))"
+  fi
+}
+
+list_alerts() {
+  local mode="$1"  # all|unread
+  if [[ ! -f "$LOG_FILE" ]]; then
+    printf 'No alerts.\n'
+    return 0
+  fi
+
+  local mark_epoch=0
+  if [[ "$mode" == "unread" && -s "$READ_MARK" ]]; then
+    local mark_iso
+    mark_iso="$(head -1 "$READ_MARK" 2>/dev/null || printf '')"
+    mark_epoch="$(iso_to_epoch "$mark_iso")"
+    mark_epoch="${mark_epoch:-0}"
+  fi
+  local id_file="${READ_MARK}.ids"
+
+  local printed=0
+  local line ts severity hash msg entry_epoch
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    ts="${line%% *}"
+    local rest="${line#* }"
+    severity="${rest%% *}"
+    rest="${rest#* }"
+    hash="${rest%% *}"
+    msg="${rest#* }"
+
+    if [[ "$mode" == "unread" ]]; then
+      entry_epoch="$(iso_to_epoch "$ts")"
+      entry_epoch="${entry_epoch:-0}"
+      if (( entry_epoch <= mark_epoch )); then
+        continue
+      fi
+      if [[ -f "$id_file" ]] && grep -Fxq "$hash" "$id_file" 2>/dev/null; then
+        continue
+      fi
+    fi
+
+    entry_epoch="$(iso_to_epoch "$ts")"
+    local ago
+    ago="$(time_ago_from_epoch "$entry_epoch")"
+    printf '[%s] %-12s %-8s %s\n' "$hash" "$ago" "$severity" "$msg"
+    printed=$((printed + 1))
+  done < "$LOG_FILE"
+
+  if (( printed == 0 )); then
+    if [[ "$mode" == "unread" ]]; then
+      printf 'No unread alerts.\n'
+    else
+      printf 'No alerts.\n'
+    fi
+  fi
+  return 0
+}
+
+# ----- argument parsing -----
+
+parse_args() {
+  LOG_FILE="${MEMORY_NOTIFY_LOG:-$DEFAULT_LOG_FILE}"
+  READ_MARK="${MEMORY_NOTIFY_READ_MARK:-$DEFAULT_READ_MARK}"
+
+  if [[ $# -eq 0 ]]; then
+    print_help >&2
+    exit 64
+  fi
+
+  # First, scan for global options that may appear before the operation.
+  local positional=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --log-file)
+        if [[ $# -lt 2 ]]; then
+          printf 'error: --log-file requires a value\n' >&2
+          exit 64
+        fi
+        LOG_FILE="$2"
+        shift 2
+        ;;
+      --read-mark)
+        if [[ $# -lt 2 ]]; then
+          printf 'error: --read-mark requires a value\n' >&2
+          exit 64
+        fi
+        READ_MARK="$2"
+        shift 2
+        ;;
+      *)
+        positional+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "${#positional[@]}" -eq 0 ]]; then
+    print_help >&2
+    exit 64
+  fi
+
+  case "${positional[0]}" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --dismiss)
+      local id="${positional[1]:-}"
+      if [[ "${#positional[@]}" -gt 2 ]]; then
+        printf 'error: --dismiss accepts at most one id\n' >&2
+        exit 64
+      fi
+      dismiss_alerts "$id"
+      exit 0
+      ;;
+    --list)
+      local mode="unread"
+      local i=1
+      while (( i < ${#positional[@]} )); do
+        case "${positional[$i]}" in
+          --all)    mode="all" ;;
+          --unread) mode="unread" ;;
+          *)
+            printf 'error: unknown --list option: %s\n' "${positional[$i]}" >&2
+            exit 64
+            ;;
+        esac
+        i=$((i + 1))
+      done
+      list_alerts "$mode"
+      exit 0
+      ;;
+    -*)
+      printf 'error: unknown option: %s\n' "${positional[0]}" >&2
+      print_help >&2
+      exit 64
+      ;;
+    *)
+      # Positional emit form: <severity> <message>
+      if [[ "${#positional[@]}" -lt 2 ]]; then
+        printf 'error: emit requires <severity> <message>\n' >&2
+        exit 64
+      fi
+      local severity="${positional[0]}"
+      # Join remaining positionals into a single message in case the caller
+      # forgot to quote. This is a convenience; recommended usage is to quote.
+      local message
+      if [[ "${#positional[@]}" -eq 2 ]]; then
+        message="${positional[1]}"
+      else
+        message="${positional[*]:1}"
+      fi
+      emit_alert "$severity" "$message"
+      exit $?
+      ;;
+  esac
+}
+
+# ----- main -----
+
+main() {
+  parse_args "$@"
+}
+
+main "$@"

--- a/tests/memory/run-notify-tests.sh
+++ b/tests/memory/run-notify-tests.sh
@@ -1,0 +1,410 @@
+#!/bin/bash
+# run-notify-tests.sh -- Integration tests for scripts/memory-notify.sh.
+#
+# Exercises memory-notify.sh against synthetic log/read-mark files in a temp
+# dir under /tmp/memory-notify-test-<pid>. The user's real ~/.claude/ tree
+# is never touched: every run uses --log-file and --read-mark overrides (or
+# the MEMORY_NOTIFY_LOG / MEMORY_NOTIFY_READ_MARK env vars).
+#
+# Test scenarios (per issue #524 Test Plan):
+#   T1   emit critical -> log line appears, exit 0
+#   T2   re-emit identical within window -> log unchanged (dedup)
+#   T3   emit different severity, same message -> log gets both
+#   T4   emit, backdate log entry past dedup window, re-emit -> log gets new entry
+#   T5   --list unread shows entries
+#   T6   --dismiss -> --list unread shows none
+#   T7   --list --all shows entries even after dismiss
+#   T8   invalid severity -> exit 1
+#   T9   empty message -> exit 2
+#   T10  no args -> exit 64
+#   T11  alias "high" maps to critical (memory-sync.sh #520 caller compat)
+#   T12  message with newlines is collapsed to single line
+#   T13  --dismiss <id> only marks that id
+#   T14  --help -> exit 0
+#
+# Bash 3.2 compatible. No `set -e`.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+NOTIFY_SCRIPT="${REPO_ROOT}/scripts/memory-notify.sh"
+
+TEST_TMP_BASE="${TMPDIR:-/tmp}/memory-notify-test-$$"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log() {
+  printf '[%s] %s\n' "$(date -u +'%H:%M:%SZ')" "$*"
+}
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    log "  PASS: $label"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    log "  FAIL: $label (expected $expected, got $actual)"
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    log "  PASS: $label"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    log "  FAIL: $label (missing '$needle')"
+    log "    haystack: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    log "  PASS: $label"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    log "  FAIL: $label (unexpectedly contained '$needle')"
+  fi
+}
+
+mk_test_dir() {
+  local d="${TEST_TMP_BASE}/case-$$-${RANDOM}"
+  mkdir -p "$d"
+  printf '%s' "$d"
+}
+
+cleanup_all() {
+  rm -rf "$TEST_TMP_BASE" 2>/dev/null || true
+}
+
+trap cleanup_all EXIT
+
+# Suppress real OS notifications during tests by neutralising notifier
+# commands on PATH for the spawned subprocess. We export a PATH-prefix dir
+# of stub no-op commands so the script still detects them but they do
+# nothing visible.
+make_silent_path() {
+  local stub_dir="$1"
+  mkdir -p "$stub_dir"
+  for cmd in osascript notify-send terminal-notifier; do
+    cat > "$stub_dir/$cmd" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+    chmod +x "$stub_dir/$cmd"
+  done
+  printf '%s' "$stub_dir"
+}
+
+# ----- T1: emit critical succeeds, log gets one line -----
+test_T1() {
+  log "T1: emit critical -> exit 0, log line appears"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "memory-sync: merge conflict on hostA"
+  local rc=$?
+  assert_eq "T1 exit code" "0" "$rc"
+
+  if [[ -f "$logf" ]]; then
+    local lines
+    lines="$(wc -l < "$logf" | tr -d ' ')"
+    assert_eq "T1 log line count" "1" "$lines"
+    local content
+    content="$(cat "$logf")"
+    assert_contains "T1 log contains severity" "critical" "$content"
+    assert_contains "T1 log contains message" "memory-sync: merge conflict on hostA" "$content"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    log "  FAIL: T1 log file not created"
+  fi
+}
+
+# ----- T2: dedup within window -----
+test_T2() {
+  log "T2: re-emit identical within window -> dedup (log unchanged)"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "sync delayed"
+  local first_lines
+  first_lines="$(wc -l < "$logf" | tr -d ' ')"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "sync delayed"
+  local rc=$?
+  local second_lines
+  second_lines="$(wc -l < "$logf" | tr -d ' ')"
+
+  assert_eq "T2 dedup exit code" "0" "$rc"
+  assert_eq "T2 line count unchanged" "$first_lines" "$second_lines"
+}
+
+# ----- T3: different severity, same message -> two entries -----
+test_T3() {
+  log "T3: different severity, same message -> log gets both"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" info "audit clean"
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "audit clean"
+
+  local lines
+  lines="$(wc -l < "$logf" | tr -d ' ')"
+  assert_eq "T3 line count" "2" "$lines"
+}
+
+# ----- T4: backdate log entry, re-emit -> new entry -----
+test_T4() {
+  log "T4: outside dedup window -> log gets new entry"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  # First emit normally.
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "old conflict"
+  # Manually replace the timestamp with one 2 hours ago to simulate aging.
+  local old_iso
+  if date -u -d '2 hours ago' +'%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    old_iso="$(date -u -d '2 hours ago' +'%Y-%m-%dT%H:%M:%SZ')"
+  else
+    # BSD date (macOS).
+    old_iso="$(date -u -v-2H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf '2020-01-01T00:00:00Z')"
+  fi
+  # Rewrite the file: replace the existing timestamp prefix with old_iso.
+  local existing_line
+  existing_line="$(head -1 "$logf")"
+  local rest="${existing_line#* }"
+  printf '%s %s\n' "$old_iso" "$rest" > "$logf"
+
+  # Re-emit; should bypass dedup because old entry is > 1 hour old.
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "old conflict"
+  local lines
+  lines="$(wc -l < "$logf" | tr -d ' ')"
+  assert_eq "T4 line count" "2" "$lines"
+}
+
+# ----- T5: --list unread shows entries -----
+test_T5() {
+  log "T5: --list shows unread entries"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "list test alert"
+  local out
+  out="$(PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --list)"
+  assert_contains "T5 list shows alert message" "list test alert" "$out"
+  assert_contains "T5 list shows severity" "critical" "$out"
+}
+
+# ----- T6: --dismiss then --list unread -> none -----
+test_T6() {
+  log "T6: --dismiss clears unread"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "dismiss me"
+  # On some systems wc -l gives leading whitespace; the count itself is
+  # what matters, not for this test.
+
+  local dis_out
+  dis_out="$(PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --dismiss)"
+  assert_contains "T6 dismiss reports count" "Dismissed" "$dis_out"
+
+  local list_out
+  list_out="$(PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --list)"
+  assert_contains "T6 list reports no unread" "No unread alerts" "$list_out"
+}
+
+# ----- T7: --list --all shows entries even after dismiss -----
+test_T7() {
+  log "T7: --list --all shows alerts after dismiss"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "history alert"
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --dismiss >/dev/null
+
+  local out
+  out="$(PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --list --all)"
+  assert_contains "T7 --all still shows entry" "history alert" "$out"
+}
+
+# ----- T8: invalid severity -> exit 1 -----
+test_T8() {
+  log "T8: invalid severity -> exit 1"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" bogus "hi" 2>/dev/null
+  assert_eq "T8 invalid severity exit" "1" "$?"
+}
+
+# ----- T9: empty message -> exit 2 -----
+test_T9() {
+  log "T9: empty message -> exit 2"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "" 2>/dev/null
+  assert_eq "T9 empty message exit" "2" "$?"
+}
+
+# ----- T10: no args -> exit 64 -----
+test_T10() {
+  log "T10: no args -> exit 64"
+  "$NOTIFY_SCRIPT" 2>/dev/null
+  assert_eq "T10 no-args exit" "64" "$?"
+}
+
+# ----- T11: high alias maps to critical -----
+test_T11() {
+  log "T11: severity alias 'high' is accepted (memory-sync.sh #520 compat)"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" high "compat alert"
+  assert_eq "T11 high alias exit" "0" "$?"
+
+  local content
+  content="$(cat "$logf")"
+  assert_contains "T11 alias logged as critical" " critical " "$content"
+}
+
+# ----- T12: newlines in message -> single line in log -----
+test_T12() {
+  log "T12: newlines in message collapse to spaces"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "$(printf 'first\nsecond')"
+  local lines
+  lines="$(wc -l < "$logf" | tr -d ' ')"
+  assert_eq "T12 single line in log" "1" "$lines"
+  local content
+  content="$(cat "$logf")"
+  assert_contains "T12 contains first" "first" "$content"
+  assert_contains "T12 contains second" "second" "$content"
+}
+
+# ----- T13: --dismiss <id> only marks that id -----
+test_T13() {
+  log "T13: --dismiss <id> only marks specific id"
+  local d
+  d="$(mk_test_dir)"
+  local stub
+  stub="$(make_silent_path "$d/stub")"
+  local logf="$d/alerts.log"
+  local mark="$d/read-mark"
+
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" critical "alpha"
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" warn "beta"
+
+  # Extract first id from the log (alpha entry).
+  local alpha_id
+  alpha_id="$(awk 'NR==1 {print $3}' "$logf")"
+  PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --dismiss "$alpha_id" >/dev/null
+
+  local out
+  out="$(PATH="$stub:$PATH" "$NOTIFY_SCRIPT" --log-file "$logf" --read-mark "$mark" --list)"
+  assert_not_contains "T13 alpha gone after id-dismiss" "alpha" "$out"
+  assert_contains "T13 beta still unread" "beta" "$out"
+}
+
+# ----- T14: --help -> exit 0 -----
+test_T14() {
+  log "T14: --help -> exit 0"
+  local out
+  out="$("$NOTIFY_SCRIPT" --help)"
+  assert_eq "T14 help exit" "0" "$?"
+  assert_contains "T14 help mentions usage" "USAGE" "$out"
+  assert_contains "T14 help mentions severity" "SEVERITY" "$out"
+}
+
+# ----- run all -----
+
+main() {
+  if [[ ! -x "$NOTIFY_SCRIPT" ]]; then
+    log "ERROR: $NOTIFY_SCRIPT is not executable"
+    exit 64
+  fi
+
+  rm -rf "$TEST_TMP_BASE" 2>/dev/null || true
+  mkdir -p "$TEST_TMP_BASE"
+
+  test_T1
+  test_T2
+  test_T3
+  test_T4
+  test_T5
+  test_T6
+  test_T7
+  test_T8
+  test_T9
+  test_T10
+  test_T11
+  test_T12
+  test_T13
+  test_T14
+
+  log "Summary: $PASS_COUNT pass, $FAIL_COUNT fail"
+  if (( FAIL_COUNT > 0 )); then
+    exit 1
+  fi
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## What

### Summary

Adds `scripts/memory-notify.sh` -- the centralized notification helper
called by `memory-sync.sh` (#520), `memory-write-guard.sh` (#521), and the
SessionStart `memory-integrity-check.sh` (#522) to surface failures
without burying them in logs.

### Change Type

- [x] Feature (new functionality)

### Affected Components

- `scripts/memory-notify.sh` (new)
- `tests/memory/run-notify-tests.sh` (new)

## Why

### Problem Solved

Without a centralized notify helper, each upstream caller (sync,
write-guard, integrity-check) would re-implement OS detection and
dedup. Worse, alerts would scatter across multiple channels and log
files, making "what's broken right now" hard to answer.

The persistent log + dedup design ensures that:

1. A flapping failure (sync fails every hour) does not spam OS
   notifications -- first alert pops, subsequent re-emits dedup.
2. Alerts persist across sessions (user can leave for the weekend,
   return, see what happened).
3. SessionStart hook (#522) surfaces "you missed N alerts" the next
   time Claude Code starts.

### Related Issues

- Closes #524
- Part of #505 (Cross-machine memory sync EPIC)
- Unblocks `memory-sync.sh` (#520) callers that already invoke
  `notify <severity> <message>` -- the engine called the hook when
  present and fell back to log-only when absent. With this PR the
  hook ships.

## Where

| File | Purpose |
|------|---------|
| `scripts/memory-notify.sh` | Centralized notification helper |
| `tests/memory/run-notify-tests.sh` | 14 scenarios, 26 assertions |

## How

### Operations

```
memory-notify.sh <severity> <message>            emit (default)
memory-notify.sh --dismiss [<id>]                mark unread alerts as read
memory-notify.sh --list [--all|--unread]         list alerts (default unread)
memory-notify.sh --help | -h                     show help
```

### Severity Levels (per #524 spec)

- `info` -- informational (e.g., "audit completed clean")
- `warn` -- needs attention but not urgent (e.g., "sync delayed")
- `critical` -- needs immediate attention (e.g., "merge conflict")
- `high` -- accepted as alias for `critical` so existing
  `memory-sync.sh` #520 callers (`notify high "..."`) keep working
  without a coordinated change in PR #547.

### Exit Codes

| Code | Meaning |
|------|---------|
| 0 | emit succeeded (regardless of OS-channel success) |
| 1 | invalid severity |
| 2 | message empty |
| 64 | usage error |

### Channels

- **macOS**: `terminal-notifier` when installed, falls back to
  `osascript display notification`. Both swallow failures.
- **Linux**: `notify-send` with severity-mapped urgency
  (`info`->low, `warn`->normal, `critical`->critical).
- **Universal**: append-only log at
  `~/.claude/logs/memory-alerts.log`, single line per alert in the
  form `<ISO timestamp> <severity> <hash12> <message>`.

### Dedup

Same `<severity, message>` SHA-256 hash (12 hex chars) within a
trailing 1-hour window: silent suppress (no log append, no OS
notification). Scan reads the trailing 200 log lines and parses
their ISO timestamps to compute the dedup-window decision.

### Caller-Friendly

A well-formed emit always exits 0 regardless of OS-channel success
or log-write success. Upstream sync/guard scripts are never blocked
by a missing `terminal-notifier`, no `notify-send`, or an unwritable
log file (which falls back to stderr).

### Channel Demo

```
$ ./scripts/memory-notify.sh critical "memory-sync: merge conflict on hostA"
# (silent on success; log line appended; OS notification fired best-effort)

$ ./scripts/memory-notify.sh critical "memory-sync: merge conflict on hostA"
# (silent dedup -- same hash within 1 hour)

$ ./scripts/memory-notify.sh --list
[a1b2c3d4e5f6] 47s ago      critical memory-sync: merge conflict on hostA

$ ./scripts/memory-notify.sh --dismiss
Dismissed 1 unread alert(s).

$ ./scripts/memory-notify.sh --list
No unread alerts.

$ ./scripts/memory-notify.sh --list --all
[a1b2c3d4e5f6] 1 min ago    critical memory-sync: merge conflict on hostA
```

### Testing Done

- [x] 14/14 scenarios pass on Linux (`tests/memory/run-notify-tests.sh`):
      26 assertions covering emit, dedup, list, dismiss (all + by id),
      invalid severity, empty message, the `high` alias, newline
      normalization, dedup-window-expiry, --help.
- [x] No regression in `tests/memory/run-sync-tests.sh` (17/17 still pass).
- [x] Bash 3.2 idioms throughout (no `mapfile`, no associative arrays,
      explicit `${var:-default}` guards).
- [x] Test runner uses `--log-file` and `--read-mark` overrides plus a
      `PATH`-prefix stub directory to neutralise real OS notifications --
      the user's real `~/.claude/` tree and notification daemon are
      never touched.

### Test Plan for Reviewers

```bash
chmod +x scripts/memory-notify.sh tests/memory/run-notify-tests.sh
tests/memory/run-notify-tests.sh
# Expect: "Summary: 26 pass, 0 fail"

scripts/memory-notify.sh --help
```

### Out of Scope (per #524 issue body)

- Push notifications to mobile / external services
- Email alerts
- Slack / Discord integrations
- Long-term alert metrics

These are explicitly listed in the issue's "Scope (out)" section.

### Breaking Changes

None -- net-new script. `memory-sync.sh` (#520) already calls this
hook via an absolute `~/.claude/scripts/memory-notify.sh` path and
falls back to log-only when absent, so this PR is purely additive.

### Rollback Plan

1. Revert this PR.
2. Existing callers (`memory-sync.sh`) continue to work; the
   `notify()` helper falls back to log-only when the script is
   absent.
