### PR TITLE
feat(memory): add SessionStart memory health summary hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1013,6 +1013,7 @@ this catalog for the canonical hook inventory.
 | [`github-api-preflight.sh`](#github-api-preflight) | PreToolUse (Bash) | yes |
 | [`instructions-loaded-reinforcer.sh`](#instructions-loaded-reinforcer) | InstructionsLoaded (sync) | yes |
 | [`markdown-anchor-validator.sh`](#markdown-anchor-validator) | PreToolUse (Bash) | yes |
+| [`memory-integrity-check.sh`](#memory-integrity-check) | SessionStart (sync) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
 | [`p4-timeline-guard.sh`](#p4-timeline-guard) | PreToolUse (Bash | Edit | Write) | yes |
 | [`p4-timeline-reminder.sh`](#p4-timeline-reminder) | SessionStart | yes |
@@ -1034,7 +1035,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 32 bash hooks, 32 with PowerShell counterparts._
+_Total: 33 bash hooks, 33 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1241,6 +1242,23 @@ Validates markdown anchor references before git commit
 | Response format | hookSpecificOutput with hookEventName |
 | PowerShell counterpart | present (`markdown-anchor-validator.ps1`) |
 | Source | `global/hooks/markdown-anchor-validator.sh` |
+
+### memory-integrity-check
+
+_File:_ `memory-integrity-check.sh`
+
+_Anchor:_ `#memory-integrity-check`
+
+Prints a brief memory health summary at SessionStart. Reads ~/.claude/memory-shared/ metadata only -- no network, no validators.
+
+| Field | Value |
+|---|---|
+| Hook Type | SessionStart (sync) |
+| Trigger / Matcher | sync |
+| Exit codes | 0 always (SessionStart must never block the session) |
+| Response format | — |
+| PowerShell counterpart | present (`memory-integrity-check.ps1`) |
+| Source | `global/hooks/memory-integrity-check.sh` |
 
 ### merge-gate-guard
 

--- a/global/hooks/memory-integrity-check.ps1
+++ b/global/hooks/memory-integrity-check.ps1
@@ -1,0 +1,299 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# memory-integrity-check.ps1
+# SessionStart hook: prints a brief memory health summary at session start.
+# Reads ~/.claude/memory-shared/ metadata only -- no network, no validators.
+#
+# Hook Type: SessionStart (sync)
+# Exit codes: 0 always (SessionStart must never block the session)
+# Output prefix: [memory]
+#
+# Silent (no stdout) when system is healthy AND no recent activity AND
+# no unread alerts AND last sync within 24 hours.
+#
+# Performance budget: < 300ms typical; hard cap 500ms with warning to stderr.
+# Issue: kcenon/claude-config#522 (Phase D engine).
+
+# --- Constants ---------------------------------------------------------------
+
+$memorySharedDir   = if ($env:MEMORY_SHARED_DIR)        { $env:MEMORY_SHARED_DIR }        else { Join-Path $HOME '.claude' 'memory-shared' }
+$memoriesDir       = Join-Path $memorySharedDir 'memories'
+$quarantineDir     = Join-Path $memorySharedDir 'quarantine'
+$alertsLog         = if ($env:MEMORY_ALERTS_LOG)        { $env:MEMORY_ALERTS_LOG }        else { Join-Path $HOME '.claude' 'logs' 'memory-alerts.log' }
+$alertsReadMark    = if ($env:MEMORY_ALERTS_READ_MARK)  { $env:MEMORY_ALERTS_READ_MARK }  else { Join-Path $HOME '.claude' '.memory-alerts-read-mark' }
+
+$RecentSecs    = 86400      # 24h
+$StaleSecs     = 7776000    # 90d
+$SyncStaleSecs = 86400      # 24h triggers warning per epic R1 mitigation
+$PerfWarnMs    = 500        # hard cap
+
+# --- Setup -------------------------------------------------------------------
+
+# SessionStart hooks may receive JSON on stdin; drain and ignore.
+try {
+    if (-not [Console]::IsInputRedirected) {
+        # No piped stdin; nothing to read.
+    } else {
+        [Console]::In.ReadToEnd() | Out-Null
+    }
+} catch {
+    # ignore
+}
+
+$startTime = Get-Date
+
+# Silent exit if the memory system is not deployed yet.
+if (-not (Test-Path -LiteralPath $memorySharedDir -PathType Container)) {
+    exit 0
+}
+
+# --- Helpers -----------------------------------------------------------------
+
+function Read-Frontmatter {
+    param([Parameter(Mandatory)][string]$FilePath)
+    if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) { return $null }
+    $lines = $null
+    try {
+        $lines = [System.IO.File]::ReadAllLines($FilePath, [System.Text.Encoding]::UTF8)
+    } catch {
+        return $null
+    }
+    if ($lines.Count -lt 1) { return $null }
+    if ($lines[0] -ne '---') { return $null }
+    $endIdx = -1
+    for ($i = 1; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^---\s*$') { $endIdx = $i; break }
+    }
+    if ($endIdx -lt 1) { return $null }
+    $fm = @{}
+    for ($i = 1; $i -lt $endIdx; $i++) {
+        $line = $lines[$i]
+        if ($line -match '^([A-Za-z0-9_\-]+):\s*(.*)$') {
+            $key   = $matches[1]
+            $value = $matches[2]
+            # Strip surrounding single or double quotes.
+            if ($value -match '^"(.*)"$' -or $value -match "^'(.*)'$") {
+                $value = $matches[1]
+            }
+            $fm[$key] = $value.Trim()
+        }
+    }
+    return $fm
+}
+
+function ConvertFrom-IsoToEpoch {
+    param([string]$Iso)
+    if ([string]::IsNullOrWhiteSpace($Iso)) { return $null }
+    $clean = $Iso.Trim('"', "'", ' ')
+    try {
+        $dt = [DateTimeOffset]::Parse($clean, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal)
+        return $dt.ToUnixTimeSeconds()
+    } catch {
+        return $null
+    }
+}
+
+function Format-TimeAgo {
+    param([Parameter(Mandatory)][long]$Seconds)
+    if ($Seconds -lt 60)    { return "$Seconds sec ago" }
+    if ($Seconds -lt 3600)  { return "$([math]::Floor($Seconds / 60)) min ago" }
+    if ($Seconds -lt 86400) { return "$([math]::Floor($Seconds / 3600)) hr ago" }
+    return "$([math]::Floor($Seconds / 86400)) days ago"
+}
+
+# --- Counts by trust-level ---------------------------------------------------
+
+$countTotal       = 0
+$countVerified    = 0
+$countInferred    = 0
+$countOther       = 0
+$countQuarantined = 0
+$recentNames      = New-Object System.Collections.Generic.List[string]
+$staleNames       = New-Object System.Collections.Generic.List[string]
+
+$nowEpoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+if (Test-Path -LiteralPath $memoriesDir -PathType Container) {
+    $memoryFiles = Get-ChildItem -LiteralPath $memoriesDir -Filter '*.md' -File -ErrorAction SilentlyContinue
+    foreach ($file in $memoryFiles) {
+        if ($file.Name -eq 'MEMORY.md') { continue }   # auto-generated index
+        $countTotal++
+        $fm = Read-Frontmatter -FilePath $file.FullName
+        if ($null -eq $fm) {
+            [Console]::Error.WriteLine("[memory] warning: cannot parse frontmatter: $($file.Name)")
+            continue
+        }
+
+        $tl = if ($fm.ContainsKey('trust-level')) { $fm['trust-level'] } else { '' }
+        switch ($tl) {
+            'verified'    { $countVerified++ }
+            'inferred'    { $countInferred++ }
+            'quarantined' { $countQuarantined++ }
+            default       { $countOther++ }
+        }
+
+        # Recent: created-at within 24h.
+        if ($fm.ContainsKey('created-at')) {
+            $caEpoch = ConvertFrom-IsoToEpoch -Iso $fm['created-at']
+            if ($null -ne $caEpoch) {
+                $age = $nowEpoch - $caEpoch
+                if ($age -ge 0 -and $age -lt $RecentSecs) {
+                    $recentNames.Add($file.BaseName)
+                }
+            }
+        }
+
+        # Stale: verified memory whose last-verified > 90d ago. Missing
+        # last-verified on a verified memory counts as stale (per #511).
+        if ($tl -eq 'verified') {
+            $staleName = $file.BaseName
+            if (-not $fm.ContainsKey('last-verified') -or [string]::IsNullOrWhiteSpace($fm['last-verified'])) {
+                $staleNames.Add($staleName)
+            } else {
+                $lvEpoch = ConvertFrom-IsoToEpoch -Iso $fm['last-verified']
+                if ($null -ne $lvEpoch -and ($nowEpoch - $lvEpoch) -ge $StaleSecs) {
+                    $staleNames.Add($staleName)
+                }
+            }
+        }
+    }
+}
+
+# Quarantined directory adds to the quarantined count.
+if (Test-Path -LiteralPath $quarantineDir -PathType Container) {
+    $qFiles = Get-ChildItem -LiteralPath $quarantineDir -Filter '*.md' -File -ErrorAction SilentlyContinue
+    $countQuarantined += $qFiles.Count
+}
+
+# --- Last-sync time + source machine via git log -----------------------------
+
+$syncSecsAgo = $null
+$syncHost    = ''
+$syncWarn    = $false
+$gitFailed   = $false
+$dotGit      = Join-Path $memorySharedDir '.git'
+if ((Test-Path -LiteralPath $dotGit) -and (Get-Command git -ErrorAction SilentlyContinue)) {
+    $syncLine = $null
+    try {
+        $syncLine = & git -C $memorySharedDir log -1 --format='%ct|%an' 2>$null
+    } catch {
+        $syncLine = $null
+    }
+    if ($syncLine -and ($syncLine -match '^(\d+)\|(.*)$')) {
+        $syncEpoch   = [long]$matches[1]
+        $syncHost    = $matches[2]
+        $syncSecsAgo = $nowEpoch - $syncEpoch
+        if ($syncSecsAgo -ge $SyncStaleSecs) { $syncWarn = $true }
+    } else {
+        $gitFailed = $true
+    }
+} else {
+    $gitFailed = $true
+}
+
+# --- Unread alerts -----------------------------------------------------------
+
+$unreadCount     = 0
+$unreadRecentMsg = ''
+if (Test-Path -LiteralPath $alertsLog -PathType Leaf) {
+    $readMarkEpoch = 0
+    if (Test-Path -LiteralPath $alertsReadMark -PathType Leaf) {
+        try {
+            $rmRaw = (Get-Content -LiteralPath $alertsReadMark -TotalCount 1 -ErrorAction SilentlyContinue).Trim()
+            if ($rmRaw -match '^\d+$') {
+                $readMarkEpoch = [long]$rmRaw
+            } else {
+                $converted = ConvertFrom-IsoToEpoch -Iso $rmRaw
+                if ($null -ne $converted) { $readMarkEpoch = $converted }
+            }
+        } catch {
+            $readMarkEpoch = 0
+        }
+    }
+
+    # Per #524 spec each line is: <ISO timestamp> <severity> <hash> <message>
+    try {
+        $tail = Get-Content -LiteralPath $alertsLog -Tail 200 -ErrorAction SilentlyContinue
+        foreach ($line in $tail) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split '\s+', 4
+            if ($parts.Count -lt 4) { continue }
+            $tsEpoch = ConvertFrom-IsoToEpoch -Iso $parts[0]
+            if ($null -eq $tsEpoch) { continue }
+            if ($tsEpoch -gt $readMarkEpoch) {
+                $unreadCount++
+                $unreadRecentMsg = $parts[3]
+            }
+        }
+    } catch {
+        # ignore alert log read failures
+    }
+}
+
+# --- Decide whether to emit summary ------------------------------------------
+
+$emit = $false
+if ($recentNames.Count -gt 0)   { $emit = $true }
+if ($staleNames.Count -gt 0)    { $emit = $true }
+if ($syncWarn)                  { $emit = $true }
+if ($unreadCount -gt 0)         { $emit = $true }
+if ($countQuarantined -gt 0)    { $emit = $true }
+if ($gitFailed -and $countTotal -gt 0) { $emit = $true }
+
+if (-not $emit) { exit 0 }
+
+# --- Build summary block -----------------------------------------------------
+
+# Line 1: counts.
+Write-Output ("[memory] {0} entries (verified:{1}, inferred:{2}, quarantined:{3})" -f $countTotal, $countVerified, $countInferred, $countQuarantined)
+
+# Line 2: last-sync info.
+if ($gitFailed) {
+    Write-Output ("[memory] cannot read git log; check {0}" -f $memorySharedDir)
+} elseif ($null -ne $syncSecsAgo) {
+    $hostLabel = if ([string]::IsNullOrWhiteSpace($syncHost)) { 'unknown' } else { $syncHost }
+    if ($syncWarn) {
+        Write-Output ("[memory] WARN last sync {0} (host: {1}) -- sync may be stuck" -f (Format-TimeAgo -Seconds $syncSecsAgo), $hostLabel)
+    } else {
+        Write-Output ("[memory] last sync {0} (host: {1})" -f (Format-TimeAgo -Seconds $syncSecsAgo), $hostLabel)
+    }
+}
+
+# Line 3: recent activity.
+if ($recentNames.Count -gt 0) {
+    $display = ($recentNames | Select-Object -First 3) -join ', '
+    if ($recentNames.Count -gt 3) { $display = "{0} (+{1} more)" -f $display, ($recentNames.Count - 3) }
+    Write-Output ("[memory] {0} added in last 24h: {1} -- review with /memory-review" -f $recentNames.Count, $display)
+}
+
+# Line 4: stale memories.
+if ($staleNames.Count -gt 0) {
+    $display = ($staleNames | Select-Object -First 3) -join ', '
+    if ($staleNames.Count -gt 3) { $display = "{0} (+{1} more)" -f $display, ($staleNames.Count - 3) }
+    Write-Output ("[memory] {0} stale (last-verified > 90d): {1} -- review with /memory-review" -f $staleNames.Count, $display)
+}
+
+# Line 5: unread alerts.
+if ($unreadCount -gt 0) {
+    if ([string]::IsNullOrWhiteSpace($unreadRecentMsg)) {
+        Write-Output ("[memory] WARN {0} unread alert(s)" -f $unreadCount)
+    } else {
+        $msg = $unreadRecentMsg
+        if ($msg.Length -gt 80) { $msg = $msg.Substring(0, 77) + '...' }
+        Write-Output ("[memory] WARN {0} unread alert(s); latest: {1}" -f $unreadCount, $msg)
+    }
+    Write-Output ("[memory]   run /memory-review or check {0}" -f $alertsLog)
+}
+
+# --- Performance budget check ------------------------------------------------
+
+$elapsed = (Get-Date) - $startTime
+$elapsedMs = [int]$elapsed.TotalMilliseconds
+if ($elapsedMs -ge $PerfWarnMs) {
+    [Console]::Error.WriteLine("[memory] note: hook took ~${elapsedMs}ms (>${PerfWarnMs}ms budget)")
+}
+
+exit 0

--- a/global/hooks/memory-integrity-check.ps1
+++ b/global/hooks/memory-integrity-check.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 # memory-integrity-check.ps1
-# SessionStart hook: prints a brief memory health summary at session start.
+# Prints a brief memory health summary at SessionStart.
 # Reads ~/.claude/memory-shared/ metadata only -- no network, no validators.
 #
 # Hook Type: SessionStart (sync)

--- a/global/hooks/memory-integrity-check.sh
+++ b/global/hooks/memory-integrity-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # memory-integrity-check.sh
-# SessionStart hook: prints a brief memory health summary at session start.
+# Prints a brief memory health summary at SessionStart.
 # Reads ~/.claude/memory-shared/ metadata only -- no network, no validators.
 #
 # Hook Type: SessionStart (sync)

--- a/global/hooks/memory-integrity-check.sh
+++ b/global/hooks/memory-integrity-check.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# memory-integrity-check.sh
+# SessionStart hook: prints a brief memory health summary at session start.
+# Reads ~/.claude/memory-shared/ metadata only -- no network, no validators.
+#
+# Hook Type: SessionStart (sync)
+# Exit codes: 0 always (SessionStart must never block the session)
+# Output prefix: [memory]
+#
+# Silent (no stdout) when the system is healthy AND no recent activity AND
+# no unread alerts AND last sync within 24 hours.
+#
+# Performance budget: < 300ms typical; hard cap 500ms with warning.
+# Bash 3.2 compatible (macOS default): no mapfile, no associative arrays,
+# BASH_REMATCH save-then-use, ${var:-0} guards, wc output normalization.
+#
+# Issue: kcenon/claude-config#522 (Phase D engine).
+
+set -u
+
+# --- Constants ---------------------------------------------------------------
+
+MEMORY_SHARED_DIR="${MEMORY_SHARED_DIR:-${HOME}/.claude/memory-shared}"
+MEMORIES_DIR="${MEMORY_SHARED_DIR}/memories"
+QUARANTINE_DIR="${MEMORY_SHARED_DIR}/quarantine"
+ALERTS_LOG="${MEMORY_ALERTS_LOG:-${HOME}/.claude/logs/memory-alerts.log}"
+ALERTS_READ_MARK="${MEMORY_ALERTS_READ_MARK:-${HOME}/.claude/.memory-alerts-read-mark}"
+
+# Thresholds (seconds).
+RECENT_SECS=86400          # 24h
+STALE_SECS=7776000         # 90d
+SYNC_STALE_SECS=86400      # 24h triggers warning per epic R1 mitigation
+PERF_WARN_MS=500           # hard cap
+
+# --- Setup -------------------------------------------------------------------
+
+# SessionStart hook receives JSON on stdin; ignore it (the hook does not need
+# event payload to compute memory health). Drain stdin to avoid SIGPIPE on
+# very small inputs from the harness.
+if [ -t 0 ]; then
+    : # no stdin
+else
+    cat >/dev/null 2>&1 || true
+fi
+
+# Capture start time for performance budget.
+if command -v date >/dev/null 2>&1; then
+    START_EPOCH="$(date +%s 2>/dev/null || echo 0)"
+else
+    START_EPOCH=0
+fi
+
+# Bail silently if the memory system is not deployed yet (first-ever session
+# before #525 migration).
+if [ ! -d "$MEMORY_SHARED_DIR" ]; then
+    exit 0
+fi
+
+# --- Helpers -----------------------------------------------------------------
+
+# Read a single-line YAML field from frontmatter text. Echoes the raw value
+# (without the `key:` prefix); empty string when the key is absent.
+get_field() {
+    local fm="$1"
+    local key="$2"
+    printf '%s\n' "$fm" | grep -E "^${key}:" | head -1 | sed "s/^${key}:[[:space:]]*//"
+}
+
+# Strip surrounding double or single quotes from a YAML scalar value.
+strip_quotes() {
+    local v="$1"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    if [[ "$v" =~ ^\"(.*)\"$ ]]; then
+        local m="${BASH_REMATCH[1]}"
+        v="$m"
+    elif [[ "$v" =~ ^\'(.*)\'$ ]]; then
+        local m="${BASH_REMATCH[1]}"
+        v="$m"
+    fi
+    printf '%s' "$v"
+}
+
+# Convert ISO 8601 (UTC) date-time to epoch seconds. Echoes empty on failure.
+# Accepts: 2026-04-30T12:34:56Z, 2026-04-30, 2026-04-30 12:34:56.
+iso_to_epoch() {
+    local iso="$1"
+    [ -z "$iso" ] && { printf ''; return; }
+    iso="$(strip_quotes "$iso")"
+    # Normalize: strip trailing Z, replace T with space.
+    iso="${iso%Z}"
+    iso="${iso/T/ }"
+    # GNU date (Linux) understands -d; BSD date (macOS) needs -j -f.
+    local epoch=""
+    epoch="$(date -u -d "$iso" +%s 2>/dev/null)" || true
+    if [ -z "$epoch" ]; then
+        # Try macOS BSD date with explicit format. Two common formats.
+        epoch="$(date -u -j -f '%Y-%m-%d %H:%M:%S' "$iso" +%s 2>/dev/null)" || true
+        if [ -z "$epoch" ]; then
+            epoch="$(date -u -j -f '%Y-%m-%d' "${iso% *}" +%s 2>/dev/null)" || true
+        fi
+    fi
+    printf '%s' "$epoch"
+}
+
+# Format seconds as a human-readable "ago" string.
+time_ago() {
+    local secs="${1:-0}"
+    if [ "$secs" -lt 60 ]; then
+        printf '%d sec ago' "$secs"
+    elif [ "$secs" -lt 3600 ]; then
+        printf '%d min ago' "$((secs / 60))"
+    elif [ "$secs" -lt 86400 ]; then
+        printf '%d hr ago' "$((secs / 3600))"
+    else
+        printf '%d days ago' "$((secs / 86400))"
+    fi
+}
+
+# Read a memory file's frontmatter into stdout. Echoes empty on failure.
+read_frontmatter() {
+    local f="$1"
+    [ -f "$f" ] || { printf ''; return; }
+    [ -r "$f" ] || { printf ''; return; }
+    local first_line
+    first_line="$(head -1 "$f" 2>/dev/null)"
+    [ "$first_line" = "---" ] || { printf ''; return; }
+    local fm_end
+    fm_end="$(awk 'NR>1 && /^---[[:space:]]*$/ {print NR; exit}' "$f" 2>/dev/null)"
+    fm_end="${fm_end:-}"
+    [ -n "$fm_end" ] || { printf ''; return; }
+    sed -n "2,$((fm_end - 1))p" "$f" 2>/dev/null
+}
+
+# --- Counts by trust-level ---------------------------------------------------
+
+count_verified=0
+count_inferred=0
+count_other=0   # files in memories/ with missing or unrecognized trust-level
+count_quarantined=0
+count_total=0
+recent_names=()
+stale_names=()
+
+now_epoch="${START_EPOCH:-0}"
+[ "$now_epoch" = "0" ] && now_epoch="$(date +%s 2>/dev/null || echo 0)"
+
+if [ -d "$MEMORIES_DIR" ]; then
+    # Bash 3.2: no nullglob; guard against literal pattern when empty.
+    for f in "$MEMORIES_DIR"/*.md; do
+        [ -f "$f" ] || continue
+        # Skip MEMORY.md auto-generated index per spec.
+        local_base="$(basename "$f")"
+        [ "$local_base" = "MEMORY.md" ] && continue
+
+        count_total=$((count_total + 1))
+        fm="$(read_frontmatter "$f")"
+        if [ -z "$fm" ]; then
+            # Frontmatter parse failure: log to stderr (not stdout) and skip
+            # in counts. Hook must never pollute session start with errors.
+            printf '[memory] warning: cannot parse frontmatter: %s\n' "$local_base" >&2
+            continue
+        fi
+
+        tl="$(get_field "$fm" "trust-level")"
+        tl="$(strip_quotes "$tl")"
+        case "$tl" in
+            verified)   count_verified=$((count_verified + 1)) ;;
+            inferred)   count_inferred=$((count_inferred + 1)) ;;
+            quarantined) count_quarantined=$((count_quarantined + 1)) ;;
+            *)          count_other=$((count_other + 1)) ;;
+        esac
+
+        # Recent: created-at within last 24h.
+        ca="$(get_field "$fm" "created-at")"
+        if [ -n "$ca" ]; then
+            ca_epoch="$(iso_to_epoch "$ca")"
+            if [ -n "$ca_epoch" ] && [ "$now_epoch" != "0" ]; then
+                age=$((now_epoch - ca_epoch))
+                if [ "$age" -ge 0 ] && [ "$age" -lt "$RECENT_SECS" ]; then
+                    # Use filename stem without .md as the human label.
+                    rec_name="${local_base%.md}"
+                    recent_names+=("$rec_name")
+                fi
+            fi
+        fi
+
+        # Stale: verified memory whose last-verified > 90d ago. Per spec,
+        # missing last-verified on a verified memory counts as stale.
+        if [ "$tl" = "verified" ]; then
+            lv="$(get_field "$fm" "last-verified")"
+            stale_name="${local_base%.md}"
+            if [ -z "$lv" ]; then
+                stale_names+=("$stale_name")
+            else
+                lv_epoch="$(iso_to_epoch "$lv")"
+                if [ -n "$lv_epoch" ] && [ "$now_epoch" != "0" ]; then
+                    if [ $((now_epoch - lv_epoch)) -ge "$STALE_SECS" ]; then
+                        stale_names+=("$stale_name")
+                    fi
+                fi
+            fi
+        fi
+    done
+fi
+
+# Count files in quarantine/ directory in addition to in-tree quarantined.
+if [ -d "$QUARANTINE_DIR" ]; then
+    for f in "$QUARANTINE_DIR"/*.md; do
+        [ -f "$f" ] || continue
+        count_quarantined=$((count_quarantined + 1))
+    done
+fi
+
+# --- Last-sync time + source machine via git log -----------------------------
+
+sync_secs_ago=""
+sync_host=""
+sync_warn=0
+git_failed=0
+if command -v git >/dev/null 2>&1 && [ -d "${MEMORY_SHARED_DIR}/.git" ]; then
+    # %ct = committer timestamp (epoch); %an = author name (used as host hint
+    # when commits set user.name = host name, which is the convention #520 uses).
+    sync_line="$(git -C "$MEMORY_SHARED_DIR" log -1 --format='%ct|%an' 2>/dev/null)"
+    if [ -n "$sync_line" ] && [[ "$sync_line" =~ ^([0-9]+)\|(.*)$ ]]; then
+        sync_epoch="${BASH_REMATCH[1]}"
+        sync_host="${BASH_REMATCH[2]}"
+        if [ "$now_epoch" != "0" ]; then
+            sync_secs_ago=$((now_epoch - sync_epoch))
+            if [ "$sync_secs_ago" -ge "$SYNC_STALE_SECS" ]; then
+                sync_warn=1
+            fi
+        fi
+    else
+        git_failed=1
+    fi
+else
+    # Memory-shared exists but is not a git clone; treat as readable-but-no-sync.
+    git_failed=1
+fi
+
+# --- Unread alerts -----------------------------------------------------------
+
+unread_count=0
+unread_recent_msg=""
+if [ -f "$ALERTS_LOG" ] && [ -r "$ALERTS_LOG" ]; then
+    # Read-mark file holds an epoch second; missing => everything is unread.
+    read_mark_epoch=0
+    if [ -f "$ALERTS_READ_MARK" ] && [ -r "$ALERTS_READ_MARK" ]; then
+        rm_raw="$(head -1 "$ALERTS_READ_MARK" 2>/dev/null)"
+        # Accept either bare epoch or ISO datetime.
+        if [[ "$rm_raw" =~ ^[0-9]+$ ]]; then
+            read_mark_epoch="$rm_raw"
+        else
+            converted="$(iso_to_epoch "$rm_raw")"
+            [ -n "$converted" ] && read_mark_epoch="$converted"
+        fi
+    fi
+
+    # Each log line per #524 spec:
+    #   <ISO timestamp> <severity> <hash> <message>
+    # Tail the last 200 lines (alerts log is small) and count unread entries.
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        # Parse ISO timestamp (first whitespace-separated token).
+        ts_token="${line%% *}"
+        rest="${line#* }"
+        ts_epoch="$(iso_to_epoch "$ts_token")"
+        if [ -z "$ts_epoch" ]; then
+            continue
+        fi
+        if [ "$ts_epoch" -gt "$read_mark_epoch" ]; then
+            unread_count=$((unread_count + 1))
+            # The "rest" begins with severity, then hash, then message.
+            sev="${rest%% *}"
+            after_sev="${rest#* }"
+            hash_token="${after_sev%% *}"
+            msg="${after_sev#* }"
+            # Best-effort: keep latest message for headline.
+            unread_recent_msg="$msg"
+            # Suppress unused-var warnings for sev/hash_token under set -u.
+            : "$sev" "$hash_token"
+        fi
+    done < <(tail -n 200 "$ALERTS_LOG" 2>/dev/null)
+fi
+
+# --- Decide whether to emit summary ------------------------------------------
+
+emit=0
+if [ ${#recent_names[@]} -gt 0 ]; then emit=1; fi
+if [ ${#stale_names[@]} -gt 0 ]; then emit=1; fi
+if [ "$sync_warn" = "1" ]; then emit=1; fi
+if [ "$unread_count" -gt 0 ]; then emit=1; fi
+if [ "$count_quarantined" -gt 0 ]; then emit=1; fi
+if [ "$git_failed" = "1" ] && [ "$count_total" -gt 0 ]; then emit=1; fi
+
+if [ "$emit" = "0" ]; then
+    # Healthy and recent: silent exit.
+    exit 0
+fi
+
+# --- Build summary block -----------------------------------------------------
+
+# Line 1: counts.
+printf '[memory] %d entries (verified:%d, inferred:%d, quarantined:%d)\n' \
+    "$count_total" "$count_verified" "$count_inferred" "$count_quarantined"
+
+# Line 2: last-sync info.
+if [ "$git_failed" = "1" ]; then
+    printf '[memory] cannot read git log; check %s\n' "$MEMORY_SHARED_DIR"
+elif [ -n "$sync_secs_ago" ]; then
+    if [ "$sync_warn" = "1" ]; then
+        printf '[memory] WARN last sync %s (host: %s) -- sync may be stuck\n' \
+            "$(time_ago "$sync_secs_ago")" "${sync_host:-unknown}"
+    else
+        printf '[memory] last sync %s (host: %s)\n' \
+            "$(time_ago "$sync_secs_ago")" "${sync_host:-unknown}"
+    fi
+fi
+
+# Line 3: recent activity.
+if [ ${#recent_names[@]} -gt 0 ]; then
+    # Cap displayed names at first 3 to avoid noise.
+    recent_display=""
+    i=0
+    for n in "${recent_names[@]}"; do
+        if [ "$i" -lt 3 ]; then
+            if [ -z "$recent_display" ]; then
+                recent_display="$n"
+            else
+                recent_display="${recent_display}, ${n}"
+            fi
+        fi
+        i=$((i + 1))
+    done
+    if [ "${#recent_names[@]}" -gt 3 ]; then
+        recent_display="${recent_display} (+$(( ${#recent_names[@]} - 3 )) more)"
+    fi
+    printf '[memory] %d added in last 24h: %s -- review with /memory-review\n' \
+        "${#recent_names[@]}" "$recent_display"
+fi
+
+# Line 4: stale memories.
+if [ ${#stale_names[@]} -gt 0 ]; then
+    stale_display=""
+    i=0
+    for n in "${stale_names[@]}"; do
+        if [ "$i" -lt 3 ]; then
+            if [ -z "$stale_display" ]; then
+                stale_display="$n"
+            else
+                stale_display="${stale_display}, ${n}"
+            fi
+        fi
+        i=$((i + 1))
+    done
+    if [ "${#stale_names[@]}" -gt 3 ]; then
+        stale_display="${stale_display} (+$(( ${#stale_names[@]} - 3 )) more)"
+    fi
+    printf '[memory] %d stale (last-verified > 90d): %s -- review with /memory-review\n' \
+        "${#stale_names[@]}" "$stale_display"
+fi
+
+# Line 5: unread alerts.
+if [ "$unread_count" -gt 0 ]; then
+    if [ -n "$unread_recent_msg" ]; then
+        # Truncate long messages.
+        msg_short="$unread_recent_msg"
+        if [ "${#msg_short}" -gt 80 ]; then
+            msg_short="${msg_short:0:77}..."
+        fi
+        printf '[memory] WARN %d unread alert(s); latest: %s\n' \
+            "$unread_count" "$msg_short"
+    else
+        printf '[memory] WARN %d unread alert(s)\n' "$unread_count"
+    fi
+    printf '[memory]   run /memory-review or check %s\n' "$ALERTS_LOG"
+fi
+
+# --- Performance budget enforcement ------------------------------------------
+
+if [ "$START_EPOCH" != "0" ] && command -v date >/dev/null 2>&1; then
+    end_epoch="$(date +%s 2>/dev/null || echo 0)"
+    if [ "$end_epoch" != "0" ]; then
+        elapsed_secs=$((end_epoch - START_EPOCH))
+        # Whole-second resolution; warn only when clearly over the budget.
+        if [ "$elapsed_secs" -ge 1 ]; then
+            elapsed_ms=$((elapsed_secs * 1000))
+            if [ "$elapsed_ms" -ge "$PERF_WARN_MS" ]; then
+                printf '[memory] note: hook took ~%dms (>%dms budget)\n' \
+                    "$elapsed_ms" "$PERF_WARN_MS" >&2
+            fi
+        fi
+    fi
+fi
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -229,6 +229,11 @@
             "type": "command",
             "command": "~/.claude/hooks/p4-timeline-reminder.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/memory-integrity-check.sh",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## What

### Summary

Adds `global/hooks/memory-integrity-check.sh` and its PowerShell mirror.
The hook is a SessionStart event handler that prints a brief memory
health summary at the beginning of each Claude Code session, reading
`~/.claude/memory-shared/` metadata only (no network, no validators).
Wires the hook into `global/settings.json` SessionStart with a 5-second
timeout.

### Change Type

- [x] Feature (new functionality)

### Affected Components

- `global/hooks/memory-integrity-check.sh` (new, ~400 lines)
- `global/hooks/memory-integrity-check.ps1` (new, ~290 lines)
- `global/settings.json` (registered SessionStart entry)

## Why

### Problem Solved

Without this hook, the user has no regular signal that the cross-machine
memory system is in a good state. Sync stoppage, lingering quarantined
memories, and stale entries surface only after something goes wrong.
A brief summary at session start makes silent drift visible:

- "Last sync 26 hours ago" -- hourly sync stopped, investigate
- "2 inferred entries added today" -- recent memory awaiting confirmation
- "1 stale entry" -- 90+ day verification due

### Related Issues

- Closes #522
- Part of #505 (Cross-machine memory sync EPIC)
- Reads metadata produced by #520 (sync engine, PR #547)
- Reads alerts log defined by #524 (centralized alerting)
- Honors trust-level taxonomy from #511

## Where

| File | Purpose |
|------|---------|
| `global/hooks/memory-integrity-check.sh` | bash hook script |
| `global/hooks/memory-integrity-check.ps1` | PowerShell mirror |
| `global/settings.json` | SessionStart registration |

## How

### Output Decision Tree

The hook stays silent (no stdout, exit 0) when **all** of:

- No memories created in the last 24 hours
- No verified memories with `last-verified > 90d`
- No quarantined memories
- Last sync within 24 hours
- No unread alerts

When any of those signals fire, it prints a 3-5 line block:

```
[memory] N entries (verified:V, inferred:I, quarantined:Q)
[memory] last sync M min ago (host: <name>)
[memory] X added in last 24h: <name1>, <name2> -- review with /memory-review
[memory] Y stale (last-verified > 90d): <name> -- review with /memory-review
[memory] WARN Z unread alert(s); latest: <message>
[memory]   run /memory-review or check ~/.claude/logs/memory-alerts.log
```

### Sample output (sync stale + recent activity + alerts)

```
[memory] 17 entries (verified:13, inferred:3, quarantined:1)
[memory] WARN last sync 1 days ago (host: mac-mini-home) -- sync may be stuck
[memory] 1 added in last 24h: project_recent -- review with /memory-review
[memory] 1 stale (last-verified > 90d): feedback_old -- review with /memory-review
[memory] WARN 1 unread alert(s); latest: memory-sync: post-pull validation found 1 quarantined memory
[memory]   run /memory-review or check /home/user/.claude/logs/memory-alerts.log
```

### Sample output (healthy)

```
(no stdout, exit 0)
```

### Epic R1 Mitigation

Per the epic R1 mitigation requirement, last sync more than 24 hours
ago triggers a `WARN` line indicating the sync may be stuck.

### Performance

- Budget: < 300ms typical, hard cap 500ms with stderr warning
- Measured locally on a 3-file fixture: 21-65ms (5 runs)
- All work is O(N) over memory files in `memories/` plus one git log
- No network, no validators, no commits, no writes

### Bash 3.2 Compatibility

- No `mapfile`, no associative arrays
- `BASH_REMATCH` save-then-use under `set -u`
- `${var:-0}` defaults guard `wc`/empty array operations
- `nullglob`-equivalent guard via `[ -f "$f" ] || continue`
- Date math handles both GNU `date -d` and BSD `date -j -f`

### Sample settings.json snippet

The hook is registered in the repo-tracked `global/settings.json`:

```json
"SessionStart": [
  {
    "hooks": [
      { "type": "command", "command": "~/.claude/hooks/session-logger.sh start", "timeout": 5 },
      { "type": "command", "command": "~/.claude/hooks/version-check.sh", "timeout": 10, "async": true },
      { "type": "command", "command": "~/.claude/hooks/p4-timeline-reminder.sh", "timeout": 5 },
      { "type": "command", "command": "~/.claude/hooks/memory-integrity-check.sh", "timeout": 5 }
    ]
  }
]
```

User's actual `~/.claude/settings.json` is **not** auto-modified by
this PR. Operators install the hook by syncing the repo template per
the existing claude-config workflow.

### Testing Done

- [x] No memory-shared dir -> silent exit 0
- [x] Healthy state (single fresh memory) -> silent exit 0
- [x] Recent + stale + quarantined -> 4-line summary
- [x] Sync >24h ago -> WARN line with "sync may be stuck"
- [x] Unread alerts log -> alert summary lines
- [x] read-mark filters older alerts -> only unread counted
- [x] Malformed frontmatter -> warning to stderr, count skipped, exit 0
- [x] JSON stdin payload (real SessionStart event) -> drained, exit 0
- [x] Performance: 5 runs averaged 21-65ms

### Test Plan for Reviewers

```bash
# Setup fixture
TMP=$(mktemp -d)
mkdir -p "$TMP/memory-shared/memories" "$TMP/memory-shared/quarantine" "$TMP/logs"

NOW=$(date +%s)
ISO_NOW=$(date -u -d "@$NOW" +%Y-%m-%dT%H:%M:%SZ)
ISO_OLD=$(date -u -d "@$((NOW - 100 * 86400))" +%Y-%m-%dT%H:%M:%SZ)

cat > "$TMP/memory-shared/memories/feedback_old.md" <<MEMEOF
---
name: Old
description: Stale memory
type: feedback
trust-level: verified
last-verified: $ISO_OLD
created-at: $ISO_OLD
source-machine: test
---
Body content for testing the stale path.
MEMEOF

(cd "$TMP/memory-shared" && git init -q && git add -A && \
  git -c user.name=macbook -c user.email=t@x.com commit -q -m init)

MEMORY_SHARED_DIR="$TMP/memory-shared" \
MEMORY_ALERTS_LOG="$TMP/logs/memory-alerts.log" \
MEMORY_ALERTS_READ_MARK="$TMP/.read-mark" \
./global/hooks/memory-integrity-check.sh

# Expected: 2 lines mentioning 1 stale memory + counts.
```

### Breaking Changes

None.

### Rollback Plan

1. Revert this PR
2. Remove `memory-integrity-check.sh` entry from `global/settings.json`
3. Remove the two hook script files
4. No data loss; hook is read-only on memory tree
