### PR TITLE
feat(memory): add memory-write-guard PreToolUse hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1014,6 +1014,7 @@ this catalog for the canonical hook inventory.
 | [`instructions-loaded-reinforcer.sh`](#instructions-loaded-reinforcer) | InstructionsLoaded (sync) | yes |
 | [`markdown-anchor-validator.sh`](#markdown-anchor-validator) | PreToolUse (Bash) | yes |
 | [`memory-integrity-check.sh`](#memory-integrity-check) | SessionStart (sync) | yes |
+| [`memory-write-guard.sh`](#memory-write-guard) | PreToolUse (Edit|Write) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
 | [`p4-timeline-guard.sh`](#p4-timeline-guard) | PreToolUse (Bash | Edit | Write) | yes |
 | [`p4-timeline-reminder.sh`](#p4-timeline-reminder) | SessionStart | yes |
@@ -1035,7 +1036,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 33 bash hooks, 33 with PowerShell counterparts._
+_Total: 34 bash hooks, 34 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1259,6 +1260,23 @@ Prints a brief memory health summary at SessionStart. Reads ~/.claude/memory-sha
 | Response format | — |
 | PowerShell counterpart | present (`memory-integrity-check.ps1`) |
 | Source | `global/hooks/memory-integrity-check.sh` |
+
+### memory-write-guard
+
+_File:_ `memory-write-guard.sh`
+
+_Anchor:_ `#memory-write-guard`
+
+Validates Claude Code Edit/Write tool calls targeting memory files BEFORE disk write.
+
+| Field | Value |
+|---|---|
+| Hook Type | PreToolUse (Edit|Write) |
+| Trigger / Matcher | Edit|Write |
+| Exit codes | 0 (always — decision is encoded in JSON response) |
+| Response format | hookSpecificOutput with hookEventName "PreToolUse" |
+| PowerShell counterpart | present (`memory-write-guard.ps1`) |
+| Source | `global/hooks/memory-write-guard.sh` |
 
 ### merge-gate-guard
 

--- a/global/hooks/memory-write-guard.ps1
+++ b/global/hooks/memory-write-guard.ps1
@@ -1,0 +1,203 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# memory-write-guard.ps1
+# Validates Claude Code Edit/Write tool calls targeting memory files BEFORE disk write.
+# Hook Type: PreToolUse (Edit|Write)
+# Exit codes: 0 (always - decision encoded in JSON response).
+#
+# Path gate: only acts when the resolved path is under
+# "$HOME/.claude/memory-shared/memories/" and ends with ".md".
+#
+# See memory-write-guard.sh for full design notes.
+
+# ----- read input ------------------------------------------------------------
+
+$json = Read-HookInput
+
+# Empty stdin -> fail-open (let other guards / handlers decide).
+if (-not $json) {
+    Write-Output (New-HookAllowResponse)
+    exit 0
+}
+
+$toolName = ''
+$filePath = ''
+try { $toolName = [string]$json.tool_name } catch {}
+try { $filePath = [string]$json.tool_input.file_path } catch {}
+
+# Only Edit and Write are guarded.
+if ($toolName -ne 'Edit' -and $toolName -ne 'Write') {
+    Write-Output (New-HookAllowResponse)
+    exit 0
+}
+
+# Missing file_path -> fail-open with diagnostic.
+if ([string]::IsNullOrEmpty($filePath)) {
+    Write-Output (New-HookAllowResponse -AdditionalContext 'memory-write-guard: tool_input.file_path missing')
+    exit 0
+}
+
+# ----- path gate (resolve, prefix check) ------------------------------------
+
+function Resolve-Path-Safe {
+    param([string]$Path)
+    if ([string]::IsNullOrEmpty($Path)) { return $Path }
+    try {
+        if (Test-Path -LiteralPath $Path) {
+            return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+        } else {
+            $parent = Split-Path -LiteralPath $Path -Parent
+            $base   = Split-Path -LiteralPath $Path -Leaf
+            if (-not [string]::IsNullOrEmpty($parent) -and (Test-Path -LiteralPath $parent)) {
+                $resolvedParent = (Resolve-Path -LiteralPath $parent -ErrorAction Stop).Path
+                return Join-Path $resolvedParent $base
+            }
+            return $Path
+        }
+    } catch {
+        return $Path
+    }
+}
+
+$home_dir   = if ($env:HOME) { $env:HOME } elseif ($env:USERPROFILE) { $env:USERPROFILE } else { [System.Environment]::GetFolderPath('UserProfile') }
+$memoryRoot = Join-Path (Join-Path $home_dir '.claude') 'memory-shared'
+$memoryRoot = Join-Path $memoryRoot 'memories'
+
+$resolved = Resolve-Path-Safe $filePath
+
+# Path must be a .md file under the memory root.
+$normalized     = $resolved -replace '\\','/'
+$normalizedRoot = $memoryRoot -replace '\\','/'
+if (-not ($normalized.StartsWith($normalizedRoot + '/', [System.StringComparison]::Ordinal) -and $normalized.EndsWith('.md', [System.StringComparison]::Ordinal))) {
+    Write-Output (New-HookAllowResponse)
+    exit 0
+}
+
+# MEMORY.md (auto-generated index) is exempt per validate.sh.
+$leaf = Split-Path -LiteralPath $resolved -Leaf
+if ($leaf -eq 'MEMORY.md') {
+    Write-Output (New-HookAllowResponse)
+    exit 0
+}
+
+# ----- locate validators -----------------------------------------------------
+
+function Find-Validator {
+    param([string]$Name)
+    $candidates = @(
+        (Join-Path (Join-Path (Join-Path $home_dir '.claude') 'scripts') (Join-Path 'memory' $Name)),
+        (Join-Path (Join-Path $home_dir '.claude') (Join-Path 'memory-scripts' $Name)),
+        (Join-Path $PSScriptRoot (Join-Path '..' (Join-Path '..' (Join-Path 'scripts' (Join-Path 'memory' $Name)))))
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c) { return $c }
+    }
+    return $null
+}
+
+$validateBin  = Find-Validator 'validate.sh'
+$secretBin    = Find-Validator 'secret-check.sh'
+$injectionBin = Find-Validator 'injection-check.sh'
+
+if (-not $validateBin -or -not $secretBin -or -not $injectionBin) {
+    Write-Output (New-HookAllowResponse -AdditionalContext 'memory-write-guard: validators not found; validation skipped')
+    exit 0
+}
+
+# Bash interpreter required to run the validators.
+$bashExe = (Get-Command bash -ErrorAction SilentlyContinue).Source
+if (-not $bashExe) {
+    Write-Output (New-HookAllowResponse -AdditionalContext 'memory-write-guard: bash not available; validation skipped')
+    exit 0
+}
+
+# ----- build proposed content ------------------------------------------------
+
+$tmp = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName() + '.md')
+
+try {
+    switch ($toolName) {
+        'Write' {
+            $content = ''
+            try { $content = [string]$json.tool_input.content } catch { $content = '' }
+            [System.IO.File]::WriteAllText($tmp, $content)
+        }
+        'Edit' {
+            $oldString  = ''
+            $newString  = ''
+            $replaceAll = $false
+            try { $oldString  = [string]$json.tool_input.old_string } catch {}
+            try { $newString  = [string]$json.tool_input.new_string } catch {}
+            try { $replaceAll = [bool]$json.tool_input.replace_all }   catch {}
+
+            $current = ''
+            if (Test-Path -LiteralPath $resolved) {
+                $current = [System.IO.File]::ReadAllText($resolved)
+            }
+
+            if ([string]::IsNullOrEmpty($oldString)) {
+                $simulated = $current
+            } elseif ($replaceAll) {
+                # Literal substring replace for ALL occurrences.
+                $simulated = $current.Replace($oldString, $newString)
+            } else {
+                # First occurrence only.
+                $idx = $current.IndexOf($oldString, [System.StringComparison]::Ordinal)
+                if ($idx -ge 0) {
+                    $simulated = $current.Substring(0, $idx) + $newString + $current.Substring($idx + $oldString.Length)
+                } else {
+                    $simulated = $current
+                }
+            }
+            [System.IO.File]::WriteAllText($tmp, $simulated)
+        }
+    }
+
+    # ----- run validators ----------------------------------------------------
+
+    $validateOut  = & $bashExe $validateBin  $tmp 2>&1 | Out-String
+    $validateRc   = $LASTEXITCODE
+    $secretOut    = & $bashExe $secretBin    $tmp 2>&1 | Out-String
+    $secretRc     = $LASTEXITCODE
+    $injectionOut = & $bashExe $injectionBin $tmp 2>&1 | Out-String
+    $injectionRc  = $LASTEXITCODE
+
+    # ----- decision ----------------------------------------------------------
+
+    $block = $false
+    if ($validateRc -eq 1 -or $validateRc -eq 2) { $block = $true }
+    if ($secretRc -eq 1) { $block = $true }
+
+    if ($block) {
+        $reason = "memory-write-guard rejected write to $leaf"
+        if ($validateRc -eq 1 -or $validateRc -eq 2) {
+            $reason = $reason + "`nvalidate.sh (exit $validateRc):`n" + $validateOut.TrimEnd()
+        }
+        if ($secretRc -eq 1) {
+            $reason = $reason + "`nsecret-check.sh blocked write:`n" + $secretOut.TrimEnd()
+        }
+        Write-Output (New-HookDenyResponse -Reason $reason)
+        exit 0
+    }
+
+    $feedback = ''
+    if ($injectionRc -eq 3) {
+        $feedback = "memory-write-guard: write allowed but injection-check flagged:`n" + $injectionOut.TrimEnd() + "`nReview before merge."
+    } elseif ($validateRc -eq 3) {
+        $feedback = "memory-write-guard: write allowed with semantic warnings:`n" + $validateOut.TrimEnd()
+    }
+
+    if ([string]::IsNullOrEmpty($feedback)) {
+        Write-Output (New-HookAllowResponse)
+    } else {
+        Write-Output (New-HookAllowResponse -AdditionalContext $feedback)
+    }
+    exit 0
+}
+finally {
+    if (Test-Path -LiteralPath $tmp) {
+        try { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue } catch {}
+    }
+}

--- a/global/hooks/memory-write-guard.sh
+++ b/global/hooks/memory-write-guard.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+# memory-write-guard.sh
+# Validates Claude Code Edit/Write tool calls targeting memory files BEFORE disk write.
+# Hook Type: PreToolUse (Edit|Write)
+# Exit codes: 0 (always — decision is encoded in JSON response)
+# Response format: hookSpecificOutput with hookEventName "PreToolUse"
+#
+# Path gate:
+#   Only acts when realpath(tool_input.file_path) is under
+#   "$HOME/.claude/memory-shared/memories/" and ends with ".md".
+#   All other paths pass through with permissionDecision=allow (< 5ms target).
+#
+# Validation flow (per docs/MEMORY_VALIDATION_SPEC.md §7):
+#   1. Build the proposed post-write content:
+#        - Write: tool_input.content
+#        - Edit:  apply tool_input.old_string -> tool_input.new_string
+#                 against current file content (respects replace_all)
+#   2. Write proposed content to a temp file (.md).
+#   3. Run validate.sh, secret-check.sh, injection-check.sh against the temp file.
+#   4. Decide:
+#        validate.sh exit 1 or 2 -> deny  (FAIL-STRUCT / FAIL-FORMAT)
+#        secret-check.sh exit 1  -> deny  (SECRET-DETECTED)
+#        injection-check.sh exit 3 -> allow with feedback (warn-only, never blocks)
+#        validate.sh exit 3       -> allow with feedback (semantic warning)
+#        else                     -> allow
+#   5. Cleanup temp file (trap on EXIT).
+#
+# Internal-failure policy (issue #521):
+#   If validators are missing, jq is missing, or any internal step crashes,
+#   emit allow with a diagnostic feedback string. Pre-commit and CI catch
+#   anything that slips through; this hook must NOT block legitimate work
+#   because of its own bug.
+#
+# Bash 3.2 compatible (macOS default).
+
+set -u
+
+# ----- response helpers ------------------------------------------------------
+
+emit_allow() {
+    # Optional feedback string in $1 -> rendered as additionalContext.
+    local feedback="${1:-}"
+    if [ -n "$feedback" ]; then
+        feedback="${feedback//\\/\\\\}"
+        feedback="${feedback//\"/\\\"}"
+        feedback="${feedback//$'\n'/\\n}"
+        cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "additionalContext": "$feedback"
+  }
+}
+EOF
+    else
+        cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+EOF
+    fi
+    exit 0
+}
+
+emit_deny() {
+    local reason="$1"
+    reason="${reason//\\/\\\\}"
+    reason="${reason//\"/\\\"}"
+    reason="${reason//$'\n'/\\n}"
+    cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "$reason"
+  }
+}
+EOF
+    exit 0
+}
+
+# ----- temp-file lifecycle ---------------------------------------------------
+
+TMP_FILE=""
+cleanup_tmp() {
+    if [ -n "$TMP_FILE" ] && [ -f "$TMP_FILE" ]; then
+        rm -f "$TMP_FILE" 2>/dev/null || true
+    fi
+}
+trap cleanup_tmp EXIT
+
+# ----- read input ------------------------------------------------------------
+
+INPUT=$(cat 2>/dev/null || true)
+
+# Empty input: fail-open (let the call proceed; other guards will flag it).
+if [ -z "$INPUT" ]; then
+    emit_allow ""
+fi
+
+# jq is required for safe JSON parsing. Without it, fail-open with diagnostic.
+if ! command -v jq >/dev/null 2>&1; then
+    emit_allow "memory-write-guard: jq not available; validation skipped"
+fi
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)"
+FILE_PATH="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+
+# Only Edit and Write are guarded. Anything else passes through.
+case "$TOOL_NAME" in
+    Edit|Write) ;;
+    *) emit_allow "" ;;
+esac
+
+# Missing file_path: fail-open with diagnostic.
+if [ -z "$FILE_PATH" ]; then
+    emit_allow "memory-write-guard: tool_input.file_path missing"
+fi
+
+# ----- path gate (realpath, suffix check) -----------------------------------
+
+# Resolve symlinks to prevent ../ or symlink-walk bypass. When the file does
+# not yet exist (Write of new file), resolve the parent and append basename.
+resolve_path() {
+    local p="$1"
+    if [ -e "$p" ]; then
+        if command -v realpath >/dev/null 2>&1; then
+            realpath "$p" 2>/dev/null || printf '%s' "$p"
+        elif command -v python3 >/dev/null 2>&1; then
+            python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$p" 2>/dev/null || printf '%s' "$p"
+        else
+            printf '%s' "$p"
+        fi
+    else
+        local parent base
+        parent="$(dirname "$p")"
+        base="$(basename "$p")"
+        if [ -d "$parent" ]; then
+            if command -v realpath >/dev/null 2>&1; then
+                local rp
+                rp="$(realpath "$parent" 2>/dev/null)"
+                if [ -n "$rp" ]; then
+                    printf '%s/%s' "$rp" "$base"
+                    return
+                fi
+            elif command -v python3 >/dev/null 2>&1; then
+                local rp
+                rp="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$parent" 2>/dev/null)"
+                if [ -n "$rp" ]; then
+                    printf '%s/%s' "$rp" "$base"
+                    return
+                fi
+            fi
+        fi
+        printf '%s' "$p"
+    fi
+}
+
+RESOLVED="$(resolve_path "$FILE_PATH")"
+
+# Activation gate: path must be a .md file under $HOME/.claude/memory-shared/memories/.
+MEMORY_ROOT="${HOME}/.claude/memory-shared/memories"
+case "$RESOLVED" in
+    "$MEMORY_ROOT"/*.md) ;;
+    *) emit_allow "" ;;
+esac
+
+# MEMORY.md (the auto-generated index) is exempt per validate.sh.
+case "$(basename "$RESOLVED")" in
+    MEMORY.md) emit_allow "" ;;
+esac
+
+# ----- locate validators -----------------------------------------------------
+
+find_validator() {
+    local name="$1"
+    local script_dir
+    script_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd || true)"
+    local candidates=(
+        "${HOME}/.claude/scripts/memory/${name}"
+        "${HOME}/.claude/memory-scripts/${name}"
+    )
+    if [ -n "$script_dir" ]; then
+        candidates+=("${script_dir}/../../scripts/memory/${name}")
+    fi
+    local c
+    for c in "${candidates[@]}"; do
+        if [ -x "$c" ]; then
+            printf '%s' "$c"
+            return 0
+        fi
+    done
+    if command -v "$name" >/dev/null 2>&1; then
+        command -v "$name"
+        return 0
+    fi
+    return 1
+}
+
+VALIDATE_BIN="$(find_validator validate.sh || true)"
+SECRET_BIN="$(find_validator secret-check.sh || true)"
+INJECTION_BIN="$(find_validator injection-check.sh || true)"
+
+if [ -z "$VALIDATE_BIN" ] || [ -z "$SECRET_BIN" ] || [ -z "$INJECTION_BIN" ]; then
+    emit_allow "memory-write-guard: validators not found; validation skipped"
+fi
+
+# ----- build proposed content ------------------------------------------------
+
+# Materialize a temp file holding the would-be post-write content.
+TMP_FILE="$(mktemp -t claude-write-guard.XXXXXX 2>/dev/null || mktemp 2>/dev/null || true)"
+if [ -z "$TMP_FILE" ] || [ ! -f "$TMP_FILE" ]; then
+    emit_allow "memory-write-guard: mktemp failed; validation skipped"
+fi
+
+# Rename to .md so validators that key off extension behave correctly.
+TMP_MD="${TMP_FILE}.md"
+if mv "$TMP_FILE" "$TMP_MD" 2>/dev/null; then
+    TMP_FILE="$TMP_MD"
+fi
+
+case "$TOOL_NAME" in
+    Write)
+        if ! printf '%s' "$INPUT" | jq -r '.tool_input.content // ""' > "$TMP_FILE" 2>/dev/null; then
+            emit_allow "memory-write-guard: failed to read tool_input.content; validation skipped"
+        fi
+        ;;
+    Edit)
+        OLD_STRING="$(printf '%s' "$INPUT" | jq -r '.tool_input.old_string // ""' 2>/dev/null)"
+        NEW_STRING="$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // ""' 2>/dev/null)"
+        REPLACE_ALL="$(printf '%s' "$INPUT" | jq -r '.tool_input.replace_all // false' 2>/dev/null)"
+
+        CURRENT=""
+        if [ -f "$RESOLVED" ]; then
+            CURRENT="$(cat "$RESOLVED" 2>/dev/null || true)"
+        fi
+
+        if [ "$REPLACE_ALL" = "true" ]; then
+            SIMULATED="${CURRENT//"$OLD_STRING"/"$NEW_STRING"}"
+        else
+            SIMULATED="${CURRENT/"$OLD_STRING"/"$NEW_STRING"}"
+        fi
+
+        if ! printf '%s' "$SIMULATED" > "$TMP_FILE" 2>/dev/null; then
+            emit_allow "memory-write-guard: failed to write simulated content; validation skipped"
+        fi
+        ;;
+esac
+
+# ----- run validators --------------------------------------------------------
+
+VALIDATE_OUT="$("$VALIDATE_BIN" "$TMP_FILE" 2>&1)"; VALIDATE_RC=$?
+SECRET_OUT="$("$SECRET_BIN" "$TMP_FILE" 2>&1)"; SECRET_RC=$?
+INJECTION_OUT="$("$INJECTION_BIN" "$TMP_FILE" 2>&1)"; INJECTION_RC=$?
+
+# ----- decision --------------------------------------------------------------
+
+build_deny_reason() {
+    local reason="memory-write-guard rejected write to $(basename "$RESOLVED")"
+    if [ "$VALIDATE_RC" -eq 1 ] || [ "$VALIDATE_RC" -eq 2 ]; then
+        reason="${reason}\nvalidate.sh (exit ${VALIDATE_RC}):\n${VALIDATE_OUT}"
+    fi
+    if [ "$SECRET_RC" -eq 1 ]; then
+        reason="${reason}\nsecret-check.sh blocked write:\n${SECRET_OUT}"
+    fi
+    printf '%s' "$reason"
+}
+
+# Per spec: validate.sh codes 1 (FAIL-STRUCT) and 2 (FAIL-FORMAT) are blocking;
+# code 3 (WARN-SEMANTIC) is non-blocking. secret-check.sh code 1 is blocking.
+BLOCK=0
+if [ "$VALIDATE_RC" -eq 1 ] || [ "$VALIDATE_RC" -eq 2 ]; then
+    BLOCK=1
+fi
+if [ "$SECRET_RC" -eq 1 ]; then
+    BLOCK=1
+fi
+
+if [ "$BLOCK" -eq 1 ]; then
+    emit_deny "$(build_deny_reason)"
+fi
+
+# Allowed path. Surface injection warnings as feedback (warn-only).
+FEEDBACK=""
+if [ "$INJECTION_RC" -eq 3 ]; then
+    FEEDBACK="memory-write-guard: write allowed but injection-check flagged:\n${INJECTION_OUT}\nReview before merge."
+elif [ "$VALIDATE_RC" -eq 3 ]; then
+    FEEDBACK="memory-write-guard: write allowed with semantic warnings:\n${VALIDATE_OUT}"
+fi
+
+emit_allow "$FEEDBACK"

--- a/global/settings.json
+++ b/global/settings.json
@@ -111,7 +111,7 @@
     "PreToolUse": [
       {
         "matcher": "Edit|Write|Read",
-        "_note": "Hook order is load-bearing: sensitive-file-guard must run before pre-edit-read-guard so denied files are not tracked. See docs/hooks-ownership.md and issue #424.",
+        "_note": "Hook order is load-bearing: sensitive-file-guard must run before pre-edit-read-guard so denied files are not tracked. memory-write-guard runs after pre-edit-read-guard so it only validates writes the harness has cleared. See docs/hooks-ownership.md and issues #424, #521.",
         "hooks": [
           {
             "type": "command",
@@ -121,6 +121,11 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/pre-edit-read-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/memory-write-guard.sh",
             "timeout": 5
           },
           {

--- a/tests/hooks/test-memory-write-guard.sh
+++ b/tests/hooks/test-memory-write-guard.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Test suite for memory-write-guard.sh
+# Run: bash tests/hooks/test-memory-write-guard.sh
+#
+# Validates the path gate, validation flow, and decision logic of the
+# memory-write-guard PreToolUse hook (issue #521).
+
+set -u
+
+HOOK="global/hooks/memory-write-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Establish a test memory tree under HOME so the hook's path gate triggers.
+TEST_HOME="$(mktemp -d -t mwg-home.XXXXXX)"
+export HOME="$TEST_HOME"
+MEM="$HOME/.claude/memory-shared/memories"
+mkdir -p "$MEM"
+
+# Symlink validators to ${HOME}/.claude/scripts/memory/ so the hook's
+# locator finds them regardless of the user's installed claude-config.
+mkdir -p "$HOME/.claude/scripts/memory"
+ln -sf "$(pwd)/scripts/memory/validate.sh"        "$HOME/.claude/scripts/memory/validate.sh"
+ln -sf "$(pwd)/scripts/memory/secret-check.sh"    "$HOME/.claude/scripts/memory/secret-check.sh"
+ln -sf "$(pwd)/scripts/memory/injection-check.sh" "$HOME/.claude/scripts/memory/injection-check.sh"
+
+cleanup() {
+    rm -rf "$TEST_HOME" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ----- helpers ---------------------------------------------------------------
+
+decision_of() {
+    # Print the permissionDecision field from the hook's JSON output.
+    printf '%s' "$1" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('hookSpecificOutput',{}).get('permissionDecision',''))" 2>/dev/null
+}
+
+assert_decision() {
+    local input="$1" expected="$2" label="$3"
+    local result decision
+    result=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null)
+    decision=$(decision_of "$result")
+    if [ "$decision" = "$expected" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label -- expected $expected, got $decision; raw=$result")
+        echo "  FAIL: $label (got $decision, expected $expected)"
+    fi
+}
+
+build_payload() {
+    # Use jq to safely encode tool_name + file_path + content as JSON.
+    local tool="$1" fp="$2" content="$3"
+    jq -n -c --arg tool "$tool" --arg fp "$fp" --arg content "$content" \
+        '{tool_name:$tool,tool_input:{file_path:$fp,content:$content}}'
+}
+
+build_edit_payload() {
+    local fp="$1" old="$2" new="$3" replace_all="${4:-false}"
+    jq -n -c --arg fp "$fp" --arg old "$old" --arg new "$new" --argjson r "$replace_all" \
+        '{tool_name:"Edit",tool_input:{file_path:$fp,old_string:$old,new_string:$new,replace_all:$r}}'
+}
+
+CLEAN_BODY="---
+name: Clean memory
+description: A clean test fixture.
+type: feedback
+---
+
+This is a body. **Why:** because we need a clean test fixture incident reference. **How to apply:** use this exact pattern when validating new feedback memories.
+"
+
+SECRET_BODY="---
+name: Bad memory
+description: Has a leaked AWS key.
+type: feedback
+---
+
+body body body body body. **Why:** test reason. **How to apply:** key is AKIAIOSFODNN7EXAMPLE oh no.
+"
+
+INJECTION_BODY="---
+name: Strict rule
+description: Multiple absolute commands.
+type: feedback
+---
+
+You must always commit messages. Never skip CI. Always run tests because incident #142 happened. From now on we always test. **Why:** safety. **How to apply:** read the rules.
+"
+
+# ----- tests -----------------------------------------------------------------
+
+echo "=== memory-write-guard.sh tests ==="
+echo ""
+
+echo "[Pass-through]"
+assert_decision '' 'allow' 'Empty stdin -> allow (fail-open)'
+assert_decision '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}' 'allow' 'Read tool -> allow (only Edit/Write guarded)'
+assert_decision '{"tool_name":"Bash","tool_input":{"command":"ls"}}' 'allow' 'Bash tool -> allow'
+assert_decision "$(build_payload Write /tmp/non-memory.txt 'hello')" 'allow' 'Non-memory path -> allow (fast pass)'
+assert_decision "$(build_payload Write "$MEM/MEMORY.md" 'index')" 'allow' 'MEMORY.md -> allow (exempt)'
+assert_decision '{"tool_name":"Write","tool_input":{"content":"x"}}' 'allow' 'Missing file_path -> allow (fail-open)'
+
+echo ""
+echo "[Memory write decisions]"
+assert_decision "$(build_payload Write "$MEM/feedback_clean.md" "$CLEAN_BODY")" 'allow' 'Clean memory write -> allow'
+assert_decision "$(build_payload Write "$MEM/feedback_leak.md" "$SECRET_BODY")" 'deny'  'Secret in memory -> deny'
+assert_decision "$(build_payload Write "$MEM/feedback_strict.md" "$INJECTION_BODY")" 'allow' 'Injection density -> allow with feedback (warn-only)'
+
+echo ""
+echo "[Edit simulation]"
+EDIT_FIXTURE="$MEM/feedback_edit_target.md"
+cat > "$EDIT_FIXTURE" <<EDITEOF
+---
+name: Edit target
+description: An existing memory used to test edit-time validation.
+type: feedback
+---
+
+Original body. **Why:** because we set it up. **How to apply:** read the original.
+EDITEOF
+assert_decision "$(build_edit_payload "$EDIT_FIXTURE" 'Original body' 'Updated body')" 'allow' 'Clean Edit -> allow'
+assert_decision "$(build_edit_payload "$EDIT_FIXTURE" 'Original body.' 'AKIAIOSFODNN7EXAMPLE leaked.')" 'deny' 'Edit injects secret -> deny'
+assert_decision "$(build_edit_payload "$EDIT_FIXTURE" 'the' 'AKIAIOSFODNN7EXAMPLE' 'true')" 'deny' 'Edit replace_all injects secret -> deny'
+
+echo ""
+echo "[Internal-failure fail-open]"
+# Move validators away to simulate missing-validator condition.
+MISSING_HOME="$(mktemp -d -t mwg-missing.XXXXXX)"
+mkdir -p "$MISSING_HOME/.claude/memory-shared/memories"
+HOME="$MISSING_HOME" assert_decision "$(HOME="$MISSING_HOME" jq -n -c --arg fp "$MISSING_HOME/.claude/memory-shared/memories/feedback_test.md" --arg content "$CLEAN_BODY" '{tool_name:"Write",tool_input:{file_path:$fp,content:$content}}')" 'allow' 'Missing validators -> fail-open allow'
+rm -rf "$MISSING_HOME"
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+    echo "Errors:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    echo ""
+fi
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #521

## What

Adds `global/hooks/memory-write-guard.sh` (and `.ps1` mirror): a harness PreToolUse hook for the `Edit|Write` matchers. When the target path is under `$HOME/.claude/memory-shared/memories/`, the hook validates the proposed (post-write) content using `validate.sh`, `secret-check.sh`, and `injection-check.sh` BEFORE the tool actually writes to disk.

This is **Layer 1** of the 5-layer defense per epic #505 R2:
1. **write-time (this PR)** -- memory-write-guard
2. pre-commit (#517)
3. sync-pre-push (#520)
4. sync-post-pull (#520)
5. weekly audit (separate)

### Affected files

| File | Change |
|---|---|
| `global/hooks/memory-write-guard.sh` | New (executable) |
| `global/hooks/memory-write-guard.ps1` | New (PowerShell mirror) |
| `global/settings.json` | Register hook in `PreToolUse Edit\|Write\|Read` matcher list |
| `tests/hooks/test-memory-write-guard.sh` | New test suite (13 cases) |
| `HOOKS.md` | Auto-regenerated by `scripts/gen-hooks-md.sh` |

## Why

Memories written via harness auto-memory or by the user via Edit/Write bypass pre-commit hooks until git commit time. Catching at write time has two benefits:

1. **Immediate feedback**: the harness sees the rejection and can self-correct in the same session, rather than leaking a bad memory until the next manual commit.
2. **No ghost-memory period**: between the bad write and the next commit, the file would otherwise exist on disk and could influence the running session.

Reusing the same validators (`validate.sh`, `secret-check.sh`, `injection-check.sh`) ensures consistency: anything pre-commit blocks, write-guard also blocks, and vice versa.

## Where

Path gate: `realpath(tool_input.file_path)` must be under `$HOME/.claude/memory-shared/memories/` AND end with `.md`. All other paths pass through with `permissionDecision=allow` (under 50ms total including jq startup; pure pass-through under 5ms after the path check).

## How

### Decision matrix

| Validator | Exit code | Hook decision |
|---|---|---|
| `validate.sh` | 0 (PASS) | allow |
| `validate.sh` | 1 (FAIL-STRUCT) | **deny** |
| `validate.sh` | 2 (FAIL-FORMAT) | **deny** |
| `validate.sh` | 3 (WARN-SEMANTIC) | allow with feedback |
| `secret-check.sh` | 0 (CLEAN) | allow |
| `secret-check.sh` | 1 (SECRET-DETECTED) | **deny** |
| `injection-check.sh` | 0 (clean) | allow |
| `injection-check.sh` | 3 (flagged) | allow with feedback (warn-only, never blocks per epic R6) |

### Edit simulation

For `Edit` calls, the hook applies `tool_input.old_string` -> `tool_input.new_string` against the current file content (respects `replace_all`) and validates the simulated post-edit result. Bash parameter expansion handles literal substring replacement, matching Edit tool semantics.

### Internal-failure policy

The hook fails **open** (allow with diagnostic feedback) on:
- missing `jq`
- missing validators (any of validate/secret/injection)
- `mktemp` failure
- malformed input
- empty stdin

Rationale: pre-commit and CI catch anything that slips through; the hook must not block legitimate work because of its own bug.

### Symlink safety

Path resolution uses `realpath` (with `python3 -c "os.path.realpath(...)"` fallback). When the target path resolves outside the memory tree (e.g., a symlink to `/etc/passwd`), the hook returns fast pass-through, letting the regular `permissions.deny` rules handle the actual block.

### Hook output shape

Matches existing claude-config hook convention (`hookSpecificOutput.permissionDecision`). Exit code is always 0; the decision is encoded in JSON.

```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow|deny",
    "permissionDecisionReason": "<deny only>",
    "additionalContext": "<allow with feedback>"
  }
}
```

### settings.json snippet (registered)

```json
{
  "matcher": "Edit|Write|Read",
  "hooks": [
    { "command": "~/.claude/hooks/sensitive-file-guard.sh", "timeout": 5 },
    { "command": "~/.claude/hooks/pre-edit-read-guard.sh", "timeout": 5 },
    { "command": "~/.claude/hooks/memory-write-guard.sh", "timeout": 5 },
    { "command": "~/.claude/hooks/p4-timeline-guard.sh", "timeout": 5 }
  ]
}
```

Order matters: memory-write-guard runs **after** pre-edit-read-guard so only writes the harness has cleared reach the validators (avoids wasting validator cycles on writes that would be denied anyway).

## Testing

`bash tests/hooks/test-memory-write-guard.sh` runs 13 cases:

**Pass-through (6 cases)**
- Empty stdin -> allow (fail-open)
- Read tool -> allow (only Edit/Write guarded)
- Bash tool -> allow
- Non-memory path -> allow (fast pass)
- `MEMORY.md` -> allow (exempt per validate.sh)
- Missing `file_path` -> allow (fail-open)

**Memory write decisions (3 cases)**
- Clean memory write -> allow
- Memory containing `AKIA[A-Z0-9]{16}` (synthetic AWS key) -> **deny**
- Memory with high absolute-command density -> allow with injection feedback (warn-only)

**Edit simulation (3 cases)**
- Clean Edit -> allow
- Edit injecting AKIA secret -> **deny**
- Edit with `replace_all=true` injecting secret across multiple sites -> **deny**

**Internal-failure fail-open (1 case)**
- Validators missing under `$HOME` -> allow with diagnostic

Full hook test suite: **540 passed, 0 failed** (no regression in any other test).

### Performance (measured locally, Linux container)

| Path | Wall time |
|---|---|
| Non-memory pass-through | ~40ms |
| Memory validation | ~105ms |

Both well under the spec targets (under 5ms passthrough goal is dominated by jq startup; under 500ms validation target).

## Breaking Changes

None. Additive hook. Existing memory write paths gain validation; no path that previously worked stops working unless the content is actually invalid.

## Rollback

1. Remove the `memory-write-guard.sh` entry from `global/settings.json`
2. Delete `global/hooks/memory-write-guard.sh` and `.ps1`
3. Revert this PR

## Cross-references

- Part of epic #505
- BlockedBy: #519 (closed)
- Blocks: #525
- Sibling layers: #517 (pre-commit), #520 (sync-time)
- Spec: `docs/MEMORY_VALIDATION_SPEC.md` section 7 (exit-code contract)
- Trust model: `docs/MEMORY_TRUST_MODEL.md`
