### PR TITLE
fix(install): deploy global/hooks/lib/*.sh in install.sh

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -478,6 +478,12 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
             Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksDir $_.Name)
         }
 
+        # Deploy global/hooks/lib/ shared libraries (.sh, .ps1, .psm1).
+        # PARITY: install.sh:617-627 must mirror this block. Both installers
+        # share the same destination ~/.claude/hooks/lib/. See issue #586 —
+        # install.sh previously skipped this directory because its top-level
+        # *.sh glob is non-recursive. Do not remove either side without a
+        # cross-platform regression check (see scripts/verify.{sh,ps1}).
         $hooksLibSource = Join-Path $hooksSource 'lib'
         if (Test-Path $hooksLibSource) {
             $hooksLibDir = Join-Path $hooksDir 'lib'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -613,7 +613,28 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         ensure_dir "$HOME/.claude/hooks"
         cp "$BACKUP_DIR/global/hooks"/*.sh "$HOME/.claude/hooks/" 2>/dev/null || true
         chmod +x "$HOME/.claude/hooks/"*.sh 2>/dev/null || true
-        success "Hook 스크립트 (hooks/) 설치 완료!"
+
+        # Deploy global/hooks/lib/*.sh (issue #586). Mirrors install.ps1:481-500.
+        # The *.sh glob above is non-recursive, so without this block the four
+        # shared libraries (tokenize-shell.sh, path-utils.sh, timeout-wrapper.sh,
+        # rotate.sh) are silently dropped. dangerous-command-guard.sh,
+        # gh-write-verb-guard.sh, bash-write-guard.sh, and
+        # bash-sensitive-read-guard.sh source tokenize-shell.sh at runtime.
+        if [ -d "$BACKUP_DIR/global/hooks/lib" ]; then
+            ensure_dir "$HOME/.claude/hooks/lib"
+            cp "$BACKUP_DIR/global/hooks/lib"/*.sh "$HOME/.claude/hooks/lib/" 2>/dev/null || true
+            chmod +x "$HOME/.claude/hooks/lib/"*.sh 2>/dev/null || true
+
+            # Post-copy regression guard for #586. tokenize-shell.sh is the
+            # canonical sub-command splitter (see #476); its absence weakens
+            # four Bash-channel guards. Surface a loud warning at install time
+            # so the regression cannot reach a user session silently.
+            if [ ! -f "$HOME/.claude/hooks/lib/tokenize-shell.sh" ]; then
+                warning "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
+            fi
+        fi
+
+        success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
 
         # Full-suite probe (issue #423): advertise which canonical guards the
         # plugin surface should stand down for. Plugin/hooks.json inspects this

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -209,6 +209,17 @@ if (Test-Path -LiteralPath $settingsJson -PathType Leaf) {
     }
 }
 
+# Hook shared library verification (issue #586 regression guard).
+# Catches a backup that ships without the canonical .sh libraries the two
+# installers (install.sh / install.ps1) deploy to ~/.claude/hooks/lib/.
+# dangerous-command-guard, gh-write-verb-guard, bash-write-guard and
+# bash-sensitive-read-guard source tokenize-shell.sh; missing files weaken
+# the Bash-channel guards.
+$hookLibDir = Join-Path $BackupDir 'global' 'hooks' 'lib'
+foreach ($lib in @('tokenize-shell.sh', 'path-utils.sh', 'timeout-wrapper.sh', 'rotate.sh')) {
+    Test-FileExists (Join-Path $hookLibDir $lib) "global/hooks/lib/$lib" | Out-Null
+}
+
 # ── Project settings file verification ───────────────────────
 
 Write-Host ""

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -170,6 +170,16 @@ if [ -f "$BACKUP_DIR/global/settings.json" ]; then
     fi
 fi
 
+# Hook 공유 라이브러리 검증 (issue #586 회귀 방지)
+# install.sh / install.ps1 가 ~/.claude/hooks/lib/ 로 복사하는 핵심 .sh 파일들이
+# 저장소에 빠진 채 머지되는 것을 CI 단계에서 잡는다. dangerous-command-guard,
+# gh-write-verb-guard, bash-write-guard, bash-sensitive-read-guard 가
+# tokenize-shell.sh 를 source 하므로 누락 시 Bash 가드가 약화된다.
+check_file "$BACKUP_DIR/global/hooks/lib/tokenize-shell.sh" "global/hooks/lib/tokenize-shell.sh"
+check_file "$BACKUP_DIR/global/hooks/lib/path-utils.sh" "global/hooks/lib/path-utils.sh"
+check_file "$BACKUP_DIR/global/hooks/lib/timeout-wrapper.sh" "global/hooks/lib/timeout-wrapper.sh"
+check_file "$BACKUP_DIR/global/hooks/lib/rotate.sh" "global/hooks/lib/rotate.sh"
+
 # 프로젝트 설정 파일 검증
 echo ""
 echo "======================================================"


### PR DESCRIPTION
## What

`scripts/install.sh:614` uses a non-recursive `*.sh` glob that silently skips `global/hooks/lib/`. Every fresh `install.sh` install therefore leaves `~/.claude/hooks/lib/` missing four shared libraries:

- `tokenize-shell.sh`
- `path-utils.sh`
- `timeout-wrapper.sh`
- `rotate.sh`

`install.ps1:481-500` has been deploying these correctly since #448. This PR brings `install.sh` to parity, plus regression guards on both sides.

### Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactor

### Affected Components

| File | Change |
|------|--------|
| `scripts/install.sh` | Add `global/hooks/lib/*.sh` copy block + post-copy regression warning. |
| `scripts/install.ps1` | PARITY comment block referencing #586 / `install.sh`. No behavior change. |
| `scripts/verify.sh` | Presence checks for the four canonical hook libraries (backup-side). |
| `scripts/verify.ps1` | Same presence checks, PowerShell side. |

## Why

### Problem Solved

Four PreToolUse Bash hooks source `lib/tokenize-shell.sh`:

| Hook | Reference |
|------|-----------|
| `dangerous-command-guard.sh` | line 129 |
| `gh-write-verb-guard.sh` | line 35 |
| `bash-write-guard.sh` | line 30 |
| `bash-sensitive-read-guard.sh` | line 30 |

Without the file, every Bash tool invocation prints:

```
/home/<user>/.claude/hooks/dangerous-command-guard.sh: line 129:
/home/<user>/.claude/hooks/lib/tokenize-shell.sh: No such file or directory
```

More importantly, `dangerous-command-guard` is the canonical quote/substitution-aware sub-command splitter (see #476). With the library absent it falls back to a partial-match path and the Bash-channel security guards run at reduced fidelity until install.sh is fixed.

### Related Issues

- Closes #586
- Relates to #448 (PowerShell side already fixed)
- Relates to #476 (dangerous-command-guard tokenizer rewrite)

> Note: this repo's default branch is `main` while PRs target `develop`, so `Closes #586` will not auto-close the issue on merge — it must be closed manually after squash merge to `develop`.

## Where

- `scripts/install.sh:611-628` — added lib/ copy block + post-copy regression warning.
- `scripts/install.ps1:481-506` — added PARITY comment, no behavior change.
- `scripts/verify.sh` — added four `check_file` calls after the global settings.json validation.
- `scripts/verify.ps1` — added four `Test-FileExists` calls in the matching position.

## How

### Implementation

`install.sh`:

```bash
if [ -d "$BACKUP_DIR/global/hooks/lib" ]; then
    ensure_dir "$HOME/.claude/hooks/lib"
    cp "$BACKUP_DIR/global/hooks/lib"/*.sh "$HOME/.claude/hooks/lib/" 2>/dev/null || true
    chmod +x "$HOME/.claude/hooks/lib/"*.sh 2>/dev/null || true

    if [ ! -f "$HOME/.claude/hooks/lib/tokenize-shell.sh" ]; then
        warning "hooks/lib/tokenize-shell.sh ... (issue #586)"
    fi
fi
```

The post-copy regression guard surfaces the bug at install time. Combined with the new `verify.sh` / `verify.ps1` checks, the same regression is caught at three layers:

| Layer | Catches |
|-------|---------|
| `verify.{sh,ps1}` | Backup-side: a PR landing without the canonical libraries. |
| `install.sh` post-copy warning | Install-time: an installer regression. |
| Plugin probe / runtime | Last resort: hook execution detects missing source. |

### Testing Done

1. `bash -n scripts/install.sh` and `bash -n scripts/verify.sh` — syntax OK.
2. Removed `~/.claude/hooks/lib/{tokenize-shell.sh,path-utils.sh,timeout-wrapper.sh,rotate.sh}`.
3. Re-ran the patched copy block manually (mirrors what `install.sh` does) — all four files restored with `chmod +x`. Existing `validate-commit-message.sh` and `validate-language.sh` were not affected.
4. Confirmed the destination has six files after install (4 new + 2 existing whitelist), no name collisions.

### Test Plan for Reviewers

```bash
rm -f ~/.claude/hooks/lib/tokenize-shell.sh ~/.claude/hooks/lib/path-utils.sh
./scripts/install.sh
ls ~/.claude/hooks/lib/                   # all four .sh files present
bash -c '. ~/.claude/hooks/lib/tokenize-shell.sh && echo OK'
./scripts/verify.sh                       # all four lib checks green
```

To exercise the regression guard:

```bash
mv global/hooks/lib/tokenize-shell.sh /tmp/
./scripts/verify.sh                       # fails with clear message
mv /tmp/tokenize-shell.sh global/hooks/lib/
```

### Breaking Changes

None. The new copy block is additive; the existing whitelist copy at `install.sh:663-669` (different source directory) is untouched and keeps working.

### Rollback Plan

`git revert` of this commit restores the previous behavior. No state migration required.

## Reviewer Checklist

- [ ] `install.sh` lib block matches `install.ps1` semantics (sh, ps1, psm1 on PS1; sh on bash).
- [ ] PARITY comment in `install.ps1` is accurate.
- [ ] `verify.{sh,ps1}` checks fail loudly when lib files are absent.
- [ ] No collision with the existing `hooks/lib/{validate-commit-message.sh, validate-language.sh}` whitelist (different source).
- [ ] No `Closes` keyword reliance for auto-close (manual close required after merge to `develop`).
