### PR TITLE
security(bootstrap): verify chained Anthropic installer integrity (sha256 pin)

### DIFF
--- a/.github/workflows/check-anthropic-installer.yml
+++ b/.github/workflows/check-anthropic-installer.yml
@@ -1,0 +1,47 @@
+name: Anthropic installer drift check
+
+# Re-validates the sha256 pin for the Anthropic Claude Code installer that
+# `bootstrap.sh` invokes. Fails (alerts maintainers) when the upstream
+# installer drifts from the pinned hash. Auto-rotation is intentionally
+# NOT performed — pin rotation requires human review per
+# docs/SUPPLY_CHAIN.md.
+
+on:
+  schedule:
+    # Weekly Monday 06:07 UTC. Off the :00 minute mark to avoid the
+    # cron-fleet thundering herd.
+    - cron: '7 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify pinned sha256 against upstream
+        run: |
+          set -euo pipefail
+          PINNED=$(grep -E '^ANTHROPIC_INSTALLER_SHA256=' bootstrap.sh \
+                    | sed -E 's/.*:-([0-9a-f]{64}).*/\1/')
+          if [ -z "$PINNED" ] || [ "${#PINNED}" -ne 64 ]; then
+            echo "Could not extract pinned sha256 from bootstrap.sh" >&2
+            exit 2
+          fi
+          ACTUAL=$(curl -fsSL https://claude.ai/install.sh | sha256sum | awk '{print $1}')
+          echo "PINNED=$PINNED"
+          echo "ACTUAL=$ACTUAL"
+          if [ "$PINNED" != "$ACTUAL" ]; then
+            {
+              echo "Anthropic installer sha256 drift detected."
+              echo "  pinned: $PINNED"
+              echo "  actual: $ACTUAL"
+              echo "Open a PR updating ANTHROPIC_INSTALLER_SHA256 in bootstrap.sh"
+              echo "after reviewing the upstream change. See docs/SUPPLY_CHAIN.md."
+            } >&2
+            exit 1
+          fi
+          echo "sha256 pin matches upstream."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,6 +33,14 @@ if [ -n "${GITHUB_BRANCH:-}" ]; then
 fi
 GITHUB_REF="${GITHUB_REF:-v1.10.0}"
 
+# Anthropic Claude Code installer pin (M1.2b — supply-chain hardening, see #565).
+# The Anthropic-hosted install script is pinned by sha256 to prevent MITM
+# substitution. Rotation policy: docs/SUPPLY_CHAIN.md. The weekly drift check
+# workflow `.github/workflows/check-anthropic-installer.yml` fails when the
+# upstream sha256 deviates from this value.
+ANTHROPIC_INSTALLER_URL="${ANTHROPIC_INSTALLER_URL:-https://claude.ai/install.sh}"
+ANTHROPIC_INSTALLER_SHA256="${ANTHROPIC_INSTALLER_SHA256:-b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830}"  # pinned 2026-05-03
+
 # 설치 디렉토리
 INSTALL_DIR="${INSTALL_DIR:-$HOME/claude_config_backup}"
 CLAUDE_DIR="$HOME/.claude"
@@ -103,25 +111,70 @@ ensure_claude_cli() {
     INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
 
     if [ "$INSTALL_CLAUDE" != "y" ]; then
-        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치:"
-        echo "    curl -fsSL https://claude.ai/install.sh | bash"
+        warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치 가이드:"
+        echo "    https://code.claude.com/docs/en/setup"
+        echo "  또는 본 스크립트를 다시 실행해 sha256 검증된 자동 설치를 진행하세요."
         return 0
     fi
 
     # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
     # 설치 경로: ~/.local/bin/claude → ~/.local/share/claude/versions/<ver>
     # check_dependencies()에서 curl-or-wget 존재를 이미 보장하므로 둘 중 하나는 반드시 사용 가능.
-    local installer_url="https://claude.ai/install.sh"
+    #
+    # Supply-chain hardening (M1.2b, see #565):
+    # The chained `curl ... | bash` pattern is replaced with download → verify
+    # sha256 → execute. The pinned hash lives in $ANTHROPIC_INSTALLER_SHA256.
+    # On mismatch we abort and instruct the user to wait for a maintainer
+    # re-pin instead of executing potentially tampered content.
+    local installer_url="$ANTHROPIC_INSTALLER_URL"
     local install_status=1
-    info "Native installer 실행 중: $installer_url"
+    local tmp_installer
+    tmp_installer="$(mktemp -t claude-installer.XXXXXX)"
+    # Ensure the temp file is removed even if the function returns early or
+    # the integrity check fails.
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp_installer'" RETURN
+
+    info "Native installer 다운로드 중: $installer_url"
+    local download_ok=1
     if command -v curl >/dev/null 2>&1; then
-        if curl -fsSL "$installer_url" | bash; then
-            install_status=0
+        if curl -fsSL "$installer_url" -o "$tmp_installer"; then
+            download_ok=0
         fi
     elif command -v wget >/dev/null 2>&1; then
-        if wget -qO- "$installer_url" | bash; then
-            install_status=0
+        if wget -qO "$tmp_installer" "$installer_url"; then
+            download_ok=0
         fi
+    fi
+
+    if [ $download_ok -ne 0 ]; then
+        warning "Native installer 다운로드 실패: $installer_url"
+        echo "  네트워크 또는 Anthropic 측 일시 장애일 수 있습니다."
+        echo "  수동 설치 가이드: https://code.claude.com/docs/en/setup"
+        return 0
+    fi
+
+    info "sha256 무결성 확인 중 (pin: ${ANTHROPIC_INSTALLER_SHA256:0:12}...)"
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        warning "sha256sum 미설치 — 무결성 검증을 건너뛸 수 없습니다."
+        echo "  coreutils (Linux) 또는 'brew install coreutils' (macOS)로 설치하세요."
+        return 0
+    fi
+    if ! echo "${ANTHROPIC_INSTALLER_SHA256}  ${tmp_installer}" | sha256sum -c - >/dev/null 2>&1; then
+        local actual_hash
+        actual_hash="$(sha256sum "$tmp_installer" | awk '{print $1}')"
+        warning "Anthropic installer sha256 불일치 — 설치 중단."
+        echo "  expected: $ANTHROPIC_INSTALLER_SHA256"
+        echo "  actual:   $actual_hash"
+        echo "  Anthropic가 정상적으로 installer를 갱신했다면 maintainer가 docs/SUPPLY_CHAIN.md 절차에 따라 재핀합니다."
+        echo "  MITM 또는 캐시 변조 가능성이 있으므로 수동 진행 전에 보안 팀에 알리세요."
+        return 1
+    fi
+    success "sha256 검증 통과"
+
+    info "Native installer 실행 중"
+    if bash "$tmp_installer"; then
+        install_status=0
     fi
 
     if [ $install_status -eq 0 ]; then
@@ -141,9 +194,8 @@ ensure_claude_cli() {
         fi
     else
         warning "Claude Code CLI 자동 설치 실패."
-        echo "  수동 설치:"
-        echo "    curl -fsSL https://claude.ai/install.sh | bash"
-        echo "  또는 Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
+        echo "  Anthropic 공식 설치 가이드를 참고하세요: https://code.claude.com/docs/en/setup"
+        echo "  또는 본 스크립트를 다시 실행해 sha256 검증된 자동 설치를 재시도하세요."
     fi
 }
 

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -1,0 +1,127 @@
+# Supply-Chain Integrity Policy
+
+This document describes how `claude-config` defends its install path against
+supply-chain tampering, and how maintainers rotate pinned artifacts when
+upstream legitimately changes.
+
+## Threat model in scope
+
+`bootstrap.sh` performs network fetches that, if compromised in transit or at
+the origin, would execute attacker-controlled code on the user's machine.
+The two surfaces are:
+
+1. The `claude-config` source itself, fetched from GitHub. See M1.2a (#564 /
+   PR #571) — pinned to a release tag and cloned with `git clone --branch`,
+   eliminating mutable-`main` exposure.
+2. The chained Anthropic Claude Code installer (`https://claude.ai/install.sh`)
+   that `bootstrap.sh` invokes to install the `claude` CLI. The original
+   pattern was `curl -fsSL ... | bash` — the canonical supply-chain pipe.
+   This document covers the M1.2b mitigation (issue #565).
+
+## Anthropic installer pin (M1.2b)
+
+We pin the sha256 of the Anthropic install script. The pinned value lives
+in `bootstrap.sh` as `ANTHROPIC_INSTALLER_SHA256`. When `ensure_claude_cli`
+runs, it:
+
+1. Downloads the installer to a temp file (no piping to bash).
+2. Computes the sha256 of the downloaded bytes.
+3. Compares against `ANTHROPIC_INSTALLER_SHA256`.
+4. Aborts on mismatch with a clear error; only on match does it `bash` the
+   temp file.
+
+The pin is enforced at install time and re-validated weekly by CI (see
+"Drift detection" below).
+
+### Why pinning, not TLS alone
+
+TLS protects bytes in transit, but the install pattern still trusts whatever
+content the origin returns. A pinned sha256 binds the install to a specific,
+human-reviewed version of the upstream installer — defense in depth against:
+
+- A compromised CDN or origin returning malicious content under a valid TLS
+  certificate.
+- An MITM with a stolen or forged certificate (rare in practice, but cheap
+  to defend against).
+- A regression or accidental breaking change in upstream that we have not
+  vetted yet — rotation forces a human to ack the new content.
+
+### Why we do not auto-update the pin
+
+Auto-rotation defeats the purpose: an attacker who controls the upstream for
+a brief window would have their hash silently accepted. The drift workflow
+intentionally fails CI rather than committing a new pin — a maintainer must
+review the upstream change and open a manual PR.
+
+## Drift detection
+
+`.github/workflows/check-anthropic-installer.yml` runs every Monday at
+06:07 UTC and on demand (`workflow_dispatch`). It re-fetches
+`https://claude.ai/install.sh`, computes its sha256, and compares against
+the pinned value extracted from `bootstrap.sh`. On mismatch the workflow
+exits non-zero with both hashes printed to the job log, surfacing an alert
+that a maintainer can investigate.
+
+Failure paths the workflow surfaces:
+
+- Anthropic published a legitimate update (release notes, blog post, or
+  similar). Action: maintainer reviews the new installer content, computes
+  the new sha256, and rotates the pin via PR.
+- Origin or CDN serving unexpected content. Action: maintainer holds the
+  pin, raises with Anthropic security, and notifies users via release
+  notes if this drags on.
+- Network blip during the workflow. Action: re-run the workflow manually.
+
+## Rotating the pin
+
+A pin rotation MUST be a human-authored PR with explicit rationale.
+
+```bash
+# 1. Verify the upstream change is legitimate.
+#    Check Anthropic announcements, release notes, or contact Anthropic
+#    security if the change is unexplained.
+
+# 2. Compute the new sha256.
+NEW_HASH=$(curl -fsSL https://claude.ai/install.sh | sha256sum | awk '{print $1}')
+echo "$NEW_HASH"
+
+# 3. Open a branch and update the pin in bootstrap.sh.
+#    Edit ANTHROPIC_INSTALLER_SHA256 and the `# pinned YYYY-MM-DD` comment.
+
+# 4. Commit and PR.
+git commit -am "security(bootstrap): rotate Anthropic installer pin to <date>"
+gh pr create --base develop --title "security(bootstrap): rotate Anthropic installer pin"
+# In the PR body: link the upstream change, explain what changed and why
+# we trust it.
+```
+
+PR review checklist for a pin rotation:
+
+- [ ] Upstream change is documented (Anthropic announcement, release notes,
+      diff inspection).
+- [ ] New sha256 was independently re-computed by the reviewer.
+- [ ] Pin date comment in `bootstrap.sh` is updated.
+- [ ] No other unrelated changes in the PR.
+
+## Tamper test
+
+A local sanity check that the verification path actually aborts on a
+forced mismatch:
+
+```bash
+# Override the pin to an obviously-wrong value and run the installer arm
+# of bootstrap.sh interactively. The script must fail with the
+# "sha256 불일치 — 설치 중단." message and a non-zero exit.
+ANTHROPIC_INSTALLER_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
+    bash bootstrap.sh
+```
+
+Expected: install aborts with the mismatch banner before any code from
+`https://claude.ai/install.sh` is executed.
+
+## Related
+
+- Issue: #565 (M1.2b)
+- Parent EPIC: #562 (supply-chain hardening rollup)
+- Sibling: #564 / PR #571 (M1.2a — pin `claude-config` source by tag)
+- Workflow: `.github/workflows/check-anthropic-installer.yml`


### PR DESCRIPTION
Closes #565
Part of #562

## What

Replace the unverified `curl -fsSL https://claude.ai/install.sh | bash`
pattern in `bootstrap.sh` with a download → verify sha256 → execute
pattern that pins the Anthropic Claude Code installer by hash.

| Surface | Before | After |
|---------|--------|-------|
| `bootstrap.sh` install path | piped curl/wget directly to `bash` | downloads to temp file, verifies sha256 against pin, then runs |
| Drift visibility | none | weekly CI check + on-demand `workflow_dispatch` |
| Rotation policy | none | documented in `docs/SUPPLY_CHAIN.md` |

## Why

`curl ... | bash` is the canonical supply-chain pipe. Even if `claude.ai`
itself is uncompromised, an MITM controlling the network path can swap
content in flight. Pinning the sha256 binds installs to a human-reviewed
upstream artifact: a successful MITM cannot pass the integrity check, and
a legitimate upstream change is surfaced via the weekly drift workflow
(intentionally fails CI rather than auto-rotating — pin rotation requires
human review per `docs/SUPPLY_CHAIN.md`).

This is independent of M1.2a (#564 / PR #571), which protects the
`claude-config` source itself; M1.2b protects the chained Anthropic
installer that `bootstrap.sh` invokes.

## Where

- `bootstrap.sh`
  - Pin constants (`ANTHROPIC_INSTALLER_URL`, `ANTHROPIC_INSTALLER_SHA256`)
    inserted near the top.
  - `ensure_claude_cli` rewritten to download → verify → execute. Mismatch
    aborts with a clear error pointing at `docs/SUPPLY_CHAIN.md`.
  - User-facing fallback messages (skipped install, failed install)
    updated to reference the official Anthropic setup guide instead of
    printing the raw piped command.
- `docs/SUPPLY_CHAIN.md` (new) — threat model, why we pin, drift detection,
  rotation procedure, tamper-test instructions.
- `.github/workflows/check-anthropic-installer.yml` (new) — weekly drift
  check (Mondays 06:07 UTC) + `workflow_dispatch`.

## How

### Pinned values

| Field | Value |
|-------|-------|
| URL | `https://claude.ai/install.sh` |
| sha256 | `b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830` |
| Pinned date | 2026-05-03 |
| Override env | `ANTHROPIC_INSTALLER_URL`, `ANTHROPIC_INSTALLER_SHA256` |

The pin was obtained by:

```
curl -fsSL https://claude.ai/install.sh | sha256sum
```

Re-fetch confirmed the same hash for consistency.

### Verification flow in `ensure_claude_cli`

1. `mktemp` a temp file (with `trap rm RETURN` cleanup).
2. `curl -fsSL ... -o "$tmp"` (or `wget -qO "$tmp" ...`).
3. `echo "${ANTHROPIC_INSTALLER_SHA256}  $tmp" | sha256sum -c -`.
4. On match: `bash "$tmp"`. On mismatch: print expected/actual + rotation
   guidance, return 1.

### Drift detection workflow

- Triggers: weekly cron (Mon 06:07 UTC, off the :00 minute) + manual.
- Extracts `ANTHROPIC_INSTALLER_SHA256` from `bootstrap.sh`, fetches
  upstream, compares. Non-zero exit on mismatch with both hashes printed.

### Test plan

Local:

```bash
bash -n bootstrap.sh                # syntax
grep ANTHROPIC_INSTALLER_SHA256 bootstrap.sh
grep -E 'curl.*\| bash|wget.*\| bash' bootstrap.sh
# Only matches: header docstring (bootstrap.sh self-invocation, separate
# concern) and the in-code comment explaining what was replaced.
```

Tamper test (manual, requires interactive input):

```bash
ANTHROPIC_INSTALLER_SHA256="0000000000000000000000000000000000000000000000000000000000000000" \
    bash bootstrap.sh
# Expected: aborts with "Anthropic installer sha256 불일치 — 설치 중단."
# before any code from upstream is executed.
```

### Acceptance criteria mapping

- [x] No executable `curl ... | bash` pattern remains in the codebase
      (header docstring of `bootstrap.sh` itself + replacement-comment
      reference are the only matches; both are documentation).
- [x] Pinned sha256 documented and verified at install time.
- [x] CI alert workflow in place (`check-anthropic-installer.yml`).
- [x] sha256 mismatch results in install abort with a clear error message.
- [x] `docs/SUPPLY_CHAIN.md` published.

## Risk

Medium. If Anthropic legitimately updates `install.sh`, installs fail
until a maintainer re-pins. Mitigated by the weekly drift workflow that
surfaces upstream changes within a week. Manual rotation procedure is
documented end-to-end in `docs/SUPPLY_CHAIN.md`.
