### PR TITLE
feat(skills): extend issue-create to enforce regulated metadata when compliance/ exists

### DIFF
--- a/global/skills/_internal/issue-create/SKILL.md
+++ b/global/skills/_internal/issue-create/SKILL.md
@@ -6,7 +6,8 @@ user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh issue *)"
 loop_safe: false
-iso_class: none
+iso_class: A
+applies_at_or_above: A
 ---
 
 # Issue Create Command
@@ -61,6 +62,77 @@ else
     fi
 fi
 ```
+
+## Phase 0a -- Regulated-track detection
+
+After organization detection, before any prompts, detect whether the consumer project
+is on the regulated-industry track. Set `$REGULATED_TRACK=true` when the project root
+contains a `compliance/` directory (typically `compliance/iec-62304.md`, `iso-13485.md`,
+`iso-14971.md`); set `$REGULATED_TRACK=false` otherwise.
+
+```bash
+# Resolve the consumer-project root from the parsed PROJECT name (or current cwd
+# when invoked via the skill alias from inside a project).
+PROJECT_ROOT="${PROJECT_ROOT:-$(pwd)}"
+if [ -d "$PROJECT_ROOT/$PROJECT" ]; then
+    PROJECT_ROOT="$PROJECT_ROOT/$PROJECT"
+fi
+
+if [ -d "$PROJECT_ROOT/compliance" ]; then
+    REGULATED_TRACK=true
+else
+    REGULATED_TRACK=false
+fi
+```
+
+**Behavior matrix:**
+
+| `$REGULATED_TRACK` | Effect on the rest of the skill |
+|--------------------|---------------------------------|
+| `false` (default) | Skill proceeds exactly as documented in sections 1-5 below. No regulated-field prompts. No template change. No behavior change relative to pre-#602 invocations. |
+| `true` | After the standard prompts in section 1, the skill enters Phase 0b (regulated-fields prompts) before proceeding to section 2. The created issue body is built from the regulated-issue templates under `reference/templates/`, with the regulated metadata embedded in a YAML code block at the top so the `traceability` skill's next run picks it up. |
+
+The detection is a single test on directory presence -- no parsing, no glob. When
+`compliance/` is absent the skill is functionally identical to its pre-#602 form;
+this is the most important functional invariant of this extension.
+
+## Phase 0b -- Regulated-fields prompts (only when `$REGULATED_TRACK=true`)
+
+Skipped entirely when `$REGULATED_TRACK=false`.
+
+When the regulated track is active, after gathering the standard fields in section 1
+the skill prompts for the additional metadata defined by the per-issue-type matrix in
+`reference/regulated-fields.md`:
+
+| Field | Prompt (asked when required by the type matrix) |
+|-------|--------------------------------------------------|
+| `requirement_id` | "Which requirement does this issue trace to (e.g. SRS-CALC-001)?" |
+| `risk_level` | "What is the ISO 14971 risk level after controls (acceptable / ALARP / unacceptable)?" |
+| `clause_refs` | "Which standard clauses justify this change? Comma-separated, e.g. IEC-62304-5.3.3, ISO-14971-7.3" |
+
+**Field requirement enforcement:** see the matrix in `reference/regulated-fields.md`.
+The skill MUST halt with a clear message when a required field is missing -- it MUST
+NOT silently create a bare issue. Optional fields may be left blank.
+
+**Field validation rules** (also in `reference/regulated-fields.md`):
+
+1. `requirement_id` matches `^SRS-[A-Z0-9]+-[0-9]+$`. When `docs/.index/manifest.yaml`
+   is present in the project, the value must resolve via the manifest's
+   `id_routes.SRS` entry; unknown IDs are rejected with a list of close matches.
+2. `risk_level` is one of the three ISO 14971 acceptability levels: `acceptable`,
+   `ALARP`, `unacceptable`. Case-sensitive (matches the `risk-control` skill's
+   record schema).
+3. `clause_refs[]` entries match the format `<STANDARD>-<NUMBER>` per
+   `traceability/reference/matrix-schema.md` (e.g. `IEC-62304-5.3.3`,
+   `ISO-13485-7.3.3`, `ISO-14971-7.3`). When the matching `compliance/<standard>.md`
+   file is present, each ID must resolve to an `> **Clause**: <id>` anchor in that
+   file; unknown IDs are rejected.
+
+The exact embedded YAML block format is documented in
+`reference/regulated-fields.md` "Embedded YAML block format". Both regulated
+templates under `reference/templates/` open with that block so the traceability
+skill (and the future `pr-work` regulated extension landing in #603) can parse the
+regulated metadata from the issue body without rerunning this skill.
 
 ## Options
 

--- a/global/skills/_internal/issue-create/reference/regulated-fields.md
+++ b/global/skills/_internal/issue-create/reference/regulated-fields.md
@@ -1,0 +1,180 @@
+# Regulated-Issue Fields
+
+Per-issue-type matrix for the additional metadata fields required when the
+`issue-create` skill detects a `compliance/` directory in the consumer project root
+(`$REGULATED_TRACK=true` in Phase 0a of the SKILL body). Validation rules and the
+embedded YAML block format are normative for the skill, the templates under
+`templates/`, and the downstream consumers (`traceability` skill, the `pr-work`
+regulated extension landing in #603).
+
+> **Loading**: Loaded only when Phase 0a sets `$REGULATED_TRACK=true`. Skip when the
+> consumer project has no `compliance/` directory.
+
+## Per-Issue-Type Field Matrix
+
+The matrix below defines, for each GitHub issue `type/*` label, which of the three
+regulated fields are required, optional, or conditionally required. A value of
+`required` means the skill MUST halt with a clear message when the field is missing.
+`required-if-safety` means required when the issue's "Where" section names code under a
+safety-relevant path (any path matched by a `paths:` glob in
+`compliance/<standard>.md`). `optional` means the field may be left blank.
+
+| Issue type        | `requirement_id`         | `risk_level`         | `clause_refs`           |
+|-------------------|--------------------------|----------------------|-------------------------|
+| `type/feature`    | required                 | required-if-safety   | >=1 required            |
+| `type/bug`        | required-if-safety       | required-if-safety   | >=1 if safety           |
+| `type/security`   | required                 | required             | >=1 required            |
+| `type/chore`      | optional                 | optional             | optional                |
+| `type/docs`       | optional                 | optional             | optional                |
+| `type/test`       | linked-to-test-target    | optional             | optional                |
+| `type/refactor`   | required-if-safety       | required-if-safety   | >=1 if safety           |
+
+**`linked-to-test-target` (test issues only):** the prompt asks for the
+`requirement_id` that the new or modified test verifies. The id is recorded so the
+matrix can derive the `test_ids[]` -> `requirement_id` link without re-scanning.
+
+**Safety-relevant detection.** The skill considers the issue safety-relevant when
+the user's "Where" entry names any path matched by a `paths:` glob in
+`compliance/iec-62304.md`, `compliance/iso-13485.md`, or `compliance/iso-14971.md`
+(e.g. `risk-file/**`, `docs/risk-management/**`, `tests/safety/**`,
+`src/medical/**`). When the consumer project ships additional standards files
+(`compliance/iso-26262.md`, `compliance/do-178c.md`, etc.) those `paths:` are
+unioned in.
+
+## Allowed Values
+
+### `requirement_id`
+
+| Property | Rule |
+|----------|------|
+| Format   | `^SRS-[A-Z0-9]+-[0-9]+$` (e.g. `SRS-CALC-001`, `SRS-AUTH-014`). Matches the `id_routes.SRS` regex from `traceability/reference/matrix-schema.md`. |
+| Validation | When `docs/.index/manifest.yaml` is present in the project, the value must resolve via that manifest's `id_routes.SRS` entry; unknown IDs are rejected with a list of close matches (Levenshtein distance <= 2). |
+| Cardinality | Single value (one issue traces to one requirement). |
+| Empty case | Permitted only when the matrix row above marks the field `optional`. |
+
+### `risk_level`
+
+| Property | Rule |
+|----------|------|
+| Allowed values | `acceptable`, `ALARP`, `unacceptable`. Case-sensitive. |
+| Source | ISO 14971 risk acceptability scale, mirrored in the `risk-control` skill's record schema (`risk-control/reference/risk-record-schema.md` "Risk Level" enumeration). |
+| Validation | Reject any value not in the three-element enum above. |
+| Empty case | Permitted only when the matrix row above marks the field `optional` or the issue is not safety-relevant (per the safety-relevant detection rule). |
+
+### `clause_refs[]`
+
+| Property | Rule |
+|----------|------|
+| Format   | `<STANDARD>-<NUMBER>` per `traceability/reference/matrix-schema.md` "Clause Reference Format" (e.g. `IEC-62304-5.3.3`, `ISO-13485-7.3.3`, `ISO-14971-7.3`). Hyphens between standard and number; dotted clause path verbatim from the standard. |
+| Cardinality | List of one or more values. The skill prompt asks for a comma-separated string and parses on `,`. |
+| Validation | Each value's `<STANDARD>` prefix must match an existing `compliance/<standard>.md` file (e.g. `IEC-62304` -> `compliance/iec-62304.md`); each `<NUMBER>` must resolve to an `> **Clause**: <id>` anchor in that file. Unknown IDs are rejected. |
+| Empty case | Permitted only when the matrix row above marks the field `optional` or `>=1 if safety` and the issue is not safety-relevant. |
+
+## Embedded YAML Block Format
+
+When `$REGULATED_TRACK=true`, the regulated-issue templates open with a fenced
+YAML code block at the very top of the issue body. The block is the canonical
+serialization that downstream skills parse. The format is fixed; do not vary it.
+
+```yaml
+regulated:
+  requirement_id: SRS-CALC-001
+  risk_level: ALARP
+  clause_refs:
+    - IEC-62304-5.3.3
+    - ISO-14971-7.3
+```
+
+**Format rules** (the same rules the templates and the future `pr-work` extension
+must honor):
+
+1. The block MUST be the first non-blank content of the issue body, fenced by
+   ```` ```yaml ```` and ```` ``` ````. Nothing precedes it -- not the title, not
+   a heading, not a comment.
+2. The top-level key is `regulated:`. No alternative key (no `meta:`, no `iso:`).
+3. Field order inside the block is fixed: `requirement_id` -> `risk_level` ->
+   `clause_refs`. Downstream parsers MAY rely on this order for diff stability.
+4. Omitted optional fields are written as the literal value `null` (so the field
+   is still present and a parser can distinguish "not asked" from "asked but
+   empty"). Required fields that the user supplied are written as scalar strings.
+5. `clause_refs:` is always a YAML list (block style with `- ` markers), even
+   when only one entry is present. Single-line flow style is not used so a `git
+   diff` of an added clause is one inserted line, not a rewritten line.
+6. The block is followed by exactly one blank line, then the standard 5W1H
+   sections (`## What`, `## Why`, ...).
+
+**Worked example -- a feature issue.**
+
+````markdown
+```yaml
+regulated:
+  requirement_id: SRS-CALC-014
+  risk_level: ALARP
+  clause_refs:
+    - IEC-62304-5.3.3
+    - ISO-14971-7.3
+```
+
+## What
+
+Add range-validation guard to the dosing calculator so out-of-range
+parameters are rejected before therapy delivery.
+
+...
+````
+
+**Worked example -- a chore issue (all regulated fields omitted).**
+
+````markdown
+```yaml
+regulated:
+  requirement_id: null
+  risk_level: null
+  clause_refs: null
+```
+
+## What
+
+Bump CI image to ubuntu-24.04 LTS.
+
+...
+````
+
+The `null` placeholders are intentional. Downstream parsers MAY treat an entirely
+absent block as "this issue predates the regulated extension" (a legitimate
+distinction), but a present block with `null` fields means "the skill ran on the
+regulated track and the per-type matrix permitted omission". Both states matter to
+the audit trail.
+
+## Halt Behavior
+
+When a required field is missing or invalid, the skill MUST halt before calling
+`gh issue create`. The halt message is structured so the operator can recover
+without re-running the entire interaction:
+
+```
+issue-create halted: regulated-track field violation
+
+  field      : <name>
+  rule       : <one-line rule from the matrix or validation table above>
+  user input : <verbatim>
+  hint       : <suggestion if available; e.g. "Did you mean SRS-CALC-014?">
+
+No issue was created. Re-run /issue-create with a corrected value.
+```
+
+The skill MUST NOT silently fall back to creating a bare (non-regulated) issue --
+that would defeat the purpose of the gate.
+
+## Cross-references
+
+- Matrix schema that consumes `requirement_id` and `clause_refs`:
+  `../../traceability/reference/matrix-schema.md`
+- Risk record schema that defines `risk_level` enumeration:
+  `../../risk-control/reference/risk-record-schema.md`
+- Per-standard clause IDs:
+  `compliance/iec-62304.md`, `compliance/iso-13485.md`, `compliance/iso-14971.md`
+- Issue templates that embed the YAML block:
+  `templates/regulated-feature.md`, `templates/regulated-bug.md`
+- Skill body that calls into this reference:
+  `../SKILL.md` Phase 0a / 0b

--- a/global/skills/_internal/issue-create/reference/templates/regulated-bug.md
+++ b/global/skills/_internal/issue-create/reference/templates/regulated-bug.md
@@ -1,0 +1,100 @@
+# Regulated Bug Issue Template
+
+Issue body template used when `$REGULATED_TRACK=true` (Phase 0a) and the user
+selects `type/bug`. The opening fenced YAML block is the canonical regulated
+metadata serialization defined in `../regulated-fields.md` "Embedded YAML block
+format" -- preserve it verbatim. The 5W1H sections that follow match the standard
+issue template (`workflow/reference/5w1h-examples.md`), with a Reproduction
+sub-section under "How" because bugs need it.
+
+> **Loading**: Loaded only when Phase 0a sets `$REGULATED_TRACK=true` and the
+> chosen issue type is `type/bug`.
+
+---
+
+````markdown
+```yaml
+regulated:
+  requirement_id: <SRS-CAT-NNN | null>
+  risk_level: <acceptable | ALARP | unacceptable | null>
+  clause_refs:
+    - <STANDARD-NUMBER>
+    - <STANDARD-NUMBER>
+```
+
+## What
+
+<one-paragraph description of the defect: the observed behavior, the expected behavior, and the gap between them>
+
+- Observed: <what the system does that is wrong>
+- Expected: <what the system should do per requirement / standard>
+- Severity context: <whether this defect can produce a hazard situation, and at what frequency>
+
+## Why
+
+<why this defect matters: the safety / compliance / functional impact>
+
+- Impact: <e.g. "Range guard in SRS-CALC-014 fails open under specific input shape; can lead to over-dose hazard H-12">
+- Standard: <clause refs that the defect violates; mirror the YAML block above when the bug is safety-relevant>
+- Priority justification: <why this priority given the regulated context>
+
+## Where
+
+- Files / Components: <repository-relative paths>
+- Standards in scope: <e.g. "IEC 62304 Class B software item SI-CALC; ISO 14971 hazard H-12">
+- Affected version(s): <commit / tag range where the defect is reachable>
+- Related issues / PRs: <#NNN cross-references>
+
+## How
+
+### Reproduction Steps
+
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+Minimum reproduction artifact: <command line, input file, or test case id>
+
+### Root Cause Hypothesis
+
+<one to three bullets if known; "unknown -- to be determined during triage" is acceptable>
+
+### Acceptance Criteria
+
+- [ ] A failing test exists that reproduces the defect on the current main commit (verify-fail-first per `core/principles.md` "Verify & Iterate")
+- [ ] The fix makes that test pass without regressing the existing safety test suite
+- [ ] Traceability matrix row for `<requirement_id>` is updated when the fix changes the code paths or test ids associated with the requirement
+- [ ] Risk record(s) referenced in `clause_refs` are reviewed; if the defect created a residual-risk regression, the record's status moves back to `draft` until re-controlled
+
+### Verification Notes
+
+- Test ids that will verify the fix: <TC-CAT-NNN, ...>
+- Risk-control link: <H-NN or R-NN, plus the control measure id `CM-NN` if applicable>
+- Hazard escalation needed: <yes / no -- yes if this defect alters the residual-risk evaluation of a hazard>
+````
+
+---
+
+## Notes for the skill body
+
+1. The YAML block at the top is filled in from the Phase 0b prompts. Optional
+   fields the operator left blank are written as the literal `null`, never
+   omitted -- see `../regulated-fields.md` "Embedded YAML block format" rule 4.
+2. The bug template's matrix row in `regulated-fields.md` is more permissive
+   than the feature template: `requirement_id` and `risk_level` are
+   `required-if-safety`, and `clause_refs` is `>=1 if safety`. Phase 0b decides
+   which prompts to ask based on the safety-relevant detection rule (any path
+   matched by a `paths:` glob in `compliance/<standard>.md`) before falling
+   back to omission with `null`.
+3. The "Reproduction Steps" sub-section is mandatory for bugs and absent from
+   the feature template -- a bug without a reproduction is unreviewable, and
+   the regulated track does not change that. Keep it under "How" so the issue
+   structure stays consistent with the project's `workflow/github-issue-5w1h.md`.
+4. The "Acceptance Criteria" section includes the verify-fail-first rule from
+   `core/principles.md`. Do not strip it on edit -- the regulated track relies
+   on it to keep test-first verification visible to auditors.
+5. "Hazard escalation needed" is the new bullet that distinguishes a regulated
+   bug from a regulated feature. When the answer is `yes`, the implementer
+   knows to re-run `/risk-control evaluate` after the fix lands so the risk
+   file's residual-risk evaluation is regenerated. When `no`, no extra step
+   is required beyond the matrix update.

--- a/global/skills/_internal/issue-create/reference/templates/regulated-feature.md
+++ b/global/skills/_internal/issue-create/reference/templates/regulated-feature.md
@@ -1,0 +1,86 @@
+# Regulated Feature Issue Template
+
+Issue body template used when `$REGULATED_TRACK=true` (Phase 0a) and the user
+selects `type/feature`. The opening fenced YAML block is the canonical regulated
+metadata serialization defined in `../regulated-fields.md` "Embedded YAML block
+format" -- preserve it verbatim. The 5W1H sections that follow match the standard
+issue template (`workflow/reference/5w1h-examples.md`).
+
+> **Loading**: Loaded only when Phase 0a sets `$REGULATED_TRACK=true` and the
+> chosen issue type is `type/feature`.
+
+---
+
+````markdown
+```yaml
+regulated:
+  requirement_id: <SRS-CAT-NNN>
+  risk_level: <acceptable | ALARP | unacceptable | null>
+  clause_refs:
+    - <STANDARD-NUMBER>
+    - <STANDARD-NUMBER>
+```
+
+## What
+
+<one-paragraph description of the new functionality and the user-visible behavior change>
+
+- Current: <what exists today, or "no equivalent functionality">
+- Expected: <what the feature delivers>
+- Scope: <what is in / out of scope for this issue>
+
+## Why
+
+<motivation: the safety / compliance / functional driver>
+
+- Driver: <e.g. "Risk-control measure for hazard H-12 requires an in-firmware range guard">
+- Standard: <which clause refs this feature satisfies; mirror the YAML block above>
+- Priority justification: <why this priority level given the regulated context>
+
+## Where
+
+- Files / Components: <repository-relative paths or component names>
+- Standards in scope: <e.g. "IEC 62304 Class B software item SI-CALC; ISO 14971 hazard H-12">
+- Related issues / PRs: <#NNN cross-references>
+
+## How
+
+### Technical Approach
+
+<brief implementation outline; one to three bullets is enough at issue time>
+
+### Acceptance Criteria
+
+- [ ] <testable behavior 1>
+- [ ] <testable behavior 2>
+- [ ] Traceability matrix row for `<requirement_id>` is updated to include the new code paths and test ids
+- [ ] Risk record(s) referenced in `clause_refs` remain in `controlled` status with no residual-risk regression
+
+### Verification Notes
+
+- Test ids that will verify this feature: <TC-CAT-NNN, ...>
+- Risk-control link: <H-NN or R-NN, plus the control measure id `CM-NN` if applicable>
+````
+
+---
+
+## Notes for the skill body
+
+1. The YAML block at the top is filled in from the Phase 0b prompts. Optional
+   fields the operator left blank are written as the literal `null`, never
+   omitted -- see `../regulated-fields.md` "Embedded YAML block format" rule 4.
+2. The angle-bracketed placeholders inside the block (`<SRS-CAT-NNN>`,
+   `<STANDARD-NUMBER>`, etc.) are the literal placeholder shape shown to the
+   operator during the interactive walk; the skill substitutes the operator's
+   answers before calling `gh issue create`.
+3. The "Acceptance Criteria" section deliberately includes two regulated-track
+   bullets (matrix update, risk record status). Do not strip them on edit -- the
+   `traceability` skill's `--check-only` validator looks for them as a heuristic
+   for "the regulated track was followed when this feature was opened".
+4. The `## Where` section names the standard scope so reviewers can pivot
+   directly to the clause source. This is the only field where the standards
+   list is repeated outside the YAML block (because human reviewers read the
+   prose, machines read the block).
+5. No section headings beyond the four 5W1H sections. The skill's later
+   `## Output` summary table is appended by `gh issue create` consumers, not by
+   this template.


### PR DESCRIPTION
Closes #602
Part of #588

## What

### Summary

Extends the existing `issue-create` skill (`global/skills/_internal/issue-create/SKILL.md`)
so that, when the consumer project has a `compliance/` directory present, the skill
enforces three additional regulated-issue fields at issue-creation time:
`requirement_id`, `risk_level`, and `clause_refs`.

The behavior is strictly opt-in. When no `compliance/` directory is present, the skill
is functionally identical to its pre-extension form -- this is the most important
functional invariant of the change. Two new phases (Phase 0a regulated-track detection
and Phase 0b regulated-fields prompts) are inserted after the argument parsing block
and before the existing Options table; the existing argument parsing, sections 1-5,
and the Options/Title/Policies/Output blocks are unchanged.

The created issue body opens with a fenced YAML block at the very top so the next
`traceability` skill run picks the regulated metadata up automatically without
re-running this skill.

### Change Type

- [x] Feature (extension to existing skill)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation (3 new reference documents under `reference/`)
- [ ] Test
- [ ] Chore

### Affected Components

| Path | Change |
|------|--------|
| `global/skills/_internal/issue-create/SKILL.md` | +73 / -1 lines: new Phase 0a / 0b sections, frontmatter `iso_class: A`, `applies_at_or_above: A` |
| `global/skills/_internal/issue-create/reference/regulated-fields.md` | New: per-issue-type field requirement matrix, validation rules, embedded YAML block format, halt behavior |
| `global/skills/_internal/issue-create/reference/templates/regulated-feature.md` | New: `type/feature` template with the canonical YAML block at the top |
| `global/skills/_internal/issue-create/reference/templates/regulated-bug.md` | New: `type/bug` template with the YAML block plus reproduction and hazard-escalation sections |

## Why

### Problem Solved

P0-3 (PR #594) introduced clause IDs (e.g. `IEC-62304-5.3.3`). P1-2 (PR #599)
introduced risk records and the `risk_level` enumeration. But there was no point at
which a new issue was forced to declare its requirement trace, risk level, and clause
linkage -- that gap meant the matrix and risk file fell out of date the moment a
contributor opened an issue without those fields. Auditors reading the matrix later
could not tell if "no clause reference" meant "not safety-relevant" or "not yet
captured".

This extension closes the loop at the earliest possible moment: at issue creation,
when the operator still has the context needed to fill in the fields. The embedded
YAML block at the top of the issue body is the canonical serialization the
`traceability` skill (and the future `pr-work` regulated extension landing in #603)
will parse on their next run.

### Related Issues

- Closes #602 (P2-2: issue-create extension for regulated-track metadata)
- Part of #588 (Epic: ISO/Traceability/Evidence track for regulated-industry users)

### Alternative Approaches Considered

1. **Add a separate `issue-create-regulated` skill alias.** Rejected because the
   alias table in `global/CLAUDE.md` is already large; an extension to the
   existing skill keeps a single entry point and lets the regulated track auto-
   activate via directory presence rather than asking the operator to remember
   which alias to use.
2. **Push regulated-field enforcement into a PreToolUse `gh issue create` hook.**
   Rejected as a follow-up only -- a hook would also catch direct `gh issue
   create` invocations outside the skill (which is desirable), but it requires
   writing a non-trivial validator that parses titles + bodies. The issue
   #602 acceptance criteria explicitly defer that to a separate
   `issue-edit-guard` hook; this PR stays inside the skill body.
3. **Validate fields against `manifest.yaml` only at PR time, via the `pr-work`
   extension (#603).** Rejected because by PR time the issue is already filed;
   the auditor still cannot tell from the issue body alone whether the regulated
   track was followed. Earlier is better for an audit trail.

## Who

### Reviewers

Standard maintainer review. No security-team sign-off required (the skill is
contract documentation only and ships no executable code -- matches the pattern
established by #592 / #598 / #599 / #604).

### Stakeholders

- Compliance / regulatory team (consumers of the resulting matrix and risk file)
- Future P2-3 sub-agent implementing #603 (`pr-work` extension), which depends on
  the regulated-field schema introduced here -- specifically the embedded YAML
  block format documented in `reference/regulated-fields.md` "Embedded YAML
  block format"

## When

### Urgency

- [x] Normal -- Follow standard review process

### Target Release

Aligns with the rest of Epic #588 (ISO/Traceability/Evidence track).

### Dependencies

- Depends on: P0-3 (#591 / PR #594 -- compliance rules), P1-2 (#596 / PR #599 --
  risk-control), P2-1 (#601 / PR #604 -- soup-inventory). All merged.
- Blocks: #603 (pr-work extension for regulated-fields surfacing in PR
  descriptions). The next sub-agent will parse the YAML block format
  documented here.

## Where

### Files Changed

| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/skills/_internal/issue-create/` | 1 SKILL.md modified | Phase 0a / 0b sections + frontmatter |
| `global/skills/_internal/issue-create/reference/` | 1 new file | Field matrix and validation rules |
| `global/skills/_internal/issue-create/reference/templates/` | 2 new files | Per-type regulated issue templates |

Total: 4 files changed, 439 insertions, 1 deletion.

### Schema / Contract Changes

- New canonical serialization: the `regulated:` YAML block at the top of issue
  bodies created via the regulated track. Format documented in
  `reference/regulated-fields.md` "Embedded YAML block format" (rules 1-6).
- Frontmatter `iso_class` for `issue-create/SKILL.md` moves from `none` to `A`
  (the skill becomes safety-relevant when it enforces regulated metadata).
  `applies_at_or_above: A` is added to match the convention used by
  `traceability`, `risk-control`, `evidence-pack`, and `soup-inventory`.

### Documentation Changes

- New reference documents under `reference/` (3 files, 366 lines total):
  - `regulated-fields.md` (180 lines) -- matrix + validation rules + YAML format
  - `templates/regulated-feature.md` (86 lines)
  - `templates/regulated-bug.md` (100 lines)

## How

### Implementation Highlights

1. **Opt-in gate via directory presence.** Phase 0a is a single
   `[ -d "$PROJECT_ROOT/compliance" ]` test. When the directory is absent,
   `$REGULATED_TRACK=false` and the skill proceeds along the existing path
   exactly as documented in sections 1-5. This is the most important functional
   invariant of the change; it preserves backward compatibility for every
   non-regulated invocation.
2. **Per-issue-type field matrix.** The matrix in `reference/regulated-fields.md`
   defines per `type/*` label which fields are `required`, `required-if-safety`,
   `optional`, or `linked-to-test-target` (the test-issue special case). Phase
   0b consults the matrix before prompting; missing required fields cause an
   explicit halt rather than a silent fall back to a bare issue.
3. **Embedded YAML block at the top of the issue body.** The block is fenced by
   ` ```yaml ` and the literal three backticks. Field order is fixed
   (`requirement_id` -> `risk_level` -> `clause_refs`) so downstream parsers
   can rely on it for diff stability. Optional omitted fields are written as
   the literal `null` so a parser can distinguish "not asked" (block absent)
   from "asked but permitted to omit" (block present, field is `null`). Both
   states matter to the audit trail.
4. **Validation rules cite existing schemas.** `requirement_id` follows
   `traceability/reference/matrix-schema.md` `id_routes.SRS` (regex
   `^SRS-[A-Z0-9]+-[0-9]+$`). `risk_level` is the three-element ISO 14971
   acceptability enum from `risk-control/reference/risk-record-schema.md`.
   `clause_refs[]` follows the `<STANDARD>-<NUMBER>` format with hyphens between
   standard and number, and each entry is checked against an
   `> **Clause**: <id>` anchor in the matching `compliance/<standard>.md` file
   (the format established by P0-3 / PR #594).
5. **Surgical SKILL.md edit.** The two new sections (Phase 0a and Phase 0b)
   are inserted between the existing argument parsing block and the existing
   Options table. No existing phase was renumbered. No existing wording was
   reflowed. Only the frontmatter `iso_class` line and the new sections
   contribute to the diff.
6. **iso_class declaration consistent with the regulated trio.** SKILL.md
   frontmatter declares `iso_class: A` and `applies_at_or_above: A`,
   consistent with `soup-inventory`, `risk-control`, `traceability`, and
   `evidence-pack` (the safety-relevant set established by the iso_class
   metadata sweep -- P1-3 / PR #600).

### Testing Done

- [x] `scripts/validate_skills.sh` runs clean on the modified SKILL.md (302
  total checks, 0 failures, the pre-existing 15 warnings are unchanged from
  `develop` HEAD; pre-commit hook executed it on commit and reported 0
  failures).
- [x] All three new reference documents are linked from the SKILL.md body via
  `reference/regulated-fields.md` and `reference/templates/...` paths.
- [x] Surgical-edit verification: `git diff` on `SKILL.md` shows only the
  frontmatter `iso_class` change and the two new section blocks. No drive-by
  formatting changes; no renumbering of existing phases.
- [x] Mental walk of the non-regulated path: with `compliance/` absent,
  `$REGULATED_TRACK=false` is set in Phase 0a, Phase 0b is skipped entirely,
  and the rest of the SKILL body proceeds unchanged.

### Test Plan for Reviewers

1. Read `global/skills/_internal/issue-create/SKILL.md` Phase 0a and Phase 0b
   sections and confirm the regulated-track gate is a single directory-presence
   test with no fall-through to silent issue creation.
2. Read `reference/regulated-fields.md` and confirm the per-type matrix matches
   the table in #602 acceptance criteria, the validation rules cite the
   existing schemas (matrix-schema, risk-record-schema, compliance), and the
   embedded YAML block format rules (1-6) are unambiguous.
3. Read `reference/templates/regulated-feature.md` and
   `reference/templates/regulated-bug.md` and confirm both open with the
   fenced YAML block as the very first content (no leading heading).
4. Verify the surgical edit to SKILL.md changes only what is required:
   `git log -p f30bcd6 -- global/skills/_internal/issue-create/SKILL.md` shows
   the frontmatter change plus the two new section insertions, no other diff.

### Breaking Changes

None. The skill is unchanged for non-regulated projects (no `compliance/`
directory). For regulated projects the prompts are additive; existing
invocations on a regulated project that did not previously fill in the
regulated fields will halt with a clear message, but no silent failure mode is
introduced.

### Rollback Plan

1. Revert this PR.
2. No data loss -- nothing is generated until a regulated-track project
   invokes the skill.
3. The `iso_class: A` frontmatter change is reversible (back to `none`)
   without affecting consumers; the validate_skills.sh check accepts both.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation added (3 reference documents under `reference/`)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (2 commits: SKILL.md extension,
  reference docs)
- [x] Related issue(s) linked with closing keywords (Closes #602, Part of #588)
- [x] Comment will be added to #602 and #588 after PR creation
