### PR TITLE
feat(skills): add soup-inventory skill for SOUP register management

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -50,6 +50,7 @@ When the user types one of the keywords below as a leading command (with or with
 | `traceability`         | `~/.claude/skills/_internal/traceability/SKILL.md`          |
 | `evidence-pack`        | `~/.claude/skills/_internal/evidence-pack/SKILL.md`         |
 | `risk-control`         | `~/.claude/skills/_internal/risk-control/SKILL.md`          |
+| `soup-inventory`       | `~/.claude/skills/_internal/soup-inventory/SKILL.md`        |
 
 Ambiguity rule: if a keyword appears mid-sentence (not as a leading command) or inside quotes, ask whether the user meant the skill or a literal mention before invoking.
 

--- a/global/skills/_internal/soup-inventory/SKILL.md
+++ b/global/skills/_internal/soup-inventory/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: soup-inventory
+description: "Maintain a SOUP (Software Of Unknown Provenance) register for every third-party software item the project depends on. Discovers candidates from lockfiles (package-lock.json, go.sum, Cargo.lock, requirements.txt, pyproject.toml, pom.xml, packages.lock.json), enriches with human-supplied risk class and verification refs, validates against a license allow-list and the requirements catalogue, and emits a per-supplier report. Outputs docs/.index/soup.yaml plus docs/.index/soup.md. Subcommands: discover | enrich | validate | list | report. Bidirectional linking with traceability via the soup_ids[] field on requirement rows. Opt-in: no-op when no lockfile is detected and docs/.index/soup.yaml is absent. Atomic writes (*.tmp + rename); idempotent (records sorted by id). Implements IEC 62304 sections 5.3.3 (SOUP requirements) and 8.1.1 (configuration items)."
+argument-hint: "<discover|enrich|validate|list|report> [--ci] [--verbose]"
+user-invocable: true
+disable-model-invocation: true
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - Grep
+loop_safe: true
+max_iterations: 1
+halt_conditions:
+  - { type: success, expr: "subcommand completed successfully and soup.yaml is well-formed (atomic rename succeeded)" }
+  - { type: success, expr: "no-op exit when no lockfile is detected and docs/.index/soup.yaml is absent" }
+  - { type: failure, expr: "validate --ci reports a missing record, a forbidden license, an unset risk_class, or a dangling verification reference" }
+  - { type: failure, expr: "lockfile/soup-file parse error or write step errors out" }
+on_halt: "Print per-record findings table (or no-op message) and exit non-zero on failure, zero on success or no-op"
+tiers:
+  light:
+    ref_docs: []
+    deep_checks: false
+  standard:
+    ref_docs: [schema, sources]
+    deep_checks: true
+  deep:
+    ref_docs: [schema, sources, license]
+    deep_checks: true
+default_tier: standard
+iso_class: A
+applies_at_or_above: A
+# ref_docs keys:
+#   schema  -> reference/soup-record-schema.md
+#   sources -> reference/discovery-sources.md
+#   license -> reference/license-policy.md
+---
+
+# soup-inventory Skill
+
+Maintain the SOUP (Software Of Unknown Provenance) register for projects that have adopted
+the regulated-industry track. The skill is the third-party-software counterpart to
+`risk-control` (which owns the hazard records) and `traceability` (which owns the
+requirements-to-evidence matrix): it produces and maintains the per-project SOUP file that
+the traceability matrix references via a new `soup_ids[]` field on each requirement row, and
+that the `evidence-pack` skill collects under a future `soup_register` kind.
+
+The skill does not invent regulatory content; it provides a structured, validatable home
+for the records that IEC 62304 sections 5.3.3 (specify functional and performance
+requirements of SOUP items) and 8.1.1 (identify configuration items) already require.
+
+## Usage
+
+```
+/soup-inventory discover                     # Scan lockfiles; produce candidate records (status: needs_review)
+/soup-inventory enrich <id>                  # Open editor for human-supplied fields (purpose, risk_class, verification_refs)
+/soup-inventory validate                     # Schema + cross-reference + license check (warnings only)
+/soup-inventory validate --ci                # Same; exit non-zero on any finding
+/soup-inventory list                         # Print a table of all records and their status
+/soup-inventory list --verbose               # Same with control_measures and verification expanded
+/soup-inventory report                       # Emit docs/.index/soup.md grouped by supplier
+```
+
+Exactly one subcommand is required as the first positional argument. The `enrich` subcommand
+takes a record id (`SOUP-NNN`) as the second positional argument; the others take none.
+
+## Arguments
+
+| Position / Flag | Behavior |
+|-----------------|----------|
+| `<subcommand>` (positional, required) | One of `discover`, `enrich`, `validate`, `list`, `report`. Any other value exits non-zero with a usage hint. |
+| `<id>` (positional, required for `enrich`) | Record identifier matching `^SOUP-[0-9]{3}$` (see `reference/soup-record-schema.md`). `enrich` refuses an id absent from the register. |
+| `--ci` | Applies to `validate`. Exit non-zero on any finding. Intended for the GitHub Actions validate job. |
+| `--verbose` | Applies to `list`. Expand `dependent_requirements` and `verification_refs` columns. Otherwise prints only the headline status per record. |
+
+`--ci` is ignored (with a warning) on `discover`, `enrich`, `list`, and `report`.
+
+## Inputs
+
+| Path | Required | Purpose |
+|------|----------|---------|
+| Project lockfile (any of: `package-lock.json`, `go.sum`, `Cargo.lock`, `requirements.txt`, `pyproject.toml`, `pom.xml`, `packages.lock.json`) | Yes (gate) for `discover`; optional otherwise | Source of candidate SOUP entries. The skill is a no-op when no lockfile is present and `docs/.index/soup.yaml` does not yet exist. |
+| `docs/.index/soup.yaml` | Optional on `discover` (created or merged); required on `enrich`/`validate`/`list`/`report` | The SOUP register the skill maintains. See `reference/soup-record-schema.md` for the exact YAML shape. |
+| `soup-license-policy.yaml` (repo root) | Optional | Per-project override of the default license allow-list and forbid-list. Defaults documented in `reference/license-policy.md`. |
+| `docs/.index/manifest.yaml` | Optional | Used by `validate` to confirm every requirement listed under `dependent_requirements[]` resolves to a real document. Skipped (with a warning) when absent. |
+| `compliance/iec-62304.md` | Optional | Source of truth for clause IDs referenced in `verification_refs[]`. When present, `validate` confirms every cited clause exists. Skipped (with one info line) when absent. |
+
+The skill never reads source code, never runs builds, and never calls out to external systems.
+
+## Outputs
+
+| Path | Format | Audience |
+|------|--------|----------|
+| `docs/.index/soup.yaml` | YAML | Single normalized SOUP register. Consumed by `traceability` (via `soup_ids[]`) and `evidence-pack` (via the future `soup_register` kind). Schema: `reference/soup-record-schema.md`. |
+| `docs/.index/soup.md` | Markdown | Human-readable per-supplier report produced by `report`. Suitable for inclusion in audit-time exports. |
+
+Both files are written atomically: the skill writes to a sibling `*.tmp` file and renames on
+success. A failed run never produces a half-written artifact. Records are sorted by `id` on
+every write to guarantee byte-identical output for unchanged input (idempotency contract,
+matches `traceability`, `evidence-pack`, and `risk-control`).
+
+## Opt-in Gate
+
+The skill is purely additive and must not break repos that have not adopted the regulated track.
+
+```bash
+if ! detect_lockfile && [[ ! -f docs/.index/soup.yaml ]]; then
+    echo "soup-inventory: no lockfile detected and docs/.index/soup.yaml absent -- skill is a no-op for this repo"
+    exit 0
+fi
+```
+
+`detect_lockfile` returns true when any of the lockfiles enumerated in
+`reference/discovery-sources.md` is present at the repo root or under a documented
+sub-directory. The check runs before any other phase. The exit code is `0` so CI invocations
+on non-regulated repos do not fail. To opt in, a consumer project either checks a lockfile
+into the repo (the common case) or hand-creates an empty `docs/.index/soup.yaml` (rare).
+
+## Instructions
+
+### Phase 0: Validate Environment
+
+1. Run the opt-in gate above; on no-op, print the message and exit 0.
+2. Validate the subcommand is one of `discover`, `enrich`, `validate`, `list`, `report`.
+   Otherwise exit non-zero with a usage hint.
+3. For `enrich`, validate the second positional argument matches `^SOUP-[0-9]{3}$`. Exit
+   non-zero on malformed ids.
+4. Detect optional inputs: `soup-license-policy.yaml` at repo root, `docs/.index/manifest.yaml`,
+   `compliance/iec-62304.md`. Record their presence; later phases gate on them.
+5. If `docs/.index/soup.yaml` exists, parse it and verify `_meta.schema` major matches the
+   schema this skill writes (current major: `1`). On a major mismatch, exit non-zero with the
+   mismatch detail. Minor mismatches are tolerated; the writer upgrades on next save.
+
+### Phase 1: Dispatch by Subcommand
+
+Each subcommand runs an independent code path. The phases below describe the per-subcommand
+behavior. All paths share the Phase 0 gate and the Phase 4 atomic-write step.
+
+#### Subcommand: discover
+
+Reference: `reference/discovery-sources.md` defines the per-language lockfile parsers and the
+auto-populated fields each one yields.
+
+1. For each lockfile present, invoke the parser documented in `discovery-sources.md` and
+   produce a candidate record per dependency. Auto-populated fields: `name`, `version`,
+   `supplier`, `source_url`, and `license_spdx` where the lockfile carries it.
+2. Mint a record id of the form `SOUP-NNN` where `NNN` is the next free three-digit slot
+   (zero-padded, sorted ascending) not already in the existing register. Reuse the existing
+   id when a candidate's `(name, version)` pair already appears in the register.
+3. Set `status: needs_review` on every newly created record. Existing records are left
+   untouched (the skill never overwrites enrichment data on re-discovery).
+4. Set `risk_class: unset` (sentinel) and `purpose: ""` on new records. The operator fills
+   these in via `enrich`.
+5. Merge the new and existing record lists; proceed to Phase 4 to write the updated register.
+
+#### Subcommand: enrich
+
+1. Refuse if `<id>` is absent from `docs/.index/soup.yaml`.
+2. Load the existing record into memory.
+3. Prompt the operator for each enrichment field listed in `reference/soup-record-schema.md`
+   "Enrichment Fields" section, prefilling current values:
+   - `purpose` (one-line description of why this SOUP is used)
+   - `risk_class` (one of `A`, `B`, `C`; matches IEC 62304 software item classification)
+   - `dependent_requirements[]` (list of `SRS-{CAT}-{NNN}` ids that depend on this SOUP)
+   - `dependent_si_ids[]` (list of `SI-{CODE}` design ids that allocate this SOUP)
+   - `verification_refs[]` (list of clause ids, requirement ids, or evidence file paths)
+4. On successful submission, set `status: ready`. Auto-populated fields (`name`, `version`,
+   `supplier`, `source_url`, `license_spdx`) are not editable through `enrich`; they are
+   refreshed only by `discover`.
+5. Replace the in-memory record; proceed to Phase 4.
+
+#### Subcommand: validate
+
+Reference: `reference/license-policy.md` defines the default allow-list and the override
+mechanism. `reference/soup-record-schema.md` "Validation Rules" defines the full finding set.
+
+1. Load every record from `docs/.index/soup.yaml`.
+2. Cross-check the lockfile entry list against the register: every lockfile entry must have a
+   matching SOUP record (finding `lockfile_entry_without_record`). Records present in the
+   register but absent from the lockfile are warned only (the dependency may have been
+   removed; the operator decides whether to retire the record).
+3. For each record in the register, run the validation checks documented in
+   `reference/soup-record-schema.md`, which cover at minimum:
+   - `risk_class` is one of `A`, `B`, `C` (finding `risk_class_unset` when value is `unset`).
+   - `license_spdx` is in the active allow-list and not in the forbid-list (findings
+     `license_outside_allow_list` and `license_in_forbid_list`).
+   - Every `dependent_requirements[]` entry resolves to a `SRS-*` id present in
+     `manifest.yaml` (when manifest is available; finding `dangling_requirement_ref`).
+   - Every `verification_refs[]` entry resolves to one of: a clause id present in
+     `compliance/iec-62304.md` (when present), a `SRS-*` id present in `manifest.yaml`, or
+     a repo-relative file path that exists on disk (finding `dangling_verification_ref`).
+   - `status` is one of `needs_review` or `ready`.
+4. Print the findings table to stdout. Format documented in
+   `reference/soup-record-schema.md` "Validation Output" section.
+5. In `--ci` mode, exit non-zero on any finding. Default mode emits warnings and exits 0.
+6. `validate` does not write to disk; skip Phase 4.
+
+#### Subcommand: list
+
+1. Load every record from `docs/.index/soup.yaml`.
+2. Print a Markdown table sorted by `id`. Default columns: `id`, `name`, `version`,
+   `license_spdx`, `risk_class`, `status`. With `--verbose`, additionally expand
+   `dependent_requirements` and `verification_refs` as nested rows under each record.
+3. `list` does not write to disk; skip Phase 4.
+
+#### Subcommand: report
+
+1. Load every record from `docs/.index/soup.yaml`.
+2. Group records by `supplier`. Within each group, sort by `id`.
+3. Render `docs/.index/soup.md.tmp` with one section per supplier. Each section contains a
+   table of records and a list of dependent requirements / design items, suitable for
+   inclusion in audit-time exports.
+4. Atomically rename `docs/.index/soup.md.tmp` to `docs/.index/soup.md`. On any error,
+   delete the `*.tmp` file and exit non-zero.
+5. `report` does not modify `soup.yaml`; skip Phase 4 for the YAML file.
+
+### Phase 4: Atomic Write
+
+Skip when subcommand is `validate`, `list`, or `report` (the latter writes its own atomic
+file under `report`'s Phase 1 step 4), or when no record changed.
+
+1. Sort the in-memory record list by `id` (stable, ASCII order). Recompute `_meta.generated`
+   timestamp.
+2. Render the YAML using the canonical layout in `reference/soup-record-schema.md`. Empty
+   list fields are emitted as `[]`, never as `~` or as an omitted key, so consumers never
+   need to distinguish "absent" from "empty".
+3. Write to `docs/.index/soup.yaml.tmp`.
+4. On success, rename to `docs/.index/soup.yaml`. On any error, delete the `*.tmp` file and
+   exit non-zero.
+
+### Phase 5: Report
+
+Emit a one-line summary on stdout per subcommand:
+
+| Subcommand | Summary line |
+|------------|--------------|
+| `discover` | `soup-inventory: discovered <N> candidates from <M> lockfile(s); records=<R> (new=<X>, existing=<E>)` |
+| `enrich` | `soup-inventory: enriched <id> (risk_class=<A|B|C>); records=<N>` |
+| `validate` | `soup-inventory: validated <N> records; findings=<F> (errors=<E>, warnings=<W>)` |
+| `list` | `soup-inventory: listed <N> records` |
+| `report` | `soup-inventory: wrote docs/.index/soup.md with <S> supplier sections covering <N> records` |
+
+Append the per-finding or per-record table required by the subcommand to stdout above the
+summary.
+
+## Bidirectional SOUP-Requirement Linking
+
+Each SOUP record carries `dependent_requirements[]` and `dependent_si_ids[]` lists naming
+the SRS and SI ids that depend on this third-party component. The link is one-directional in
+the SOUP file (SOUP -> requirements), but the next `traceability` skill run picks it up in
+the other direction without any new wiring: the matrix row schema reserves `soup_ids[]` on
+every requirement row (see `traceability/reference/matrix-schema.md`), and the matrix's
+Phase 1 step would collect SOUP ids from `docs/.index/soup.yaml` when it is present. When
+the SOUP register is the source of truth, the matrix's SOUP-side data source is this skill
+rather than ad-hoc registries.
+
+The integration contract is: `soup-inventory` owns the SOUP records; `traceability` reads
+them and stitches them into the matrix. No bidirectional write coordination is required
+because the SOUP register is the single source of truth for third-party-component metadata.
+
+## Output
+
+The skill produces only `docs/.index/soup.yaml` (and, for `report`, `docs/.index/soup.md`)
+plus the on-stdout summary. No other files in the consumer project are modified -- in
+particular, the skill never edits `manifest.yaml`, `bundles.yaml`, `graph.yaml`,
+`router.yaml`, `traceability.yaml`, or `risk-file.yaml`. Those remain `doc-index`'s,
+`traceability`'s, and `risk-control`'s responsibilities.
+
+## Error Handling
+
+| Condition | Action |
+|-----------|--------|
+| No lockfile detected and `docs/.index/soup.yaml` absent | No-op exit 0 (opt-in gate, see Phase 0). |
+| Subcommand argument missing or invalid | Exit non-zero with usage hint. |
+| `<id>` malformed for `enrich` | Exit non-zero with the expected format from the schema. |
+| `enrich` invoked with an absent id | Exit non-zero with the suggestion to run `discover` first. |
+| `_meta.schema` major mismatch on existing SOUP file | Exit non-zero with the detected vs. expected schema versions. |
+| Lockfile parse error during `discover` | Exit non-zero with the lockfile path and the parse error; do not partially update the register. |
+| `soup-license-policy.yaml` malformed | Exit non-zero with the YAML parse error and the offending line. |
+| Validation finding in `--ci` mode | Print the finding table, exit non-zero. (Per IEC 62304 8.1.1, an unidentified configuration item must not pass review; CI mirrors that policy.) |
+| Validation finding in default mode | Print the finding table, exit 0. |
+| Write step fails (permission, disk) | Delete the `*.tmp` file, report the path, exit non-zero. |
+| `compliance/iec-62304.md` referenced but absent | Skip clause validation; print one informational line; do not fail. |
+
+## Policies
+
+### Side Effects and Loop-Safety
+
+This skill is `loop_safe: true`. The `validate`, `list`, and `report` subcommands are pure
+reads of the YAML register (with `report` writing only the regenerated Markdown view, which
+the idempotency contract makes safe). The `discover` subcommand is also idempotent: re-running
+on an unchanged lockfile produces a byte-identical register because (a) ids are stable for
+existing `(name, version)` pairs and (b) records are sorted by id on every write. The
+`enrich` subcommand is gated by operator input, so wrapping in `/loop` would no-op after the
+first prompt -- safe but pointless.
+
+### Command-Specific Rules
+
+| Item | Rule |
+|------|------|
+| Inputs | Lockfiles enumerated in `reference/discovery-sources.md`, `docs/.index/{manifest,soup}.yaml`, optional `soup-license-policy.yaml`, optional `compliance/iec-62304.md`. The skill never crawls source-code directories. |
+| Outputs | Only `docs/.index/soup.yaml` and `docs/.index/soup.md`. No other file is touched. |
+| Opt-in | No lockfile and no existing register is a no-op exit 0, never a failure. |
+| Atomicity | Writes go to `*.tmp` first, then rename on success. Failure deletes the temp file. |
+| Idempotency | Same input always produces byte-identical output. Re-running `discover` on an unchanged lockfile is a no-op; re-running `report` produces a byte-identical Markdown file. |
+| Bidirectional linking | One-directional in the SOUP file (SOUP -> requirements). `traceability` reads it and produces the inverse view in the matrix. |
+| External submission | Never. Submission to eQMS / regulator portals is out of scope. |
+| CVE / vulnerability scanning | Out of scope. The register tracks provenance, license, and verification, not vulnerabilities. A separate skill (future) handles the CVE channel. |
+
+### Validation Message Style
+
+When `validate --ci` reports a finding, the message must include the relevant IEC 62304
+clause id (e.g. `IEC-62304-5.3.3` for a missing SOUP requirement, `IEC-62304-8.1.1` for a
+missing configuration item) so an auditor reading the CI log can pivot directly to the
+standard. The clause-to-finding mapping is documented in
+`reference/soup-record-schema.md` "Validation Rules" -- the skill body must use that table
+verbatim rather than inventing new mappings.
+
+## How Other Components Use the SOUP Register
+
+| Consumer | Use |
+|----------|-----|
+| `traceability` skill (P0-1) | Reads `soup.yaml` to populate `soup_ids[]` on requirement matrix rows. Bidirectional linking comes for free. |
+| `evidence-pack` skill (P1-1) | Will mirror `soup.yaml` (and the per-supplier `soup.md` report when present) under a future `soup_register` kind in the per-release evidence pack. The current `evidence-pack` source-mapping does not yet enumerate this kind; a follow-up issue will add it. |
+| `risk-control` skill (P1-2) | Cross-references SOUP records when a hazard's failure mode involves third-party software; the link is recorded as a `verification_refs[]` entry pointing to the relevant `H-NN` id. |
+| `traceability-guard` PreToolUse hook (P0-2) | Could be extended to detect when a PR adds or bumps a lockfile entry without updating the SOUP register. |
+| External auditor | Reads `soup.yaml` and `soup.md` directly from the repo at any tagged release; consumes them alongside the matrix as the operational SOUP-management record. |
+
+## References
+
+- SOUP record schema: `reference/soup-record-schema.md`
+- Per-language discovery sources: `reference/discovery-sources.md`
+- Default license policy and per-project override format: `reference/license-policy.md`
+- IEC 62304 clause source: `compliance/iec-62304.md` (project root, when present)
+- Sibling matrix consumer: `global/skills/_internal/traceability/SKILL.md`
+- Sibling release-time consumer: `global/skills/_internal/evidence-pack/SKILL.md`
+- Sibling risk-side consumer: `global/skills/_internal/risk-control/SKILL.md`
+- Parent epic: `kcenon/claude-config#588`
+- Originating issue: `kcenon/claude-config#601`

--- a/global/skills/_internal/soup-inventory/reference/discovery-sources.md
+++ b/global/skills/_internal/soup-inventory/reference/discovery-sources.md
@@ -1,0 +1,165 @@
+# SOUP Discovery Sources
+
+Per-language lockfile parsers used by the `soup-inventory` skill's `discover` subcommand.
+For each ecosystem this file documents the lockfile path glob, the parser strategy, and
+which fields the parser auto-populates on a candidate SOUP record.
+
+> **Loading**: Loaded under `tier: standard` and `tier: deep` via the skill's `ref_docs.sources`
+> entry. Skip when invoking under `tier: light`.
+
+The skill body must not invent discovery strategies -- it implements exactly the contracts
+documented here. Adding a new ecosystem requires updating this file and adding a parser
+implementation note.
+
+## Discovery Contract Template
+
+Each section below follows this structure:
+
+| Field | Meaning |
+|-------|---------|
+| **Lockfile glob** | Path glob the discoverer scans for. Project-relative. |
+| **Lockfile authority** | Whether the file is the canonical pin (always YES for discovery; the manifest file like `package.json` is not used). |
+| **Auto-populated fields** | Fields the parser fills on a candidate record. Other fields are left to `enrich`. |
+| **Field-extraction rules** | Per-field rules for where in the lockfile each value comes from. |
+| **Skip rules** | Lockfile entry types that are intentionally not added to the SOUP register (e.g. dev-only test fixtures, the project's own packages). |
+
+The discoverer always treats the lockfile as the source of truth for `(name, version)`
+pairs. Manifest files (`package.json`, `pyproject.toml` `[project]` table, `Cargo.toml`,
+`go.mod`) are not used because they often carry version ranges rather than exact pins, and
+the SOUP register requires exact pins per IEC 62304 §8.1.1.
+
+## ecosystem: npm (Node.js)
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `package-lock.json` (root or any sub-directory checked into the repo) |
+| **Lockfile authority** | YES -- `lockfileVersion >= 2` carries flat `packages{}` with exact versions and license metadata. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` from the `packages.<path>.name` (or the path key when name is absent). `version` from `packages.<path>.version`. `license_spdx` from `packages.<path>.license` (string form) or the `licenses[].type` array fallback. `supplier` from `packages.<path>._npmUser.name` when present, else from the `homepage` URL host, else `"unknown"`. `source_url` from `packages.<path>.repository.url` (stripped of `git+` prefix), else from `homepage`, else from `https://www.npmjs.com/package/<name>`. |
+| **Skip rules** | Skip the root entry (the project itself). Skip entries with `dev: true` whose path matches the configured dev-only allow-list (default: empty -- the operator opts in by setting `soup-license-policy.yaml` `npm.skip_dev: true`). |
+
+The npm v2/v3 lockfile schema is the only supported form. Older `package-lock.json` v1 files
+are detected and emit a parse error directing the operator to upgrade with
+`npm install --package-lock-only`.
+
+## ecosystem: PyPI (Python)
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `requirements.txt`, `requirements-*.txt`, `pyproject.toml` (when `[tool.poetry.lock]` or `[tool.uv.lock]` is present), `poetry.lock`, `uv.lock`, `Pipfile.lock` |
+| **Lockfile authority** | YES when the file pins exact versions (`==X.Y.Z`). `requirements.txt` files using `~=` or `>=` are not authoritative and emit a parse error directing the operator to use `pip-compile` or a true lockfile. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` from the requirement specifier or the lockfile's `package.name`. `version` from `==X.Y.Z` or `package.version`. `license_spdx` from PyPI metadata cached in the lockfile (`poetry.lock` `package.metadata.license`, `uv.lock` `[[package]] license`); falls back to `UNKNOWN` for `requirements.txt` since it carries no license metadata. `supplier` from `package.metadata.author` when present, else `"unknown"`. `source_url` from `package.metadata.home-page` or `package.source.url` for git/path sources, else `https://pypi.org/project/<name>/<version>/`. |
+| **Skip rules** | Skip `python` itself when the lockfile lists it as a dependency. Skip editable installs (`-e .` or `develop = true`) since they refer to the project's own source. |
+
+Plain `requirements.txt` files without exact pins are common but unsuitable for SOUP
+discovery. The skill emits a parse error rather than guess versions; the operator is
+expected to materialize a true lockfile via `pip-compile` (pip-tools), `poetry lock`, or
+`uv lock`.
+
+## ecosystem: Go modules
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `go.sum` (alongside `go.mod` for module path resolution) |
+| **Lockfile authority** | YES -- `go.sum` carries exact module versions and content hashes. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` from the module path (e.g. `github.com/gin-gonic/gin`). `version` from the version column (`v1.9.1`); the `/go.mod` rows are skipped (they are duplicate hashes). `supplier` from the module path's host + first path segment (e.g. `github.com/gin-gonic` -> `gin-gonic`); falls back to `"unknown"` for non-VCS hosts. `source_url` constructed as `https://<module-path>` (Go's import-path convention). `license_spdx` is `UNKNOWN` (Go modules carry no in-lockfile license metadata; the operator resolves via `go-licenses` or manual inspection during `enrich`). |
+| **Skip rules** | Skip the project's own module (matched against the `module` directive in `go.mod`). Skip `+incompatible` versions only when `soup-license-policy.yaml` `go.skip_incompatible: true` (off by default). |
+
+Go's lockfile-as-content-addressable-store design means license metadata is intentionally
+out-of-band. The `UNKNOWN` license forces operator review on `validate --ci`, which is the
+correct conservative default for an audit-facing register.
+
+## ecosystem: Cargo (Rust)
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `Cargo.lock` |
+| **Lockfile authority** | YES -- `Cargo.lock` pins exact crate versions and source URLs. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` from each `[[package]] name`. `version` from `[[package]] version`. `source_url` from `[[package]] source` (stripped of the `registry+` or `git+` prefix); falls back to `https://crates.io/crates/<name>` for crates.io packages. `supplier` from the source URL's host + author (e.g. `crates.io/<name>` -> `crates.io`); refined by the operator. `license_spdx` is `UNKNOWN` (Cargo lockfile does not carry license metadata; `cargo metadata --format-version 1` does, but invoking it requires an active toolchain so the discoverer keeps the parser pure-text). |
+| **Skip rules** | Skip the workspace root and any `[[package]]` entry whose `source` field is absent (those are local path dependencies, i.e. the project itself). |
+
+Rust's situation mirrors Go: license metadata is not in the lockfile. The operator resolves
+via `cargo-license` or manual inspection during `enrich`.
+
+## ecosystem: Maven (Java)
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `pom.xml` (when used with the Maven Resolver locking plugin or `mvn dependency:resolve` output checked in), or `dependency-tree.txt` produced by `mvn dependency:tree -DoutputFile=...` |
+| **Lockfile authority** | YES when using the Maven Resolver locking plugin (`.mvn/dependency-locks/*.xml`); otherwise the discoverer falls back to parsing the explicit `<version>` pins in `pom.xml` and refuses to discover from version ranges. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` constructed as `<groupId>:<artifactId>`. `version` from the locked `<version>` (or the pinned `<version>` in `pom.xml`). `supplier` from `<organization><name>` when present, else from the `<groupId>` (e.g. `org.apache.commons` -> `Apache Commons`). `source_url` from `<scm><url>` or `<url>`, else `https://search.maven.org/artifact/<groupId>/<artifactId>/<version>/jar`. `license_spdx` from `<licenses><license><name>` mapped to the closest SPDX id; emits `UNKNOWN` when the mapping is ambiguous. |
+| **Skip rules** | Skip the parent POM and the project's own artifact (matched against the top-level `<groupId>:<artifactId>`). Skip `<scope>test</scope>` dependencies when `soup-license-policy.yaml` `maven.skip_test: true` (off by default). |
+
+The Maven ecosystem's SPDX mapping is imperfect; the parser uses a conservative subset
+(MIT, Apache-2.0, BSD-2/3-Clause, EPL-1.0/2.0, GPL-2.0/3.0, LGPL-2.1/3.0, MPL-2.0) and falls
+back to `UNKNOWN` for everything else. The operator refines via `enrich`.
+
+## ecosystem: NuGet (.NET)
+
+| Field | Value |
+|-------|-------|
+| **Lockfile glob** | `packages.lock.json` (per-project, requires `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` in the `.csproj`) |
+| **Lockfile authority** | YES -- `packages.lock.json` pins exact NuGet package versions per target framework. |
+| **Auto-populated fields** | `name`, `version`, `supplier`, `source_url`, `license_spdx` |
+| **Field-extraction rules** | `name` from each `dependencies.<framework>.<name>` key. `version` from the `resolved` field (not `requested`, which may be a range). `supplier` from `https://api.nuget.org/v3/registration5-semver1/<name>/index.json` cached in `packages.lock.json` `contentHash`-adjacent metadata when present; falls back to `"unknown"`. `source_url` is `https://www.nuget.org/packages/<name>/<version>`. `license_spdx` is `UNKNOWN` (NuGet's per-package license metadata is fetched on restore but not persisted to the lockfile; the operator resolves via `dotnet list package --vulnerable --include-transitive` or the NuGet web UI). |
+| **Skip rules** | Skip entries marked `type: Project` (those are project-references). Skip the framework reference packages (`Microsoft.NETCore.App.Ref`, `Microsoft.AspNetCore.App.Ref`, etc.) that ship with the .NET SDK rather than as third-party SOUP. |
+
+NuGet projects without `packages.lock.json` cannot be discovered automatically -- the
+operator must enable `<RestorePackagesWithLockFile>` first. The skill emits an informational
+message rather than a parse error in this case (the project may not have opted into lockfiles
+yet).
+
+## Multi-ecosystem Projects
+
+A consumer project may have multiple lockfiles (e.g. a Node.js frontend plus a Python
+backend). The discoverer scans for all supported lockfile globs in parallel and merges
+candidates into a single register. Id collisions (same `(name, version)` pair from two
+ecosystems) are impossible by construction because npm and PyPI do not share package names
+across registries -- the namespace is scoped per ecosystem. When a true name collision
+occurs (rare), the discoverer prefixes the id label with the ecosystem (`npm:express` vs
+`maven:io.express:express`) and the operator can rename via `enrich`.
+
+## Skip-List Mechanism
+
+The `soup-license-policy.yaml` per-project override file (see `license-policy.md`) carries
+an optional `skip:` section listing `(name, version)` pairs to exclude from the register.
+This is the escape hatch for documented exemptions (e.g. internal mirror packages that are
+audited via a separate process). Format:
+
+```yaml
+skip:
+  - name: "internal-mirror-pkg"
+    version: "*"           # "*" means all versions
+    reason: "Audited via internal-quality-system; tracked outside SOUP register"
+  - name: "lodash"
+    version: "4.17.21"
+    reason: "Audited under SOUP-002 in v1.0.0; pre-existing register entry"
+```
+
+The discoverer logs each skip on stdout for the audit trail. Skipped entries do not appear
+in `soup.yaml`.
+
+## Adding a New Ecosystem
+
+When a new lockfile-bearing ecosystem must be supported (e.g. `composer.lock` for PHP,
+`mix.lock` for Elixir, `Gemfile.lock` for Ruby):
+
+1. Pick a snake_case ecosystem id matching the existing pattern.
+2. Add a section to this file with all five contract fields populated.
+3. Document the field-extraction rules in enough detail that a second implementer would
+   produce byte-identical candidate records on the same input.
+4. Update the skill body's Phase 1 step 1 candidate-lockfile list (the `discover` subcommand
+   description in `../SKILL.md`).
+5. Bump `_meta.schema` minor in `soup-record-schema.md` only if the new ecosystem requires
+   a new optional field on the record schema (e.g. `framework_target` for NuGet).
+
+## Cross-references
+
+- Record shape: `soup-record-schema.md`
+- License allow-list and override format: `license-policy.md`
+- Skill body that runs these parsers: `../SKILL.md`
+- Source of truth for SOUP-relevant clauses: `compliance/iec-62304.md` (project root)

--- a/global/skills/_internal/soup-inventory/reference/license-policy.md
+++ b/global/skills/_internal/soup-inventory/reference/license-policy.md
@@ -1,0 +1,188 @@
+# SOUP License Policy
+
+Default license allow-list and forbid-list applied by the `soup-inventory` skill's
+`validate` subcommand, and the per-project override mechanism for both lists.
+
+> **Loading**: Loaded under `tier: deep` only via the skill's `ref_docs.license` entry. The
+> default lists below are small enough that `tier: standard` operates from the SKILL.md
+> body's reference. Load this file when authoring a project-specific override or when
+> investigating an unexpected `license_outside_allow_list` finding.
+
+## Default Allow-List
+
+The default allow-list covers the licenses that are unambiguously safe for proprietary
+medical / regulated-industry products to consume without distribution-level obligations:
+
+| SPDX ID | License Name | Notes |
+|---------|--------------|-------|
+| `MIT` | MIT License | Permissive; no source disclosure on distribution. |
+| `Apache-2.0` | Apache License 2.0 | Permissive; explicit patent grant. |
+| `BSD-2-Clause` | BSD 2-Clause "Simplified" License | Permissive. |
+| `BSD-3-Clause` | BSD 3-Clause "New" or "Revised" License | Permissive. |
+| `BSD-0-Clause` | BSD Zero Clause License | Public-domain equivalent. |
+| `ISC` | ISC License | Functionally equivalent to BSD-2-Clause. |
+| `Unlicense` | The Unlicense | Public-domain dedication. |
+| `CC0-1.0` | Creative Commons Zero v1.0 Universal | Public-domain dedication. |
+| `Zlib` | zlib License | Permissive. |
+| `BlueOak-1.0.0` | Blue Oak Model License 1.0.0 | Modern permissive license. |
+| `Python-2.0` | Python Software Foundation License 2.0 | Permissive; CPython interpreter. |
+| `PostgreSQL` | PostgreSQL License | Permissive; substantially MIT. |
+
+The default list is intentionally narrow. Anything outside this set requires an explicit
+project override (see "Per-Project Override" below) accompanied by a documented rationale
+that an auditor can review.
+
+## Default Forbid-List
+
+The default forbid-list covers licenses whose obligations are typically incompatible with
+proprietary distribution of medical / regulated-industry software:
+
+| SPDX ID | License Name | Reason |
+|---------|--------------|--------|
+| `GPL-1.0` | GNU General Public License v1.0 only | Strong copyleft. |
+| `GPL-1.0-only` | GNU General Public License v1.0 only | Strong copyleft. |
+| `GPL-2.0` | GNU General Public License v2.0 only | Strong copyleft. |
+| `GPL-2.0-only` | GNU General Public License v2.0 only | Strong copyleft. |
+| `GPL-3.0` | GNU General Public License v3.0 only | Strong copyleft + patent retaliation. |
+| `GPL-3.0-only` | GNU General Public License v3.0 only | Strong copyleft + patent retaliation. |
+| `GPL-3.0-or-later` | GNU General Public License v3.0 or later | Strong copyleft + patent retaliation. |
+| `AGPL-3.0` | GNU Affero General Public License v3.0 | Network-use disclosure obligation. |
+| `AGPL-3.0-only` | GNU Affero General Public License v3.0 only | Network-use disclosure obligation. |
+| `AGPL-3.0-or-later` | GNU Affero General Public License v3.0 or later | Network-use disclosure obligation. |
+| `SSPL-1.0` | Server Side Public License 1.0 | Source-available, not OSI-approved. |
+| `BUSL-1.1` | Business Source License 1.1 | Source-available with use restrictions. |
+| `Commons-Clause` | Commons Clause | Restricts commercial use. |
+
+The default forbid-list is conservative: a project may legitimately use a copyleft license
+in a way that does not violate its terms (e.g. an internal-only tool that is never
+distributed). In that case, the project explicitly removes the entry from the forbid-list
+in its override file with a documented rationale.
+
+## Licenses That Require Per-Project Decision
+
+These licenses are neither in the default allow-list nor the default forbid-list -- the
+project must declare a stance for each one it consumes. The skill emits
+`license_outside_allow_list` for each occurrence until a project-specific override either
+allows or forbids the license:
+
+| SPDX ID | License Name | Typical Concern |
+|---------|--------------|-----------------|
+| `LGPL-2.0` / `LGPL-2.1` / `LGPL-3.0` | GNU Lesser GPL | Weak copyleft; static linking implications must be reviewed. |
+| `MPL-1.1` / `MPL-2.0` | Mozilla Public License | File-level copyleft; review whether modified files are distributed. |
+| `EPL-1.0` / `EPL-2.0` | Eclipse Public License | File-level copyleft + patent retaliation. |
+| `CDDL-1.0` / `CDDL-1.1` | Common Development and Distribution License | File-level copyleft. |
+| `CC-BY-*` / `CC-BY-SA-*` | Creative Commons (attribution / share-alike) | Mostly used for documentation; copyleft variants need review. |
+| `OFL-1.1` | SIL Open Font License | Permissive but with naming restrictions. |
+| `OpenSSL` | OpenSSL License | Pre-3.0 OpenSSL; 3.0 onwards is Apache-2.0. |
+| `Artistic-1.0` / `Artistic-2.0` | Artistic License | Perl ecosystem; review distribution clauses. |
+| `WTFPL` | Do What The F*ck You Want To Public License | OSI-controversial; some projects forbid its use. |
+
+`UNKNOWN` is also treated as outside the allow-list -- the skill always emits
+`license_unknown` for records whose `license_spdx` is `UNKNOWN`, regardless of the override
+file.
+
+## Per-Project Override
+
+A consumer project overrides the default lists by checking in
+`soup-license-policy.yaml` at the repo root. Format:
+
+```yaml
+# soup-license-policy.yaml
+# Per-project license policy for the soup-inventory skill
+# Schema version
+schema: "1.0.0"
+
+allow:
+  - SPDX_ID         # Adds to the default allow-list
+  - SPDX_ID
+
+forbid:
+  - SPDX_ID         # Adds to the default forbid-list
+  - SPDX_ID
+
+allow_remove:
+  - SPDX_ID         # Removes from the default allow-list (rare; usually only after a project decision to ban a previously allowed license)
+
+forbid_remove:
+  - SPDX_ID         # Removes from the default forbid-list (e.g. an internal-only tool that does not distribute and so can use GPL-2.0)
+
+# Per-record exemptions for one-off cases
+exemptions:
+  - id: SOUP-007
+    license_spdx: "LGPL-2.1"
+    rationale: "Dynamic linking only; LGPL terms satisfied per legal review 2025-12-01"
+    approved_by: "compliance-officer"
+    approved_at: "2025-12-01"
+
+# Per-ecosystem skip flags (consumed by discovery-sources.md parsers)
+npm:
+  skip_dev: false
+maven:
+  skip_test: false
+go:
+  skip_incompatible: false
+
+# Optional skip-list (see discovery-sources.md "Skip-List Mechanism")
+skip:
+  - name: "internal-mirror-pkg"
+    version: "*"
+    reason: "Audited via internal-quality-system"
+```
+
+### Override Resolution Order
+
+The `validate` subcommand resolves the active allow-list and forbid-list as follows:
+
+1. Start with the default allow-list.
+2. Add every entry in the override's `allow:` list.
+3. Remove every entry in the override's `allow_remove:` list.
+4. Start with the default forbid-list.
+5. Add every entry in the override's `forbid:` list.
+6. Remove every entry in the override's `forbid_remove:` list.
+7. For each record being validated, check the override's `exemptions:` list first; an
+   exemption with matching `id` and `license_spdx` skips both the allow-list and
+   forbid-list checks for that record (the rationale is logged on stdout for the audit
+   trail).
+
+A license appearing in both the allow-list and the forbid-list after merging is a hard
+configuration error (`policy_conflict`); the skill exits non-zero with the conflicting SPDX
+id and the relevant override stanzas.
+
+## Exemption Discipline
+
+Exemptions are first-class records in the audit trail. Each exemption must carry:
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `id` | Yes | The `SOUP-NNN` id this exemption applies to. |
+| `license_spdx` | Yes | The exact SPDX id being exempted. The exemption does not extend to a different version of the same license. |
+| `rationale` | Yes | One-line explanation. Auditors read this; keep it factual and citable. |
+| `approved_by` | Yes | Role name (not a person; roles outlive employees). |
+| `approved_at` | Yes | ISO 8601 date the approval was recorded. |
+
+Exemptions without a `rationale` field are rejected at policy-load time. Rationales such as
+`"approved"` or `"OK"` are technically permitted but should be flagged in PR review --
+auditors will challenge them.
+
+## SPDX Identifier Style
+
+The skill compares `license_spdx` values using exact string match against the SPDX License
+List (https://spdx.org/licenses/). Common normalization rules:
+
+- Use `Apache-2.0`, not `Apache 2.0` or `ASL-2.0`.
+- Use `BSD-3-Clause`, not `New BSD` or `BSD3`.
+- Use `MIT`, not `Expat` (Expat is the SPDX deprecated alias).
+- For dual-licensed packages, use the SPDX expression form: `(MIT OR Apache-2.0)`. The
+  skill treats expressions as satisfying the allow-list when at least one operand is in the
+  allow-list and none of the operands are in the forbid-list.
+
+The skill does not maintain a synonym table -- licenses that lockfiles report under
+non-SPDX names (e.g. `BSD` for an unspecified BSD variant) are resolved to `UNKNOWN` and
+the operator must specify the exact SPDX id during `enrich`.
+
+## Cross-references
+
+- Where license values come from: `discovery-sources.md`
+- Record field that carries the SPDX id: `soup-record-schema.md`
+- Skill body that applies these rules: `../SKILL.md`
+- SPDX License List authority: https://spdx.org/licenses/

--- a/global/skills/_internal/soup-inventory/reference/soup-record-schema.md
+++ b/global/skills/_internal/soup-inventory/reference/soup-record-schema.md
@@ -1,0 +1,266 @@
+# SOUP Record Schema
+
+YAML schema for `docs/.index/soup.yaml` records produced and maintained by the
+`soup-inventory` skill. This file is the single source of truth for record shape and field
+semantics.
+
+> **Loading**: Loaded under `tier: standard` and `tier: deep` via the skill's `ref_docs.schema`
+> entry. Skip when invoking under `tier: light`.
+
+## Top-Level Document Layout
+
+```yaml
+# docs/.index/soup.yaml
+# Generated and maintained by /soup-inventory -- do not edit by hand
+_meta:
+  schema: "1.0.0"           # Schema version of this document
+  generated: "YYYY-MM-DDTHH:MM:SSZ"  # ISO 8601 UTC timestamp of last write
+  generator: "soup-inventory"        # Skill name that produced this artifact
+  source_index_version: ""  # docs/.index/manifest.yaml _meta.schema, copied verbatim when manifest is present
+  records: N                # Total record count
+  needs_review: N           # Subset with status: needs_review
+  ready: N                  # Subset with status: ready
+
+records:
+  - <record>                # See "Record Schema" below
+  - <record>
+  - ...
+```
+
+`_meta.schema` follows semantic versioning. Consumers must check `_meta.schema` before
+parsing records; mismatched majors mean the schema has changed in a backward-incompatible way.
+
+Records are sorted by `id` (stable, ASCII order) on every write to guarantee byte-identical
+output for unchanged input (idempotency contract, matches the sibling skills).
+
+## Record Schema
+
+Every record is one third-party software item the project depends on.
+
+```yaml
+- id: SOUP-001                          # MANDATORY -- primary key, format SOUP-NNN
+  name: "express"                       # MANDATORY -- package name as it appears in the lockfile
+  version: "4.18.2"                     # MANDATORY -- exact pinned version
+  supplier: "OpenJS Foundation"         # MANDATORY -- upstream maintainer or organization
+  source_url: "https://github.com/expressjs/express"  # MANDATORY -- canonical upstream URL
+  license_spdx: "MIT"                   # MANDATORY -- SPDX identifier (or "UNKNOWN" when the lockfile carries no license metadata)
+  purpose: "HTTP request routing for the device-facing REST API"  # MANDATORY for status: ready
+  risk_class: B                         # MANDATORY -- one of A, B, C, or unset (sentinel for status: needs_review)
+  dependent_requirements:               # MANDATORY (may be empty list)
+    - SRS-API-001
+    - SRS-API-014
+  dependent_si_ids:                     # MANDATORY (may be empty list)
+    - SI-IL
+  verification_refs:                    # MANDATORY (may be empty list)
+    - IEC-62304-5.3.3
+    - tests/integration/test_express_routing.py
+  status: ready                         # MANDATORY -- one of needs_review, ready
+  notes: ""                             # OPTIONAL -- free-form, single line for human reviewers
+```
+
+### Field Definitions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Format `SOUP-NNN` (three zero-padded digits). Primary key for the record. Assigned by the skill on `discover`; never reused after retirement. |
+| `name` | string | Yes | Package name as it appears in the lockfile. Auto-populated by `discover`; not editable by `enrich`. |
+| `version` | string | Yes | Exact pinned version. Auto-populated by `discover`; refreshed on re-discovery when the lockfile entry's version changes. |
+| `supplier` | string | Yes | Upstream maintainer name or organization. Auto-populated where the lockfile carries it (npm `_npmUser`, PyPI `Author`, etc.); falls back to the value `"unknown"` otherwise. Operator can refine via `enrich`. |
+| `source_url` | string | Yes | Canonical upstream URL (homepage, repository, or registry page). Auto-populated where available. |
+| `license_spdx` | string | Yes | SPDX license identifier (e.g. `MIT`, `Apache-2.0`, `BSD-3-Clause`). Set to `UNKNOWN` when the lockfile carries no license metadata; the operator must resolve this before `validate --ci` will pass. |
+| `purpose` | string | Conditional | One-line description of why the project uses this SOUP. Required when `status: ready`. Empty string is permitted only when `status: needs_review`. |
+| `risk_class` | enum | Yes | One of `A`, `B`, `C` (matches IEC 62304 software item classification), or `unset` (sentinel for newly discovered records). `validate --ci` rejects `unset`. |
+| `dependent_requirements` | list[string] | Yes (may be empty) | Format `SRS-{CAT}-{NNN}`. Empty list is permitted for SOUP items that support infrastructure rather than a specific requirement (e.g. test runners). |
+| `dependent_si_ids` | list[string] | Yes (may be empty) | Format `SI-{CODE}`. Empty list is permitted for cross-cutting SOUP items that no single design item owns. |
+| `verification_refs` | list[string] | Yes (may be empty) | Each entry must resolve to one of: a clause id present in `compliance/iec-62304.md`, a `SRS-*` id present in `manifest.yaml`, a `H-*` id present in `risk-file.yaml`, or a repo-relative file path that exists on disk. Empty list is permitted only when `status: needs_review`. |
+| `status` | enum | Yes | One of `needs_review` (newly discovered, awaiting enrichment) or `ready` (fully enriched and ready for the matrix). |
+| `notes` | string | No | Free-form, single line. Auditors read this; keep it factual. |
+
+### Enrichment Fields
+
+The `enrich` subcommand prompts for these fields only:
+
+| Field | Purpose |
+|-------|---------|
+| `purpose` | Why the project uses this SOUP. |
+| `risk_class` | A / B / C per IEC 62304 software item classification, derived from the failure-mode impact this SOUP can have on the device. |
+| `dependent_requirements[]` | Which `SRS-*` ids depend on this SOUP. |
+| `dependent_si_ids[]` | Which `SI-*` design items allocate this SOUP. |
+| `verification_refs[]` | What evidence (clause / requirement / file path) demonstrates this SOUP has been verified for the project's intended use. |
+
+Auto-populated fields (`name`, `version`, `supplier`, `source_url`, `license_spdx`) are not
+editable through `enrich`; they are refreshed only by `discover`.
+
+### Status Field
+
+The `status` value tracks the record's enrichment progress. The skill writes one of the two
+values; consumers must not invent new ones.
+
+| Status | Derivation rule |
+|--------|-----------------|
+| `needs_review` | Record was just created by `discover`. `purpose` is empty, `risk_class` is `unset`, `verification_refs[]` is empty. The matrix should not consume this record's `dependent_requirements[]` until enrichment completes. |
+| `ready` | `purpose` is non-empty, `risk_class` is one of `A`/`B`/`C`, `verification_refs[]` is non-empty. The matrix consumes this record. |
+
+`enrich` flips a record from `needs_review` to `ready` on successful submission. There is no
+explicit "retire" state; instead, retired SOUPs are removed from the lockfile (which `discover`
+detects via the lockfile cross-check) and the operator deletes the orphaned record from the
+register manually.
+
+## Identifier Format Conventions
+
+Identifiers in SOUP records must match the formats produced by the sibling skills:
+
+| Entity | Format | Example | Source |
+|--------|--------|---------|--------|
+| SOUP record | `SOUP-{NNN}` | `SOUP-001` | This file |
+| Requirement | `SRS-{CAT}-{NNN}` | `SRS-API-001` | `traceability/reference/matrix-schema.md` |
+| Design item | `SI-{CODE}` | `SI-IL` | `traceability/reference/matrix-schema.md` |
+| Hazard | `H-{NN}` | `H-03` | `risk-control/reference/risk-record-schema.md` |
+| Clause | `<STANDARD>-<NUMBER>` | `IEC-62304-5.3.3` | `traceability/reference/matrix-schema.md` |
+
+### File Path Format
+
+`verification_refs[]` entries that point to evidence files use repo-relative paths with
+forward slashes (`tests/integration/test_x.py`), no leading `./`, no leading `/`. The skill
+resolves them against the repo root at validation time.
+
+## Validation Rules
+
+The `validate` subcommand runs the following checks. The IEC 62304 clause column is the
+clause id the message must cite when the finding triggers in `--ci` mode.
+
+| Finding | Trigger | IEC 62304 clause | Severity |
+|---------|---------|------------------|----------|
+| `lockfile_entry_without_record` | A lockfile entry has no matching SOUP record. | `IEC-62304-8.1.1` | error |
+| `record_without_lockfile_entry` | A SOUP record has no matching lockfile entry. | `IEC-62304-8.1.1` | warning |
+| `risk_class_unset` | `risk_class` is the `unset` sentinel. | `IEC-62304-5.3.3` | error |
+| `license_unknown` | `license_spdx` is `UNKNOWN`. | `IEC-62304-5.3.3` | error |
+| `license_outside_allow_list` | `license_spdx` is not in the active allow-list (see `license-policy.md`). | `IEC-62304-5.3.3` | error |
+| `license_in_forbid_list` | `license_spdx` is in the active forbid-list. | `IEC-62304-5.3.3` | error |
+| `dangling_requirement_ref` | A `dependent_requirements[]` entry does not resolve to a `SRS-*` id in `manifest.yaml`. | `IEC-62304-5.3.3` | error |
+| `dangling_si_ref` | A `dependent_si_ids[]` entry does not resolve to a `SI-*` id in `manifest.yaml`. | `IEC-62304-5.3.3` | error |
+| `dangling_verification_ref` | A `verification_refs[]` entry does not resolve to a clause / requirement / file path. | `IEC-62304-5.3.3` | error |
+| `purpose_empty_when_ready` | `purpose` is empty but `status` is `ready`. | `IEC-62304-5.3.3` | error |
+| `verification_refs_empty_when_ready` | `verification_refs[]` is empty but `status` is `ready`. | `IEC-62304-5.3.3` | error |
+
+In default mode, every finding emits a warning and the skill exits 0. In `--ci` mode, every
+`error`-severity finding causes a non-zero exit; warnings remain non-fatal.
+
+### Validation Output
+
+Findings are printed as a Markdown table:
+
+```markdown
+## SOUP Inventory Validation Findings
+
+| ID | Finding | Detail | Clause |
+|----|---------|--------|--------|
+| SOUP-005 | risk_class_unset | risk_class is "unset"; run `enrich SOUP-005` | IEC-62304-5.3.3 |
+| SOUP-012 | license_in_forbid_list | license_spdx "GPL-3.0" is in the project forbid-list | IEC-62304-5.3.3 |
+| -        | lockfile_entry_without_record | lockfile entry "vue@3.4.0" has no SOUP record; run `discover` | IEC-62304-8.1.1 |
+
+Summary: 2 errors, 0 warnings across 14 records.
+```
+
+## Example: Minimal Register
+
+A small but complete `soup.yaml` for a project with two SOUP records, one fully enriched
+and one freshly discovered:
+
+```yaml
+_meta:
+  schema: "1.0.0"
+  generated: "2026-05-04T12:34:56Z"
+  generator: "soup-inventory"
+  source_index_version: "1.0.0"
+  records: 2
+  needs_review: 1
+  ready: 1
+
+records:
+  - id: SOUP-001
+    name: "express"
+    version: "4.18.2"
+    supplier: "OpenJS Foundation"
+    source_url: "https://github.com/expressjs/express"
+    license_spdx: "MIT"
+    purpose: "HTTP request routing for the device-facing REST API"
+    risk_class: B
+    dependent_requirements:
+      - SRS-API-001
+      - SRS-API-014
+    dependent_si_ids:
+      - SI-IL
+    verification_refs:
+      - IEC-62304-5.3.3
+      - tests/integration/test_express_routing.py
+    status: ready
+    notes: ""
+
+  - id: SOUP-002
+    name: "lodash"
+    version: "4.17.21"
+    supplier: "unknown"
+    source_url: "https://github.com/lodash/lodash"
+    license_spdx: "MIT"
+    purpose: ""
+    risk_class: unset
+    dependent_requirements: []
+    dependent_si_ids: []
+    verification_refs: []
+    status: needs_review
+    notes: ""
+```
+
+## Example: Record Cross-Referencing a Hazard
+
+```yaml
+- id: SOUP-007
+  name: "openssl"
+  version: "3.2.1"
+  supplier: "OpenSSL Software Foundation"
+  source_url: "https://www.openssl.org"
+  license_spdx: "Apache-2.0"
+  purpose: "TLS termination for the cloud sync channel"
+  risk_class: A
+  dependent_requirements:
+    - SRS-SEC-001
+    - SRS-SEC-004
+  dependent_si_ids:
+    - SI-WA
+  verification_refs:
+    - IEC-62304-5.3.3
+    - IEC-62304-7.1.1
+    - H-08
+    - tests/security/test_tls_handshake.py
+  status: ready
+  notes: "Hazard H-08 covers the failure mode where openssl returns an unverified peer cert"
+```
+
+The `verification_refs[]` list mixes a clause id, a hazard id, and a test file path -- the
+schema permits all three forms because each one is a valid pivot point for an auditor.
+
+## Schema Evolution
+
+Schema changes are versioned via `_meta.schema`. The current major is `1`. Bump rules:
+
+| Change | Bump |
+|--------|------|
+| Add a new optional field | Minor -- `1.0.0` -> `1.1.0`. Older consumers ignore the field. |
+| Add a new allowed `status` value | Minor -- existing entries unchanged; older consumers should warn rather than fail on unknown statuses. |
+| Add a new allowed `risk_class` value | Major -- existing classification logic depends on the closed enum. |
+| Rename or remove a field | Major -- `1.x.x` -> `2.0.0`. Consumers must guard on the major. |
+| Change the meaning of an existing field | Major. |
+
+The `soup-inventory` skill writes the matching schema version into `_meta.schema` on every
+write. External tooling that consumes `soup.yaml` should refuse to parse when the major does
+not match the schema this file documents.
+
+## Cross-references
+
+- Per-language lockfile parsing: `discovery-sources.md`
+- Default license allow-list / forbid-list: `license-policy.md`
+- Skill body that produces records: `../SKILL.md`
+- Sibling matrix consumer: `../../traceability/reference/matrix-schema.md` (see `soup_ids[]` row field)
+- Sibling risk-side consumer: `../../risk-control/reference/risk-record-schema.md`
+- Parent epic: `kcenon/claude-config#588`

--- a/global/skills/_internal/traceability/reference/matrix-schema.md
+++ b/global/skills/_internal/traceability/reference/matrix-schema.md
@@ -46,6 +46,7 @@ Every row is one requirement and the evidence chain that satisfies it.
   clause_refs:                          # MANDATORY (may be empty list) — standard-clause references
     - IEC-62304-5.1.1
     - ISO-13485-7.3.3
+  soup_ids: []                          # OPTIONAL (may be empty list) — SOUP record IDs this requirement depends on; populated from docs/.index/soup.yaml when present
   status: complete                      # MANDATORY — see "Status Field" below
   notes: ""                             # OPTIONAL — free-form notes (kept for human review)
 ```
@@ -60,6 +61,7 @@ Every row is one requirement and the evidence chain that satisfies it.
 | `test_ids` | list[string] | Yes (may be empty) | Format `TC-{CAT}-{NNN}`. Empty list signals a `requirement_without_test` finding. |
 | `risk_ids` | list[string] | Yes (may be empty) | Format `H-{NN}`. Empty list is allowed and does not flag a finding by default. |
 | `clause_refs` | list[string] | Yes (may be empty) | Format `<STANDARD>-<NUMBER>`, e.g. `IEC-62304-5.1.1`. Validated against `compliance/` when that directory exists. |
+| `soup_ids` | list[string] | No (may be empty) | Format `SOUP-{NNN}`. SOUP records this requirement depends on; populated from `docs/.index/soup.yaml` when present (produced by the `soup-inventory` skill). Empty list and omission are both permitted. |
 | `status` | enum | Yes | One of `complete`, `incomplete`, `deferred`, `needs_review`. See table below. |
 | `notes` | string | No | Free-form, single line. Auditors read this; keep it factual. |
 


### PR DESCRIPTION
Closes #601
Part of #588

## What

### Summary

Adds a new lifecycle skill `soup-inventory` under
`global/skills/_internal/soup-inventory/` that maintains a SOUP (Software Of
Unknown Provenance) register for every third-party software item the project
depends on. Five subcommands (`discover | enrich | validate | list | report`)
cover the full lifecycle: scan lockfiles, enrich with human-supplied risk
classification, validate against a license allow-list and the requirements
catalogue, list the register, and emit a per-supplier audit report.

Outputs `docs/.index/soup.yaml` (machine-readable register) and
`docs/.index/soup.md` (audit-facing per-supplier report). Both files are
written atomically (`*.tmp` + rename); records are sorted by `id` on every
write for byte-identical idempotent output.

### Change Type

- [x] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation (schema addition, skill alias registration)
- [ ] Test
- [ ] Chore

### Affected Components

| Path | Change |
|------|--------|
| `global/skills/_internal/soup-inventory/SKILL.md` | New skill body (340 lines) |
| `global/skills/_internal/soup-inventory/reference/soup-record-schema.md` | New YAML schema for `docs/.index/soup.yaml` |
| `global/skills/_internal/soup-inventory/reference/discovery-sources.md` | Per-language lockfile parser registry (npm, PyPI, Go, Cargo, Maven, NuGet) |
| `global/skills/_internal/soup-inventory/reference/license-policy.md` | Default SPDX allow-list / forbid-list and per-project override format |
| `global/CLAUDE.md` | Add `soup-inventory` row to Skill Aliases table (1-line addition) |
| `global/skills/_internal/traceability/reference/matrix-schema.md` | Add `soup_ids[]` optional field on requirement rows (2-line addition) |

## Why

### Problem Solved

IEC 62304 sections 5.3.3 (specify functional and performance requirements of
SOUP items) and 8.1.1 (identify configuration items) mandate a SOUP register
for medical-device software. Today this register is built and maintained
manually -- error-prone and the largest single time sink in the pre-audit
window. The project already has the language-specific dependency lockfiles
(`package-lock.json`, `requirements.txt`, `go.sum`, `Cargo.lock`, etc.); the
missing piece is the assembly + risk-classification + evidence-link layer.

ISO 14971 (P0-3 `compliance/iso-14971.md`) treats SOUP failures as hazard
sources requiring control measures. The `verification_refs[]` field on each
SOUP record permits a hazard ID (`H-NN`) as a valid reference, so the
soup-inventory register cross-cuts both the requirements axis (via
`dependent_requirements[]`) and the risk-management axis.

### Related Issues

- Closes #601 (P2-1: soup-inventory skill)
- Part of #588 (Epic: ISO/Traceability/Evidence track)

### Alternative Approaches Considered

1. Extend `traceability` skill to also crawl lockfiles -- rejected because
   the matrix is already a heavy artifact and SOUP discovery has its own
   lifecycle (discover/enrich/validate) that doesn't fit the traceability
   skill's regenerate-from-index pattern.
2. Push everything into `evidence-pack` -- rejected because the SOUP
   register is a per-commit artifact (it changes whenever a lockfile
   changes), not a per-release one.
3. Hand-maintained YAML in `docs/` -- the status quo this PR replaces.

## Who

### Reviewers

Standard maintainer review. No security-team sign-off required (the skill
is contract documentation only and ships no executable code).

### Stakeholders

- Compliance / regulatory team (consumers of the resulting register)
- Future P2 sub-agents implementing #602 (issue-create extension) and
  #603 (pr-work extension), which build on the SOUP register

## When

### Urgency

- [x] Normal -- Follow standard review process

### Target Release

Aligns with the rest of Epic #588 (ISO/Traceability/Evidence track).

### Dependencies

- Depends on: P0-1 (#589 / PR #592 -- traceability skill), P0-3 (#591 /
  PR #594 -- compliance rules), P1-2 (#596 / PR #599 -- risk-control
  skill). All merged.
- Blocks: #602 (issue-create extension for SOUP-aware issue creation),
  #603 (pr-work extension for SOUP-impact surfacing in PR descriptions).

## Where

### Files Changed

| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/skills/_internal/soup-inventory/` | 1 SKILL.md + 3 reference docs | New skill |
| `global/CLAUDE.md` | 1 | 1-line alias addition |
| `global/skills/_internal/traceability/reference/` | 1 | 2-line schema addition (`soup_ids[]`) |

Total: 5 files changed, 962 insertions, 0 deletions.

### Schema Changes

- `traceability` matrix row: new optional field `soup_ids: list[string]`.
  Schema major remains `1` (backward-compatible minor addition; older
  matrices without the field remain valid).
- New schema: `docs/.index/soup.yaml` (`_meta.schema: "1.0.0"`).

### Documentation Changes

The new skill ships with three reference documents covering the YAML
schema, per-language discovery sources, and the license policy. The body
is contract documentation only (matches the pattern from #592 / #598 /
#599) -- no executable backing required.

## How

### Implementation Highlights

1. **Opt-in gate**: skill is a no-op when no lockfile is detected and
   `docs/.index/soup.yaml` does not yet exist. Non-regulated repos are
   unaffected.
2. **Atomic writes**: every write goes to a `*.tmp` sibling and is
   renamed on success; failure deletes the temp file. Matches the
   pattern used by `traceability`, `evidence-pack`, and `risk-control`.
3. **Idempotency**: records sorted by `id` on every write, so re-running
   `discover` on an unchanged lockfile produces a byte-identical
   register. Diffs in version control are minimal and reviewable.
4. **Bidirectional linking**: SOUP record carries
   `dependent_requirements[]` and `dependent_si_ids[]` (SOUP -> SRS / SI).
   The matrix carries the new `soup_ids[]` field (SRS -> SOUP). The
   single source of truth for the link is `soup.yaml`; `traceability`
   reads it and stitches the inverse view into the matrix.
5. **License policy**: default allow-list (MIT, Apache-2.0, BSD-*, ISC,
   Zlib, etc.) and forbid-list (GPL-*, AGPL-*, SSPL, BUSL) ship with the
   skill. Projects override via `soup-license-policy.yaml` at the repo
   root with per-record exemption support.
6. **iso_class declaration**: SKILL.md frontmatter declares
   `iso_class: A` and `applies_at_or_above: A`, consistent with the
   safety-relevant trio established by the iso_class metadata sweep
   (P1-3 / PR #600). The new skill avoids the `validate_skills.sh`
   warning for missing `iso_class:`.

### Testing Done

- [x] `scripts/validate_skills.sh` runs clean on the new SKILL.md
  (description 861 chars, file 340 lines, frontmatter parses, all checks
  pass; pre-commit hook executed it on commit and reported 0 failures).
- [x] All three reference documents are linked from the SKILL.md body
  via `ref_docs.{schema,sources,license}` keys.
- [x] Surgical-edit verification: `git diff` shows 1-line addition to
  `global/CLAUDE.md` and 2-line addition to
  `traceability/reference/matrix-schema.md`. No drive-by formatting
  changes.

### Test Plan for Reviewers

1. Read `global/skills/_internal/soup-inventory/SKILL.md` and confirm
   the five subcommands map cleanly to the acceptance criteria in #601.
2. Read `reference/soup-record-schema.md` and confirm the YAML shape is
   unambiguous (every field has a type, a required-flag, and a
   description).
3. Read `reference/discovery-sources.md` and confirm each ecosystem
   section names a specific lockfile glob and lists the auto-populated
   fields with field-extraction rules.
4. Read `reference/license-policy.md` and confirm the override file
   format is symmetric (allow / forbid + add / remove operators).
5. Verify the surgical edits to `global/CLAUDE.md` and
   `traceability/reference/matrix-schema.md` change only what is
   required.

### Breaking Changes

None. The `soup_ids[]` field is OPTIONAL on matrix rows; existing
matrices without the field remain valid. The new skill is opt-in via
the lockfile-detection gate.

### Rollback Plan

1. Revert this PR.
2. No data loss -- nothing is generated until a project opts in by
   running `/soup-inventory discover` against a real lockfile.
3. The `soup_ids[]` schema addition is backward-compatible; reverting
   it does not affect existing matrices.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation added (3 reference docs, 2 schema additions)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (3 commits: skill, schema,
  alias)
- [x] Related issue(s) linked with closing keywords
- [x] Comment will be added to #601 and #588 after PR creation
