### PR TITLE
feat(skills): extend pr-work with traceability-impact injection and evidence-attachment gate

### DIFF
--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -23,7 +23,8 @@ tiers:
     ref_docs: [core, advanced]
     deep_checks: true
 default_tier: standard
-iso_class: none
+iso_class: A
+applies_at_or_above: A
 # ref_docs keys:
 #   core     -> reference/error-handling.md
 #   advanced -> reference/batch-mode.md, reference/team-mode.md,
@@ -195,6 +196,42 @@ else
     fi
 fi
 ```
+
+## Phase 0a -- Regulated-track detection
+
+After argument parsing, before any mode routing or PR work, detect whether the
+consumer project is on the regulated-industry track. Set `$REGULATED_TRACK=true`
+when the project root contains a `compliance/` directory (typically
+`compliance/iec-62304.md`, `iso-13485.md`, `iso-14971.md`); set
+`$REGULATED_TRACK=false` otherwise.
+
+```bash
+# Resolve the consumer-project root from the parsed PROJECT name (or current
+# cwd when invoked via the skill alias from inside a project).
+PROJECT_ROOT="${PROJECT_ROOT:-$(pwd)}"
+if [ -n "$PROJECT" ] && [ -d "$PROJECT_ROOT/$PROJECT" ]; then
+    PROJECT_ROOT="$PROJECT_ROOT/$PROJECT"
+fi
+
+if [ -d "$PROJECT_ROOT/compliance" ]; then
+    REGULATED_TRACK=true
+else
+    REGULATED_TRACK=false
+fi
+```
+
+**Behavior matrix:**
+
+| `$REGULATED_TRACK` | Effect on the rest of the skill |
+|--------------------|---------------------------------|
+| `false` (default)  | Skill proceeds exactly as documented in the existing phases below. Phase 5b and Phase 9b are skipped entirely. No behavior change relative to pre-#603 invocations. |
+| `true`             | After the existing Phase 5 (push and `gh pr create`) the skill runs Phase 5b (traceability impact injection). Before the existing Phase 10 (`gh pr merge`) the skill runs Phase 9b (evidence-attachment gate). All other phases are unchanged. |
+
+The detection is a single test on directory presence -- no parsing, no glob.
+When `compliance/` is absent the skill is functionally identical to its
+pre-#603 form; this is the most important functional invariant of this
+extension. The two regulated phases (5b and 9b) gate on `$REGULATED_TRACK=true`
+at every entry point and are no-ops otherwise.
 
 ## Instructions
 
@@ -392,12 +429,211 @@ After push, monitor CI with non-blocking polling (30s intervals, 10min max). Do 
 
 > See `reference/build-verification.md` for the full CI monitoring protocol, status interpretation table, and polling limits.
 
+### 5b. Traceability impact injection (regulated track only)
+
+**Gate:** runs only when `$REGULATED_TRACK=true` (see Phase 0a). Skipped
+entirely when the consumer project has no `compliance/` directory; non-regulated
+projects see no behavior change from this extension.
+
+After the push in Step 8 (and on every subsequent iteration that pushes new
+commits), compute the traceability cascade impacted by the diff and inject a
+`## Traceability Impact` section into the PR body. This surfaces, in narrative
+form, the same information the `traceability-guard` PreToolUse hook (#590,
+PR #593) checks silently. Reviewers see which downstream tests, risks, and
+clauses are touched without leaving the PR conversation.
+
+**Reuse rule (mandatory):** the cascade walk MUST source the shared library at
+`hooks/lib/validate-traceability.sh`. Do NOT re-derive cascade-walk logic in
+this skill body. The library is the single source of truth for cascade rules
+and is already used by `traceability-guard` (PreToolUse) and `pre-push` (git
+hook).
+
+```bash
+# Skip when the regulated track is off.
+if [ "$REGULATED_TRACK" != "true" ]; then
+    echo "pr-work: regulated track off -- Phase 5b skipped"
+    return 0
+fi
+
+# Source the shared cascade library. The library exposes
+# validate_traceability_range <base_ref> <head_ref> <repo_root>, but Phase 5b
+# needs the per-edge listing rather than a pass/fail return code, so it
+# additionally invokes the underlying graph_cascade_targets and
+# extract_doc_ids_from_path helpers the library exports.
+. "$PROJECT_ROOT/hooks/lib/validate-traceability.sh"
+
+BASE_REF=$(gh pr view "$PR_NUMBER" --repo "$ORG/$PROJECT" --json baseRefName -q .baseRefName)
+HEAD_REF="$HEAD_BRANCH"
+
+# Build the impact rows: one matrix row per touched doc_id whose cascade
+# graph carries downstream targets. Format is documented in
+# reference/traceability-impact-template.md.
+IMPACT_TABLE=$(cd "$PROJECT_ROOT" && \
+    git diff --name-only --diff-filter=ACMR "origin/$BASE_REF" "$HEAD_REF" \
+    | while IFS= read -r p; do
+        [ -n "$p" ] && extract_doc_ids_from_path "$PROJECT_ROOT" "$p"
+    done | sort -u | while IFS= read -r doc_id; do
+        [ -z "$doc_id" ] && continue
+        targets=$(graph_cascade_targets "$PROJECT_ROOT/docs/.index/graph.yaml" "$doc_id")
+        [ -n "$targets" ] && printf '%s\t%s\n' "$doc_id" "$(printf '%s' "$targets" | paste -sd, -)"
+    done)
+```
+
+**Injection rules** (full template:
+`reference/traceability-impact-template.md`):
+
+1. The injected section is bracketed by sentinel HTML comments
+   `<!-- traceability-impact:start -->` and `<!-- traceability-impact:end -->`.
+   On every re-run the skill replaces the existing block between those
+   sentinels rather than appending. This is the idempotency contract -- a
+   reviewer who refreshes the PR page does not see duplicated sections.
+2. The block is inserted at the very top of the PR body, before any
+   user-supplied content, so reviewers see the cascade at a glance.
+3. When `$IMPACT_TABLE` is empty (the diff touches no doc_id with cascade
+   targets), the injected block still appears -- with the literal line "No
+   traceability cascade impact detected for this diff." Empty-with-rationale
+   is auditable; silent omission is not.
+4. The PR body update goes through `gh pr edit "$PR_NUMBER" --body-file <tmp>`
+   so the rest of the body is preserved verbatim. The skill writes the new
+   body to a sibling `*.tmp` file and renames on success; a failed update
+   leaves the existing body intact.
+5. The sentinels are matched literally; the skill does not parse the markdown
+   in between. Manual edits to the impact table by a reviewer are overwritten
+   on the next push, which is the correct behavior -- the cascade is computed
+   from the diff, not asserted by hand.
+
+When the impact computation itself fails (e.g. the shared library exits
+non-zero), Phase 5b prints a one-line warning and continues; it does not block
+the PR. The next push retries.
+
+> See `reference/traceability-impact-template.md` for the exact markdown
+> template, the per-row format, sentinel comment placement, and the
+> failure-mode message. The template is the single source of truth for the
+> injected section's wording.
+
 ### 9. Iterate if Needed
 
 If workflows still fail, repeat steps 2-8. Max 3 retry attempts with 30s CI polling intervals. Each fix is a separate commit. Post a follow-up failure analysis comment at the start of each iteration.
 
 > See `reference/build-verification.md` for iteration limits, CI polling loop, and iteration rules.
 > See `reference/comment-templates.md` for the per-attempt follow-up comment template.
+
+### 9b. Evidence-attachment gate (regulated track only)
+
+**Gate:** runs only when `$REGULATED_TRACK=true` (see Phase 0a). Skipped
+entirely when the consumer project has no `compliance/` directory; non-regulated
+projects see no behavior change from this extension.
+
+After CI is green (Step 9 confirms every check passes) and immediately before
+the merge in Step 10, verify that the PR has the regulated metadata an
+auditor will need to reconstruct the change. The gate has two checks; both
+must pass for the merge to proceed.
+
+**Check (a) -- Linked-issue regulated YAML block.** The PR must reference at
+least one issue (via `Closes #N`, `Fixes #N`, or `Resolves #N` in the body),
+and the linked issue body must open with the regulated YAML block per the
+six format invariants documented in
+`global/skills/_internal/issue-create/reference/regulated-fields.md`
+"Embedded YAML block format":
+
+1. Block is the very first non-blank content of the issue body, fenced by
+   ` ```yaml ` and three backticks.
+2. Top-level key is `regulated:` (no alternative key).
+3. Field order is fixed: `requirement_id` -> `risk_level` -> `clause_refs`.
+4. Omitted optional fields are written as the literal `null`.
+5. `clause_refs:` is always block-style YAML list with `- ` markers.
+6. Exactly one blank line between the closing fence and the first 5W1H
+   heading.
+
+A linked issue without the block, or a block with only `null` fields where
+the per-issue-type matrix in `regulated-fields.md` requires a value, fails
+the gate. The skill prints the missing field name and the matrix row that
+demanded it.
+
+**Check (b) -- Fresh evidence pack manifest.** The PR body or one of the
+repository files added in the diff must reference an `evidence/<version>/`
+directory whose `manifest.yaml` was generated within the last 24 hours
+(`_meta.generated` timestamp inside the manifest). The 24-hour window
+matches a typical merge-window cadence; older manifests must be regenerated
+via `/evidence-pack <version> --force` before the merge proceeds. The
+manifest's required content per `kind` and `iso_class` follows the matrix
+in `reference/evidence-attachment-policy.md`.
+
+```bash
+# Skip when the regulated track is off.
+if [ "$REGULATED_TRACK" != "true" ]; then
+    echo "pr-work: regulated track off -- Phase 9b skipped"
+    return 0
+fi
+
+# Honor the documented override flag.
+if [ "$SKIP_EVIDENCE_GATE" = "true" ]; then
+    echo "pr-work: Phase 9b skipped via --skip-evidence-gate flag"
+    gh pr comment "$PR_NUMBER" --repo "$ORG/$PROJECT" \
+        --body "Evidence-attachment gate bypassed via --skip-evidence-gate. Reason: $SKIP_EVIDENCE_GATE_REASON"
+    return 0
+fi
+
+# Check (a) -- linked-issue regulated YAML block.
+PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$ORG/$PROJECT" --json body -q .body)
+LINKED_ISSUES=$(printf '%s\n' "$PR_BODY" \
+    | grep -ioE '(closes|fixes|resolves)[[:space:]]*#[0-9]+' \
+    | grep -oE '[0-9]+' | sort -u)
+
+if [ -z "$LINKED_ISSUES" ]; then
+    echo "pr-work: Phase 9b -- PR has no linked issue (Closes / Fixes / Resolves)"
+    echo "         see reference/evidence-attachment-policy.md 'Failure messages'"
+    return 1
+fi
+
+for issue in $LINKED_ISSUES; do
+    ISSUE_BODY=$(gh issue view "$issue" --repo "$ORG/$PROJECT" --json body -q .body)
+    if ! printf '%s\n' "$ISSUE_BODY" | head -1 | grep -qF '```yaml'; then
+        echo "pr-work: Phase 9b -- linked issue #$issue lacks the regulated YAML block (rule 1 violated)"
+        return 1
+    fi
+    # Per-field validation against the per-issue-type matrix is delegated to
+    # reference/evidence-attachment-policy.md "Required fields by issue type".
+done
+
+# Check (b) -- fresh evidence pack manifest.
+EV_DIR=$(printf '%s\n' "$PR_BODY" | grep -oE 'evidence/[A-Za-z0-9._-]+' | head -1)
+if [ -z "$EV_DIR" ]; then
+    EV_DIR=$(cd "$PROJECT_ROOT" && \
+        git diff --name-only --diff-filter=ACMR "origin/$BASE_REF" "$HEAD_BRANCH" \
+        | grep -oE '^evidence/[A-Za-z0-9._-]+' | sort -u | head -1)
+fi
+if [ -z "$EV_DIR" ] || [ ! -f "$PROJECT_ROOT/$EV_DIR/manifest.yaml" ]; then
+    echo "pr-work: Phase 9b -- no evidence/<version>/manifest.yaml referenced or present"
+    return 1
+fi
+
+# Manifest freshness: _meta.generated must be within the last 24 hours.
+MANIFEST_TS=$(grep -E '^[[:space:]]*generated:' \
+    "$PROJECT_ROOT/$EV_DIR/manifest.yaml" \
+    | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+NOW_EPOCH=$(date -u +%s)
+MANIFEST_EPOCH=$(date -u -d "$MANIFEST_TS" +%s 2>/dev/null || echo 0)
+AGE_SECONDS=$(( NOW_EPOCH - MANIFEST_EPOCH ))
+if [ "$AGE_SECONDS" -lt 0 ] || [ "$AGE_SECONDS" -gt 86400 ]; then
+    echo "pr-work: Phase 9b -- $EV_DIR/manifest.yaml is older than 24h (generated=$MANIFEST_TS)"
+    echo "         regenerate via '/evidence-pack <version> --force' before merging"
+    return 1
+fi
+```
+
+**Override path.** When the regulated metadata is genuinely not yet ready
+but the merge cannot wait (e.g. an emergency hotfix cleared a blocking CI
+issue and the audit trail will be backfilled in a follow-up), the operator
+may pass `--skip-evidence-gate "<reason>"`. The skill posts the reason as a
+PR comment so the bypass is permanently recorded and exits Phase 9b with
+status 0. The flag is NOT a routine bypass; default-mode runs without it
+and the gate enforces the checks above.
+
+> See `reference/evidence-attachment-policy.md` for the per-issue-type and
+> per-iso-class evidence requirement matrix, the formal "within the last
+> 24h" definition, the full failure-message format, and the override-flag
+> contract.
 
 ### 10. Auto-Merge on Success
 

--- a/global/skills/_internal/pr-work/reference/evidence-attachment-policy.md
+++ b/global/skills/_internal/pr-work/reference/evidence-attachment-policy.md
@@ -1,0 +1,212 @@
+# Evidence-Attachment Policy
+
+Per-issue-type, per-iso-class evidence requirement matrix used by the
+`pr-work` skill's Phase 9b (Evidence-attachment gate). The matrix defines
+exactly what evidence a regulated PR must carry to merge, the formal
+"within the last 24h" freshness check, the override mechanism, and the
+failure-message format. The skill body delegates the per-row enforcement
+to this document so the policy lives in one place.
+
+> **Loading**: Loaded only when Phase 9b runs (which requires Phase 0a's
+> `$REGULATED_TRACK=true`). Skip when the consumer project has no
+> `compliance/` directory.
+
+## Required Fields by Issue Type
+
+The first dimension is the GitHub issue `type/*` label on the issue the PR
+closes (parsed from `Closes #N` / `Fixes #N` / `Resolves #N` keywords in
+the PR body). The second dimension is the `iso_class` declared in the
+SKILL.md frontmatter of any skill the PR's diff edits, OR `none` when the
+diff edits no SKILL.md. When the PR closes multiple issues, the strictest
+row applies. When the diff touches multiple SKILLs at different classes,
+the highest class applies.
+
+| Issue type           | `iso_class: none`        | `iso_class: A`                                              |
+|----------------------|--------------------------|-------------------------------------------------------------|
+| `type/feature`       | (no requirement)         | `manifest.yaml` + `risk-file.yaml` excerpt + test reports   |
+| `type/bug` (safety)  | (no requirement)         | `manifest.yaml` + `risk-file.yaml` excerpt + regression test report |
+| `type/bug` (other)   | (no requirement)         | (no requirement)                                            |
+| `type/security`      | `manifest.yaml`          | `manifest.yaml` + full evidence pack                        |
+| `type/refactor` (safety) | (no requirement)     | `manifest.yaml` + `risk-file.yaml` excerpt                  |
+| `type/chore`         | (no requirement)         | (no requirement)                                            |
+| `type/docs`          | (no requirement)         | (no requirement)                                            |
+| `type/test`          | (no requirement)         | (no requirement)                                            |
+
+**"Safety-relevant" detection.** A `type/bug` or `type/refactor` issue is
+considered safety-relevant when its "Where" section names any path matched
+by a `paths:` glob in `compliance/iec-62304.md`, `compliance/iso-13485.md`,
+or `compliance/iso-14971.md` (e.g. `risk-file/**`, `docs/risk-management/**`,
+`tests/safety/**`, `src/medical/**`). This rule is the same one
+`issue-create`'s `reference/regulated-fields.md` applies; the two
+extensions share one definition so their behavior is consistent across the
+issue and PR lifecycle.
+
+**Per-cell artifact mapping.** When a cell requires `manifest.yaml`, the
+PR must reference an `evidence/<version>/manifest.yaml` whose freshness
+check passes (see "Within the last 24h" below). When it requires the
+`risk-file.yaml` excerpt, the manifest must include an entry with
+`kind: risk_file` and `status: collected` (per
+`evidence-pack/reference/manifest-schema.md` "Allowed kind values"). When
+it requires "test reports" or "regression test report", the manifest must
+include `kind: ci_run_log` with `status: collected`. "Full evidence pack"
+means every `kind` listed in the manifest schema is `collected` or
+`skipped: source_absent` -- no `failed` entries are tolerated for
+`type/security` PRs at `iso_class: A`.
+
+## "Within the Last 24h" Definition
+
+The 24-hour window is a freshness check on the manifest itself, not on the
+underlying source artifacts the manifest references. The check is:
+
+```
+NOW_UTC - manifest._meta.generated  <  86400 seconds
+```
+
+Where `NOW_UTC` is the wall-clock UTC time at the moment Phase 9b runs.
+The 86400-second budget is exact; a manifest generated 86399 seconds ago
+passes, one generated 86401 seconds ago fails. Phase 9b uses
+`date -u +%s` for `NOW_UTC` and parses the manifest's
+`_meta.generated:` field (ISO 8601 UTC, second precision, `Z` suffix; see
+`evidence-pack/reference/manifest-schema.md` "Timestamp Format").
+
+**Why 24 hours.** A typical PR that survives review and CI for more than
+a day has accumulated additional commits, additional risk-file edits, or
+external test-report updates that the original manifest does not reflect.
+Twenty-four hours is the operational cadence at which a Design History
+File entry stays current without forcing a regeneration on every review
+comment. Projects that need a tighter window can lower it via repository
+configuration in a future iteration; the current implementation is fixed
+at 24h.
+
+**Remediation when stale.** Regenerate the manifest with
+`/evidence-pack <version> --force` (see
+`global/skills/_internal/evidence-pack/SKILL.md` Phase 0 -- the `--force`
+flag is the documented way to overwrite an existing pack). The next push
+or re-run of Phase 9b reads the fresh `_meta.generated` value and the
+gate passes.
+
+## Override Mechanism
+
+The `pr-work` skill accepts `--skip-evidence-gate "<reason>"` to bypass
+Phase 9b entirely. The flag exists for genuine emergencies -- a hotfix
+that cleared a CI block where the audit trail will be backfilled in a
+follow-up PR -- and is NOT a routine bypass. Default-mode runs without
+the flag and the gate enforces the matrix above.
+
+When the flag is set:
+
+1. The skill posts a PR comment recording the bypass and the operator's
+   reason. The comment is permanent (not deleted on subsequent runs) and
+   serves as the audit trail entry for the bypass.
+2. Phase 9b exits with status 0 immediately after posting the comment,
+   without running checks (a) or (b).
+3. The follow-up PR that backfills the audit trail must close a new
+   issue and the gate runs normally on that PR.
+
+The comment body uses the literal format below. Reviewers and external
+auditors search for this exact string when reconstructing the audit trail
+of a release.
+
+```markdown
+**Evidence-attachment gate bypassed via --skip-evidence-gate**
+
+Reason: <verbatim operator-supplied string>
+Operator: <gh actor login that ran pr-work>
+Bypass timestamp: <UTC ISO 8601 timestamp>
+
+This PR was merged without the manifest.yaml + linked-issue YAML block
+checks Phase 9b normally enforces. A follow-up PR must backfill the
+audit trail.
+```
+
+Operators must NOT use `--skip-evidence-gate` to silence a transient
+freshness failure; the correct response in that case is to regenerate
+the manifest. The bypass exists for cases where the operator has
+already decided that the missing evidence will be supplied separately.
+
+## Failure-Message Format
+
+When a check fails, Phase 9b prints a structured message on stderr and
+returns non-zero. The next push or manual re-run retries. The message
+format is the same shape `evidence-pack` and `risk-control` use for
+their own validation findings, so an operator reading multiple skill
+outputs in a CI log sees consistent structure.
+
+```
+pr-work: Phase 9b -- evidence-attachment gate failed
+
+  check       : (a) linked-issue YAML block | (b) manifest freshness
+  rule        : <one-line rule from this document>
+  pr_number   : <NNN>
+  linked_issue: <#NNN | N/A>
+  manifest    : <evidence/<version>/manifest.yaml | not referenced>
+  generated   : <ISO 8601 timestamp | unparseable>
+  age_seconds : <integer | not applicable>
+
+Remediation:
+  - For (a): run /issue-create on the linked issue with the regulated track,
+    or edit the issue body to embed the YAML block per the six rules in
+    issue-create/reference/regulated-fields.md "Embedded YAML block format".
+  - For (b): regenerate via /evidence-pack <version> --force, then push.
+
+To bypass (emergency only), re-run pr-work with --skip-evidence-gate "<reason>".
+```
+
+The `Remediation` section names the exact recovery commands so an operator
+who has not memorized the regulated track can fix the gate without
+re-reading three reference documents.
+
+## Multi-Issue and Multi-Class PR Handling
+
+When a PR closes more than one issue OR touches more than one SKILL.md,
+the gate applies the strictest row of the matrix:
+
+1. Determine the strictest issue type across all `Closes #N` keywords.
+   Order: `type/security` > `type/feature` > `type/refactor` (safety) >
+   `type/bug` (safety) > all others.
+2. Determine the highest `iso_class` across all touched SKILL.md
+   frontmatters. Order: `A` > `none` (the project does not yet ship `B`
+   or `C`, so they are out of scope for this matrix).
+3. Look up the cell. The cell's requirement applies to the entire PR.
+
+Phase 9b prints which issue type and which class it selected so the
+operator can audit the choice when the PR closes a heterogeneous set.
+
+## Coordination with Phase 5b
+
+Phase 5b (traceability impact injection) and Phase 9b (this gate) are
+independent. Phase 5b runs on every push that introduces commits and
+modifies the PR body; Phase 9b runs once per merge attempt and reads
+the PR body and the linked-issue body. The two phases share `$PROJECT_ROOT`
+and `$REGULATED_TRACK` from Phase 0a but otherwise do not interact:
+
+| Property | Phase 5b | Phase 9b |
+|----------|----------|----------|
+| Trigger | After Step 8 (push) | Before Step 10 (auto-merge) |
+| Reads | `git diff`, `docs/.index/graph.yaml`, `hooks/lib/validate-traceability.sh` | PR body, linked-issue bodies, `evidence/<version>/manifest.yaml` |
+| Writes | PR body (between sentinel comments) | PR comment (only on `--skip-evidence-gate`) |
+| Failure mode | Warn and continue (does not block) | Return non-zero (blocks merge) |
+| Override | None (informational) | `--skip-evidence-gate "<reason>"` |
+
+The two gate semantics are deliberate: Phase 5b is informational
+documentation, Phase 9b is a merge-blocking enforcement. A PR can
+legitimately have a stale or empty Phase 5b table while still passing
+Phase 9b (the cascade is computed from the diff, the gate is computed
+from the audit-trail metadata).
+
+## Cross-references
+
+- Issue-create extension that produces the YAML block Phase 9b reads:
+  `../../issue-create/reference/regulated-fields.md` "Embedded YAML
+  block format".
+- Evidence-pack manifest schema referenced by the freshness check:
+  `../../evidence-pack/reference/manifest-schema.md`.
+- Risk-control schema that defines the `risk-file.yaml` shape an
+  excerpt must conform to:
+  `../../risk-control/reference/risk-record-schema.md`.
+- Sister phase that injects the impact narrative:
+  `traceability-impact-template.md`.
+- Skill body that calls into this policy: `../SKILL.md` Phase 9b.
+- ISO 14971 clauses on residual-risk acceptability and design-output
+  verification that motivate the matrix:
+  `compliance/iso-14971.md` (consumer project, when present).

--- a/global/skills/_internal/pr-work/reference/traceability-impact-template.md
+++ b/global/skills/_internal/pr-work/reference/traceability-impact-template.md
@@ -1,0 +1,163 @@
+# Traceability Impact Template
+
+Markdown template for the `## Traceability Impact` section that the `pr-work`
+skill's Phase 5b injects into a PR body when `$REGULATED_TRACK=true`. The
+template is the single source of truth for the section's wording, the
+sentinel-comment placement, and the per-row format. The skill body must
+preserve the structure documented here verbatim so downstream auditors and
+reviewers always see the same shape.
+
+> **Loading**: Loaded only when Phase 5b runs (which requires Phase 0a's
+> `$REGULATED_TRACK=true`). Skip when the consumer project has no
+> `compliance/` directory.
+
+## Section Skeleton
+
+The injected block is bracketed by two HTML-comment sentinels and is placed
+at the very top of the PR body, before any user-supplied content. The
+sentinels are matched literally; the skill never parses the markdown between
+them and replaces the entire region on every re-run.
+
+```markdown
+<!-- traceability-impact:start -->
+## Traceability Impact
+
+This PR touches the following traceability cascade. Source of truth:
+`docs/.index/graph.yaml` resolved by `hooks/lib/validate-traceability.sh`.
+
+| Touched doc_id | Cascade targets | Coverage in diff |
+|----------------|-----------------|------------------|
+| `<doc_id_1>`   | `<target_1>, <target_2>, ...` | <covered \| missing> |
+| `<doc_id_2>`   | `<target_3>` | <covered \| missing> |
+
+Generated at: `<UTC ISO 8601 timestamp>`
+Diff range: `origin/<base>..<head_branch>` (<N> commits)
+<!-- traceability-impact:end -->
+```
+
+## Per-Row Format
+
+Each row of the table corresponds to one doc_id discovered in the diff (via
+`extract_doc_ids_from_path` in the shared library) whose
+`graph_cascade_targets` returned a non-empty list. The cells are filled as
+follows.
+
+| Column | Source | Format |
+|--------|--------|--------|
+| `Touched doc_id` | The doc_id key from `graph.yaml`. | Backtick-wrapped uppercase identifier (e.g. `` `SRS-CALC-001` ``). |
+| `Cascade targets` | Output of `graph_cascade_targets <graph_yaml> <doc_id>`. | Backtick-wrapped, comma-separated. Repo-relative paths and downstream doc_ids both render verbatim. |
+| `Coverage in diff` | Per-target check: `covered` when the target appears in the diff (either as a path or as a touched doc_id), `missing` otherwise. | Lowercase literal. The whole-row value is `covered` only when every target is covered; otherwise `missing`. |
+
+Rows are sorted by `Touched doc_id` ASCII-ascending so a re-run on the same
+diff produces a byte-identical block. Idempotency is the contract.
+
+## Empty-Diff Case
+
+When the diff touches no doc_id with a non-empty cascade (the common case
+for a docs-only or test-only commit), the section still appears -- with the
+literal placeholder line shown below. Empty-with-rationale is auditable;
+silent omission is not.
+
+```markdown
+<!-- traceability-impact:start -->
+## Traceability Impact
+
+No traceability cascade impact detected for this diff.
+
+Generated at: `<UTC ISO 8601 timestamp>`
+Diff range: `origin/<base>..<head_branch>` (<N> commits)
+<!-- traceability-impact:end -->
+```
+
+The skill MUST NOT skip injecting the section just because the table is
+empty. A reviewer reading the PR who sees no section cannot tell whether
+the regulated track is off, the cascade is empty, or the skill failed --
+all three are different states with different remediations.
+
+## Failure-Mode Message
+
+When the impact computation itself fails (e.g.
+`hooks/lib/validate-traceability.sh` exits non-zero, the graph file is
+malformed, or `git diff` cannot be resolved), Phase 5b prints a one-line
+warning on stderr and continues. It does NOT block the PR. The next push
+re-runs Phase 5b.
+
+The injected section in the failure case carries an explicit notice so
+reviewers know the table is stale rather than empty:
+
+```markdown
+<!-- traceability-impact:start -->
+## Traceability Impact
+
+Cascade computation failed during this push. Re-run will retry on the next
+commit. See the previous Phase 5b log for the underlying cause.
+
+Generated at: `<UTC ISO 8601 timestamp>`
+Diff range: `origin/<base>..<head_branch>` (<N> commits)
+<!-- traceability-impact:end -->
+```
+
+The failure-message variant is always recoverable -- the next successful
+Phase 5b run replaces it with the regular table or the empty-diff
+placeholder.
+
+## Idempotency Contract
+
+The skill body locates the existing block by searching for the literal
+`<!-- traceability-impact:start -->` and `<!-- traceability-impact:end -->`
+sentinels in the current PR body, then replaces the entire region between
+(and including) them with the freshly rendered block. Implementation
+sketch (the SKILL.md body invokes the equivalent):
+
+```bash
+# In Phase 5b, after IMPACT_TABLE is built.
+PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$ORG/$PROJECT" --json body -q .body)
+NEW_BLOCK=$(render_traceability_impact_block "$IMPACT_TABLE")
+
+if printf '%s' "$PR_BODY" | grep -qF '<!-- traceability-impact:start -->'; then
+    # Replace the existing block in place.
+    UPDATED=$(printf '%s' "$PR_BODY" | awk -v new="$NEW_BLOCK" '
+        /<!-- traceability-impact:start -->/ { in_block=1; print new; next }
+        /<!-- traceability-impact:end -->/   { in_block=0; next }
+        !in_block { print }
+    ')
+else
+    # First run on this PR: prepend the block.
+    UPDATED=$(printf '%s\n\n%s' "$NEW_BLOCK" "$PR_BODY")
+fi
+
+printf '%s' "$UPDATED" > /tmp/pr-body.tmp
+gh pr edit "$PR_NUMBER" --repo "$ORG/$PROJECT" --body-file /tmp/pr-body.tmp
+rm -f /tmp/pr-body.tmp
+```
+
+A reviewer who manually edits the table is overwritten on the next push.
+That is the correct behavior -- the table is computed from the diff, not
+asserted by hand. Reviewer prose belongs outside the sentinel comments.
+
+## Whitespace and Encoding
+
+| Property | Rule |
+|----------|------|
+| Newline at the end of each line | LF (`\n`); never CRLF. |
+| Leading whitespace on a row | None. The pipe character starts the line. |
+| Trailing whitespace | None. Trim before writing. |
+| Encoding | UTF-8 without BOM. |
+| Non-ASCII glyphs | Avoid in the injected block to keep the `pr-language-guard` hook happy. ASCII `->` for arrows, ASCII hyphen-minus for dashes. |
+
+The encoding rules are the same `pr-work` already enforces on commit
+messages and PR comments; the injected block respects them so the
+language-guard hook never trips on the skill's own output.
+
+## Cross-references
+
+- Shared library invoked to compute the cascade:
+  `../../../../hooks/lib/validate-traceability.sh`
+- Graph file consumed by the library: `docs/.index/graph.yaml` (in the
+  consumer project; produced by `doc-index`).
+- Sister gate that consumes the same impact data:
+  `evidence-attachment-policy.md` (Phase 9b).
+- Skill body that calls into this template: `../SKILL.md` Phase 5b.
+- Sibling extension that produces the upstream YAML block consumed by
+  Phase 9b: `../../issue-create/reference/regulated-fields.md` "Embedded
+  YAML block format".


### PR DESCRIPTION
Closes #603
Part of #588

## What

### Summary

Extends the existing `pr-work` skill (`global/skills/_internal/pr-work/SKILL.md`)
so that, when the consumer project has a `compliance/` directory present, the
skill performs two additional documented phases around the existing PR
workflow:

1. **Phase 5b (traceability impact injection)** -- runs after the push in
   Step 8. Computes the cascade impact via the shared library at
   `hooks/lib/validate-traceability.sh` (the SSoT used by the
   `traceability-guard` PreToolUse hook and the `pre-push` git hook -- this
   extension reuses the library, it does not duplicate the cascade-walk
   logic). Injects a `## Traceability Impact` section into the PR body,
   bracketed by sentinel HTML comments so re-runs replace the existing
   region rather than appending.
2. **Phase 9b (evidence-attachment gate)** -- runs after the CI gate in
   Step 9 and before the merge in Step 10. Two checks: (a) the PR's linked
   issue body opens with the regulated YAML block per the six format
   invariants documented in `issue-create`'s `regulated-fields.md`
   (P2-2 / PR #605), and (b) the PR references an
   `evidence/<version>/manifest.yaml` whose `_meta.generated` timestamp is
   within the last 24 hours. Bypassable via `--skip-evidence-gate "<reason>"`
   with the reason posted as a permanent PR comment.

Behavior is strictly opt-in. When no `compliance/` directory is present,
`$REGULATED_TRACK=false` in Phase 0a, and Phases 5b and 9b are skipped
entirely. Non-regulated projects see no behavior change from this
extension -- the most important functional invariant.

### Change Type

- [x] Feature (extension to existing skill)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation (2 new reference documents under `reference/`)
- [ ] Test
- [ ] Chore

### Affected Components

| Path | Change |
|------|--------|
| `global/skills/_internal/pr-work/SKILL.md` | +237 / -1 lines: new Phase 0a / 5b / 9b sections, frontmatter `iso_class: A`, `applies_at_or_above: A` |
| `global/skills/_internal/pr-work/reference/traceability-impact-template.md` | New: markdown template, sentinel-comment placement, per-row format, empty-diff and failure-mode placeholders, encoding rules |
| `global/skills/_internal/pr-work/reference/evidence-attachment-policy.md` | New: per-issue-type and per-iso-class evidence requirement matrix, 24-hour freshness definition, `--skip-evidence-gate` override mechanism, failure-message format, multi-issue / multi-class handling |

## Why

### Problem Solved

P0-2 (`traceability-guard` hook, PR #593) blocks PR creation when the diff
touches a `doc_id` without updating cascade targets. The block is binary
(pass / fail) and offers no narrative -- a reviewer is told "you missed
updating something" but cannot see which downstream tests, risks, and
clauses are impacted without re-running the analysis manually. This
extension turns the hook's silent enforcement into visible documentation
that lives in the PR body itself.

P1-1 (`evidence-pack`, PR #598) introduced the per-release manifest, and
P1-2 (`risk-control`, PR #599) introduced the risk file. But there was no
point at which a PR closing a regulated issue was forced to verify those
artifacts existed and were current -- a release could ship with a stale or
absent evidence pack and the audit trail would not catch it until the next
external review. Phase 9b closes that loop at the merge gate.

### Related Issues

- Closes #603 (P2-3: pr-work extension for traceability impact and
  evidence-attachment gate)
- Part of #588 (Epic: ISO/Traceability/Evidence track for regulated-industry
  users)

### Alternative Approaches Considered

1. **Add a separate `pr-work-regulated` skill alias.** Rejected for the
   same reason P2-2 rejected the alternative for `issue-create`: the alias
   table in `global/CLAUDE.md` is already large; an extension to the
   existing skill keeps a single entry point and lets the regulated track
   auto-activate via directory presence.
2. **Push impact injection into the `traceability-guard` hook.** Rejected
   because the hook runs on every `gh pr create` and `gh pr edit` invocation
   and cannot distinguish "already injected this iteration" from "first
   injection". A skill phase that runs once per push, with sentinel-comment
   idempotency, is the right granularity.
3. **Compute the cascade in the skill body via a fresh awk pass.** Rejected
   per the issue acceptance criteria's reuse rule: the cascade walk MUST
   source `hooks/lib/validate-traceability.sh` (the SSoT). Re-deriving the
   logic in the skill would let the two implementations drift.
4. **Make the evidence gate fail-soft (warn but allow merge).** Rejected
   because the whole point of P0/P1/P2 is to enforce the audit trail at
   the latest possible moment when an operator still has the context to
   fix it; a soft gate is no gate.

## Who

### Reviewers

Standard maintainer review. No security-team sign-off required (the skill
is contract documentation only and ships no executable code -- matches the
pattern established by #592 / #598 / #599 / #604 / #605).

### Stakeholders

- Compliance / regulatory team (consumers of the surfaced traceability
  impact and the enforced evidence pack)
- Future epic-closure decision (see "Notes" in the final report) -- this
  PR completes the third and final P2 child of Epic #588

## When

### Urgency

- [x] Normal -- Follow standard review process

### Target Release

Aligns with the rest of Epic #588 (ISO/Traceability/Evidence track). With
this PR merged, all 9 child issues of the epic (P0-1..P2-3) are closed.

### Dependencies

- Depends on:
  - P0-1 (#589 / PR #592) -- `traceability` skill, the matrix Phase 5b
    surfaces.
  - P0-2 (#590 / PR #593) -- `traceability-guard` and the shared library
    `hooks/lib/validate-traceability.sh` Phase 5b reuses (do NOT
    duplicate).
  - P1-1 (#595 / PR #598) -- `evidence-pack`, the manifest Phase 9b
    verifies.
  - P1-2 (#596 / PR #599) -- `risk-control`, the risk file Phase 9b's
    matrix references.
  - P2-2 (#602 / PR #605) -- `issue-create` regulated extension, the
    YAML block format Phase 9b parses.
  All merged.
- Blocks: nothing in Epic #588 (this is the final child).

## Where

### Files Changed

| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `global/skills/_internal/pr-work/` | 1 SKILL.md modified | Phase 0a / 5b / 9b sections + frontmatter |
| `global/skills/_internal/pr-work/reference/` | 2 new files | Impact template and evidence-attachment policy |

Total: 3 files changed, 612 insertions, 1 deletion.

### Schema / Contract Changes

- New canonical injected section: the `## Traceability Impact` block
  bracketed by `<!-- traceability-impact:start -->` and
  `<!-- traceability-impact:end -->` sentinel comments in PR bodies on the
  regulated track. Format documented in
  `reference/traceability-impact-template.md`.
- New override flag: `--skip-evidence-gate "<reason>"` for Phase 9b. The
  bypass is permanent (PR-comment audit trail) and the comment body
  follows the literal format documented in
  `reference/evidence-attachment-policy.md` "Override Mechanism".
- Frontmatter `iso_class` for `pr-work/SKILL.md` moves from `none` to `A`
  (the skill becomes safety-relevant once it enforces the evidence gate).
  `applies_at_or_above: A` is added to match the convention used by
  `traceability`, `risk-control`, `evidence-pack`, `soup-inventory`, and
  `issue-create`.

### Documentation Changes

- New reference documents under `reference/` (2 files, 375 lines total):
  - `traceability-impact-template.md` (~150 lines) -- markdown template
    and idempotency contract for Phase 5b
  - `evidence-attachment-policy.md` (~225 lines) -- requirement matrix,
    freshness check, override mechanism, failure-message format

## How

### Implementation Highlights

1. **Opt-in gate via directory presence.** Phase 0a is a single
   `[ -d "$PROJECT_ROOT/compliance" ]` test. When the directory is absent,
   `$REGULATED_TRACK=false` and the skill proceeds along the existing
   path exactly as documented in the existing phases. This is the most
   important functional invariant of the change; it preserves backward
   compatibility for every non-regulated invocation.
2. **Reuse, don't duplicate, the cascade library.** Phase 5b documents
   sourcing `hooks/lib/validate-traceability.sh` and calling its
   `extract_doc_ids_from_path` and `graph_cascade_targets` functions. The
   library is the SSoT; re-deriving cascade-walk logic in the skill would
   let the two implementations drift. Per the issue acceptance criteria.
3. **Idempotent injection via sentinel comments.** Phase 5b writes the
   impact section between the literal sentinels
   `<!-- traceability-impact:start -->` and
   `<!-- traceability-impact:end -->`. On re-runs the skill replaces the
   region between (and including) the sentinels rather than appending.
   A reviewer who refreshes the PR page after additional pushes does not
   see duplicated sections -- the contract is byte-identical output for
   byte-identical input.
4. **Empty-diff and failure-mode placeholders.** Phase 5b always injects
   the section, even when the cascade is empty or the computation failed.
   Empty-with-rationale is auditable; silent omission is not. The
   placeholder text is documented in
   `reference/traceability-impact-template.md` "Empty-Diff Case" and
   "Failure-Mode Message".
5. **Two-check evidence gate at the merge boundary.** Phase 9b runs
   between Step 9 (CI gate) and Step 10 (auto-merge). Check (a) parses
   the PR body for `Closes #N` / `Fixes #N` / `Resolves #N` keywords,
   loads the linked-issue body, and verifies the regulated YAML block is
   present per the six invariants from `issue-create`'s
   `regulated-fields.md`. Check (b) parses the PR body and the diff for
   an `evidence/<version>/` reference, opens its `manifest.yaml`, and
   verifies `_meta.generated` is within 86400 seconds of the current UTC
   time. Both checks must pass for the merge to proceed.
6. **Override path with permanent audit trail.** The
   `--skip-evidence-gate "<reason>"` flag bypasses Phase 9b but posts the
   reason as a PR comment using the literal format documented in
   `reference/evidence-attachment-policy.md` "Override Mechanism". The
   comment is never deleted; an external auditor can always reconstruct
   the bypass decision from the PR thread.
7. **Surgical SKILL.md edit.** No existing phase was renumbered. The new
   sections appear as Phase 0a (regulated-track detection), Phase 5b
   (impact injection), and Phase 9b (evidence gate) so the existing
   1..11 numbering survives. No drive-by formatting changes; the only
   frontmatter change is `iso_class` and the addition of
   `applies_at_or_above`.
8. **iso_class declaration consistent with the regulated set.** SKILL.md
   frontmatter declares `iso_class: A` and `applies_at_or_above: A`,
   matching `issue-create`, `traceability`, `risk-control`,
   `evidence-pack`, and `soup-inventory`. The skill becomes safety-relevant
   once it enforces the evidence gate, so the class change is the correct
   downstream consequence.

### Testing Done

- [x] `scripts/validate_skills.sh` runs clean on the modified SKILL.md
  (303 total checks, 0 failures, 14 warnings -- the warnings are
  pre-existing and unchanged in nature; the file-length warning crossed
  the 500-line threshold pre-#603 already at 521 lines).
- [x] All two new reference documents are linked from the SKILL.md body
  via `reference/traceability-impact-template.md` (Phase 5b) and
  `reference/evidence-attachment-policy.md` (Phase 9b).
- [x] Surgical-edit verification: `git diff` on `SKILL.md` shows only
  the frontmatter `iso_class` change, the addition of
  `applies_at_or_above`, and the three new section blocks. No drive-by
  formatting changes; no renumbering of existing phases.
- [x] Mental walk of the non-regulated path: with `compliance/` absent,
  `$REGULATED_TRACK=false` is set in Phase 0a, Phases 5b and 9b are
  skipped (each with a one-line skip notice on stdout), and the rest
  of the SKILL body proceeds unchanged.
- [x] Reuse-not-duplicate verification: Phase 5b's bash block sources
  `hooks/lib/validate-traceability.sh` and calls its exported helpers;
  no cascade-walk logic is re-derived in the skill body.
- [x] Encoding check on the injected section: the template uses ASCII
  hyphens and ASCII `->` arrows so the language-guard hook does not trip
  on Phase 5b's own output.

### Test Plan for Reviewers

1. Read `global/skills/_internal/pr-work/SKILL.md` Phase 0a, Phase 5b,
   and Phase 9b sections and confirm the regulated-track gate is a
   single directory-presence test, Phase 5b sources the shared library
   instead of re-deriving the cascade walk, and Phase 9b's two checks
   match the issue acceptance criteria.
2. Read `reference/traceability-impact-template.md` and confirm the
   sentinel-comment placement, the per-row format, and the empty-diff
   and failure-mode placeholders. Verify the idempotency contract is
   explicit (re-runs replace, do not append).
3. Read `reference/evidence-attachment-policy.md` and confirm the
   per-issue-type and per-iso-class matrix matches the table in #603
   acceptance criteria, the 24-hour freshness check is unambiguous,
   and the override mechanism is documented as
   non-routine (operator records a reason in a PR comment that is never
   deleted).
4. Verify the surgical edit to SKILL.md changes only what is required:
   `git log -p 34fa5bd -- global/skills/_internal/pr-work/SKILL.md`
   shows the frontmatter change plus the three new section insertions,
   no other diff.

### Breaking Changes

None. The skill is unchanged for non-regulated projects (no `compliance/`
directory). For regulated projects the new phases are additive -- existing
PRs that did not previously embed the regulated YAML block in their linked
issues will fail Phase 9b on next merge attempt, but the failure message
points the operator to the exact remediation (run `/issue-create` or edit
the issue body to add the block). No silent failure mode is introduced.

### Rollback Plan

1. Revert this PR.
2. No data loss -- nothing is generated until a regulated-track project
   invokes the skill.
3. The `iso_class: A` frontmatter change is reversible (back to `none`)
   without affecting consumers; the validate_skills.sh check accepts
   both.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation added (2 reference documents under `reference/`)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described (2 commits: SKILL.md
  extension, reference docs)
- [x] Related issue(s) linked with closing keywords (Closes #603,
  Part of #588)
- [x] Comment will be added to #603 and #588 after PR creation
