### PR TITLE
security(scripts): tighten rm -rf path guards in bootstrap.sh and backup.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,6 +61,43 @@ success() { echo -e "${GREEN}✅ $1${NC}"; }
 warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 error() { echo -e "${RED}❌ $1${NC}"; exit 1; }
 
+# Path-guarded rm helper (M1.3, see #566).
+# This file is consumed via `curl | bash`, so the canonical helper at
+# scripts/lib/safe-rm.sh is unavailable when clone_repository() removes
+# a stale $INSTALL_DIR. The function is intentionally inlined here and
+# kept byte-equivalent in semantics with scripts/lib/safe-rm.sh.
+# Resolves the canonical path via `realpath -e`, then asserts it lies
+# under an allow-listed prefix before deleting. See safe-rm.sh for the
+# full threat model and allow-list rationale.
+safe_rm_rf() {
+    local raw="${1:-}"
+    if [ -z "$raw" ]; then
+        echo "safe_rm_rf: target required" >&2
+        return 1
+    fi
+    # Idempotent: missing target is not an error.
+    if [ ! -e "$raw" ] && [ ! -L "$raw" ]; then
+        return 0
+    fi
+    local target
+    target=$(realpath -e "$raw") || {
+        echo "safe_rm_rf: cannot resolve $raw" >&2
+        return 1
+    }
+    case "$target" in
+        "$HOME"/.claude/*) ;;
+        "$HOME"/.claude-backup/*) ;;
+        "$HOME"/claude_config_backup/*) ;;
+        /tmp/claude-*) ;;
+        /tmp/claude-config-*) ;;
+        *)
+            echo "safe_rm_rf: refused — $target is outside allow-listed prefix" >&2
+            return 1
+            ;;
+    esac
+    rm -rf -- "$target"
+}
+
 # 의존성 확인
 check_dependencies() {
     info "의존성 확인 중..."
@@ -209,7 +246,7 @@ clone_repository() {
         OVERWRITE=${OVERWRITE:-n}
 
         if [ "$OVERWRITE" = "y" ]; then
-            rm -rf "$INSTALL_DIR"
+            safe_rm_rf "$INSTALL_DIR"
         else
             info "기존 디렉토리를 사용합니다. git pull 실행..."
             cd "$INSTALL_DIR"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,6 +17,12 @@ NC='\033[0m'
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BACKUP_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Path-guarded rm helper (M1.3, see #566). Replaces direct `rm -rf` on
+# variable-derived targets with an allow-list check on the resolved
+# canonical path.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/safe-rm.sh"
+
 echo -e "${BLUE}"
 cat << 'EOF'
 ╔═══════════════════════════════════════════════════════════════╗
@@ -209,7 +215,7 @@ if [ "$REPLACE" = "y" ]; then
     # enterprise 디렉토리 업데이트
     if [ -d "$TEMP_BACKUP/enterprise" ] && [ -n "$(ls -A "$TEMP_BACKUP/enterprise" 2>/dev/null)" ]; then
         mkdir -p "$BACKUP_DIR/enterprise/rules"
-        rm -rf "$BACKUP_DIR/enterprise"/*
+        safe_rm_rf "$BACKUP_DIR/enterprise"
         mkdir -p "$BACKUP_DIR/enterprise/rules"
         cp -r "$TEMP_BACKUP/enterprise"/* "$BACKUP_DIR/enterprise/" || error "Enterprise 백업 업데이트 실패"
         success "Enterprise 백업 업데이트됨"
@@ -217,20 +223,22 @@ if [ "$REPLACE" = "y" ]; then
 
     # global 디렉토리 업데이트
     if [ -d "$TEMP_BACKUP/global" ] && [ -n "$(ls -A "$TEMP_BACKUP/global" 2>/dev/null)" ]; then
-        rm -rf "$BACKUP_DIR/global"/*
+        safe_rm_rf "$BACKUP_DIR/global"
+        mkdir -p "$BACKUP_DIR/global"
         cp -r "$TEMP_BACKUP/global"/* "$BACKUP_DIR/global/" || error "글로벌 백업 업데이트 실패"
         success "글로벌 백업 업데이트됨"
     fi
 
     # project 디렉토리 업데이트
     if [ -d "$TEMP_BACKUP/project" ] && [ -n "$(ls -A "$TEMP_BACKUP/project" 2>/dev/null)" ]; then
-        rm -rf "$BACKUP_DIR/project"/*
+        safe_rm_rf "$BACKUP_DIR/project"
+        mkdir -p "$BACKUP_DIR/project"
         cp -r "$TEMP_BACKUP/project"/* "$BACKUP_DIR/project/" || error "프로젝트 백업 업데이트 실패"
         success "프로젝트 백업 업데이트됨"
     fi
 
     # 임시 백업 제거
-    rm -rf "$TEMP_BACKUP"
+    safe_rm_rf "$TEMP_BACKUP"
     info "임시 백업 제거됨"
 else
     success "타임스탬프 백업 유지: $TEMP_BACKUP"

--- a/scripts/lib/safe-rm.sh
+++ b/scripts/lib/safe-rm.sh
@@ -1,0 +1,92 @@
+# scripts/lib/safe-rm.sh
+# =====================================================================
+# Sourced library: no shebang, no `set -e`. The caller is responsible
+# for strict mode (`set -euo pipefail`); this file inherits it.
+#
+# Public API
+# ----------
+#   safe_rm_rf <target>
+#     Removes <target> recursively after asserting the resolved canonical
+#     path lies within an allow-listed prefix. Idempotent: a missing
+#     target succeeds quietly so cleanup blocks can run twice.
+#
+# Threat model
+# ------------
+#   The original `rm -rf "$BACKUP_DIR/<sub>"/*` callers in bootstrap.sh
+#   and scripts/backup.sh derive `$BACKUP_DIR` from `dirname "$SCRIPT_DIR"`
+#   where `$SCRIPT_DIR` is built from `$BASH_SOURCE`. An attacker who
+#   controls `$BASH_SOURCE` (e.g. via `source` of a hostile script) or a
+#   misconfigured invocation that leaves the variable empty can redirect
+#   the deletion target to an arbitrary path — historically up to the
+#   parent directory of whatever `$SCRIPT_DIR` resolves to. With `set -u`
+#   addressed in M1.1, undefined variables now error early, but symlinks
+#   and `..` traversal remain. This helper converts the assumption
+#   "the variable is honest" into the verifiable invariant "the resolved
+#   target lies under a prefix the project owns."
+#
+# Allow-list
+# ----------
+#   The prefixes below cover every legitimate deletion target across the
+#   repository. Extend this list — do not weaken it — when adding new
+#   callers. Each addition should name the script and rationale.
+#
+#   1. "$HOME"/.claude/*           — global Claude Code config tree
+#                                   (rotated by install/sync flows)
+#   2. "$HOME"/.claude-backup/*    — historical backup snapshots
+#                                   (legacy layout, kept for migration)
+#   3. "$HOME"/claude_config_backup/*
+#                                  — bootstrap.sh INSTALL_DIR default and
+#                                   backup.sh BACKUP_DIR (project clone
+#                                   acting as a backup carrier)
+#   4. /tmp/claude-*               — sha256-pinned installer scratch
+#                                   files from bootstrap.sh ensure_claude_cli
+#   5. /tmp/claude-config-*        — test fixtures created by tests/
+#                                   safe-rm-rf.sh and other suites
+# =====================================================================
+
+# Idempotency guard: avoid redefining the function or duplicating
+# realpath cost when sourced multiple times in the same shell.
+if [ -n "${SAFE_RM_SH_LOADED:-}" ]; then
+    return 0
+fi
+SAFE_RM_SH_LOADED=1
+
+safe_rm_rf() {
+    local raw="${1:-}"
+
+    if [ -z "$raw" ]; then
+        echo "safe_rm_rf: target required" >&2
+        return 1
+    fi
+
+    # Idempotent cleanup: a missing target is not an error. Repeated
+    # invocations on the same path (e.g. retry of a partial restore)
+    # must be safe.
+    if [ ! -e "$raw" ] && [ ! -L "$raw" ]; then
+        return 0
+    fi
+
+    local target
+    # `realpath -e` requires every component to exist and follows
+    # symlinks. This collapses `..` traversal and resolves symlinks
+    # before the allow-list check, so a symlinked redirect cannot
+    # bypass the guard.
+    target=$(realpath -e "$raw") || {
+        echo "safe_rm_rf: cannot resolve $raw" >&2
+        return 1
+    }
+
+    case "$target" in
+        "$HOME"/.claude/*) ;;
+        "$HOME"/.claude-backup/*) ;;
+        "$HOME"/claude_config_backup/*) ;;
+        /tmp/claude-*) ;;
+        /tmp/claude-config-*) ;;
+        *)
+            echo "safe_rm_rf: refused — $target is outside allow-listed prefix" >&2
+            return 1
+            ;;
+    esac
+
+    rm -rf -- "$target"
+}

--- a/tests/safe-rm-rf.sh
+++ b/tests/safe-rm-rf.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# tests/safe-rm-rf.sh
+# =====================================================================
+# Unit tests for scripts/lib/safe-rm.sh (M1.3, see #566).
+#
+# Bats is not available in CI; this is a plain bash harness.
+# Each test is a function returning non-zero on failure. The runner at
+# the bottom collects results and exits with the failure count.
+#
+# Coverage (matches the issue acceptance criteria):
+#   - relative path resolution
+#   - symlink pointing outside the allow-listed prefix
+#   - `..` traversal
+#   - `$HOME` direct
+#   - `/` direct
+#   - allow-listed paths
+#   - empty argument
+#   - non-existent target (idempotent)
+# =====================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/lib/safe-rm.sh"
+
+if [ ! -f "$HELPER" ]; then
+    echo "FAIL: helper not found at $HELPER" >&2
+    exit 1
+fi
+
+# Test sandbox lives under /tmp/claude-config-* — itself an allow-listed
+# prefix, which is convenient: positive tests that delete real fixtures
+# can run inside the sandbox without tripping the guard.
+SANDBOX="$(mktemp -d -t claude-config-tests.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+
+# Run a single test: $1 = name, remaining args = command to evaluate.
+# A test passes when the command's exit status matches the expectation.
+run_test() {
+    local name="$1"
+    shift
+    local expected_status="$1"
+    shift
+    # Run the test command in a subshell so failures don't kill the runner.
+    local actual_status=0
+    ( "$@" ) >/dev/null 2>&1 || actual_status=$?
+    if [ "$actual_status" = "$expected_status" ]; then
+        echo "PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name (expected exit $expected_status, got $actual_status)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------
+# Test cases. Each defines a clean sandbox state, sources the helper in
+# a subshell, and calls safe_rm_rf with the target under test.
+# ---------------------------------------------------------------------
+
+# 1. Empty argument -> refused with exit 1.
+test_empty_arg() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf ""
+}
+
+# 2. Non-existent target -> idempotent success (exit 0).
+test_nonexistent() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf "/tmp/this-path-must-not-exist-$$"
+}
+
+# 3. Root path -> refused.
+test_root_refused() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf "/"
+}
+
+# 4. $HOME direct -> refused (HOME itself is not in any prefix; only
+#    $HOME/.claude/* and $HOME/claude_config_backup/* etc. are allowed).
+test_home_refused() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf "$HOME"
+}
+
+# 5. Path outside allow-list (e.g. /etc) -> refused.
+test_outside_refused() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf "/etc/hostname"
+}
+
+# 6. `..` traversal that escapes the allow-list -> refused after
+#    realpath collapses the segments. The literal path is dressed up to
+#    look like an allow-listed location, but `..` segments resolve it
+#    back to a non-allow-listed parent.
+test_dotdot_traversal_refused() {
+    # Create a fixture in /tmp directly using a name that is NOT
+    # /tmp/claude-* nor /tmp/claude-config-*, so resolving back to
+    # the fixture root escapes the allow-list.
+    local outside_root
+    outside_root="$(mktemp -d -t safe-rm-outside.XXXXXX)"
+    mkdir -p "$outside_root/.claude/inner"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    local rc=0
+    # Lexically contains /.claude/, but `../..` resolves to outside_root
+    # itself (e.g. /tmp/safe-rm-outside.*) — not allow-listed.
+    safe_rm_rf "$outside_root/.claude/inner/../.." || rc=$?
+    rm -rf "$outside_root"
+    return "$rc"
+}
+
+# 7. Symlink pointing outside the allow-list -> refused. The link itself
+#    lives in an allow-listed prefix, but realpath -e follows it to /etc.
+test_symlink_outside_refused() {
+    local link="/tmp/claude-config-symlink-$$"
+    rm -f "$link"
+    ln -s "/etc" "$link"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    local rc=0
+    safe_rm_rf "$link" || rc=$?
+    rm -f "$link"
+    return "$rc"
+}
+
+# 8. Allow-listed path under /tmp/claude-config-* -> succeeds.
+test_allowlisted_tmp_succeeds() {
+    local fixture="$SANDBOX/positive-case"
+    mkdir -p "$fixture/sub"
+    touch "$fixture/sub/file"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    safe_rm_rf "$fixture"
+    [ ! -e "$fixture" ]
+}
+
+# 9. Relative path that resolves into an allow-listed prefix -> succeeds.
+#    Verifies realpath promotion, not just literal prefix match.
+test_relative_path_succeeds() {
+    local fixture="$SANDBOX/relative-case"
+    mkdir -p "$fixture/inner"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    ( cd "$fixture" && safe_rm_rf "./inner" )
+    [ ! -e "$fixture/inner" ]
+}
+
+# 10. Relative path that resolves OUTSIDE the allow-list -> refused.
+test_relative_path_refused() {
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    ( cd /etc && safe_rm_rf "./hostname" )
+}
+
+# ---------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------
+echo "Running safe_rm_rf tests..."
+echo "Helper: $HELPER"
+echo "Sandbox: $SANDBOX"
+echo ""
+
+run_test "empty argument refused"            1 test_empty_arg
+run_test "non-existent target idempotent"    0 test_nonexistent
+run_test "/ refused"                         1 test_root_refused
+run_test "\$HOME refused"                    1 test_home_refused
+run_test "outside allow-list refused"        1 test_outside_refused
+run_test ".. traversal refused"              1 test_dotdot_traversal_refused
+run_test "symlink to outside refused"        1 test_symlink_outside_refused
+run_test "allow-listed path succeeds"        0 test_allowlisted_tmp_succeeds
+run_test "relative path inside succeeds"     0 test_relative_path_succeeds
+run_test "relative path outside refused"     1 test_relative_path_refused
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #566
Part of #562

## Summary
Introduces `safe_rm_rf()` in `scripts/lib/safe-rm.sh` and replaces 5 unsafe `rm -rf` callsites in `bootstrap.sh` and `scripts/backup.sh` (lines 212/220/227/233 in original numbering). The helper resolves the target via `realpath -e` and asserts it lies under an allow-listed prefix (`$HOME/.claude/*`, `$HOME/.claude-backup/*`, `$HOME/claude_config_backup/*`, `/tmp/claude-*`, `/tmp/claude-config-*`).

The allow-list was extended beyond the issue's reference set to cover `$HOME/claude_config_backup/*` (bootstrap.sh INSTALL_DIR default and backup.sh BACKUP_DIR root) and `/tmp/claude-config-*` (test-fixture prefix), per the instruction to extend rather than weaken when legitimate callsites resolve outside the initial list. Each prefix is documented inline in the helper.

`bootstrap.sh` is consumed via `curl | bash` and runs its `rm -rf` before the repo is cloned, so the canonical helper at `scripts/lib/safe-rm.sh` is unavailable at that point. The function is intentionally inlined in `bootstrap.sh` with byte-equivalent semantics; both copies share the same allow-list.

## Test Plan
- `bash -n` syntax check passes on all modified scripts under strict mode
- New `tests/safe-rm-rf.sh` (10 cases) covers: empty argument, non-existent target (idempotent), `/`, `$HOME`, outside allow-list, `..` traversal that escapes the prefix, symlink to outside, allow-listed path success, relative path inside, relative path outside
- Negative smoke tests: `safe_rm_rf /`, `safe_rm_rf $HOME`, both refused with clear stderr; `safe_rm_rf /tmp/this-does-not-exist` returns 0 (idempotent)
- All 10 unit tests pass locally

## Source
10-round cross-validation, R5/R8 findings.