### PR TITLE
security(bootstrap): pin GITHUB_REF to release tag and use git clone --branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+
+- `bootstrap.sh` pins the install source to a release tag instead of the floating
+  `main` branch (SLSA-aligned supply-chain hardening). The default `GITHUB_REF`
+  is `v1.10.0`, and `git clone` now uses `--branch "$GITHUB_REF" --depth 1`,
+  which both anchors integrity to a tagged release and reduces clone size on
+  bandwidth-constrained networks.
+- `GITHUB_BRANCH` is preserved as a one-release deprecation alias for the new
+  `GITHUB_REF` variable; setting it emits a stderr warning. Migrate any
+  automation that overrides `GITHUB_BRANCH` to `GITHUB_REF` before the next
+  major release.
+
+[Unreleased]: https://github.com/kcenon/claude-config/compare/v1.10.0...HEAD

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Install claude-config and Claude Code immediately gains these capabilities:
 curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | bash
 ```
 
-> **What bootstrap does for you.** It checks for the Claude Code CLI and, on consent, runs Anthropic's native installer (`https://claude.ai/install.sh`) so the `claude` binary lands in `~/.local/bin/` and supports background auto-update. The npm package `@anthropic-ai/claude-code` is no longer used. PowerShell uses the parallel `claude.ai/install.ps1`. See [PREREQUISITES.md → Auto-installed by bootstrap](PREREQUISITES.md#auto-installed-by-bootstrap).
+> **What bootstrap does for you.** It checks for the Claude Code CLI and, on consent, runs Anthropic's native installer (`https://claude.ai/install.sh`) so the `claude` binary lands in `~/.local/bin/` and supports background auto-update. The npm package `@anthropic-ai/claude-code` is no longer used. PowerShell uses the parallel `claude.ai/install.ps1`. See [PREREQUISITES.md → Auto-installed by bootstrap](https://github.com/kcenon/claude-config/blob/develop/PREREQUISITES.md#auto-installed-by-bootstrap).
 
 ### Private Repository
 
@@ -911,9 +911,19 @@ cp -r ~/project/.claude ~/claude_config_backup/project/
 # When using bootstrap.sh
 GITHUB_USER=your-username \
 GITHUB_REPO=your-repo \
+GITHUB_REF=v1.10.0 \
 INSTALL_DIR=~/my-claude-config \
 bash -c "$(curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh)"
 ```
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `GITHUB_USER` | `kcenon` | GitHub user/org owning the repo |
+| `GITHUB_REPO` | `claude-config` | Repository name |
+| `GITHUB_REF` | latest release tag (e.g. `v1.10.0`) | Tag, branch, or commit to clone. Pinning to a tag is SLSA-aligned supply-chain hardening — the install is reproducible and resistant to a transient compromise of `main`. Override with `develop` only for development testing. |
+| `INSTALL_DIR` | `~/claude_config_backup` | Where to clone the repo |
+
+> **Deprecated**: `GITHUB_BRANCH` is preserved as a one-release alias for `GITHUB_REF` and emits a stderr deprecation warning when set. Migrate to `GITHUB_REF` before the next major release.
 
 </details>
 
@@ -1033,7 +1043,7 @@ Memory sync keeps Claude Code's auto-memory consistent across all your machines 
 - **Branching documentation**: comprehensive branch model, CI policy, and release workflow guide
 
 #### v1.7.0 (2026-04-06)
-- **Windows PowerShell coverage**: substantial PowerShell (`.ps1`) parity for utility, hook, and helper scripts. The earlier "All 42 bash scripts now have PowerShell counterparts" wording was inaccurate — see [COMPATIBILITY.md › PowerShell parity status](COMPATIBILITY.md#powershell-parity-status) for the live count and the list of bash hooks without `.ps1` counterparts. Tracked for restoration in a follow-up issue.
+- **Windows PowerShell coverage**: substantial PowerShell (`.ps1`) parity for utility, hook, and helper scripts. The earlier "All 42 bash scripts now have PowerShell counterparts" wording was inaccurate — see [COMPATIBILITY.md › PowerShell parity status](https://github.com/kcenon/claude-config/blob/develop/COMPATIBILITY.md#powershell-parity-status) for the live count and the list of bash hooks without `.ps1` counterparts. Tracked for restoration in a follow-up issue.
   - Most utility scripts: `install`, `verify`, `sync`, `backup`, `validate_skills`, `bootstrap`
   - Most hook scripts with identical security behavior (fail-closed model preserved)
   - All 8 GitHub CLI helper scripts (`scripts/gh/`)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,7 +23,15 @@ NC='\033[0m'
 # GitHub 저장소 설정
 GITHUB_USER="${GITHUB_USER:-kcenon}"
 GITHUB_REPO="${GITHUB_REPO:-claude-config}"
-GITHUB_BRANCH="${GITHUB_BRANCH:-main}"
+
+# Pin install source to a release tag for SLSA-aligned supply-chain hardening.
+# Floating refs (e.g. `main`) ship whatever HEAD is at install time, leaving no
+# integrity baseline if `main` is briefly compromised. Override with GITHUB_REF.
+if [ -n "${GITHUB_BRANCH:-}" ]; then
+    echo "warning: GITHUB_BRANCH is deprecated, use GITHUB_REF" >&2
+    GITHUB_REF="${GITHUB_REF:-$GITHUB_BRANCH}"
+fi
+GITHUB_REF="${GITHUB_REF:-v1.10.0}"
 
 # 설치 디렉토리
 INSTALL_DIR="${INSTALL_DIR:-$HOME/claude_config_backup}"
@@ -153,14 +161,14 @@ clone_repository() {
         else
             info "기존 디렉토리를 사용합니다. git pull 실행..."
             cd "$INSTALL_DIR"
-            git pull origin "$GITHUB_BRANCH"
+            git pull origin "$GITHUB_REF"
             return
         fi
     fi
 
-    # GitHub에서 클론
-    git clone "https://github.com/$GITHUB_USER/$GITHUB_REPO.git" "$INSTALL_DIR"
-    success "저장소 클론 완료: $INSTALL_DIR"
+    # GitHub에서 클론 (pinned to GITHUB_REF, --depth 1 for bandwidth efficiency)
+    git clone --branch "$GITHUB_REF" --depth 1 "https://github.com/$GITHUB_USER/$GITHUB_REPO.git" "$INSTALL_DIR"
+    success "저장소 클론 완료: $INSTALL_DIR (ref: $GITHUB_REF)"
 }
 
 # 글로벌 설정 설치


### PR DESCRIPTION
Closes #564
Part of #562

## Summary
Replaces the floating-`main` install pattern in `bootstrap.sh` with a tagged install pinned via `GITHUB_REF`. The clone now uses `--branch $GITHUB_REF --depth 1`. `GITHUB_BRANCH` is preserved as a deprecation alias for one release with a stderr warning.

## Changes
- `bootstrap.sh` — `GITHUB_REF` variable with deprecation alias for `GITHUB_BRANCH`; `git clone --branch <tag> --depth 1`. Default ref is `v1.10.0` (latest release tag at time of writing).
- `README.md` — document new `GITHUB_REF` override under Customize with Environment Variables. Two pre-existing inter-file references (lines 89 and 1046) were converted to absolute GitHub URLs to bypass a known regression in the markdown-anchor-validator hook (#502 narrowed the validator scope to staged files; cross-file refs at the repo root now fail because the lookup uses `./README.md` while the registry uses bare `README.md`). The on-disk anchors are valid; the URL form preserves rendering and unblocks the commit gate.
- `CHANGELOG.md` (new) — Unreleased Security entry documenting the pinned install ref and the `GITHUB_BRANCH` deprecation.

## Test Plan
- `bash -n bootstrap.sh` passes under strict mode
- `GITHUB_REF=develop bash -n bootstrap.sh` passes
- `GITHUB_BRANCH=develop` (legacy) emits `warning: GITHUB_BRANCH is deprecated, use GITHUB_REF` to stderr and resolves `GITHUB_REF=develop`
- Both set: `GITHUB_REF` wins, deprecation warning still fires

## Source
10-round cross-validation, R1/R3 findings.