### PR TITLE
security(hooks): adopt resolve_path normalization in sensitive-file-guard

### DIFF
--- a/global/hooks/bash-write-guard.sh
+++ b/global/hooks/bash-write-guard.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
 # shellcheck source=lib/tokenize-shell.sh
 . "$LIB_DIR/tokenize-shell.sh"
+# shellcheck source=lib/path-utils.sh
+. "$LIB_DIR/path-utils.sh"
 
 # --- helpers ----------------------------------------------------------------
 
@@ -59,43 +61,9 @@ EOF
     exit 0
 }
 
-# resolve_path <raw_path>
-#   Expands ~/ and $HOME at the head, then resolves the path through
-#   realpath so symlinks collapse and macOS `/var/...` is canonicalized
-#   to `/private/var/...`. Falls back to a manual cleanup when realpath
-#   cannot resolve the path (BSD realpath rejects missing files).
-resolve_path() {
-    local p="$1"
-    [ -z "$p" ] && return 0
-    case "$p" in
-        '~')         p="${HOME:-$p}" ;;
-        '~/'*)       p="${HOME}/${p#'~/'}" ;;
-        '$HOME')     p="${HOME:-$p}" ;;
-        '$HOME/'*)   p="${HOME}/${p#'$HOME/'}" ;;
-    esac
-    local resolved
-    if command -v realpath >/dev/null 2>&1; then
-        resolved=$(realpath "$p" 2>/dev/null) || resolved=""
-    fi
-    if [ -z "$resolved" ]; then
-        # Fallback: resolve the parent directory (which usually exists)
-        # and reattach the basename. This collapses `//` and trailing
-        # `/` while keeping behavior consistent for write targets that
-        # don't exist yet.
-        local parent base
-        parent=$(dirname "$p")
-        base=$(basename "$p")
-        if [ -d "$parent" ] && command -v realpath >/dev/null 2>&1; then
-            local rp
-            rp=$(realpath "$parent" 2>/dev/null) || rp="$parent"
-            resolved="${rp%/}/$base"
-        else
-            # Last-resort manual cleanup.
-            resolved=$(printf '%s' "$p" | sed -e 's://*:/:g' -e 's:/$::')
-        fi
-    fi
-    printf '%s' "$resolved"
-}
+# resolve_path is provided by lib/path-utils.sh (sourced above).
+# This consolidation ensures sensitive-file-guard.sh and bash-write-guard.sh
+# share identical canonicalization semantics — see Issue #569.
 
 # is_sensitive_target <path>
 #   Path patterns that must NEVER be written by the Bash channel without an

--- a/global/hooks/lib/path-utils.sh
+++ b/global/hooks/lib/path-utils.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# path-utils.sh
+# Shared path-resolution helpers for hook scripts.
+#
+# Sourced by:
+#   - global/hooks/sensitive-file-guard.sh
+#   - global/hooks/bash-write-guard.sh
+#
+# Rationale (Issue #569)
+# ----------------------
+# Multiple guards need the same canonicalization semantics: expand `~`/`$HOME`
+# at the head, run through `realpath` so symlinks collapse and macOS
+# `/var/...` becomes `/private/var/...`, and fall back to a manual cleanup
+# when realpath cannot resolve the path (BSD realpath rejects missing files,
+# which the Write tool legitimately produces for new files).
+#
+# This file is the single source of truth for `resolve_path()`. Both guards
+# previously carried near-identical copies; consolidating them here eliminates
+# drift and lets future hooks reuse the same primitive.
+
+set -euo pipefail
+
+# resolve_path <raw_path>
+#   Expands ~/ and $HOME at the head, then resolves the path through
+#   realpath so symlinks collapse and macOS `/var/...` is canonicalized
+#   to `/private/var/...`. Falls back to a manual cleanup when realpath
+#   cannot resolve the path (BSD realpath rejects missing files).
+#
+#   Always returns 0. Empty input prints nothing (caller decides policy).
+resolve_path() {
+    local p="$1"
+    [ -z "$p" ] && return 0
+    case "$p" in
+        '~')         p="${HOME:-$p}" ;;
+        '~/'*)       p="${HOME}/${p#'~/'}" ;;
+        '$HOME')     p="${HOME:-$p}" ;;
+        '$HOME/'*)   p="${HOME}/${p#'$HOME/'}" ;;
+    esac
+    local resolved
+    if command -v realpath >/dev/null 2>&1; then
+        resolved=$(realpath "$p" 2>/dev/null) || resolved=""
+    fi
+    if [ -z "$resolved" ]; then
+        # Fallback: resolve the parent directory (which usually exists)
+        # and reattach the basename. This collapses `//` and trailing
+        # `/` while keeping behavior consistent for write targets that
+        # don't exist yet.
+        local parent base
+        parent=$(dirname "$p")
+        base=$(basename "$p")
+        if [ -d "$parent" ] && command -v realpath >/dev/null 2>&1; then
+            local rp
+            rp=$(realpath "$parent" 2>/dev/null) || rp="$parent"
+            resolved="${rp%/}/$base"
+        else
+            # Last-resort manual cleanup.
+            resolved=$(printf '%s' "$p" | sed -e 's://*:/:g' -e 's:/$::')
+        fi
+    fi
+    printf '%s' "$resolved"
+}

--- a/global/hooks/sensitive-file-guard.sh
+++ b/global/hooks/sensitive-file-guard.sh
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+# Source the shared path-utils helper (resolve_path).
+# Issue #569 — consolidate canonicalization with bash-write-guard.sh.
+# shellcheck source=lib/path-utils.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/path-utils.sh"
+
 # Helper function for deny response
 deny_response() {
     local reason="$1"
@@ -59,12 +64,43 @@ if [ -z "$FILE" ]; then
     allow_response
 fi
 
-# Check sensitive file extensions
-if echo "$FILE" | grep -qE '(^|/)\.env($|\.)|\.(pem|key|p12|pfx)$'; then
-    deny_response "Access to sensitive file blocked: $FILE (protected extension)"
-fi
+# Resolve the path so symlinks, ~, $HOME, and macOS /var → /private/var
+# all canonicalize. resolve_path is purely string-transforming for
+# non-existent targets, so newly-created files still flow through.
+TARGET=$(resolve_path "$FILE")
 
-# Check sensitive directories
+# Lowercased basename with surrounding whitespace stripped. The strip
+# defends against ".env " (trailing space) and similar whitespace-padded
+# bypasses; case folding defends against ".ENV" / ".Env" variants.
+BASENAME_RAW=$(basename -- "$TARGET")
+BASENAME_TRIMMED="${BASENAME_RAW#"${BASENAME_RAW%%[![:space:]]*}"}"
+BASENAME_TRIMMED="${BASENAME_TRIMMED%"${BASENAME_TRIMMED##*[![:space:]]}"}"
+BASENAME_LOWER=$(printf '%s' "$BASENAME_TRIMMED" | tr '[:upper:]' '[:lower:]')
+
+# Pattern set covers env files, credential containers, SSH private keys,
+# and AWS credential files. NUL-byte truncation is handled implicitly
+# because bash variables cannot carry NUL bytes — the path is truncated
+# at the first NUL before reaching this check.
+case "$BASENAME_LOWER" in
+    .env|.env.*|.envrc)
+        deny_response "Access to sensitive file blocked: $FILE (env file)"
+        ;;
+    *.pem|*.key|*.p12|*.pfx)
+        deny_response "Access to sensitive file blocked: $FILE (credential file)"
+        ;;
+    id_rsa|id_rsa.*|id_ed25519|id_ed25519.*|id_ecdsa|id_ecdsa.*|id_dsa|id_dsa.*)
+        deny_response "Access to sensitive file blocked: $FILE (SSH private key)"
+        ;;
+    credentials|config)
+        case "$TARGET" in
+            */.aws/*)
+                deny_response "Access to sensitive file blocked: $FILE (AWS credentials)"
+                ;;
+        esac
+        ;;
+esac
+
+# Check sensitive directories (case-insensitive)
 if echo "$FILE" | grep -qiE '(secrets|credentials|passwords)[/\\]'; then
     deny_response "Access to sensitive directory blocked: $FILE (protected path)"
 fi

--- a/tests/hooks/test-sensitive-file-guard-bypass.sh
+++ b/tests/hooks/test-sensitive-file-guard-bypass.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Test suite for sensitive-file-guard.sh — historical bypass cases.
+# Run: bash tests/hooks/test-sensitive-file-guard-bypass.sh
+#
+# Validates Issue #569: the 11 cases below previously bypassed the guard.
+# After adopting resolve_path() normalization, lowercase basename matching,
+# and an expanded pattern set, all 11 must now be BLOCKED (deny).
+
+set -uo pipefail
+
+HOOK="global/hooks/sensitive-file-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+assert_deny() {
+    local input="$1" label="$2"
+    local result
+    result=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label - expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local input="$1" label="$2"
+    local result
+    result=$(printf '%s' "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label - expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+# Some cases need a fixture file because shell printf cannot embed a NUL byte
+# into a tool argument. assert_deny_from_file pipes the raw bytes from a file.
+assert_deny_from_file() {
+    local fixture="$1" label="$2"
+    local result
+    result=$(bash "$HOOK" < "$fixture" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label - expected deny, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== sensitive-file-guard.sh historical bypass tests (Issue #569) ==="
+echo ""
+
+echo "[Case 1: .ENV (uppercase) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":".ENV"}}' ".ENV uppercase"
+
+echo ""
+echo "[Case 2: .Env (mixed case) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":".Env"}}' ".Env mixed case"
+
+echo ""
+echo "[Case 3: /foo/.ENV (uppercase in path) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":"/foo/.ENV"}}' "/foo/.ENV uppercase in path"
+
+echo ""
+echo "[Case 4: .env (trailing space) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":".env "}}' ".env trailing space"
+
+echo ""
+echo "[Case 5: .env<NUL>.txt (NUL truncation) - was BYPASS]"
+# Build the JSON payload via python because shell printf cannot embed
+# a NUL byte into command arguments. After jq parses the JSON, the NUL
+# either truncates the bash variable to ".env" or survives concatenated
+# as ".env.txt"; both shapes match the .env|.env.* pattern set.
+NUL_FIXTURE=$(mktemp -t sfg-nul.XXXXXX 2>/dev/null) || NUL_FIXTURE="/tmp/sfg-nul.$$"
+trap 'rm -f "$NUL_FIXTURE"' EXIT
+if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import sys; sys.stdout.buffer.write(b"{\"tool_input\":{\"file_path\":\".env\x00.txt\"}}")' > "$NUL_FIXTURE"
+elif command -v python >/dev/null 2>&1; then
+    python -c 'import sys; sys.stdout.write("{\"tool_input\":{\"file_path\":\".env\x00.txt\"}}")' > "$NUL_FIXTURE"
+else
+    # Fallback uses printf with octal NUL, which works on most platforms.
+    printf '{"tool_input":{"file_path":".env\0.txt"}}' > "$NUL_FIXTURE"
+fi
+assert_deny_from_file "$NUL_FIXTURE" ".env<NUL>.txt NUL truncation"
+
+echo ""
+echo "[Case 6: ../.aws/credentials (traversal + AWS) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":"../.aws/credentials"}}' "../.aws/credentials traversal"
+
+echo ""
+echo "[Case 7: id_rsa (SSH key) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":"id_rsa"}}' "id_rsa SSH key"
+
+echo ""
+echo "[Case 8: .envrc (env extension variant) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":".envrc"}}' ".envrc env variant"
+
+echo ""
+echo "[Case 9: /Users/x/.ssh/id_ed25519 (SSH path) - was BYPASS]"
+assert_deny '{"tool_input":{"file_path":"/Users/x/.ssh/id_ed25519"}}' "id_ed25519 SSH path"
+
+echo ""
+echo "[Case 10: .env (canonical baseline) - already BLOCKED]"
+assert_deny '{"tool_input":{"file_path":".env"}}' ".env canonical"
+
+echo ""
+echo "[Case 11: secret.pem (canonical baseline) - already BLOCKED]"
+assert_deny '{"tool_input":{"file_path":"secret.pem"}}' "secret.pem canonical"
+
+echo ""
+echo "[Negative tests - legitimate writes must NOT be blocked]"
+assert_allow '{"tool_input":{"file_path":"package.json"}}' "package.json"
+assert_allow '{"tool_input":{"file_path":"README.md"}}' "README.md"
+assert_allow '{"tool_input":{"file_path":"src/main.ts"}}' "src/main.ts"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Refactors `global/hooks/sensitive-file-guard.sh:55-66` to call a shared `resolve_path()` helper, applies lowercase basename matching, and expands the pattern set to cover SSH private keys, AWS credentials, `.envrc`, and case/whitespace variants. The shared helper now lives in `global/hooks/lib/path-utils.sh` and is sourced by both `sensitive-file-guard.sh` and `bash-write-guard.sh`.

| Component | Change |
|-----------|--------|
| `global/hooks/lib/path-utils.sh` | New — `resolve_path()` extracted verbatim from `bash-write-guard.sh:67`. |
| `global/hooks/sensitive-file-guard.sh` | Sources `path-utils.sh`. Trims surrounding whitespace, lowercases basename, replaces the single grep with a typed `case` covering env files, credentials, SSH keys, AWS files. |
| `global/hooks/bash-write-guard.sh` | Drops its inline `resolve_path()` copy in favor of the shared helper (SSOT). |
| `tests/hooks/test-sensitive-file-guard-bypass.sh` | New — exercises all 11 historical bypass cases plus 3 negative cases. |

## Why

The previous guard pattern `grep -qE '(^|/)\.env($|\.)|\.(pem|key|p12|pfx)'` was empirically bypassable in 9 of 11 test cases (issue #569 R4 round). Case folding, NUL-truncation, trailing-space variants, SSH keys, `.envrc`, and `../.aws/credentials` traversal all slipped through. After this refactor: **0/11 bypass**.

The `resolve_path()` helper that already worked in `bash-write-guard.sh:67` is now the SSOT, eliminating both the original gap and the drift risk from carrying two copies.

## Who

- Implementer: solo agent
- Reviewer: maintainer (security review recommended)

## When

After M1.1 merges. Independent of M1.5a (different file, different concern).

## Where

- `global/hooks/sensitive-file-guard.sh:55-66` — replaced.
- `global/hooks/bash-write-guard.sh:62-98` — inline `resolve_path()` removed.
- `global/hooks/lib/path-utils.sh` — new shared library.
- `tests/hooks/test-sensitive-file-guard-bypass.sh` — new test suite.

## How

### Acceptance Criteria

- [x] `resolve_path()` extracted to `global/hooks/lib/path-utils.sh`
- [x] Both `sensitive-file-guard.sh` and `bash-write-guard.sh` source the shared helper
- [x] All 11 historical bypass cases now BLOCKED (0/11 bypass) in `tests/hooks/test-sensitive-file-guard-bypass.sh`
- [x] No regression on legitimate writes (`package.json`, `README.md`, `src/main.ts`)
- [x] Existing `tests/hooks/test-sensitive-file-guard.sh` continues to pass (23/23)
- [x] Existing `tests/hooks/test-bash-write-guard.sh` continues to pass (29/29)
- [ ] CI green

### Test Plan

```bash
bash -n global/hooks/lib/path-utils.sh
bash -n global/hooks/sensitive-file-guard.sh
bash -n global/hooks/bash-write-guard.sh

bash tests/hooks/test-sensitive-file-guard-bypass.sh
# Expected: 14 passed, 0 failed (11 bypass + 3 negative)

bash tests/hooks/test-sensitive-file-guard.sh
# Expected: 23 passed, 0 failed (regression)

bash tests/hooks/test-bash-write-guard.sh
# Expected: 29 passed, 0 failed (regression)
```

### Breaking Changes

None. This change adds blocks for paths that previously bypassed the guard. Legitimate writes are unaffected.

### Rollback Plan

Revert this commit. `bash-write-guard.sh` keeps a self-contained `resolve_path()` after revert (the inline copy is preserved in git history).

## Risk

Low. Refactor adds blocks; legitimate writes are unaffected. The shared `path-utils.sh` is small and well-understood, with `bash-write-guard.sh` already exercising the same `realpath` flow in production.

## Related

Closes #569
Part of #562
