### PR TITLE
chore(skills): add iso_class metadata to all SKILL.md frontmatter

### DIFF
--- a/global/skills/_internal/_shared/invariants.md
+++ b/global/skills/_internal/_shared/invariants.md
@@ -31,3 +31,13 @@ Skills with iterative work (batch loops, CI polling, multi-round research, per-r
 Skills prepend a context label when emitting inline (e.g., `[Item 5/30] Required rules:`) and then copy the Core block verbatim. Optional block is added only when the skill's current phase touches those dimensions (direct pushes, batch pacing, epic closure, toolchain checks).
 
 Changes to canonical rules happen here. Skills that copy the block inline must stay in sync with this file.
+
+## Frontmatter Invariants
+
+Every `SKILL.md` must declare the following frontmatter fields:
+
+- `name` -- skill identifier (lowercase, digits, hyphens; max 64 chars)
+- `description` -- non-empty trigger text (max 1024 chars)
+- `iso_class` -- IEC 62304 SW Safety Class applicability: `A | B | C | none`. Default `none` for skills that are not safety-relevant. See `global/skills/_policy.md` "Safety-Class Metadata" for the field contract and the optional `safety_class` and `applies_at_or_above` companion fields.
+
+`scripts/validate_skills.sh` enforces these. The `iso_class` check is warn-only during the one-release grace period; subsequent releases convert the warning to a hard failure.

--- a/global/skills/_internal/branch-cleanup/SKILL.md
+++ b/global/skills/_internal/branch-cleanup/SKILL.md
@@ -7,6 +7,7 @@ disable-model-invocation: true
 context: fork
 allowed-tools: "Bash(git *)"
 loop_safe: false
+iso_class: none
 ---
 
 # Branch Cleanup Command

--- a/global/skills/_internal/ci-fix/SKILL.md
+++ b/global/skills/_internal/ci-fix/SKILL.md
@@ -11,6 +11,7 @@ halt_conditions:
   - { type: fallback, expr: "failure maps to an unknown error class not in reference/known-fixes.md" }
 on_halt: "Escalate to user with failing log excerpt and classification result"
 loop_safe: true
+iso_class: none
 ---
 
 # ci-fix Skill

--- a/global/skills/_internal/doc-index/SKILL.md
+++ b/global/skills/_internal/doc-index/SKILL.md
@@ -14,6 +14,7 @@ halt_conditions:
   - { type: success, expr: "all index files generated under docs/.index/" }
   - { type: failure, expr: "manifest generation or write step errors out" }
 on_halt: "Report which index files were produced before failure and stop"
+iso_class: none
 ---
 
 # Document Index Generator

--- a/global/skills/_internal/doc-review/SKILL.md
+++ b/global/skills/_internal/doc-review/SKILL.md
@@ -12,6 +12,7 @@ halt_conditions:
   - { type: success, expr: "review report emitted with all in-scope findings" }
   - { type: failure, expr: "fatal error reading the docs directory or scope cannot be resolved" }
 on_halt: "Emit partial report listing what was reviewed and what was skipped"
+iso_class: none
 ---
 
 # Document Review Command

--- a/global/skills/_internal/evidence-pack/SKILL.md
+++ b/global/skills/_internal/evidence-pack/SKILL.md
@@ -31,6 +31,8 @@ tiers:
     ref_docs: [manifest, sources]
     deep_checks: true
 default_tier: standard
+iso_class: A
+applies_at_or_above: A
 # ref_docs keys:
 #   manifest -> reference/manifest-schema.md
 #   sources  -> reference/source-mapping.md

--- a/global/skills/_internal/fleet-orchestrator/SKILL.md
+++ b/global/skills/_internal/fleet-orchestrator/SKILL.md
@@ -11,6 +11,7 @@ halt_conditions:
   - { type: limit,   expr: "--max-parallel worker pool drains with no pending items" }
 on_halt: "Render final fleet-status table with per-repo outcome and exit"
 loop_safe: false
+iso_class: none
 ---
 
 # Fleet Orchestrator -- Parallel Multi-Repo Directive Executor

--- a/global/skills/_internal/harness/SKILL.md
+++ b/global/skills/_internal/harness/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[domain-or-project-description]"
 user-invocable: true
 disable-model-invocation: true
 loop_safe: false
+iso_class: none
 ---
 
 # Harness -- Agent Team & Skill Architect

--- a/global/skills/_internal/implement-all-levels/SKILL.md
+++ b/global/skills/_internal/implement-all-levels/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "<feature-description> [--solo|--team]"
 user-invocable: true
 disable-model-invocation: true
 loop_safe: false
+iso_class: none
 ---
 
 # Implement All Levels Command

--- a/global/skills/_internal/issue-create/SKILL.md
+++ b/global/skills/_internal/issue-create/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh issue *)"
 loop_safe: false
+iso_class: none
 ---
 
 # Issue Create Command

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -22,6 +22,7 @@ tiers:
     ref_docs: [core, advanced]
     deep_checks: true
 default_tier: standard
+iso_class: none
 # ref_docs keys:
 #   core     -> reference/error-handling.md
 #   advanced -> reference/batch-mode.md, reference/team-mode.md

--- a/global/skills/_internal/memory-review/SKILL.md
+++ b/global/skills/_internal/memory-review/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Read Edit Grep Glob Bash"
 loop_safe: false
+iso_class: none
 ---
 
 # /memory-review — Interactive Memory Triage

--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -23,6 +23,7 @@ tiers:
     ref_docs: [core, advanced]
     deep_checks: true
 default_tier: standard
+iso_class: none
 # ref_docs keys:
 #   core     -> reference/error-handling.md
 #   advanced -> reference/batch-mode.md, reference/team-mode.md,

--- a/global/skills/_internal/preflight/SKILL.md
+++ b/global/skills/_internal/preflight/SKILL.md
@@ -10,6 +10,7 @@ halt_conditions:
   - { type: success, expr: "all selected preflight checks complete with non-zero failures = 0" }
   - { type: failure, expr: "any selected check reports failure or its runner errors out" }
 on_halt: "Print per-check summary table and exit non-zero if any check failed"
+iso_class: none
 ---
 
 # preflight Skill

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -13,6 +13,7 @@ halt_conditions:
   - { type: failure, expr: "integrity check fails" }
 on_halt: "Report incomplete release state, leave tag/PR in whatever state they are in, do not force-publish"
 loop_safe: false
+iso_class: none
 ---
 
 # Release Command

--- a/global/skills/_internal/research/SKILL.md
+++ b/global/skills/_internal/research/SKILL.md
@@ -21,6 +21,7 @@ halt_conditions:
   - { type: limit, expr: "no new sources surface for 2 consecutive rounds" }
 on_halt: "Write report with partial findings and explicit coverage-gap section"
 loop_safe: true
+iso_class: none
 ---
 
 # Research Command

--- a/global/skills/_internal/risk-control/SKILL.md
+++ b/global/skills/_internal/risk-control/SKILL.md
@@ -29,6 +29,8 @@ tiers:
     ref_docs: [schema, matrix]
     deep_checks: true
 default_tier: standard
+iso_class: A
+applies_at_or_above: A
 # ref_docs keys:
 #   schema -> reference/risk-record-schema.md
 #   matrix -> reference/risk-matrix.md

--- a/global/skills/_internal/traceability/SKILL.md
+++ b/global/skills/_internal/traceability/SKILL.md
@@ -29,6 +29,8 @@ tiers:
     ref_docs: [schema, validation]
     deep_checks: true
 default_tier: standard
+iso_class: A
+applies_at_or_above: A
 # ref_docs keys:
 #   schema     -> reference/matrix-schema.md
 #   validation -> reference/validation-rules.md

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -147,3 +147,56 @@ When `--tier` is omitted, the skill runs at its declared `default_tier`. Unknown
 ### Cross-reference
 
 See `docs/TOKEN_OPTIMIZATION.md` for token-impact figures and empirical guidance on when each tier is appropriate.
+
+## Safety-Class Metadata
+
+Skills declare their applicability to safety-classified projects via frontmatter so consumers on the regulated-industry track can filter activities by the SW Safety Class of the calling project. The fields are metadata-only -- declaring a class does not change skill behavior; it exposes the contract that future filtering layers (e.g. `evidence-pack`'s manifest) can read.
+
+```yaml
+iso_class: A | B | C | none
+safety_class:                        # Optional, multi-domain map
+  iec_62304: A | B | C
+  iso_26262: QM | ASIL-A | ASIL-B | ASIL-C | ASIL-D
+  iec_61508: SIL-1 | SIL-2 | SIL-3 | SIL-4
+  do_178c:   A | B | C | D | E
+applies_at_or_above: A | B | C       # Optional, minimum class for participation
+```
+
+### `iso_class` (required)
+
+Every `SKILL.md` must declare `iso_class`. The value is the IEC 62304 §5.3 SW Safety Classification the skill applies to.
+
+| Value | Meaning |
+|-------|---------|
+| `A`   | Skill applies at every safety class (Class A and above). Safety-relevant skills (`traceability`, `evidence-pack`, `risk-control`) and any skill whose body explicitly references compliance, traceability, or evidence collection use this value. |
+| `B`   | Skill applies at Class B and above. Reserved for skills that introduce rigor only meaningful when the project handles non-serious-injury risk. |
+| `C`   | Skill applies at Class C only. Reserved for skills tied to life-supporting / life-sustaining device development. |
+| `none`| Default. Skill is not safety-relevant; it neither requires nor produces evidence the regulated-industry track depends on. Use this for general workflow skills (`git-status`, `documentation`, `pr-review`, etc.). |
+
+### `safety_class` (optional, multi-domain)
+
+When a skill needs to express applicability across more than the IEC 62304 axis, it adds a `safety_class:` map. The map's keys are domain identifiers; the values are domain-native enums. The keys are mutually independent -- a skill may set any subset.
+
+| Key | Domain | Values |
+|-----|--------|--------|
+| `iec_62304` | Medical-device software (IEC 62304:2006 + Amd 1:2015) | `A`, `B`, `C` |
+| `iso_26262` | Automotive functional safety (ISO 26262) | `QM`, `ASIL-A`, `ASIL-B`, `ASIL-C`, `ASIL-D` |
+| `iec_61508` | General functional safety (IEC 61508) | `SIL-1`, `SIL-2`, `SIL-3`, `SIL-4` |
+| `do_178c`   | Airborne software (RTCA DO-178C) | `A`, `B`, `C`, `D`, `E` |
+
+`safety_class.iec_62304` is informational; the canonical IEC 62304 declaration is `iso_class`. The two are kept consistent by convention -- if `iso_class: A` then `safety_class.iec_62304: A` (when present).
+
+### `applies_at_or_above` (optional)
+
+Names the minimum class at or above which the skill participates in regulated workflows. Consumers filter the active skill set by comparing the calling project's declared class against this field. Example: `applies_at_or_above: A` means the skill participates whenever the project is Class A, B, or C.
+
+### When to Apply
+
+Required for every `SKILL.md` (default `iso_class: none`). The validator (`scripts/validate_skills.sh`) emits a warning when the field is missing during the one-release grace period; subsequent releases convert the warning to a hard failure.
+
+### Cross-reference
+
+- IEC 62304 §5.3 source: `project/.claude/rules/compliance/iec-62304.md`
+- ISO 14971 risk-management context: `project/.claude/rules/compliance/iso-14971.md`
+- Validator: `scripts/validate_skills.sh`
+- Invariant: `global/skills/_internal/_shared/invariants.md`

--- a/plugin-lite/skills/behavioral-guardrails/SKILL.md
+++ b/plugin-lite/skills/behavioral-guardrails/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: behavioral-guardrails
 description: Core behavioral corrections for LLM coding. Reduces over-engineering, surfaces assumptions, enforces surgical changes, and defines verifiable success criteria. Use when writing code, reviewing code, fixing bugs, or implementing features.
+iso_class: none
 ---
 
 # Behavioral Guardrails

--- a/plugin/skills/api-design/SKILL.md
+++ b/plugin/skills/api-design/SKILL.md
@@ -5,6 +5,7 @@ model: sonnet
 argument-hint: "<endpoint-or-file>"
 paths: "**/api/**, **/routes/**, **/handlers/**"
 when_to_use: "designing or reviewing API endpoints"
+iso_class: none
 ---
 
 # API Design Skill

--- a/plugin/skills/ci-debugging/SKILL.md
+++ b/plugin/skills/ci-debugging/SKILL.md
@@ -8,6 +8,7 @@ argument-hint: "<run-id-or-url>"
 paths: ".github/workflows/**, Makefile, CMakeLists.txt"
 when_to_use: "CI failure, build error, test timeout"
 finding_levels: [S1, S2, S3]
+iso_class: none
 ---
 
 # CI/CD Debugging Skill

--- a/plugin/skills/coding-guidelines/SKILL.md
+++ b/plugin/skills/coding-guidelines/SKILL.md
@@ -5,6 +5,7 @@ model: sonnet
 argument-hint: "<file-path>"
 paths: "**/*.{cpp,py,ts,go,rs,kt}"
 when_to_use: "reviewing or writing code"
+iso_class: none
 ---
 
 # Coding Guidelines Skill

--- a/plugin/skills/documentation/SKILL.md
+++ b/plugin/skills/documentation/SKILL.md
@@ -4,6 +4,7 @@ description: "Provides documentation standards for README files, API references,
 model: haiku
 argument-hint: "<file-or-topic>"
 paths: "**/*.md, **/README*"
+iso_class: none
 ---
 
 # Documentation Skill

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -7,6 +7,7 @@ context: fork
 agent: Explore
 argument-hint: "<file-or-directory>"
 finding_levels: [S1, S2, S3]
+iso_class: none
 ---
 
 # Performance Review Skill

--- a/plugin/skills/project-workflow/SKILL.md
+++ b/plugin/skills/project-workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: project-workflow
 description: Provides workflow guidelines for problem-solving, git commits, GitHub issues, PRs, build management, and testing. Use when planning tasks, creating issues, submitting PRs, managing builds, or writing tests.
+iso_class: none
 ---
 
 # Project Workflow Skill

--- a/plugin/skills/security-audit/SKILL.md
+++ b/plugin/skills/security-audit/SKILL.md
@@ -7,6 +7,7 @@ context: fork
 agent: Explore
 argument-hint: "<file-or-directory>"
 finding_levels: [S1, S2, S3]
+iso_class: none
 ---
 
 # Security Audit Skill

--- a/project/.claude/skills/api-design/SKILL.md
+++ b/project/.claude/skills/api-design/SKILL.md
@@ -12,6 +12,7 @@ model: sonnet
 argument-hint: "<endpoint-or-file>"
 paths: "**/api/**, **/routes/**, **/handlers/**"
 when_to_use: "designing or reviewing API endpoints"
+iso_class: none
 ---
 
 # API Design Skill

--- a/project/.claude/skills/ci-debugging/SKILL.md
+++ b/project/.claude/skills/ci-debugging/SKILL.md
@@ -12,6 +12,7 @@ context: fork
 argument-hint: "<run-id-or-url>"
 paths: ".github/workflows/**, Makefile, CMakeLists.txt"
 when_to_use: "CI failure, build error, test timeout"
+iso_class: none
 ---
 
 # CI/CD Debugging Skill

--- a/project/.claude/skills/code-quality/SKILL.md
+++ b/project/.claude/skills/code-quality/SKILL.md
@@ -10,6 +10,7 @@ allowed-tools:
   - Glob
   - Read
 paths: "**/*.{cpp,py,ts,go,rs,kt,java}"
+iso_class: none
 ---
 
 # Code Quality Analysis Command

--- a/project/.claude/skills/coding-guidelines/SKILL.md
+++ b/project/.claude/skills/coding-guidelines/SKILL.md
@@ -11,6 +11,7 @@ model: sonnet
 argument-hint: "<file-path>"
 paths: "**/*.{cpp,py,ts,go,rs,kt}"
 when_to_use: "reviewing or writing code"
+iso_class: none
 ---
 
 # Coding Guidelines Skill

--- a/project/.claude/skills/doc-update/SKILL.md
+++ b/project/.claude/skills/doc-update/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Read
   - Edit
   - Write
+iso_class: none
 ---
 
 # Document Update Command

--- a/project/.claude/skills/documentation/SKILL.md
+++ b/project/.claude/skills/documentation/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
 model: haiku
 argument-hint: "<file-or-topic>"
 paths: "**/*.md, **/README*"
+iso_class: none
 ---
 
 # Documentation Skill

--- a/project/.claude/skills/git-status/SKILL.md
+++ b/project/.claude/skills/git-status/SKILL.md
@@ -5,6 +5,7 @@ user-invocable: true
 disable-model-invocation: true
 model: haiku
 allowed-tools: "Bash(git *)"
+iso_class: none
 ---
 
 # Git Status Command

--- a/project/.claude/skills/performance-review/SKILL.md
+++ b/project/.claude/skills/performance-review/SKILL.md
@@ -10,6 +10,7 @@ allowed-tools:
 model: sonnet
 context: fork
 argument-hint: "<file-or-directory>"
+iso_class: none
 ---
 
 # Performance Review Skill

--- a/project/.claude/skills/pr-review/SKILL.md
+++ b/project/.claude/skills/pr-review/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+iso_class: none
 ---
 
 # PR Review Command

--- a/project/.claude/skills/project-workflow/SKILL.md
+++ b/project/.claude/skills/project-workflow/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Grep
   - Bash
 model: sonnet
+iso_class: none
 ---
 
 # Project Workflow Skill

--- a/project/.claude/skills/security-audit/SKILL.md
+++ b/project/.claude/skills/security-audit/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools:
 model: sonnet
 context: fork
 argument-hint: "<file-or-directory>"
+iso_class: none
 ---
 
 # Security Audit Skill

--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -163,7 +163,25 @@ validate_skill() {
         fi
     fi
 
-    # 4. 파일 라인 수 검증 (권장: 500줄 이하)
+    # 4. iso_class 필드 검증 (issue #597)
+    # P1 grace period: 누락 시 WARNING. 다음 릴리즈에서 hard FAIL로 전환 예정 (TODO)
+    local iso_class
+    iso_class=$(get_field "$frontmatter" "iso_class")
+    if [ -z "$iso_class" ]; then
+        warning "iso_class 필드 없음 (P1 grace period: 다음 릴리즈에서 hard FAIL로 전환 예정)"
+        record_warning
+    else
+        # iso_class 값 검증: A | B | C | none
+        if ! echo "$iso_class" | grep -qE "^(A|B|C|none)$"; then
+            warning "iso_class 값 형식 오류: '$iso_class' (허용: A | B | C | none) (P1 grace period)"
+            record_warning
+        else
+            success "iso_class 유효: '$iso_class'"
+            record_pass
+        fi
+    fi
+
+    # 5. 파일 라인 수 검증 (권장: 500줄 이하)
     local line_count
     line_count=$(wc -l < "$skill_file" | tr -d ' ')
     if [ "$line_count" -gt 500 ]; then
@@ -174,7 +192,7 @@ validate_skill() {
         record_pass
     fi
 
-    # 5. reference 디렉토리 확인
+    # 6. reference 디렉토리 확인
     local skill_dir
     skill_dir=$(dirname "$skill_file")
     if [ -d "${skill_dir}/reference" ]; then
@@ -199,7 +217,7 @@ validate_skill() {
         fi
     fi
 
-    # 6. 프론트매터 대 본문 일관성 (drift)
+    # 7. 프론트매터 대 본문 일관성 (drift)
     if echo "$frontmatter" | grep -qE "^(max_iterations|halt_condition|halt_conditions):"; then
         if ! grep -qiE "(loop|retry|iteration|poll)" "$skill_file"; then
             warning "max_iterations/halt_condition(s) 선언되었으나 본문에 loop/retry/iteration/poll 참조 없음"
@@ -210,7 +228,7 @@ validate_skill() {
         fi
     fi
 
-    # 6a. P1-c (issue #458): legacy halt_condition 단일 키 deprecation
+    # 7a. P1-c (issue #458): legacy halt_condition 단일 키 deprecation
     if echo "$frontmatter" | grep -qE "^halt_condition:[[:space:]]"; then
         warning "halt_condition (legacy) 키가 사용됨 — halt_conditions array form으로 마이그레이션 필요 (P1 grace period; 다음 릴리즈에서 제거 예정)"
         record_warning


### PR DESCRIPTION
Closes #597
Part of #588

## What

### Summary

Add the `iso_class` safety-class metadata field to every `SKILL.md` frontmatter across the repository, document the field contract in `_policy.md` and `_shared/invariants.md`, and extend `scripts/validate_skills.sh` with a warn-only check.

This is a metadata-only sweep: it does NOT change skill behavior. It exposes the contract that future skills (and `evidence-pack`'s manifest) can read to filter activities by IEC 62304 SW Safety Class.

### Change Type

- [x] Chore (metadata-only)
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components

- `global/skills/_policy.md` -- new "Safety-Class Metadata" section
- `global/skills/_internal/_shared/invariants.md` -- new "Frontmatter Invariants" section
- 36 `SKILL.md` files across `global/`, `plugin/`, `plugin-lite/`, `project/.claude/skills/`
- `scripts/validate_skills.sh` -- new `iso_class` field check (warn-only)

## Why

### Problem Solved

IEC 62304 §5.3 mandates that the rigor of SW activities scale to the SW Safety Class (A / B / C). ASIL (ISO 26262) and SIL (IEC 61508) play the same role in their domains. Today, `claude-config` skills assume one rigor level -- there is no metadata declaring "this skill is required at Class B and above". Adding the field is a precondition for any future skill that filters activities by safety class.

This is intentionally the last P1 item: it touches every `SKILL.md` so it must run after P1-1 and P1-2 land their new SKILL.md files (otherwise it would conflict with their writes).

### Related Issues

- Closes #597 (this issue)
- Part of #588 (Epic: ISO/Traceability/Evidence track)

### Alternative Approaches Considered

1. Single-axis class field (`iso_class` only). Rejected -- multi-domain projects (ASIL, SIL, DO-178C) need parallel declarations; the optional `safety_class:` map keeps each domain's enum native.
2. Auto-derive `iso_class` from skill body content (e.g. mention of "compliance"). Rejected -- silent inference is too brittle for an audit-relevant field; explicit declaration is the contract.
3. Backport to closed/archived skills. Out of scope per issue body; only the four active trees are swept.

## Who

### Reviewers

- Repository maintainer (CODEOWNERS handles assignment)

### Required Approvals

- [ ] Code owner

## When

### Urgency

- [x] Normal -- follows the standard P1 review path
- [ ] High Priority
- [ ] Hotfix

### Target Release

Next minor (after P1 tier of #588 completes; this PR is the third and final P1 child).

### Dependencies

- Depends on: #592 (P0-1 traceability), #593 (P0-2 traceability-guard), #594 (P0-3 compliance rules), #598 (P1-1 evidence-pack), #599 (P1-2 risk-control) -- all merged.
- Blocks: P2 tier of #588 (when opened).

## Where

### Files Changed Summary

| Directory | Files | Change |
|-----------|-------|--------|
| `global/skills/` | 1 (`_policy.md`) | Add "Safety-Class Metadata" section (53 lines added) |
| `global/skills/_internal/_shared/` | 1 (`invariants.md`) | Add "Frontmatter Invariants" section (10 lines added) |
| `global/skills/_internal/*/SKILL.md` | 17 | Add `iso_class` field |
| `plugin/skills/*/SKILL.md` | 7 | Add `iso_class` field |
| `plugin-lite/skills/*/SKILL.md` | 1 | Add `iso_class` field |
| `project/.claude/skills/*/SKILL.md` | 11 | Add `iso_class` field |
| `scripts/` | 1 (`validate_skills.sh`) | Add `iso_class` warn-only check |

Total: 39 files changed, 124 insertions, 4 deletions.

### iso_class Distribution

| Value | Count | Skills |
|-------|-------|--------|
| `A` (with `applies_at_or_above: A`) | 3 | `traceability`, `evidence-pack`, `risk-control` |
| `none` | 33 | All other workflow / utility skills |
| `B`, `C` | 0 | Not yet used; reserved for future skills |

The 3 safety-relevant skills are the operational outputs of P0-1, P1-1, and P1-2 (Epic #588).

### API/Database Changes

None. The `iso_class` field is metadata-only -- no skill behavior changes.

## How

### Implementation Highlights

1. **Phase A -- Define the contract** (`_policy.md`, `invariants.md`):
   - `iso_class: A | B | C | none` (required, IEC 62304 §5.3 SW Safety Class).
   - `safety_class:` (optional, multi-domain map) with `iec_62304`, `iso_26262` (`QM | ASIL-A..D`), `iec_61508` (`SIL-1..4`), `do_178c` (`A..E`).
   - `applies_at_or_above:` (optional) -- minimum class for skill participation.
   - Invariant: every new `SKILL.md` must declare `iso_class`.

2. **Phase B -- Sweep all SKILL.md** (36 files):
   - Default `iso_class: none` for every workflow/utility skill.
   - Override to `iso_class: A` (with `applies_at_or_above: A`) on the three safety-relevant skills (`traceability`, `evidence-pack`, `risk-control`).
   - Each edit is surgical: only the `iso_class:` (and optional `applies_at_or_above:`) line is added; no other frontmatter or body content was touched.
   - Insertion point: after the last data field in the frontmatter, before any trailing comment block (`# ref_docs keys:`) or closing `---`. This matches the structural pattern established by `risk-control` and `evidence-pack`.

3. **Phase C -- Extend the validator** (`scripts/validate_skills.sh`):
   - New check verifies every `SKILL.md` declares `iso_class` with one of `A | B | C | none`.
   - Per the issue acceptance criteria, the check is **warn-only** during the one-release grace period; missing or invalid `iso_class` produces a WARNING rather than a hard failure.
   - A TODO comment marks the planned switch to hard FAIL in the next release.

### Testing Done

- [x] Local validator run: `scripts/validate_skills.sh` reports 293 passed / 0 failed / 14 warnings (pre-existing). Every SKILL.md emits `iso_class 유효: '<value>'`.
- [x] Frontmatter integrity: no other fields modified, body content untouched on all 36 SKILL.md files.
- [x] git pre-commit hook (which runs `validate_skills.sh` on SKILL.md changes) passed on all four commits.
- [ ] CI on this PR (will run after PR creation against `develop`).

### Test Plan for Reviewers

1. `git diff develop..HEAD -- '*/SKILL.md'` -- confirm each SKILL.md adds only `iso_class:` (and optionally `applies_at_or_above:` on the three safety-relevant skills).
2. `bash scripts/validate_skills.sh` -- confirm every file emits `iso_class 유효: '<value>'`.
3. `git diff develop..HEAD -- global/skills/_policy.md` -- review the new "Safety-Class Metadata" section.
4. `git diff develop..HEAD -- global/skills/_internal/_shared/invariants.md` -- review the new "Frontmatter Invariants" section.
5. `git diff develop..HEAD -- scripts/validate_skills.sh` -- review the warn-only check and the TODO comment for the future hard-FAIL switch.

### Breaking Changes

None. The validator's `iso_class` check is warn-only during the grace period; existing consumers see no behavior change. The metadata field is purely additive.

### Rollback Plan

1. Revert this PR.
2. The change is metadata-only; no data or runtime state to roll back.

## Checklist

- [x] Code follows project style guidelines (Conventional Commits, English, no attribution / emojis)
- [x] Self-review completed
- [x] Tests added/updated (validator extension)
- [x] Documentation updated (`_policy.md`, `invariants.md`)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (4 commits split per the issue's suggested grouping)
- [x] Related issue(s) linked with closing keywords
- [ ] Comment added to related issue(s) with PR information (post-merge)
