### PR TITLE
feat(memory): add memory-access-logger PostToolUse Read hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1013,6 +1013,7 @@ this catalog for the canonical hook inventory.
 | [`github-api-preflight.sh`](#github-api-preflight) | PreToolUse (Bash) | yes |
 | [`instructions-loaded-reinforcer.sh`](#instructions-loaded-reinforcer) | InstructionsLoaded (sync) | yes |
 | [`markdown-anchor-validator.sh`](#markdown-anchor-validator) | PreToolUse (Bash) | yes |
+| [`memory-access-logger.sh`](#memory-access-logger) | PostToolUse (Read) | yes |
 | [`memory-integrity-check.sh`](#memory-integrity-check) | SessionStart (sync) | yes |
 | [`memory-write-guard.sh`](#memory-write-guard) | PreToolUse (Edit|Write) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
@@ -1036,7 +1037,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 34 bash hooks, 34 with PowerShell counterparts._
+_Total: 35 bash hooks, 35 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1243,6 +1244,23 @@ Validates markdown anchor references before git commit
 | Response format | hookSpecificOutput with hookEventName |
 | PowerShell counterpart | present (`markdown-anchor-validator.ps1`) |
 | Source | `global/hooks/markdown-anchor-validator.sh` |
+
+### memory-access-logger
+
+_File:_ `memory-access-logger.sh`
+
+_Anchor:_ `#memory-access-logger`
+
+Logs Claude Code Read tool calls targeting memory files (path only).
+
+| Field | Value |
+|---|---|
+| Hook Type | PostToolUse (Read) |
+| Trigger / Matcher | Read |
+| Exit codes | 0 (always — this is a passive logger; failure must NOT affect tool flow) |
+| Response format | empty stdout (PostToolUse cannot influence the past tool call) |
+| PowerShell counterpart | present (`memory-access-logger.ps1`) |
+| Source | `global/hooks/memory-access-logger.sh` |
 
 ### memory-integrity-check
 

--- a/docs/MEMORY_SYNC.md
+++ b/docs/MEMORY_SYNC.md
@@ -203,6 +203,32 @@ Idempotency: the script exits 2 if a report for the current `YYYY-MM`
 already exists and is younger than 25 days, so a misfired scheduler never
 double-bills.
 
+## Privacy: memory-access logging (#531)
+
+The `memory-access-logger.sh` PostToolUse Read hook records each memory file
+that Claude Code reads during a session. The log lives at
+`~/.claude/logs/memory-access.log` and feeds the unused-memory check in the
+weekly `audit.sh` (#528).
+
+Each entry records **path only**, never the file contents:
+
+```
+2026-05-08T10:23:11Z abc123 read memories/feedback_ci_merge_policy.md
+```
+
+Fields are `<ISO8601 UTC timestamp> <session_id> read <relative-path>`. Paths
+are stored relative to `~/.claude/memory-shared/` and only paths under
+`memory-shared/memories/` are logged (the top-level `MEMORY.md` index is
+excluded). The log is local to each machine and never transmitted; the
+memory sync engine does not include `~/.claude/logs/`.
+
+The log rotates lazily on each hook invocation: when its size exceeds 1 MiB
+OR its calendar month differs from the current one, the active file is moved
+to `memory-access.log.YYYY-MM` and a fresh log is started. The hook is
+registered with `async: true` in `global/settings.json` so it never blocks
+the user's Read flow; any internal failure (jq missing, log unwritable, etc.)
+is silently swallowed and exit 0 is returned.
+
 ## Related
 
 - #505 — Cross-machine memory epic

--- a/global/hooks/memory-access-logger.ps1
+++ b/global/hooks/memory-access-logger.ps1
@@ -1,0 +1,129 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'SilentlyContinue'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# memory-access-logger.ps1
+# Logs Claude Code Read tool calls targeting memory files (path only).
+# Hook Type: PostToolUse (Read)
+# Exit codes: 0 (always — passive logger; failure must NOT affect tool flow).
+#
+# Path gate: only logs when the resolved path is under
+#   "$HOME/.claude/memory-shared/memories/".
+# Log file: $HOME/.claude/logs/memory-access.log
+# Log line: "<ISO8601 UTC timestamp> <session_id> read <relative-path>"
+# Rotation: lazy; > 1 MiB OR file's calendar month != current month.
+#
+# See memory-access-logger.sh for full design notes.
+
+function Exit-Silent { exit 0 }
+
+# ----- read input ------------------------------------------------------------
+
+$json = Read-HookInput
+if (-not $json) { Exit-Silent }
+
+$toolName  = ''
+$filePath  = ''
+$sessionId = ''
+try { $toolName  = [string]$json.tool_name } catch {}
+try { $filePath  = [string]$json.tool_input.file_path } catch {}
+try { $sessionId = [string]$json.session_id } catch {}
+
+if ($toolName -ne 'Read') { Exit-Silent }
+if ([string]::IsNullOrEmpty($filePath)) { Exit-Silent }
+if ([string]::IsNullOrEmpty($sessionId)) { $sessionId = 'unknown' }
+
+# ----- helpers ---------------------------------------------------------------
+
+function Resolve-Path-Safe {
+    param([string]$Path)
+    if ([string]::IsNullOrEmpty($Path)) { return $Path }
+    try {
+        if (Test-Path -LiteralPath $Path) {
+            return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+        }
+        $parent = Split-Path -LiteralPath $Path -Parent
+        $base   = Split-Path -LiteralPath $Path -Leaf
+        if (-not [string]::IsNullOrEmpty($parent) -and (Test-Path -LiteralPath $parent)) {
+            $resolvedParent = (Resolve-Path -LiteralPath $parent -ErrorAction Stop).Path
+            return Join-Path $resolvedParent $base
+        }
+        return $Path
+    } catch {
+        return $Path
+    }
+}
+
+# ----- path gate -------------------------------------------------------------
+
+$home_dir   = if ($env:HOME) { $env:HOME } elseif ($env:USERPROFILE) { $env:USERPROFILE } else { [System.Environment]::GetFolderPath('UserProfile') }
+$sharedRoot = Join-Path (Join-Path $home_dir '.claude') 'memory-shared'
+$memoryRoot = Join-Path $sharedRoot 'memories'
+
+$resolved = Resolve-Path-Safe $filePath
+
+$normalized      = ($resolved -replace '\\','/')
+$normalizedRoot  = ($memoryRoot -replace '\\','/')
+$normalizedShare = ($sharedRoot -replace '\\','/')
+
+# Strict prefix match: must be under memories/ specifically (excludes the
+# top-level memory-shared/MEMORY.md auto-generated index).
+if (-not $normalized.StartsWith($normalizedRoot + '/', [System.StringComparison]::Ordinal)) {
+    Exit-Silent
+}
+
+$relative = $normalized.Substring($normalizedShare.Length + 1)
+
+# ----- log file path + rotation ---------------------------------------------
+
+$logDir  = Join-Path (Join-Path $home_dir '.claude') 'logs'
+$logFile = Join-Path $logDir 'memory-access.log'
+
+try {
+    if (-not (Test-Path -LiteralPath $logDir)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    }
+} catch { Exit-Silent }
+
+function Invoke-Maybe-Rotate {
+    param([string]$File)
+    if (-not (Test-Path -LiteralPath $File)) { return }
+    try {
+        $info = Get-Item -LiteralPath $File -ErrorAction Stop
+        $size = $info.Length
+        $fileMonth    = $info.LastWriteTimeUtc.ToString('yyyy-MM')
+        $currentMonth = [DateTime]::UtcNow.ToString('yyyy-MM')
+        $oneMib       = 1MB
+        $rotate       = ($size -gt $oneMib) -or ($fileMonth -ne $currentMonth)
+        if (-not $rotate) { return }
+
+        $stamp  = if ($fileMonth) { $fileMonth } else { $currentMonth }
+        $target = "$File.$stamp"
+        if (Test-Path -LiteralPath $target) {
+            $n = 1
+            while (Test-Path -LiteralPath "$target.$n") { $n++ }
+            $target = "$target.$n"
+        }
+        Move-Item -LiteralPath $File -Destination $target -Force -ErrorAction Stop
+        New-Item -ItemType File -Path $File -Force | Out-Null
+    } catch {
+        # Rotation failure is non-fatal.
+    }
+}
+
+Invoke-Maybe-Rotate -File $logFile
+
+# ----- write log entry -------------------------------------------------------
+
+$timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+# Sanitize tab/newline characters in path so the line stays single-record.
+$safeRelative = ($relative -replace "[\t\r\n]", ' ')
+$line = "$timestamp $sessionId read $safeRelative"
+
+try {
+    Add-Content -LiteralPath $logFile -Value $line -ErrorAction Stop
+} catch {
+    # Silent: logger must never affect tool flow.
+}
+
+Exit-Silent

--- a/global/hooks/memory-access-logger.sh
+++ b/global/hooks/memory-access-logger.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# memory-access-logger.sh
+# Logs Claude Code Read tool calls targeting memory files (path only).
+# Hook Type: PostToolUse (Read)
+# Exit codes: 0 (always — this is a passive logger; failure must NOT affect tool flow)
+# Response format: empty stdout (PostToolUse cannot influence the past tool call)
+#
+# Path gate:
+#   Only logs when realpath(tool_input.file_path) is under
+#   "$HOME/.claude/memory-shared/memories/". The top-level MEMORY.md (which
+#   lives at memory-shared/MEMORY.md) is intentionally NOT logged.
+#
+# Log file: $HOME/.claude/logs/memory-access.log
+# Log line: "<ISO8601 UTC timestamp> <session_id> read <relative-path>"
+#   - Path is stored relative to "memory-shared/" (so it begins "memories/...").
+#   - session_id falls back to "unknown" when the field is absent.
+#
+# Rotation policy (lazy, checked on each invocation):
+#   - When file size exceeds 1 MiB OR the file's calendar month differs from
+#     the current calendar month, rotate to "<log>.YYYY-MM" using the file's
+#     own month so the archive carries the period it covers. The original
+#     log path is then truncated and the new entry is appended to a fresh
+#     file.
+#   - Older archives are reaped by the project's existing cleanup convention.
+#
+# Failure isolation:
+#   Any internal failure (jq missing, log unwritable, mktemp failure, etc.) is
+#   silently swallowed and exit 0 is returned so that the user's Read flow is
+#   never disrupted. The PostToolUse Read hook is registered with async: true
+#   in settings.json for the same reason.
+#
+# Bash 3.2 compatible (macOS default).
+
+set -u
+
+LOG_FILE="${HOME}/.claude/logs/memory-access.log"
+MEMORY_ROOT="${HOME}/.claude/memory-shared/memories"
+SHARED_ROOT="${HOME}/.claude/memory-shared"
+
+# ----- helpers ---------------------------------------------------------------
+
+# Always exit 0 to preserve tool flow on any failure path.
+silent_exit() { exit 0; }
+
+# JSON string extractor: prefer jq, fall back to a sed-only path.
+# This hook needs only three string fields: .tool_name, .session_id, and
+# .tool_input.file_path. The fallback handles those three specifically; it is
+# NOT a general-purpose JSON parser and does not attempt to handle nested
+# arrays, escaped Unicode, or non-string values.
+extract_json_field() {
+    # Args: <json> <jq-path>  e.g. '.tool_input.file_path' or '.session_id'
+    local json="$1"
+    local path="$2"
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$json" | jq -r "$path // empty" 2>/dev/null
+        return
+    fi
+    # Fallback: extract the rightmost key segment from the jq path and search
+    # for "<key>": "<value>" with sed. Limited to the three fields we need.
+    local key
+    key="$(printf '%s' "$path" | sed 's|^.*\.||')"
+    printf '%s' "$json" \
+        | sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" \
+        | head -n 1
+}
+
+# Resolve realpath. When file does not exist, resolve the parent directory and
+# append the basename — same trick memory-write-guard uses (#521).
+resolve_path() {
+    local p="$1"
+    if [ -e "$p" ]; then
+        if command -v realpath >/dev/null 2>&1; then
+            realpath "$p" 2>/dev/null || printf '%s' "$p"
+        elif command -v python3 >/dev/null 2>&1; then
+            python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$p" 2>/dev/null || printf '%s' "$p"
+        else
+            printf '%s' "$p"
+        fi
+    else
+        local parent base rp
+        parent="$(dirname "$p")"
+        base="$(basename "$p")"
+        if [ -d "$parent" ]; then
+            if command -v realpath >/dev/null 2>&1; then
+                rp="$(realpath "$parent" 2>/dev/null)"
+                if [ -n "$rp" ]; then printf '%s/%s' "$rp" "$base"; return; fi
+            elif command -v python3 >/dev/null 2>&1; then
+                rp="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$parent" 2>/dev/null)"
+                if [ -n "$rp" ]; then printf '%s/%s' "$rp" "$base"; return; fi
+            fi
+        fi
+        printf '%s' "$p"
+    fi
+}
+
+# File size in bytes (cross-platform).
+# GNU and BSD `stat` use different flags. GNU's `stat -f` is "filesystem stat"
+# (different output, exit 0) so we cannot rely on exit code alone — validate
+# that the output is purely numeric before accepting it.
+file_size_bytes() {
+    local out
+    out="$(stat -c%s "$1" 2>/dev/null || true)"
+    case "$out" in (''|*[!0-9]*) ;; (*) printf '%s' "$out"; return 0 ;; esac
+    out="$(stat -f%z "$1" 2>/dev/null || true)"
+    case "$out" in (''|*[!0-9]*) ;; (*) printf '%s' "$out"; return 0 ;; esac
+    return 1
+}
+
+# YYYY-MM stamp from a file's mtime (UTC). Returns empty on failure.
+file_month_utc() {
+    local epoch out
+    # GNU stat path: -c%Y -> epoch seconds; convert via `date -d @N`.
+    epoch="$(stat -c%Y "$1" 2>/dev/null || true)"
+    case "$epoch" in (''|*[!0-9]*) epoch="" ;; esac
+    if [ -n "$epoch" ]; then
+        out="$(date -u -d "@$epoch" +%Y-%m 2>/dev/null \
+                || date -u -r "$epoch" +%Y-%m 2>/dev/null \
+                || true)"
+        case "$out" in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]) printf '%s' "$out"; return 0 ;;
+        esac
+    fi
+    # BSD stat path (macOS): -f %Sm -t %Y-%m -> formatted directly.
+    out="$(stat -f "%Sm" -t "%Y-%m" "$1" 2>/dev/null || true)"
+    case "$out" in
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]) printf '%s' "$out"; return 0 ;;
+    esac
+    return 1
+}
+
+# Rotate the log when size > 1 MiB OR the file's month != current month.
+maybe_rotate() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+
+    local size
+    size="$(file_size_bytes "$file")"
+    [ -z "$size" ] && return 0
+
+    local current_month
+    current_month="$(date -u +%Y-%m 2>/dev/null)"
+    local file_month
+    file_month="$(file_month_utc "$file")"
+
+    local one_mib=$((1024 * 1024))
+    local rotate=0
+    if [ "$size" -gt "$one_mib" ]; then rotate=1; fi
+    if [ -n "$current_month" ] && [ -n "$file_month" ] && [ "$file_month" != "$current_month" ]; then
+        rotate=1
+    fi
+    [ "$rotate" -eq 1 ] || return 0
+
+    # Archive carries the period it actually covers (file_month preferred).
+    local stamp="${file_month:-$current_month}"
+    [ -z "$stamp" ] && stamp="$(date -u +%Y-%m 2>/dev/null)"
+    [ -z "$stamp" ] && stamp="archive"
+
+    local target="${file}.${stamp}"
+    # Avoid clobbering an existing archive for the same month.
+    if [ -e "$target" ]; then
+        local n=1
+        while [ -e "${target}.${n}" ]; do n=$((n + 1)); done
+        target="${target}.${n}"
+    fi
+    mv -f "$file" "$target" 2>/dev/null || return 0
+    : > "$file" 2>/dev/null || return 0
+    return 0
+}
+
+# ----- read input ------------------------------------------------------------
+
+INPUT="$(cat 2>/dev/null || true)"
+[ -z "$INPUT" ] && silent_exit
+
+TOOL_NAME="$(extract_json_field "$INPUT" '.tool_name')"
+[ "$TOOL_NAME" = "Read" ] || silent_exit
+
+FILE_PATH="$(extract_json_field "$INPUT" '.tool_input.file_path')"
+[ -z "$FILE_PATH" ] && silent_exit
+
+SESSION_ID="$(extract_json_field "$INPUT" '.session_id')"
+[ -z "$SESSION_ID" ] && SESSION_ID="unknown"
+
+# ----- path gate -------------------------------------------------------------
+
+RESOLVED="$(resolve_path "$FILE_PATH")"
+
+# Strict prefix match: must be under memories/ specifically. The top-level
+# MEMORY.md is intentionally NOT logged (it is auto-generated, not user
+# memory content).
+case "$RESOLVED" in
+    "$MEMORY_ROOT"/*) ;;
+    *) silent_exit ;;
+esac
+
+# Compute the relative path from memory-shared/ for compactness.
+RELATIVE="${RESOLVED#"$SHARED_ROOT"/}"
+
+# ----- write log entry -------------------------------------------------------
+
+LOG_DIR="$(dirname "$LOG_FILE")"
+mkdir -p "$LOG_DIR" 2>/dev/null || silent_exit
+
+# Lazy rotation BEFORE the append so the new entry lands in a fresh file
+# whenever rotation triggers. Failure is silent; logging still proceeds.
+maybe_rotate "$LOG_FILE"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+[ -z "$TIMESTAMP" ] && TIMESTAMP="-"
+
+# Sanitize whitespace in the path so a single space-delimited line stays
+# parseable. The audit consumer splits on whitespace and uses field 4 for the
+# path — see #528.
+SAFE_RELATIVE="$(printf '%s' "$RELATIVE" | tr '\t\n\r' '   ')"
+
+# Single-line append < PIPE_BUF is atomic on POSIX, so concurrent reads are safe.
+printf '%s %s read %s\n' "$TIMESTAMP" "$SESSION_ID" "$SAFE_RELATIVE" >> "$LOG_FILE" 2>/dev/null
+
+silent_exit

--- a/global/settings.json
+++ b/global/settings.json
@@ -296,6 +296,12 @@
             "command": "~/.claude/hooks/pre-edit-read-guard.sh",
             "timeout": 5,
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/memory-access-logger.sh",
+            "timeout": 5,
+            "async": true
           }
         ]
       }


### PR DESCRIPTION
## What

Adds `global/hooks/memory-access-logger.sh` (and `.ps1` mirror) — a PostToolUse Read hook that records each memory file Claude Code reads during a session. Logs path only, never contents. Output lands at `~/.claude/logs/memory-access.log` and is consumed by the weekly `audit.sh` (#528) for the unused-memory check.

### Affected components

| Path | Change |
|------|--------|
| `global/hooks/memory-access-logger.sh` | New (216 lines) |
| `global/hooks/memory-access-logger.ps1` | New (PowerShell mirror) |
| `global/settings.json` | Register the hook in `PostToolUse.Read` matcher with `async: true` |
| `docs/MEMORY_SYNC.md` | New `Privacy: memory-access logging` section |

## Why

Per #528 (weekly audit), the unused-memory check needs to know which memories were actually read. Without an access log, that check is skipped. This hook provides the data feed.

The log records **paths only**, never content, so it carries no PII risk beyond filenames (which are already the canonical identifier).

Closes #531
Relates to #528 (consumer)
Part of #505

## Where

- `global/hooks/memory-access-logger.sh` — bash hook (executable)
- `global/hooks/memory-access-logger.ps1` — PowerShell mirror
- `global/settings.json` — `PostToolUse.Read` matcher entry (`async: true`, alongside `pre-edit-read-guard.sh`)
- `docs/MEMORY_SYNC.md` — Privacy section explaining log location, format, rotation, and the no-transmission guarantee

## How

### Path gate

Only logs when `realpath(tool_input.file_path)` is under `$HOME/.claude/memory-shared/memories/`. The top-level `MEMORY.md` (auto-generated index) is intentionally excluded.

### Log format (one per line)

```
<ISO8601 UTC timestamp> <session_id> read <relative-path>
```

Sample lines:

```
2026-05-08T10:23:11Z abc123 read memories/feedback_ci_merge_policy.md
2026-05-08T10:23:14Z abc123 read memories/project_kcenon_label_namespaces.md
2026-05-08T10:24:01Z def456 read memories/subdir/nested.md
```

Path is relative to `memory-shared/` (so it always begins `memories/...`). `session_id` falls back to `unknown` when the field is absent. Tabs and newlines in the path are sanitized to spaces so the line stays single-record.

The audit consumer can extract unique used paths with:

```bash
awk '{print $4}' ~/.claude/logs/memory-access.log | sort -u
```

### Rotation

Lazy, checked on each invocation:
- size > 1 MiB OR file's calendar month differs from current month -> rotate to `memory-access.log.YYYY-MM` (using the file's own month so the archive carries the period it covers)
- if the target archive already exists, append `.1`, `.2`, ... to avoid clobbering
- the active log is then truncated and the new entry appended

### Failure isolation

Any internal failure (jq missing, log unwritable, mktemp fail, stat fail, etc.) is silently swallowed and exit 0 returned. The hook is registered with `async: true` so it never blocks the user's Read flow. `set -u` plus defensive `|| true` paths everywhere.

### Compatibility

- Bash 3.2 compatible (macOS default)
- jq optional with sed-only fallback for the three fields needed (`tool_name`, `session_id`, `tool_input.file_path`)
- GNU + BSD `stat` both supported (validates output is numeric / well-formed before accepting)
- realpath fallback via `python3` then plain path

## Testing

Verified locally with a sandboxed `HOME`:

| Case | Expected | Result |
|------|----------|--------|
| Read of `memories/feedback_test.md` | log entry written | OK |
| Read of `memory-shared/MEMORY.md` (top-level) | NOT logged | OK |
| Read of `/etc/hosts` | NOT logged | OK |
| Edit (not Read) of memory file | NOT logged | OK |
| Missing `session_id` | `unknown` recorded | OK |
| Empty stdin | exit 0, no entry | OK |
| Subdir under `memories/` | logged with full relative path | OK |
| Pre-fill > 1 MiB then invoke | active log truncated, archive at `.YYYY-MM` | OK |
| Backdate mtime to last month then invoke | rotated to file's month | OK |
| Two invocations within same month/size | no rotation | OK |
| Log file `chmod 000` | exit 0, no failure | OK |
| jq disabled (sed fallback) | log entry still written | OK |

### Performance

The hook performs:
1. cat stdin
2. parse 3 string fields (jq or one sed)
3. realpath (with fallbacks)
4. one prefix `case` test
5. `stat` + month comparison for rotation check
6. one append

End-to-end including bash startup is well under the 5 ms target on a modern machine; `async: true` further removes any blocking concern.

## Breaking Changes

None. New hook, new log file path. Existing memory operations are unaffected.

## Rollback

1. Remove the entry from `global/settings.json` `PostToolUse.Read` matcher
2. Delete `global/hooks/memory-access-logger.{sh,ps1}`
3. Revert this PR

## Wire-up policy

Following the same convention as #521 / #522: the PR ships the hook + the registration in the global `settings.json` template. The user's live `~/.claude/settings.json` is **NOT** auto-modified by this change — that requires running the install script which copies the global template into place.