### PR TITLE
fix(language): make instruction layer respect CLAUDE_CONTENT_LANGUAGE

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -289,9 +289,9 @@ Hooks are user-defined commands that automatically execute during specific Claud
 
 ### 13. PR Language Guard (PreToolUse)
 
-*Hard-blocks non-English titles and bodies in `gh pr` and `gh issue` commands — eliminates the rule drift that lets Korean PR/issue content slip through in long-running batch workflows.*
+*Hard-blocks `gh pr` and `gh issue` titles/bodies that violate the active `CLAUDE_CONTENT_LANGUAGE` policy — eliminates the rule drift that lets off-policy content slip through in long-running batch workflows.*
 
-**Purpose**: Enforces the "All GitHub Issues and Pull Requests must be written in English" rule from `commit-settings.md` at the Bash tool boundary. Mirrors the `commit-message-guard` enforcement model that proved effective for commit messages.
+**Purpose**: Enforces the per-policy artifact rule from `commit-settings.md` (default policy `english`; other values: `korean_plus_english`, `exclusive_bilingual`, `any`) at the Bash tool boundary. Mirrors the `commit-message-guard` enforcement model that proved effective for commit messages.
 
 **Trigger**: `Bash` tool calls matching `gh (pr|issue) (create|edit|comment)`.
 
@@ -302,11 +302,15 @@ Hooks are user-defined commands that automatically execute during specific Claud
 **Logic**:
 1. Scope gate: only process `gh (pr|issue) (create|edit|comment)` commands (all others pass through). Six combinations are guarded — `gh pr create`, `gh pr edit`, `gh pr comment`, `gh issue create`, `gh issue edit`, `gh issue comment`.
 2. Skip command-substitution / heredoc bodies (`--body "$(...)"`) and `--body-file` references — these cannot be parsed at the shell layer, so the hook defers to other safeguards.
-3. Extract `--title` / `-t` and `--body` / `-b` values, supporting both double-quoted and single-quoted forms and `--flag value` / `--flag=value` layouts.
-4. Reject if any extracted value contains a byte outside ASCII printable (0x20-0x7E) or ASCII whitespace (0x09-0x0D).
-5. Deny reason includes the first offending character so Claude can self-correct (e.g. `first: '한'`).
+3. Extract `--title` / `-t`, `--body` / `-b`, and `--notes` / `-n` values, supporting both double-quoted and single-quoted forms and `--flag value` / `--flag=value` layouts.
+4. Dispatch to `validate_content_language` in `hooks/lib/validate-language.sh`, which selects the active validator from `CLAUDE_CONTENT_LANGUAGE` (default `english`).
+5. Deny reason includes the first offending substring and references `commit-settings.md` so Claude can self-correct under whichever policy is active.
 
-**Allowed characters**: ASCII printable (0x20-0x7E) and ASCII whitespace (tab, LF, VT, FF, CR). Anything else — accented Latin, CJK, emoji, symbols outside ASCII — is blocked.
+**Allowed characters (depends on `CLAUDE_CONTENT_LANGUAGE`)**:
+- `english` (default): ASCII printable + whitespace + allowlisted English typographic punctuation (em-dash, en-dash, curly quotes, ellipsis, NBSP).
+- `korean_plus_english`: ASCII + Hangul Syllables / Jamo / Compat Jamo, mixed inline.
+- `exclusive_bilingual`: per-artifact — English-only **or** Korean-only (Korean side allows fenced code, inline code, URLs, and the `한국어(English)` translation form as ASCII containers).
+- `any`: validation skipped.
 
 **Not covered**: `gh pr review --body` is intentionally not guarded (review comments may have different tone/content needs and would warrant a separate policy decision).
 
@@ -333,7 +337,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "PR/issue --body rejected: Text contains non-ASCII characters (first run: '한국어'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+    "permissionDecisionReason": "PR/issue --body rejected: Text contains Korean (Hangul) characters (first run: '한국어'). Active CLAUDE_CONTENT_LANGUAGE='english' rejects this artifact. To allow Korean, set CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual or korean_plus_english. See commit-settings.md."
   }
 }
 ```
@@ -463,7 +467,7 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 
 *Re-asserts critical policy (commit-settings, branching, conventional commits) immediately after `CLAUDE.md` and `.claude/rules/*.md` are loaded — closes the gap where long sessions drift away from policy that lives only in the system prompt.*
 
-**Purpose**: Inject a policy-reinforcement block right after Claude finishes loading instruction files. The block restates AI-attribution prohibition, English-only PR/issue rule, branching policy, and Conventional Commits format so they remain in active context even when the original instruction files scroll out.
+**Purpose**: Inject a policy-reinforcement block right after Claude finishes loading instruction files. The block restates AI-attribution prohibition, the active `CLAUDE_CONTENT_LANGUAGE` PR/issue rule (resolved from `commit-settings.md`), branching policy, and Conventional Commits format so they remain in active context even when the original instruction files scroll out.
 
 **Trigger**: `InstructionsLoaded` event — fires once per session, after `CLAUDE.md` / `.claude/rules/*.md` have been ingested.
 
@@ -502,7 +506,7 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 {
   "hookSpecificOutput": {
     "hookEventName": "InstructionsLoaded",
-    "additionalContext": "## Critical Policy Reinforcement (auto-injected after instruction load)\n\n# Commit, Issue, and PR Settings\n\nNo AI/Claude attribution in commits, issues, or PRs.\nAll GitHub Issues and Pull Requests must be written in English.\n\n## Branching\n\n- Default working branch: `develop`. Never push directly to `main` or `develop`.\n..."
+    "additionalContext": "## Critical Policy Reinforcement (auto-injected after instruction load)\n\n# Commit, Issue, and PR Settings\n\nNo AI/Claude attribution in commits, issues, or PRs.\nAll GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy (values: english | korean_plus_english | exclusive_bilingual | any; default: english). See commit-settings.md for the per-policy artifact rule.\n\n## Branching\n\n- Default working branch: `develop`. Never push directly to `main` or `develop`.\n..."
   }
 }
 ```

--- a/global/commit-settings.md
+++ b/global/commit-settings.md
@@ -5,4 +5,15 @@ Enforced by `settings.json` (`attribution: ""`), the `commit-message-guard` PreT
 
 Filename references to project root config files (`CLAUDE.md`, `CLAUDE.local.md`) and narrative mentions of the config (e.g. "the CLAUDE config loader") are allowed in commit subjects — only attribution patterns (`Co-Authored-By:` trailers, bot emoji adjacent to Claude/Anthropic, "generated/created/authored {with|by|using} {Claude|Anthropic}" prose) are rejected. See the three-pattern design comment in `hooks/lib/validate-commit-message.sh` for the exact rules.
 
-All GitHub Issues and Pull Requests must be written in English.
+All GitHub Issues and Pull Requests must follow the active `CLAUDE_CONTENT_LANGUAGE` policy. Validation is dispatched by `hooks/lib/validate-language.sh` (single source of truth — see issue #410 for the design and #447 for the `exclusive_bilingual` mode):
+
+| `CLAUDE_CONTENT_LANGUAGE` | Per-artifact rule |
+|---------------------------|-------------------|
+| `english` (default, unset, or empty) | ASCII only. Allowlisted English typographic punctuation accepted: em-dash, en-dash, curly quotes, ellipsis, NBSP. |
+| `korean_plus_english`     | ASCII + Hangul (Syllables / Jamo / Compat Jamo). Mixed inline allowed. |
+| `exclusive_bilingual`     | Each artifact (title / body / comment) is **either** English-only **or** Korean-only — no inline mixing. Inside Korean artifacts, the following ASCII containers are allowed: fenced code blocks, inline code, URLs, and the `한국어(English)` translation form. |
+| `any`                     | Skip language validation. |
+
+Sub-agents, skills, and reinforcer hooks MUST resolve the runtime policy from `CLAUDE_CONTENT_LANGUAGE` rather than hard-coding "English only". When in doubt, defer to this file and the dispatcher in `validate-language.sh`.
+
+Conversation language (the language Claude uses to *talk to the user* and reason in `<thinking>`) is a separate axis governed by `conversation-language.md` and `settings.json` `language`. Artifact language ≠ conversation language: a Korean-speaking user may publish English-only PRs (or vice versa) depending on the policy above.

--- a/global/hooks/instructions-loaded-reinforcer.ps1
+++ b/global/hooks/instructions-loaded-reinforcer.ps1
@@ -28,7 +28,9 @@ if (-not $policyText) {
 # Commit, Issue, and PR Settings
 
 No AI/Claude attribution in commits, issues, or PRs.
-All GitHub Issues and Pull Requests must be written in English.
+All GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy
+(values: english | korean_plus_english | exclusive_bilingual | any; default: english).
+See commit-settings.md for the per-policy artifact rule.
 '@
 }
 
@@ -47,7 +49,7 @@ $policyText
 
 Conventional Commits: ``type(scope): description`` or ``type: description``.
 Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security.
-Description: lowercase start, no trailing period, no emojis, no AI attribution.
+Description: first char is lowercase ASCII (default) or Hangul (when CLAUDE_CONTENT_LANGUAGE permits Korean). No trailing period, no emojis, no AI attribution.
 "@
 
 $reinforcement = ($reinforcement -replace "`r`n", "`n").TrimEnd("`n") + "`n"

--- a/global/hooks/instructions-loaded-reinforcer.sh
+++ b/global/hooks/instructions-loaded-reinforcer.sh
@@ -23,7 +23,9 @@ if [ -z "$POLICY_TEXT" ]; then
 # Commit, Issue, and PR Settings
 
 No AI/Claude attribution in commits, issues, or PRs.
-All GitHub Issues and Pull Requests must be written in English.
+All GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy
+(values: english | korean_plus_english | exclusive_bilingual | any; default: english).
+See commit-settings.md for the per-policy artifact rule.
 EOF
 )
 fi
@@ -43,7 +45,7 @@ ${POLICY_TEXT}
 
 Conventional Commits: \`type(scope): description\` or \`type: description\`.
 Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security.
-Description: lowercase start, no trailing period, no emojis, no AI attribution.
+Description: first char is lowercase ASCII (default) or Hangul (when CLAUDE_CONTENT_LANGUAGE permits Korean). No trailing period, no emojis, no AI attribution.
 EOF
 )
 

--- a/global/hooks/lib/LanguageValidator.psm1
+++ b/global/hooks/lib/LanguageValidator.psm1
@@ -183,7 +183,7 @@ function Test-ContentLanguage {
             $reason = "Text contains characters outside the English+Korean policy (first: '$bad'). CLAUDE_CONTENT_LANGUAGE=korean_plus_english allows ASCII and Hangul only."
         }
         default {
-            $reason = "Text contains non-ASCII characters (first: '$bad'). GitHub Issues and Pull Requests must be written in English only — see commit-settings.md."
+            $reason = "Text contains non-ASCII characters (first: '$bad'). Active CLAUDE_CONTENT_LANGUAGE='$policy' rejects this artifact. To allow Korean, set CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual (per-artifact strict) or korean_plus_english (mixed inline). See commit-settings.md."
         }
     }
 

--- a/global/hooks/pr-language-guard.sh
+++ b/global/hooks/pr-language-guard.sh
@@ -83,11 +83,18 @@ if ! command -v validate_content_language >/dev/null 2>&1; then
             any)
                 return 0
                 ;;
-            korean_plus_english)
+            korean_plus_english|exclusive_bilingual)
+                # Fallback note: when the shared library validate-language.sh is
+                # absent, both Korean-allowing policies collapse to the relaxed
+                # ASCII+Hangul check. The strict per-artifact exclusivity rule
+                # of `exclusive_bilingual` (no inline mixing) is enforced only
+                # by the shared library. Preferring false negatives over false
+                # positives here avoids wrongly rejecting legitimate Korean
+                # artifacts when the library is missing.
                 if ! printf '%s' "$text" | perl -CSDA -ne '
                     exit 1 if /[^\x{09}-\x{0D}\x{20}-\x{7E}\x{AC00}-\x{D7A3}\x{1100}-\x{11FF}\x{3130}-\x{318F}]/
                 ' 2>/dev/null; then
-                    echo "Text contains characters outside the English+Korean policy. CLAUDE_CONTENT_LANGUAGE=korean_plus_english allows ASCII and Hangul only." >&2
+                    echo "Text contains characters outside the English+Korean policy. CLAUDE_CONTENT_LANGUAGE=$policy fallback allows ASCII and Hangul only (shared library validate-language.sh absent — install it for full enforcement)." >&2
                     return 1
                 fi
                 return 0
@@ -114,7 +121,7 @@ if ! command -v validate_content_language >/dev/null 2>&1; then
                     fi
                     local sample
                     sample=$(printf '%s' "$cleaned" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
-                    echo "Text contains $category characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only -- see commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed.)" >&2
+                    echo "Text contains $category characters (first run: '$sample'). Active CLAUDE_CONTENT_LANGUAGE='${policy}' rejects this artifact. To allow Korean, set CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual (per-artifact strict) or korean_plus_english (mixed inline). See commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed under the english policy.)" >&2
                     return 1
                 fi
                 return 0

--- a/global/skills/_internal/_shared/invariants.md
+++ b/global/skills/_internal/_shared/invariants.md
@@ -9,7 +9,7 @@ Skills with iterative work (batch loops, CI polling, multi-round research, per-r
 ## Core (5 lines, re-anchor target)
 
 ```
-- PR title/body, commit messages, issue comments: English only
+- PR title/body, commit messages, issue comments: per CLAUDE_CONTENT_LANGUAGE (default english; see commit-settings.md)
 - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
 - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
 - Branch: feature off develop, squash merge back via PR

--- a/global/skills/_internal/fleet-orchestrator/reference/worker-template.md
+++ b/global/skills/_internal/fleet-orchestrator/reference/worker-template.md
@@ -51,8 +51,8 @@ Your per-worker workspace (for logs and intermediate artifacts):
 
 ## Non-Negotiable Rules
 
-1. **Language**: All commit messages, PR titles, PR bodies, and issue comments MUST be English.
-2. **No AI attribution**: Never add "Claude", "Co-Authored-By: Claude", or emojis to commits/PRs.
+1. **Language**: All commit messages, PR titles, PR bodies, and issue comments MUST comply with the active `CLAUDE_CONTENT_LANGUAGE` policy resolved from `~/.claude/commit-settings.md` (default `english`; supports `korean_plus_english`, `exclusive_bilingual`, `any`). Resolve the policy at the start of the worker session — do not hard-code English-only.
+2. **No AI attribution**: Never add "Claude", "Co-Authored-By: Claude", or emojis to commits/PRs (applies under every policy).
 3. **Commit format**: `type(scope): description` (Conventional Commits).
 4. **Branching**: Feature branch off `develop`; squash-merge back via PR. Never push directly to `main` or `develop`.
 5. **ABSOLUTE CI GATE**: Before `gh pr merge`, run `gh pr checks <PR>` and verify every check shows `pass` or `neutral`. Any `fail`, `pending`, `queued`, `in_progress`, `cancelled`, `timed_out`, or `startup_failure` blocks merge.

--- a/global/skills/_internal/implement-all-levels/reference/team-mode.md
+++ b/global/skills/_internal/implement-all-levels/reference/team-mode.md
@@ -84,7 +84,7 @@ Agent(
     - NO placeholder returns: no 'return 0', 'return None', 'return {}'
     - NO untested tiers: each tier MUST have passing tests
 
-    Commit format: feat(scope): implement <tier> tier (English only, no emojis)
+    Commit format: feat(scope): implement <tier> tier (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     Test commit: test(scope): add tests for <tier> tier
 
     Check TaskList for your assigned tasks. Mark each as completed when done."
@@ -139,7 +139,7 @@ Agent(
     Rules:
     - Document each tier as it's completed (don't wait for all tiers)
     - Match existing documentation style
-    - Commit format: docs(scope): document <tier> tier (English only)
+    - Commit format: docs(scope): document <tier> tier (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md)
 
     Check TaskList for your assigned tasks. Mark each as completed when done."
 )

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -335,8 +335,8 @@ as you implement, not in a separate planning phase.
 
 4. **Commit per logical unit**:
    - Format: `type(scope): description`
-   - **Language: MANDATORY English only** - All commit messages MUST be written in English
-   - **Forbidden**: Claude/AI references, emojis, Co-Authored-By
+   - **Language**: Follow the active `CLAUDE_CONTENT_LANGUAGE` policy resolved from `commit-settings.md` (default `english`; supports `korean_plus_english`, `exclusive_bilingual`, `any`). Do **not** assume English-only.
+   - **Forbidden** (every policy): Claude/AI references, emojis, Co-Authored-By
 
 ### 6. Build and Test Verification
 
@@ -427,8 +427,8 @@ gh pr create --repo $ORG/$PROJECT \
 
 **Required**:
 - `Closes #<NUMBER>` keyword to link issue
-- **Language: MANDATORY English only** - All PR titles and descriptions MUST be written in English
-- No Claude/AI references, emojis, or Co-Authored-By (see `commit-settings.md`)
+- **Language**: Follow the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`). PR title and description must each comply with the per-artifact rule of the resolved policy; under `exclusive_bilingual`, each artifact must be wholly English-only or wholly Korean-only.
+- No Claude/AI references, emojis, or Co-Authored-By regardless of policy (see `commit-settings.md`)
 
 After PR creation, capture the PR URL from `gh pr create` output for the summary.
 
@@ -517,7 +517,7 @@ with a summary comment.
 
 ### 12. Update Original Issue
 
-**IMPORTANT**: All issue comments **MUST** be written in **English only**, regardless of the project's primary language or user's locale.
+**IMPORTANT**: Issue comments must comply with the active `CLAUDE_CONTENT_LANGUAGE` policy (resolved from `commit-settings.md`; default `english`). Do not hard-code "English only" — under `exclusive_bilingual` a Korean-only comment is valid, and under `korean_plus_english` mixed inline is valid.
 
 ```bash
 gh issue comment <NUMBER> --repo $ORG/$PROJECT \
@@ -538,7 +538,7 @@ See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-P
 
 | Item | Rule |
 |------|------|
-| **Language** | **All issue comments, PR titles, PR descriptions, and commit messages MUST be written in English only** |
+| **Language** | All issue comments, PR titles, PR descriptions, and commit messages follow the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`) |
 | Issue linking | `Closes #NUM` required in PR |
 | Build verification | Must pass before PR creation |
 

--- a/global/skills/_internal/issue-work/reference/batch-mode.md
+++ b/global/skills/_internal/issue-work/reference/batch-mode.md
@@ -111,7 +111,7 @@ Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`). The five b
 
 ```
 [Item ${PROCESSED+1}/${TOTAL}] Required rules:
-- PR title/body, commit messages, issue comments: English only
+- PR title/body, commit messages, issue comments: per CLAUDE_CONTENT_LANGUAGE (default english; see commit-settings.md)
 - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
 - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
 - Branch: feature off develop, squash merge back via PR
@@ -144,7 +144,7 @@ for each item in approved batch plan:
                Execute /issue-work $REPO $ISSUE_NUMBER --$MODE with full CLAUDE.md compliance.
 
                Required rules (do not skip — canonical source: global/skills/_internal/_shared/invariants.md Core block):
-               - PR title/body, commit messages, issue comments: English only
+               - PR title/body, commit messages, issue comments: per CLAUDE_CONTENT_LANGUAGE (default english; see commit-settings.md)
                - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
                - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
                - Branch: feature off develop, squash merge back via PR

--- a/global/skills/_internal/issue-work/reference/team-mode.md
+++ b/global/skills/_internal/issue-work/reference/team-mode.md
@@ -101,7 +101,7 @@ Agent(
     Rules:
     - Validate incrementally: build after each logical change
     - Follow existing code style strictly
-    - Commit format: type(scope): description (English only, no emojis)
+    - Commit format: type(scope): description (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     - No Claude/AI references in commits
     - When Task 5 is done, send a message to reviewer:
       'Implementation complete. Files changed: [list]. Ready for review.'
@@ -148,7 +148,7 @@ Agent(
        - Push: git push -u origin $BRANCH_NAME
        - Create PR with Closes #$ISSUE_NUMBER
        - PR body: include review summary, all findings and their resolution
-       - English only, no AI references
+       - Language per active CLAUDE_CONTENT_LANGUAGE policy (see commit-settings.md); no AI references
 
     Feedback loop rules:
     - If findings exist, send change requests to dev via SendMessage:
@@ -184,7 +184,7 @@ Agent(
     - Only update docs that are affected by the implementation
     - Do not create new documentation files unless necessary
     - Match existing documentation style and structure
-    - Commit format: docs(scope): description (English only, no emojis)
+    - Commit format: docs(scope): description (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     - No Claude/AI references in commits
 
     Check TaskList for your assigned tasks. Mark each as completed when done."

--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -340,7 +340,7 @@ For each failed workflow:
 
 ### 3. Post Failure Analysis Comment
 
-**MANDATORY**: Post a failure analysis comment to the PR after analysis, before attempting a fix. All comments must be in **English only**. Sanitize secrets, IPs, PII, and connection strings before posting.
+**MANDATORY**: Post a failure analysis comment to the PR after analysis, before attempting a fix. Comment language must comply with the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`; default `english`). Sanitize secrets, IPs, PII, and connection strings before posting regardless of policy.
 
 > See `reference/comment-templates.md` for the full comment template, guidelines, and sensitive data handling rules.
 
@@ -410,8 +410,8 @@ Fixes CI failure: <brief explanation>"
 
 **Commit rules**:
 - Type: Usually `fix`, `build`, `test`, or `ci`
-- **Language: MANDATORY English only** - All commit messages MUST be written in English
-- No Claude/AI references, emojis, or Co-Authored-By (see `commit-settings.md`)
+- **Language**: Follow the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`; default `english`).
+- No Claude/AI references, emojis, or Co-Authored-By regardless of policy (see `commit-settings.md`)
 
 ### 8. Push and Verify
 
@@ -668,7 +668,7 @@ and skip merge. Do not force-merge.
 
 ### 11. Failure Escalation
 
-When max retry attempts (3) are exceeded: post summary comment to PR (English only), add `needs-manual-review` label, and report final status to user.
+When max retry attempts (3) are exceeded: post summary comment to PR (language per active `CLAUDE_CONTENT_LANGUAGE` policy — see `commit-settings.md`), add `needs-manual-review` label, and report final status to user.
 
 > See `reference/comment-templates.md` for the escalation comment template and decision matrix.
 
@@ -686,7 +686,7 @@ See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-P
 
 | Item | Rule |
 |------|------|
-| **Language** | **All PR comments and commit messages MUST be written in English only** |
+| **Language** | All PR comments and commit messages follow the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`) |
 | Max retry attempts | 3 before escalation |
 | CI poll interval | >= 30 seconds (respect API rate limits) |
 | CI max poll duration | 10 minutes per run (20 polls x 30s) |

--- a/global/skills/_internal/pr-work/reference/batch-mode.md
+++ b/global/skills/_internal/pr-work/reference/batch-mode.md
@@ -118,7 +118,7 @@ Use this exact template (substitute `${PROCESSED+1}` and `${TOTAL}`):
 
 ```
 [Item ${PROCESSED+1}/${TOTAL}] Required rules:
-- PR title/body, commit messages, issue comments: English only
+- PR title/body, commit messages, issue comments: per CLAUDE_CONTENT_LANGUAGE (default english; see commit-settings.md)
 - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
 - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
 - Never rationalize a CI failure as "unrelated" or "pre-existing"
@@ -150,7 +150,7 @@ for each item in approved batch plan:
                Execute /pr-work $REPO $PR_NUMBER --$MODE with full CLAUDE.md compliance.
 
                Required rules (do not skip):
-               - PR title/body, commit messages, issue comments: English only
+               - PR title/body, commit messages, issue comments: per CLAUDE_CONTENT_LANGUAGE (default english; see commit-settings.md)
                - Commit format: type(scope): description (no Claude/AI attribution, no emojis)
                - ABSOLUTE CI GATE: gh pr checks must show every check passing before merge
                - Never rationalize a CI failure as "unrelated" or "pre-existing"

--- a/global/skills/_internal/pr-work/reference/comment-templates.md
+++ b/global/skills/_internal/pr-work/reference/comment-templates.md
@@ -8,7 +8,7 @@ Templates for CI/CD failure analysis comments posted to pull requests, including
 
 **MANDATORY**: After analyzing failures, post a comment to the PR documenting the analysis.
 
-**IMPORTANT**: All PR comments **MUST** be written in **English only**, regardless of the project's primary language or user's locale.
+**IMPORTANT**: PR comments must comply with the active `CLAUDE_CONTENT_LANGUAGE` policy resolved from `commit-settings.md` (default `english`; other values: `korean_plus_english`, `exclusive_bilingual`, `any`). Do not hard-code "English only" — under `exclusive_bilingual` a Korean-only comment is valid.
 
 ```bash
 gh pr comment $PR_NUMBER --repo $ORG/$PROJECT --body "$(cat <<'EOF'
@@ -58,7 +58,7 @@ EOF
 
 | Item | Requirement |
 |------|-------------|
-| **Language** | **MANDATORY: English only** - All PR comments MUST be written in English, regardless of project language or user locale |
+| **Language** | Comply with the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`). Per-artifact rule applies: under `exclusive_bilingual`, each comment must be wholly English-only or wholly Korean-only. |
 | Timing | Immediately after failure analysis, before attempting fix |
 | Content | Include actual error messages (sanitized if needed) |
 | Format | Use tables and code blocks for readability |
@@ -78,7 +78,7 @@ Before posting, sanitize the following from error logs:
 
 For subsequent attempts, update the PR with a follow-up comment:
 
-**IMPORTANT**: All PR comments **MUST** be written in **English only**.
+**IMPORTANT**: Comment language follows the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`).
 
 ```bash
 gh pr comment $PR_NUMBER --repo $ORG/$PROJECT --body "$(cat <<'EOF'
@@ -129,7 +129,7 @@ EOF
 
 When max retry attempts (3) are exceeded without success:
 
-**IMPORTANT**: All escalation comments **MUST** be written in **English only**.
+**IMPORTANT**: Escalation comment language follows the active `CLAUDE_CONTENT_LANGUAGE` policy (see `commit-settings.md`).
 
 1. **Add summary comment to PR**:
    ```bash

--- a/global/skills/_internal/pr-work/reference/team-mode.md
+++ b/global/skills/_internal/pr-work/reference/team-mode.md
@@ -75,7 +75,7 @@ Agent(
        apply the requested changes and re-verify locally.
 
     Rules:
-    - Commit format: fix(scope): description (English only, no emojis)
+    - Commit format: fix(scope): description (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     - No Claude/AI references in commits
     - Validate incrementally: build after each fix
     - Do NOT retry the same build without changes -- diagnose first
@@ -103,7 +103,7 @@ Agent(
        For each failure: identify workflow name, job, step, root cause, error category.
        Categorize: build-error | test-failure | lint-error | type-error | link-error | other.
        Propose specific fixes with file paths.
-    2. Task 2: Post failure analysis comment to the PR (English only).
+    2. Task 2: Post failure analysis comment to the PR (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md).
        Include: failed workflows table, root cause analysis, proposed fixes.
     3. Task 5: After dev applies fixes, review the changes:
        - Does the fix address the root cause (not just symptoms)?
@@ -144,7 +144,7 @@ Agent(
 
     Rules:
     - Only update docs affected by the fix
-    - Commit format: docs(scope): description (English only, no emojis)
+    - Commit format: docs(scope): description (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     - No Claude/AI references in commits
     - Match existing documentation style
 

--- a/global/skills/_internal/release/reference/team-mode.md
+++ b/global/skills/_internal/release/reference/team-mode.md
@@ -75,7 +75,7 @@ Agent(
        git push origin 'v$VERSION'
 
     Rules:
-    - Commit format: chore(release): prepare v$VERSION (English only, no emojis)
+    - Commit format: chore(release): prepare v$VERSION (language per active CLAUDE_CONTENT_LANGUAGE policy — see commit-settings.md; no emojis)
     - Do NOT create tag until reviewer approves changelog
 
     Check TaskList for your assigned tasks. Mark each as completed when done."

--- a/hooks/lib/validate-language.sh
+++ b/hooks/lib/validate-language.sh
@@ -92,7 +92,7 @@ validate_english_only() {
 
         local sample
         sample=$(printf '%s' "$cleaned" | LC_ALL=C grep -oE '[^[:print:][:space:]]+' | head -n1)
-        echo "Text contains $category characters (first run: '$sample'). GitHub Issues and Pull Requests must be written in English only -- see commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed.)" >&2
+        echo "Text contains $category characters (first run: '$sample'). Active CLAUDE_CONTENT_LANGUAGE='${CLAUDE_CONTENT_LANGUAGE:-english}' rejects this artifact. To allow Korean, set CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual (per-artifact strict) or korean_plus_english (mixed inline). See commit-settings.md. (English typographic punctuation such as em-dash, curly quotes, and ellipsis is allowed under the english policy.)" >&2
         return 1
     fi
 


### PR DESCRIPTION
## What

Replace every hard-coded "English only" enforcement in the **instruction
layer** with a runtime reference to the active `CLAUDE_CONTENT_LANGUAGE`
policy resolved from `commit-settings.md`.

## Why

The validator layer (`hooks/lib/validate-language.sh`) already dispatches
on `CLAUDE_CONTENT_LANGUAGE` and supports four policies — `english`
(default), `korean_plus_english`, `exclusive_bilingual`, `any`. However,
natural-language instructions in `SKILL.md` files, `team-mode` /
`batch-mode` docs, the `instructions-loaded-reinforcer` fallback text,
and the `HOOKS.md` examples still hard-coded `"English only"` /
`"MANDATORY English only"` / `"regardless of the project's primary
language or user's locale"`.

The model follows the loudest text in its context window, so users who
set a Korean-permitting policy (e.g. `exclusive_bilingual`) still
received English-only PRs and issues in practice. The validator was
correctly relaxed but the LLM was being told the opposite by the
instruction layer.

## Where

17 files. Highlights:

- `global/commit-settings.md` — single-line English rule replaced with a
  four-policy table and an explicit note separating *conversation
  language* from *artifact language*.
- `global/skills/_internal/_shared/invariants.md` — Core 5-line reanchor
  block (SSOT) artifact-language line now references the policy. Both
  `batch-mode.md` copies (`issue-work`, `pr-work`) synced.
- `global/skills/_internal/issue-work/SKILL.md`,
  `pr-work/SKILL.md`,
  `pr-work/reference/comment-templates.md` — every
  `MANDATORY English only` / `regardless of locale` enforcement
  replaced. The `regardless of locale` phrasing that explicitly
  overrode user preference is removed.
- `global/skills/_internal/fleet-orchestrator/reference/worker-template.md`
  + four `team-mode.md` files (`issue-work`, `pr-work`,
  `implement-all-levels`, `release`) — sub-agent non-negotiable rules
  and per-team commit-format reminders now resolve the policy at
  session start.
- `global/hooks/instructions-loaded-reinforcer.{sh,ps1}` — fallback
  inline policy text + commit description first-char rule (Hangul start
  allowed under Korean-permitting policies).
- `global/hooks/pr-language-guard.sh` — fallback `case` was missing
  `exclusive_bilingual`; it silently fell through to the English-only
  branch. Now folds into the relaxed Korean+English check so legitimate
  Korean artifacts are not wrongly rejected when the shared library is
  absent.
- `global/hooks/lib/LanguageValidator.psm1`,
  `hooks/lib/validate-language.sh`, `HOOKS.md` sections 13 and 16 —
  deny messages and example payloads updated with policy name and
  remediation.

## How

Replaced English-only enforcement strings with references to
`CLAUDE_CONTENT_LANGUAGE` (default `english`). The validator dispatcher
already handled all four policies, so this PR is purely the
instruction-layer alignment plus the one fallback gap fix in
`pr-language-guard.sh`.

### Test Plan

- `CLAUDE_CONTENT_LANGUAGE=english` (default) — `pr-language-guard`
  still rejects Korean text. **Behavior unchanged.**
- `CLAUDE_CONTENT_LANGUAGE=exclusive_bilingual` — guard accepts a
  Korean-only PR body and an English-only PR body; rejects mixed inline
  when the shared library is loaded; the inline fallback (no shared lib)
  accepts ASCII+Hangul with a notice.
- Open a session and inspect the `instructions-loaded-reinforcer`
  `additionalContext` payload — confirm it no longer injects
  `"must be written in English"` verbatim.

## Risk / Rollback

Low risk. Documentation-layer + fallback-only changes; default-policy
users see no behavioral difference. Rollback via revert of the squash
commit on `develop`.

## Related

No linked issue (initiated as a follow-up to a Claude session that
diagnosed why Korean-policy users were still seeing English artifacts).
