### PR TITLE
fix(hooks): allow English typographic punctuation in pr-language-guard

### DIFF
--- a/global/hooks/pr-language-guard.sh
+++ b/global/hooks/pr-language-guard.sh
@@ -93,10 +93,28 @@ if ! command -v validate_content_language >/dev/null 2>&1; then
                 return 0
                 ;;
             *)
-                if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+                # Strip allowlisted English typographic punctuation
+                # (em-dash, en-dash, curly quotes, ellipsis, NBSP) before
+                # the ASCII check so unambiguously English typography is
+                # not rejected. See issue #583.
+                local cleaned
+                cleaned=$(printf '%s' "$text" | perl -CSDA -pe '
+                    s/[\x{2014}\x{2013}\x{201C}\x{201D}\x{2018}\x{2019}\x{2026}\x{00A0}]//g;
+                ' 2>/dev/null)
+                if printf '%s' "$cleaned" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+                    local category="non-Latin script"
+                    if ! printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/' 2>/dev/null; then
+                        category="Korean (Hangul)"
+                    elif ! printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{3400}-\x{4DBF}]/' 2>/dev/null; then
+                        category="CJK (Chinese/Japanese)"
+                    elif ! printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{0400}-\x{04FF}]/' 2>/dev/null; then
+                        category="Cyrillic"
+                    elif ! printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{0370}-\x{03FF}]/' 2>/dev/null; then
+                        category="Greek"
+                    fi
                     local sample
-                    sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
-                    echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
+                    sample=$(printf '%s' "$cleaned" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
+                    echo "Text contains $category characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only -- see commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed.)" >&2
                     return 1
                 fi
                 return 0

--- a/hooks/lib/validate-language.sh
+++ b/hooks/lib/validate-language.sh
@@ -35,8 +35,15 @@
 #     ASCII whitespace (space, tab, newline, carriage return, form feed,
 #     vertical tab). LC_ALL=C forces grep to interpret character classes
 #     as 7-bit ASCII regardless of the user's locale.
-#   - Any byte outside that set — accented Latin, CJK, emoji, symbols —
-#     fails validation.
+#   - Common English typographic punctuation is allowlisted before the
+#     ASCII check (see issue #583): em-dash (U+2014), en-dash (U+2013),
+#     curly double/single quotes (U+201C/D, U+2018/9), horizontal
+#     ellipsis (U+2026), and non-breaking space (U+00A0). These are
+#     unambiguously English typography and must not be rejected.
+#   - Any other byte outside the ASCII set -- accented Latin, CJK,
+#     Cyrillic, Greek, emoji, other symbols -- fails validation. The
+#     error message identifies the offending script category when it
+#     can be determined.
 validate_english_only() {
     local text="$1"
 
@@ -44,10 +51,48 @@ validate_english_only() {
         return 0
     fi
 
-    if printf '%s' "$text" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+    # Strip allowlisted English typographic punctuation before the
+    # ASCII check. perl -CSDA decodes input as UTF-8 regardless of locale.
+    local cleaned
+    cleaned=$(printf '%s' "$text" | perl -CSDA -pe '
+        s/[\x{2014}\x{2013}\x{201C}\x{201D}\x{2018}\x{2019}\x{2026}\x{00A0}]//g;
+    ' 2>/dev/null)
+
+    if printf '%s' "$cleaned" | LC_ALL=C grep -q '[^[:print:][:space:]]'; then
+        # Identify the offending script category for a more useful error
+        # message. Falls back to "non-Latin script" when no specific
+        # category matches.
+        local category="non-Latin script"
+        if printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/' 2>/dev/null; then
+            :
+        else
+            category="Korean (Hangul)"
+        fi
+        if [ "$category" = "non-Latin script" ]; then
+            if printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{3400}-\x{4DBF}]/' 2>/dev/null; then
+                :
+            else
+                category="CJK (Chinese/Japanese)"
+            fi
+        fi
+        if [ "$category" = "non-Latin script" ]; then
+            if printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{0400}-\x{04FF}]/' 2>/dev/null; then
+                :
+            else
+                category="Cyrillic"
+            fi
+        fi
+        if [ "$category" = "non-Latin script" ]; then
+            if printf '%s' "$cleaned" | perl -CSDA -ne 'exit 1 if /[\x{0370}-\x{03FF}]/' 2>/dev/null; then
+                :
+            else
+                category="Greek"
+            fi
+        fi
+
         local sample
-        sample=$(printf '%s' "$text" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
-        echo "Text contains non-ASCII characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md." >&2
+        sample=$(printf '%s' "$cleaned" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
+        echo "Text contains $category characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only -- see commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed.)" >&2
         return 1
     fi
 

--- a/tests/hooks/test-pr-language-guard-env.sh
+++ b/tests/hooks/test-pr-language-guard-env.sh
@@ -232,6 +232,62 @@ assert_decision \
     "$(run_hook "korean_plus_english" "gh release create v1.0.0 --notes \"한국어 릴리스 노트\"")"
 
 # ---------------------------------------------------------------------------
+# English typographic punctuation allowlist (issue #583)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== English typographic punctuation (issue #583) ==="
+
+assert_decision \
+    "english: em-dash allowed in body" \
+    "allow" \
+    "$(run_hook "english" "gh issue comment 1 --body \"Resolved by PR #2 — see notes\"")"
+
+assert_decision \
+    "english: en-dash allowed in body" \
+    "allow" \
+    "$(run_hook "english" "gh issue comment 1 --body \"Range 1–10 inclusive\"")"
+
+assert_decision \
+    "english: curly double quotes allowed in body" \
+    "allow" \
+    "$(run_hook "english" "gh issue comment 1 --body \"He said “hello” to her\"")"
+
+assert_decision \
+    "english: curly single quotes allowed in body" \
+    "allow" \
+    "$(run_hook "english" "gh issue comment 1 --body \"It’s a test of the user’s input\"")"
+
+assert_decision \
+    "english: horizontal ellipsis allowed in body" \
+    "allow" \
+    "$(run_hook "english" "gh issue comment 1 --body \"Loading…\"")"
+
+assert_decision \
+    "english: em-dash allowed in title" \
+    "allow" \
+    "$(run_hook "english" "gh issue create --title \"fix bug — handle edge case\" --body \"ascii body\"")"
+
+assert_decision \
+    "english: Korean still blocked despite typography allowlist" \
+    "deny" \
+    "$(run_hook "english" "gh issue create --title \"fix\" --body \"한글 본문 — em-dash present\"")"
+
+assert_decision \
+    "english: Japanese Hiragana still blocked" \
+    "deny" \
+    "$(run_hook "english" "gh issue create --title \"fix\" --body \"こんにちは — typography here\"")"
+
+assert_decision \
+    "english: Japanese Kanji still blocked" \
+    "deny" \
+    "$(run_hook "english" "gh issue create --title \"fix\" --body \"日本語 — text\"")"
+
+assert_decision \
+    "english: Cyrillic still blocked" \
+    "deny" \
+    "$(run_hook "english" "gh issue create --title \"fix\" --body \"Привет — hello\"")"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## What

Allow common English typographic punctuation (em-dash, en-dash, curly quotes, ellipsis, NBSP) in PR/issue text validated by pr-language-guard. CJK and other non-Latin scripts remain blocked.

## Why

The prior "any non-ASCII" check rejected unambiguously English typography along with non-Latin scripts, forcing rewrites of natural prose to ASCII hyphens and straight quotes. Recurring friction documented in kcenon/claude-docker#254. Closes #583.

## How

- Strip an allowlist of English typographic codepoints (U+2014, U+2013, U+201C/D, U+2018/9, U+2026, U+00A0) before the ASCII grep.
- Replace generic "non-ASCII" error with a script-category-aware message (Korean, CJK, Cyrillic, Greek, or "non-Latin script").
- Apply the same change to both the canonical validator (hooks/lib/validate-language.sh) and the inline fallback (global/hooks/pr-language-guard.sh) to preserve byte-equivalent behavior.

## Test Plan

- bash tests/hooks/test-pr-language-guard-env.sh -- 31 passed, 0 failed (10 new typography cases added).
- bash tests/hooks/test-language-validator.sh -- 48 passed, 0 failed (no regressions).
- Manual: em-dash in this PR body itself was authored as ASCII hyphens because the OLD hook is still active for this PR creation; once merged the new hook permits typographic punctuation.

## Notes

- Per repo memory: kcenon/* repos use default=main but PR target=develop, so 'Closes #583' will not auto-close. Manual 'gh issue close 583' will be run after merge.
- Size: 3 files changed, ~127 LOC, well within size/XS.

Closes #583