### PR TITLE
feat(hooks): add traceability-guard PreToolUse + pre-push pair

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1033,11 +1033,12 @@ this catalog for the canonical hook inventory.
 | [`task-created-validator.sh`](#task-created-validator) | TaskCreated (sync, blocking) | yes |
 | [`team-limit-guard.sh`](#team-limit-guard) | PreToolUse (TeamCreate) | yes |
 | [`tool-failure-logger.sh`](#tool-failure-logger) | ToolFailure | yes |
+| [`traceability-guard.sh`](#traceability-guard) | PreToolUse (Bash) | yes |
 | [`version-check.sh`](#version-check) | SessionStart | yes |
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 35 bash hooks, 35 with PowerShell counterparts._
+_Total: 36 bash hooks, 36 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1585,6 +1586,23 @@ Logs tool execution failures for debugging and analysis.
 | Response format | none (lifecycle event, no JSON output needed) |
 | PowerShell counterpart | present (`tool-failure-logger.ps1`) |
 | Source | `global/hooks/tool-failure-logger.sh` |
+
+### traceability-guard
+
+_File:_ `traceability-guard.sh`
+
+_Anchor:_ `#traceability-guard`
+
+Deterministic traceability cascade validator.
+
+| Field | Value |
+|---|---|
+| Hook Type | PreToolUse (Bash) |
+| Trigger / Matcher | Bash |
+| Exit codes | 0 (always — decision is in JSON) |
+| Response format | hookSpecificOutput with hookEventName |
+| PowerShell counterpart | present (`traceability-guard.ps1`) |
+| Source | `global/hooks/traceability-guard.sh` |
 
 ### version-check
 

--- a/global/hooks/traceability-guard.ps1
+++ b/global/hooks/traceability-guard.ps1
@@ -1,0 +1,74 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# traceability-guard.ps1
+# Deterministic traceability cascade validator.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# PowerShell counterpart for the bash traceability-guard.sh. The shared
+# validator (hooks/lib/validate-traceability.sh) is bash-only, so this
+# script delegates to bash via WSL / Git Bash when available. When bash
+# is missing the hook fails open and defers to the pre-push git hook.
+#
+# Scope: only fires for `gh pr create` invocations.
+# Opt-in: silently allows when docs/.index/graph.yaml is absent.
+
+# Read input from stdin
+$json = Read-HookInput
+
+# Empty input: allow (the pre-push hook is the terminal gate)
+if (-not $json) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Extract command
+$CMD = $null
+try { $CMD = $json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+
+# Scope: only validate gh pr create commands
+if ($CMD -notmatch 'gh\s+pr\s+create') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Discover repo root
+$repoRoot = (& git rev-parse --show-toplevel 2>$null) | Out-String
+$repoRoot = $repoRoot.Trim()
+if (-not $repoRoot) { $repoRoot = (Get-Location).Path }
+
+# Opt-in gate: skip silently when graph.yaml is absent.
+$graphYaml = Join-Path $repoRoot 'docs' '.index' 'graph.yaml'
+if (-not (Test-Path $graphYaml)) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Locate the bash counterpart and delegate. The shared validator uses
+# POSIX shell features (awk, sed, here-docs) that are inconvenient to
+# port; instead we re-exec the canonical traceability-guard.sh. This
+# keeps PowerShell users on the exact same enforcement logic.
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if (-not $bash) {
+    # Bash unavailable on PATH (rare on CI runners; possible on bare
+    # Windows). Fail open - the pre-push.ps1 gate remains.
+    New-HookAllowResponse
+    exit 0
+}
+
+$bashGuard = Join-Path $PSScriptRoot 'traceability-guard.sh'
+if (-not (Test-Path $bashGuard)) {
+    # Companion script missing from this install. Fail open.
+    New-HookAllowResponse
+    exit 0
+}
+
+# Re-encode the JSON we already parsed so the bash script sees the same
+# payload via stdin. This avoids losing the original raw string.
+$payload = $json | ConvertTo-Json -Compress -Depth 10
+$payload | & $bash.Source $bashGuard
+exit 0

--- a/global/hooks/traceability-guard.sh
+++ b/global/hooks/traceability-guard.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# traceability-guard.sh
+# Deterministic traceability cascade validator.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Mirrors the multi-layer pattern proven by commit-message-guard
+# (PreToolUse) + commit-msg (git hook) + validate-commit-message.sh
+# (shared library). This hook is the Claude-side feedback loop for
+# the cascade-update obligation captured in
+# global/skills/_internal/traceability/reference/matrix-schema.md.
+#
+# Scope: only fires for `gh pr create` invocations. Other commands —
+# including `git push`, which is the pre-push hook's responsibility —
+# pass through untouched.
+#
+# Opt-in: when docs/.index/graph.yaml is absent, the hook allows the
+# command silently. This keeps the hook safe to ship globally without
+# breaking repos that have not adopted the regulated track.
+#
+# Sources shared validation rules from hooks/lib/validate-traceability.sh
+# (single source of truth shared with the pre-push git hook).
+
+set -euo pipefail
+
+# --- Response helpers (match commit-message-guard.sh / pr-target-guard.sh) ---
+deny_response() {
+    local reason="$1"
+    jq -nc \
+        --arg reason "$reason" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+    exit 0
+}
+
+allow_response() {
+    jq -nc \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
+    exit 0
+}
+
+# --- Source shared validation library (fail-closed) ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR=""
+
+# Try 1: repo-relative path (development / CI testing)
+REPO_ROOT_DEV="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
+if [ -f "$REPO_ROOT_DEV/hooks/lib/validate-traceability.sh" ]; then
+    VALIDATOR="$REPO_ROOT_DEV/hooks/lib/validate-traceability.sh"
+# Try 2: sibling lib/ directory (deployed to ~/.claude/hooks/)
+elif [ -f "$SCRIPT_DIR/lib/validate-traceability.sh" ]; then
+    VALIDATOR="$SCRIPT_DIR/lib/validate-traceability.sh"
+fi
+
+if [ -z "$VALIDATOR" ]; then
+    echo "traceability-guard: canonical validator not found at \$REPO_ROOT/hooks/lib/validate-traceability.sh nor \$SCRIPT_DIR/lib/validate-traceability.sh. Reinstall claude-config so hooks/lib/ is bundled alongside global/hooks/." >&2
+    # Fail-open here — the pre-push git hook is the authoritative gate. A
+    # missing PreToolUse validator must not block legitimate PR creation.
+    allow_response
+fi
+
+# shellcheck source=../../hooks/lib/validate-traceability.sh
+. "$VALIDATOR"
+
+# --- Read input from stdin ---
+INPUT=$(cat)
+
+# Empty input: allow. The pre-push hook is the terminal gate.
+if [ -z "$INPUT" ]; then
+    allow_response
+fi
+
+JQ_RC=0
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || JQ_RC=$?
+if [ "$JQ_RC" -ne 0 ]; then
+    # Fail-open on JSON parse errors — pre-push remains the gate.
+    allow_response
+fi
+
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+# --- Scope: only validate `gh pr create` commands ---
+if ! echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create'; then
+    allow_response
+fi
+
+# --- Discover repo root (current working directory tree) ---
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+# Opt-in gate: skip silently when graph.yaml is absent.
+if [ ! -f "$REPO_ROOT/docs/.index/graph.yaml" ]; then
+    allow_response
+fi
+
+# --- Resolve base / head refs for the diff range ---
+# Default base is the repo's default branch. We follow the convention used
+# by `gh pr create`: when --base is omitted, gh asks the server, but for
+# pre-PR validation we approximate that with origin/HEAD or `develop`.
+BASE_REF=""
+BASE_FROM_CMD=$(echo "$CMD" | sed -nE 's/.*(--base[= ])[\"'"'"']?([a-zA-Z0-9._\/-]+).*/\2/p' | head -1)
+BASE_REF="${BASE_FROM_CMD:-}"
+if [ -z "$BASE_REF" ]; then
+    if git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/develop; then
+        BASE_REF="origin/develop"
+    elif git -C "$REPO_ROOT" show-ref --verify --quiet refs/heads/develop; then
+        BASE_REF="develop"
+    else
+        BASE_REF="HEAD~1"
+    fi
+fi
+# Strip surrounding quotes if present.
+BASE_REF=$(echo "$BASE_REF" | sed -E "s/^[\"']//;s/[\"']$//")
+
+# If the user passed an unqualified branch name and a matching remote ref
+# exists, prefer the remote so the diff matches what GitHub will compute.
+if echo "$BASE_REF" | grep -qE '^[A-Za-z0-9_.\-]+$'; then
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$BASE_REF"; then
+        BASE_REF="origin/$BASE_REF"
+    fi
+fi
+
+HEAD_REF="HEAD"
+
+# --- Validate ---
+REPORT_FILE=""
+if REPORT_FILE=$(mktemp 2>/dev/null); then
+    :
+else
+    REPORT_FILE="${TMPDIR:-/tmp}/traceability-guard.$$.txt"
+    : > "$REPORT_FILE"
+fi
+# shellcheck disable=SC2064
+trap "rm -f '$REPORT_FILE'" EXIT
+
+set +e
+( cd "$REPO_ROOT" && validate_traceability_range "$BASE_REF" "$HEAD_REF" "$REPO_ROOT" ) 2>"$REPORT_FILE"
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+    allow_response
+fi
+
+# Build a concise reason string from the report.
+REASON_BODY=$(head -20 "$REPORT_FILE" 2>/dev/null || echo "")
+if [ -z "$REASON_BODY" ]; then
+    REASON_BODY="validate-traceability returned exit code $RC but produced no report"
+fi
+deny_response "Traceability cascade not satisfied for ${BASE_REF}..${HEAD_REF}. Update the cascade targets declared in docs/.index/graph.yaml before creating the PR.
+${REASON_BODY}"

--- a/global/settings.json
+++ b/global/settings.json
@@ -174,6 +174,12 @@
             "timeout": 5
           },
           {
+            "_note": "Opt-in: silently allows when the project lacks docs/.index/graph.yaml. Only fires for `gh pr create`. See issue #590.",
+            "type": "command",
+            "command": "~/.claude/hooks/traceability-guard.sh",
+            "timeout": 10
+          },
+          {
             "type": "command",
             "command": "~/.claude/hooks/conflict-guard.sh",
             "timeout": 5

--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -139,6 +139,12 @@ info "검증 라이브러리 설치 중..."
 mkdir -p "$GIT_HOOKS_DIR/lib"
 cp "$SCRIPT_DIR/lib/validate-commit-message.sh" "$GIT_HOOKS_DIR/lib/"
 chmod +x "$GIT_HOOKS_DIR/lib/validate-commit-message.sh"
+# Traceability cascade validator (issue #590). Sourced by the pre-push hook
+# above; opt-in (no-op when docs/.index/graph.yaml is absent).
+if [ -f "$SCRIPT_DIR/lib/validate-traceability.sh" ]; then
+    cp "$SCRIPT_DIR/lib/validate-traceability.sh" "$GIT_HOOKS_DIR/lib/"
+    chmod +x "$GIT_HOOKS_DIR/lib/validate-traceability.sh"
+fi
 success "검증 라이브러리 설치 완료!"
 
 echo ""

--- a/hooks/lib/validate-traceability.sh
+++ b/hooks/lib/validate-traceability.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# validate-traceability.sh
+# Shared traceability cascade validation library.
+# Single source of truth for traceability rules.
+#
+# Sourced by:
+#   - hooks/pre-push                       (git hook — terminal-side gate)
+#   - global/hooks/traceability-guard.sh   (PreToolUse — Claude-side feedback loop)
+#
+# Opt-in: when docs/.index/graph.yaml is absent, validate_traceability_range
+# returns 0 silently so non-regulated repos are unaffected.
+#
+# Usage:
+#   . /path/to/validate-traceability.sh
+#   if ! validate_traceability_range "$BASE_REF" "$HEAD_REF" "$REPO_ROOT"; then
+#       echo "cascade missing" >&2
+#   fi
+#
+# The function prints a deterministic, line-per-finding report to stderr on
+# failure and exits with the broken-edge count via the function's return code.
+
+# Doc-id pattern recognised in graph.yaml. Mirrors the identifier conventions
+# documented in global/skills/_internal/traceability/reference/matrix-schema.md
+# (SRS-CAT-NNN, SI-CODE, IF-NNN, TC-CAT-NNN, H-NN, HUS-NN, SCR-NNN, FLW-NNN).
+readonly VT_DOC_ID_REGEX='[A-Z]+(-[A-Z0-9]+)+'
+
+# extract_doc_ids_from_path <repo_root> <relative_path>
+# Print one doc_id per line found in the file's content. Doc-ids are
+# discovered from front-matter doc_id fields and from in-body identifiers.
+# Empty output when the file is binary, missing, or has no recognisable id.
+extract_doc_ids_from_path() {
+    local repo_root="$1"
+    local rel_path="$2"
+    local abs_path="$repo_root/$rel_path"
+
+    if [ ! -f "$abs_path" ]; then
+        return 0
+    fi
+
+    # 1) Front-matter doc_id field (lines like 'doc_id: SRS-CALC-001')
+    grep -hE "^doc_id:[[:space:]]*[A-Za-z0-9_.-]+" "$abs_path" 2>/dev/null \
+        | sed -E 's/^doc_id:[[:space:]]*//; s/[[:space:]]+$//; s/^["'"'"']//; s/["'"'"']$//' \
+        | grep -E "^${VT_DOC_ID_REGEX}$" 2>/dev/null
+
+    # 2) In-body identifiers in headings and explicit anchors. We deliberately
+    # match heading lines first to avoid noisy hits in prose; auditors keep
+    # ids in '## SRS-CAT-NNN: Title' or table rows.
+    grep -hoE "${VT_DOC_ID_REGEX}-[0-9]+" "$abs_path" 2>/dev/null
+    grep -hoE "${VT_DOC_ID_REGEX}" "$abs_path" 2>/dev/null \
+        | grep -E "^[A-Z]+-[A-Z0-9]+(-[0-9]+)?$"
+}
+
+# graph_cascade_targets <graph_yaml_path> <doc_id>
+# Print one cascade target per line. Reads the simple cascade map
+# documented in global/skills/_internal/doc-index. Format expected:
+#
+#   graph:
+#     SRS-CALC-001:
+#       cascade:
+#         - TC-CALC-001
+#         - SI-CALC
+#     SI-CALC:
+#       cascade:
+#         - src/calc/engine.cpp
+#
+# A target may be either another doc_id or a repo-relative path.
+graph_cascade_targets() {
+    local graph_yaml="$1"
+    local doc_id="$2"
+
+    if [ ! -f "$graph_yaml" ] || [ -z "$doc_id" ]; then
+        return 0
+    fi
+
+    # NOTE on regex portability: POSIX awk recognises neither the
+    # [[:space:]] character class nor the {n} repetition quantifier, so
+    # the patterns below use literal-space sequences. The schema in
+    # global/skills/_internal/traceability/reference/matrix-schema.md fixes
+    # YAML indentation at two spaces, so the literal forms are exact.
+    awk -v id="$doc_id" '
+        BEGIN { in_node = 0; in_cascade = 0 }
+        # Top-level node line (two-space indent under graph:): "  SRS-CALC-001:"
+        /^  [A-Za-z0-9_.\/-]+:[ ]*$/ {
+            current = $1
+            sub(/:$/, "", current)
+            if (current == id) { in_node = 1 } else { in_node = 0; in_cascade = 0 }
+            next
+        }
+        # cascade: marker inside a node
+        in_node && /^    cascade:[ ]*$/ {
+            in_cascade = 1
+            next
+        }
+        # other field while in node — leaves cascade list
+        in_node && /^    [A-Za-z0-9_]+:/ {
+            in_cascade = 0
+            next
+        }
+        # cascade list item: "      - SOMETHING"
+        in_node && in_cascade && /^      - / {
+            line = $0
+            sub(/^      - +/, "", line)
+            sub(/ +$/, "", line)
+            gsub(/["'"'"']/, "", line)
+            if (length(line) > 0) print line
+        }
+    ' "$graph_yaml"
+}
+
+# resolve_target_paths <repo_root> <target>
+# Given a cascade target — either a path or another doc_id — print all
+# repository-relative paths that satisfy it. Paths pass through verbatim;
+# doc-ids are resolved via grep over the index.
+resolve_target_paths() {
+    local repo_root="$1"
+    local target="$2"
+
+    # Repo-relative path (contains a slash or extension)
+    if echo "$target" | grep -qE '/|\.[a-zA-Z0-9]+$'; then
+        printf '%s\n' "$target"
+        return 0
+    fi
+
+    # Doc-id — find files declaring it via doc_id front-matter
+    if [ -d "$repo_root/docs" ]; then
+        grep -lrE "^doc_id:[[:space:]]*${target}[[:space:]]*$" "$repo_root/docs" 2>/dev/null \
+            | sed -E "s|^${repo_root}/||"
+    fi
+}
+
+# validate_traceability_range <base_ref> <head_ref> <repo_root>
+# Returns 0 when no cascade targets are missing OR when the repo has not
+# adopted the regulated track (no docs/.index/graph.yaml).
+# Returns the number of broken edges otherwise (capped at 125 so it fits
+# in a shell exit status), with one finding per line on stderr.
+validate_traceability_range() {
+    local base_ref="$1"
+    local head_ref="$2"
+    local repo_root="${3:-$(pwd)}"
+
+    local graph_yaml="$repo_root/docs/.index/graph.yaml"
+    if [ ! -f "$graph_yaml" ]; then
+        # Opt-in gate. Repos without the regulated track are unaffected.
+        return 0
+    fi
+
+    if [ -z "$base_ref" ] || [ -z "$head_ref" ]; then
+        echo "validate-traceability: missing base/head ref — refusing to validate" >&2
+        return 1
+    fi
+
+    # Touched files in the diff range. Use --diff-filter to include
+    # additions, modifications, renames, and copies; deletions cannot
+    # carry a cascade obligation.
+    local touched
+    touched=$(cd "$repo_root" && git diff --name-only --diff-filter=ACMR \
+        "$base_ref" "$head_ref" 2>/dev/null) || {
+        echo "validate-traceability: 'git diff' failed for ${base_ref}..${head_ref}" >&2
+        return 1
+    }
+
+    if [ -z "$touched" ]; then
+        return 0
+    fi
+
+    # Build the set of touched doc_ids and the set of touched paths.
+    local touched_ids touched_paths
+    touched_paths=$(printf '%s\n' "$touched" | sort -u)
+    touched_ids=$(printf '%s\n' "$touched_paths" | while IFS= read -r p; do
+        [ -n "$p" ] && extract_doc_ids_from_path "$repo_root" "$p"
+    done | sort -u)
+
+    if [ -z "$touched_ids" ]; then
+        # Nothing in the diff carries a cascade obligation.
+        return 0
+    fi
+
+    # For each touched doc_id, every cascade target must also appear in the
+    # diff — either as the path itself, or as a doc_id whose declaring file
+    # is in the diff.
+    local broken=0
+    while IFS= read -r src_id; do
+        [ -z "$src_id" ] && continue
+        local targets
+        targets=$(graph_cascade_targets "$graph_yaml" "$src_id")
+        [ -z "$targets" ] && continue
+
+        while IFS= read -r tgt; do
+            [ -z "$tgt" ] && continue
+
+            # Resolve the target into one or more candidate paths.
+            local resolved
+            resolved=$(resolve_target_paths "$repo_root" "$tgt")
+
+            # Cascade satisfied if (a) the bare doc-id is present in
+            # touched_ids, OR (b) any resolved path is in touched_paths.
+            local satisfied=0
+
+            # Direct doc-id match.
+            if printf '%s\n' "$touched_ids" | grep -qxF "$tgt"; then
+                satisfied=1
+            fi
+
+            # Path-based satisfaction.
+            if [ "$satisfied" -eq 0 ] && [ -n "$resolved" ]; then
+                while IFS= read -r candidate; do
+                    [ -z "$candidate" ] && continue
+                    if printf '%s\n' "$touched_paths" | grep -qxF "$candidate"; then
+                        satisfied=1
+                        break
+                    fi
+                done <<EOF
+$resolved
+EOF
+            fi
+
+            if [ "$satisfied" -eq 0 ]; then
+                broken=$((broken + 1))
+                echo "BROKEN  ${src_id} -> ${tgt} (cascade target not in diff)" >&2
+            fi
+        done <<EOF
+$targets
+EOF
+    done <<EOF
+$touched_ids
+EOF
+
+    if [ "$broken" -gt 0 ]; then
+        # Cap at 125 so shells that interpret a non-zero exit as a status
+        # do not wrap. The exact number is reproduced in the report above.
+        if [ "$broken" -gt 125 ]; then
+            return 125
+        fi
+        return "$broken"
+    fi
+
+    return 0
+}

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -67,4 +67,43 @@ if [ "${CLAUDE_PREFLIGHT:-0}" = "1" ]; then
     fi
 fi
 
+# Traceability cascade enforcement (issue #590).
+# Opt-in: silently skipped when docs/.index/graph.yaml is absent.
+# Sources the same library used by the PreToolUse traceability-guard, so
+# both layers fail or pass identically for the same diff.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TRACE_VALIDATOR=""
+if [ -f "$SCRIPT_DIR/lib/validate-traceability.sh" ]; then
+    TRACE_VALIDATOR="$SCRIPT_DIR/lib/validate-traceability.sh"
+fi
+if [ -n "$TRACE_VALIDATOR" ]; then
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+    if [ -f "$REPO_ROOT/docs/.index/graph.yaml" ]; then
+        # shellcheck disable=SC1090
+        . "$TRACE_VALIDATOR"
+        # Re-read stdin lines from the in-memory snapshot. git fed us the
+        # push refs above; re-derive the same ranges and validate each.
+        # If the diff is empty we skip silently.
+        # Note: we cannot re-read stdin (already consumed by the loop above)
+        # so we validate the symbolic range "${remote_ref:-origin/develop}..HEAD"
+        # which matches what gh pr create would compare against.
+        BASE_REF=""
+        if git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/develop; then
+            BASE_REF="origin/develop"
+        elif git -C "$REPO_ROOT" show-ref --verify --quiet refs/heads/develop; then
+            BASE_REF="develop"
+        fi
+        if [ -n "$BASE_REF" ]; then
+            if ! validate_traceability_range "$BASE_REF" "HEAD" "$REPO_ROOT"; then
+                echo "" >&2
+                echo "pre-push hook rejected the push: traceability cascade incomplete." >&2
+                echo "Update the cascade targets declared in docs/.index/graph.yaml," >&2
+                echo "then re-run the push. See the BROKEN lines above for the" >&2
+                echo "specific edges that need a sibling commit." >&2
+                exit 1
+            fi
+        fi
+    fi
+fi
+
 exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -680,10 +680,11 @@ PY
         fi
     fi
 
-    # 공유 검증 라이브러리 설치 (commit-message-guard.sh 및 pr-language-guard.sh에서 사용)
+    # 공유 검증 라이브러리 설치 (commit-message-guard.sh, pr-language-guard.sh,
+    # traceability-guard.sh가 사용)
     if [ -d "$BACKUP_DIR/hooks/lib" ]; then
         ensure_dir "$HOME/.claude/hooks/lib"
-        for lib in validate-commit-message.sh validate-language.sh; do
+        for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
             if [ -f "$BACKUP_DIR/hooks/lib/$lib" ]; then
                 cp "$BACKUP_DIR/hooks/lib/$lib" "$HOME/.claude/hooks/lib/"
                 chmod +x "$HOME/.claude/hooks/lib/$lib"

--- a/tests/hooks/test-traceability-guard.sh
+++ b/tests/hooks/test-traceability-guard.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Test suite for traceability-guard.sh PreToolUse hook + the shared
+# validate-traceability.sh library. Both layers source the same library,
+# so exercising the library plus the JSON-decision wrapper covers the
+# full enforcement path documented in issue #590.
+#
+# Run: bash tests/hooks/test-traceability-guard.sh
+
+HOOK="global/hooks/traceability-guard.sh"
+LIB="hooks/lib/validate-traceability.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+REPO_DIR="$(pwd)"
+
+# --- helpers ---
+seed_repo() {
+    # Build a tiny git repo with a graph.yaml, two doc-id-bearing markdown
+    # files, and a source file. The caller picks which files end up in the
+    # diff range by editing them after the initial commit.
+    local root="$1"
+    local with_graph="${2:-1}"
+    mkdir -p "$root"
+    cd "$root" || return 1
+    git init --quiet --initial-branch=main 2>/dev/null \
+        || { git init --quiet && git checkout -q -b main; }
+    git config user.email "ci@example.com"
+    git config user.name "ci"
+    git config commit.gpgsign false 2>/dev/null || true
+
+    mkdir -p docs/srs docs/tests src/calc
+
+    cat >docs/srs/calc.md <<'EOF'
+---
+doc_id: SRS-CALC-001
+doc_title: Calculator engine
+---
+# SRS-CALC-001 Calculator engine
+
+The system shall compute sums.
+EOF
+
+    cat >docs/tests/calc.md <<'EOF'
+---
+doc_id: TC-CALC-001
+doc_title: Calculator engine test cases
+---
+# TC-CALC-001 Calculator sums
+
+Verifies SRS-CALC-001.
+EOF
+
+    cat >src/calc/engine.cpp <<'EOF'
+int add(int a, int b) { return a + b; }
+EOF
+
+    if [ "$with_graph" = "1" ]; then
+        mkdir -p docs/.index
+        cat >docs/.index/graph.yaml <<'EOF'
+graph:
+  SRS-CALC-001:
+    cascade:
+      - TC-CALC-001
+      - src/calc/engine.cpp
+  TC-CALC-001:
+    cascade: []
+EOF
+    fi
+
+    git add -A
+    git commit --quiet -m "chore: seed repo"
+    git checkout -q -b feature
+    cd "$REPO_DIR" || return 1
+}
+
+cleanup_repo() {
+    rm -rf "$1"
+}
+
+assert_lib_pass() {
+    local label="$1" base="$2" head="$3" root="$4"
+    bash -c "
+        cd '$root' && . '$REPO_DIR/$LIB' && validate_traceability_range '$base' '$head' '$root'
+    " 2>/dev/null
+    local rc=$?
+    if [ "$rc" -eq 0 ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected rc=0, got rc=$rc")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_lib_fail() {
+    local label="$1" base="$2" head="$3" root="$4"
+    bash -c "
+        cd '$root' && . '$REPO_DIR/$LIB' && validate_traceability_range '$base' '$head' '$root'
+    " 2>/dev/null
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected rc!=0, got rc=$rc")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_hook_allow() {
+    local label="$1" input="$2"
+    local result
+    result=$(echo "$input" | bash "$REPO_DIR/$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected allow, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== traceability-guard.sh / validate-traceability.sh tests ==="
+echo ""
+
+# --- Scope tests on the PreToolUse wrapper ---
+echo "[Scope: non-gh-pr-create commands pass through]"
+assert_hook_allow 'ls -la' '{"tool_input":{"command":"ls -la"}}'
+assert_hook_allow 'gh pr view' '{"tool_input":{"command":"gh pr view 123"}}'
+assert_hook_allow 'gh issue create' '{"tool_input":{"command":"gh issue create --title test"}}'
+assert_hook_allow 'git push' '{"tool_input":{"command":"git push origin develop"}}'
+
+echo ""
+echo "[Empty/malformed input → allow (pre-push is the gate)]"
+assert_hook_allow 'empty input' ''
+assert_hook_allow 'malformed JSON' 'NOT JSON'
+
+echo ""
+echo "[Library: opt-out path — no graph.yaml → return 0]"
+TMP1=$(mktemp -d)
+seed_repo "$TMP1" 0
+echo "// adjustment" >>"$TMP1/src/calc/engine.cpp"
+( cd "$TMP1" && git add -A && git commit --quiet -m "chore: edit src" )
+assert_lib_pass 'no graph.yaml → opt-out (return 0)' "main" "HEAD" "$TMP1"
+cleanup_repo "$TMP1"
+
+echo ""
+echo "[Library: happy path — SRS edited together with cascade targets]"
+TMP2=$(mktemp -d)
+seed_repo "$TMP2" 1
+# Edit all three files declared in cascade together — should pass.
+echo "" >>"$TMP2/docs/srs/calc.md"
+echo "Updated requirement statement." >>"$TMP2/docs/srs/calc.md"
+echo "" >>"$TMP2/docs/tests/calc.md"
+echo "New verification step." >>"$TMP2/docs/tests/calc.md"
+echo "// note" >>"$TMP2/src/calc/engine.cpp"
+( cd "$TMP2" && git add -A && git commit --quiet -m "feat: full cascade update" )
+assert_lib_pass 'happy path — full cascade update' "main" "HEAD" "$TMP2"
+cleanup_repo "$TMP2"
+
+echo ""
+echo "[Library: cascade-miss — SRS edited but TC + source not updated]"
+TMP3=$(mktemp -d)
+seed_repo "$TMP3" 1
+echo "" >>"$TMP3/docs/srs/calc.md"
+echo "Updated requirement statement." >>"$TMP3/docs/srs/calc.md"
+( cd "$TMP3" && git add -A && git commit --quiet -m "feat: only requirement edited" )
+assert_lib_fail 'cascade miss — SRS only' "main" "HEAD" "$TMP3"
+cleanup_repo "$TMP3"
+
+echo ""
+echo "[Library: partial cascade — only TC updated, source still missing]"
+TMP4=$(mktemp -d)
+seed_repo "$TMP4" 1
+echo "" >>"$TMP4/docs/srs/calc.md"
+echo "Updated requirement." >>"$TMP4/docs/srs/calc.md"
+echo "" >>"$TMP4/docs/tests/calc.md"
+echo "More verification." >>"$TMP4/docs/tests/calc.md"
+( cd "$TMP4" && git add -A && git commit --quiet -m "feat: partial cascade" )
+assert_lib_fail 'partial cascade — source missing' "main" "HEAD" "$TMP4"
+cleanup_repo "$TMP4"
+
+echo ""
+echo "[Library: unrelated diff — no cascade obligation]"
+TMP5=$(mktemp -d)
+seed_repo "$TMP5" 1
+mkdir -p "$TMP5/docs/notes"
+echo "Plain note, no doc_id." >"$TMP5/docs/notes/journal.md"
+( cd "$TMP5" && git add -A && git commit --quiet -m "docs: add unrelated note" )
+assert_lib_pass 'unrelated diff — no cascade obligation' "main" "HEAD" "$TMP5"
+cleanup_repo "$TMP5"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "${#ERRORS[@]}" -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #590
Part of #588

## What

Adds a multi-layer enforcement pair that blocks PR creation and pushes whenever a change touches a `doc_id` node without updating the cascade targets declared in `docs/.index/graph.yaml`.

| Layer | Path | Role |
|-------|------|------|
| PreToolUse hook | `global/hooks/traceability-guard.sh` | Claude-side feedback loop on `Bash(gh pr create*)` |
| Git hook | `hooks/pre-push` (extended) | Terminal-side gate; bypassable only via the forbidden `--no-verify` |
| Shared library | `hooks/lib/validate-traceability.sh` | Single source of truth shared by both layers |
| Installer wiring | `hooks/install-hooks.sh`, `scripts/install.sh`, `global/settings.json` | Idempotent registration and deployment |
| Tests | `tests/hooks/test-traceability-guard.sh` | Happy path, cascade-miss, opt-out, scope, fail-open |

## Why

Without this guard the matrix produced by `/traceability` (#589) silently drifts: a developer edits SI-AM source, never touches the SRS, and the trace artifact becomes stale until the next manual review. The pair fails the action that introduces the drift instead of finding it later in audit, and pairing a Claude-side feedback hook with a git-side gate gives auditors two independent technical controls for IEC 62304 §5.1.7 and ISO 13485 §4.1.6 evidence.

## Where

```
global/hooks/traceability-guard.sh   (new)   PreToolUse hook
hooks/pre-push                        (mod)   appended cascade check
hooks/lib/validate-traceability.sh   (new)   shared validator
hooks/install-hooks.sh               (mod)   copy lib into .git/hooks/lib
scripts/install.sh                   (mod)   deploy lib to ~/.claude/hooks/lib
global/settings.json                 (mod)   register PreToolUse entry
tests/hooks/test-traceability-guard.sh (new) regression suite
```

## How

### Validator behavior

`validate_traceability_range BASE HEAD ROOT` returns `0` when every doc_id touched in the diff has its declared cascade targets in the same diff, and a non-zero count otherwise. Findings are emitted one per line on stderr in the form `BROKEN <src_id> -> <target> (cascade target not in diff)`. Targets may be either downstream doc_ids or repo-relative file paths; the resolver handles both.

### Opt-in semantics

If `docs/.index/graph.yaml` is absent the library returns `0` immediately — both the PreToolUse hook and the pre-push gate are no-ops. This keeps the change safe to ship via the global installer without affecting repos that have not adopted the regulated track.

### PreToolUse scope

The hook only fires on commands matching `gh pr create`. All other Bash commands pass through. On stdin parse errors, missing validator, or empty input the hook returns `allow` and defers to the pre-push hook, matching the fail-open posture used by `commit-message-guard.sh` for the same edge cases.

### Acceptance criteria coverage

- [x] `validate-traceability.sh` is the single source of truth; both layers source it.
- [x] PreToolUse hook parses the diff (HEAD vs base) and fails when a cascade target is unmodified.
- [x] `pre-push` step performs the same check on the local commit range.
- [x] Hook is opt-in at the project level via the `docs/.index/graph.yaml` gate.
- [x] Failure messages cite the specific missing cascade edge.
- [x] Test fixtures cover the happy path, the cascade-miss path, and the opt-out path.

### Testing done

- New suite `tests/hooks/test-traceability-guard.sh` (11 cases): scope, fail-open input handling, opt-out, happy path, cascade-miss with SRS-only edit, partial cascade with source missing, unrelated diff with no obligation.
- Full local run via `bash tests/hooks/test-runner.sh` -> 582 passed, 0 failed.

### Test plan for reviewers

```bash
bash tests/hooks/test-traceability-guard.sh
bash tests/hooks/test-runner.sh
```

### Breaking changes

None. The opt-in gate guarantees existing repos are unaffected; the library is additive.

### Rollback plan

Revert the squash merge. All changes live in new files plus surgical additions to `pre-push`, `install-hooks.sh`, `scripts/install.sh`, and `global/settings.json`.
