### PR TITLE
docs(skills): align evidence-pack risk_file kind with single-file contract

### DIFF
--- a/global/skills/_internal/evidence-pack/reference/manifest-schema.md
+++ b/global/skills/_internal/evidence-pack/reference/manifest-schema.md
@@ -81,11 +81,28 @@ The kind value is a closed enum. Adding a new kind requires updating both this f
 | `pr_review` | `evidence/<version>/pr_review/` | JSON output of `gh pr list` plus per-PR `gh pr view --json reviews` for PRs merged into the release branch within the release window. |
 | `signed_commits` | `evidence/<version>/signed_commits/` | Plain text from `git log --format='%H %G? %s' <prev-tag>..<version>` showing the signature status (`G`/`B`/`U`/`N`/`X`/`Y`/`R`/`E`) of every commit in the release. |
 | `research_artifact` | `evidence/<version>/research_artifact/` | Mirror of files under `docs/research/` that document external citations (per the `research` skill output). |
-| `risk_file` | `evidence/<version>/risk_file/` | Mirror of `risk-file/` directory contents at the time of release. |
+| `risk_file` | `evidence/<version>/risk_file/risk-file.yaml` | Verbatim copy of the single normalized risk file at `docs/.index/risk-file.yaml` produced by the sibling `risk-control` skill. **Single file** contract -- the `risk_file/` subdirectory contains exactly one file, retained for per-kind directory symmetry. |
 
-A kind whose source is genuinely absent in a project (e.g. no `risk-file/` directory yet)
-should appear in the manifest with `status: skipped` and `reason: source_absent` rather than
-being omitted -- explicit absence is auditable; silent omission is not.
+A kind whose source is genuinely absent in a project (e.g. no `docs/.index/risk-file.yaml`
+yet) should appear in the manifest with `status: skipped` and `reason: source_absent` rather
+than being omitted -- explicit absence is auditable; silent omission is not.
+
+#### Single-file vs. directory-shaped kinds
+
+Each `kind` is one of two collection shapes; the distinction is fixed by `source-mapping.md`
+and must not be inferred from the `output_path`:
+
+| Shape | Kinds | sha256 over |
+|-------|-------|-------------|
+| Single file | `matrix`, `signed_commits`, `risk_file` | The bytes of the one collected file. |
+| Directory listing | `ci_run_log`, `pr_review`, `research_artifact` | `find <kind>/ -type f \| sort \| xargs sha256sum` (deterministic listing). |
+
+**The `risk_file` kind is single-file**: the collector copies the single normalized
+`docs/.index/risk-file.yaml` produced by the sibling `risk-control` skill. The
+`risk_file/` subdirectory under `evidence/<version>/` is retained only for per-kind
+directory symmetry and contains exactly one file. Future evidence-pack consumers must
+treat `risk_file` as single-file; promoting it to a directory mirror would be a
+backward-incompatible schema change requiring a major `_meta.schema` bump.
 
 ### Status Field
 
@@ -205,7 +222,7 @@ artifacts:
     notes: ""
 
   - kind: risk_file
-    source: "risk-file/"
+    source: "docs/.index/risk-file.yaml"
     collected_at: "2026-05-04T12:34:53Z"
     sha256: null
     status: skipped

--- a/global/skills/_internal/evidence-pack/reference/source-mapping.md
+++ b/global/skills/_internal/evidence-pack/reference/source-mapping.md
@@ -119,21 +119,24 @@ rather than referencing avoids the "the cited URL is dead at audit time" failure
 
 ## kind: risk_file
 
-Snapshot of the project's risk-management file.
+Snapshot of the project's risk-management file produced by the sibling `risk-control` skill.
 
 | Field | Value |
 |-------|-------|
-| **Source presence check** | `[[ -d risk-file ]]` |
-| **Required tools** | None. |
-| **Collection command(s)** | `mkdir -p evidence/<version>/risk_file`<br>`cp -R risk-file/. evidence/<version>/risk_file/` |
-| **Output layout** | Mirror of `risk-file/` under `evidence/<version>/risk_file/`. Subdirectory structure preserved. |
-| **sha256 strategy** | Directory listing. |
+| **Source presence check** | `[[ -f docs/.index/risk-file.yaml ]]` |
+| **Required tools** | None (plain file copy). |
+| **Collection command(s)** | `mkdir -p evidence/<version>/risk_file`<br>`cp docs/.index/risk-file.yaml evidence/<version>/risk_file/risk-file.yaml` |
+| **Output layout** | Single file: `evidence/<version>/risk_file/risk-file.yaml`. The `risk_file/` subdirectory is retained for symmetry with other kinds (one directory per kind), but contains exactly one file. |
+| **sha256 strategy** | Single file: `sha256sum evidence/<version>/risk_file/risk-file.yaml`. |
 | **Related clauses** | `IEC-62304-7.1.1`, `IEC-62304-7.2.1`, `IEC-62304-7.3.3`, `ISO-13485-7.3.3` |
 
-The risk file is owned by the upcoming sibling `risk-control` skill (P1-2, issue #596).
-Until that skill is shipped, this collector simply mirrors whatever a project hand-curates
-under `risk-file/`. Once `risk-control` lands, the pack will include its generated artifacts
-without changes here -- the directory mirror covers both cases.
+The risk file is owned by the sibling `risk-control` skill (issue #596, PR #599) and is
+emitted as a single normalized YAML file at `docs/.index/risk-file.yaml`. The collection
+contract is **single file**: this collector copies that one file verbatim and does not
+attempt to mirror a `risk-file/` directory. Future evidence-pack consumers must treat
+`risk_file` as a single-file kind -- if a project ever needs additional risk artifacts,
+those should be introduced under a new `kind` rather than by promoting `risk_file` to a
+directory mirror (which would be a backward-incompatible schema change).
 
 ## Atomic Write Pattern
 


### PR DESCRIPTION
## What

Align the `evidence-pack` skill's documentation of the `risk_file` evidence kind with the actual contract emitted by the sibling `risk-control` skill (PR #599).

### Change Type
- [x] Documentation (no behavior change)

### Affected Files
- `global/skills/_internal/evidence-pack/reference/source-mapping.md` -- `risk_file` collector contract
- `global/skills/_internal/evidence-pack/reference/manifest-schema.md` -- `risk_file` kind enum entry, example artifact, new "Single-file vs. directory-shaped kinds" subsection

## Why

`source-mapping.md` declared the `risk_file` kind as a directory mirror of `risk-file/`, but the `risk-control` skill emits a single normalized YAML at `docs/.index/risk-file.yaml`. At release time, `evidence-pack <version>` would test `[[ -d risk-file ]]`, find no such directory, and silently skip the most audit-critical artifact for ISO 14971 conformance.

This was first surfaced by the P1-2 sub-agent (#599) and confirmed still present by the P1-3 SKILL.md sweep (#600). Out of scope for both; queued here.

## Where

| File | Change |
|------|--------|
| `source-mapping.md` | `risk_file` section rewritten: presence check `-f docs/.index/risk-file.yaml`, single-file copy, sha256 over file bytes, output `evidence/<version>/risk_file/risk-file.yaml`. Body paragraph rewritten to assert "single file" contract and warn future consumers. |
| `manifest-schema.md` | Allowed-kind table entry for `risk_file` rewritten to describe single-file contract. New "Single-file vs. directory-shaped kinds" subsection classifies all six kinds and explicitly states that promoting `risk_file` to a directory mirror would be a backward-incompatible major schema bump. Example manifest's `risk_file` entry `source` field corrected to `docs/.index/risk-file.yaml`. |

## How

### Acceptance Criteria (all met)
- [x] `source-mapping.md`'s `risk_file` entry explicitly states: source = `docs/.index/risk-file.yaml`, output = `evidence/<version>/risk_file/risk-file.yaml` (single file in a directory of the same kind name, for symmetry with `matrix` and `signed_commits`).
- [x] `manifest-schema.md` `kind` enum entry for `risk_file` is consistent with the single-file contract.
- [x] No behavior change in `risk-control` -- the single-file output stays.
- [x] One-paragraph note in both schema docs that the contract is "single file" so future evidence-pack consumers do not infer otherwise.

### Test Plan for Reviewers
1. Read the diff -- documentation only, no code/script changes.
2. Verify `risk-control/SKILL.md` was not touched (`git show --stat`).
3. Confirm the example manifest in `manifest-schema.md` still parses as YAML (it does -- only one string literal value changed).

### Breaking Changes
None. This is a doc-only correction; the underlying contract has always been single-file (since `risk-control` shipped). The schema version (`_meta.schema: "1.0.0"`) is unchanged.

### Rollback Plan
Revert this PR. No data, no migrations.

## When

### Urgency
Normal. Blocks correct evidence-pack output at the next release, but no release is in flight.

### Dependencies
- Depends on: #599 (`risk-control` shipped, defines the actual contract). Already merged.
- Blocks: future evidence-pack runs that include the `risk_file` kind.

Closes #609
