### PR TITLE
docs(integration): align ad-sdlc-integration with plugin v0.1.0

### DIFF
--- a/docs/ad-sdlc-integration.md
+++ b/docs/ad-sdlc-integration.md
@@ -4,20 +4,23 @@ This document explains how to use claude-config resources in the [AD-SDLC (Agent
 
 ## Overview
 
-AD-SDLC is a platform that automates the software development lifecycle using 27 specialized AI agents. By referencing claude-config's Skills and Guidelines, agents can generate higher quality code.
+AD-SDLC is a platform that automates the software development lifecycle using 35 specialized AI agents (Greenfield, Enhancement, and Import modes). By referencing claude-config's Skills and Guidelines, agents can generate higher quality code. Since claude-config v2.3.0, the project also ships as an installable Claude Code plugin (`claude-config@2.3.0`) that exposes its Skills via the plugin runtime — see [Plugin Activation](#plugin-activation) below.
 
 ## Resource Mapping
 
 ### Skills → AD-SDLC Agents
 
-| claude-config Skill | Recommended AD-SDLC Agent | Purpose |
-|---------------------|---------------------------|---------|
-| `coding-guidelines` | worker, code-reader | Apply naming/structure rules during code generation |
-| `security-audit` | pr-reviewer, ci-fixer | Security vulnerability review |
-| `performance-review` | code-reader, codebase-analyzer | Performance issue identification |
-| `api-design` | sds-writer | API design pattern reference |
-| `documentation` | prd-writer, srs-writer, sds-writer | Documentation standards |
-| `project-workflow` | controller, issue-generator | Issue/PR management rules |
+| claude-config Skill | AD-SDLC Stage | Adoption | Notes |
+|---------------------|---------------|----------|-------|
+| `coding-guidelines` | worker | v0.1.0 auto-preload | AD-19 |
+| `security-audit` | worker, pr-reviewer | v0.1.0 auto-preload | AD-19 |
+| `code-quality` | pr-reviewer | v0.1.0 auto-preload | AD-19 |
+| `pr-review` | pr-reviewer | v0.1.0 auto-preload | AD-19 |
+| `ci-debugging` | ci-fixer | v0.1.0 auto-preload | AD-19 |
+| `api-design` | sds-writer | manual reference | URL or plugin enable |
+| `documentation` | prd-writer, srs-writer, sds-writer | manual reference | URL or plugin enable |
+| `performance-review` | codebase-analyzer | manual reference | |
+| `project-workflow` | controller, issue-generator | manual reference | |
 
 ### Guidelines → AD-SDLC Agents
 
@@ -32,7 +35,19 @@ AD-SDLC is a platform that automates the software development lifecycle using 27
 
 ## Reference Methods
 
-### Method 1: URL Reference in Agent Prompts
+### Recommended (v0.1.0+): Plugin + SDK Skills Frontmatter
+
+Since claude-config v2.3.0, install the plugin and let AD-SDLC v0.1.0+ agents auto-preload Skills via SDK frontmatter — no manual URL or clone is required:
+
+```bash
+# Inside a Claude Code session
+/plugins install claude-config@2.3.0
+/plugins enable claude-config
+```
+
+Once enabled, agents that declare `skills:` in their frontmatter receive the matching plugin Skills automatically at session start. AD-SDLC v0.1.0+ wires `worker`, `pr-reviewer`, and `ci-fixer` to auto-preload `coding-guidelines`, `security-audit`, `code-quality`, `pr-review`, and `ci-debugging`. Skills marked "manual reference" in the table above continue to use Methods 1-3 below.
+
+### Method 1 (legacy): URL Reference in Agent Prompts
 
 Add references to AD-SDLC agent definition files (`.claude/agents/*.md`):
 
@@ -44,7 +59,7 @@ Follow these guidelines when generating code:
 - [Error Handling](https://github.com/kcenon/claude-config/blob/main/project/.claude/rules/coding/error-handling.md)
 ```
 
-### Method 2: Local Clone Reference
+### Method 2 (legacy): Local Clone Reference
 
 ```bash
 # Clone claude-config
@@ -54,11 +69,11 @@ git clone https://github.com/kcenon/claude-config.git ../claude-config
 # "Follow the rules in ../claude-config/project/.claude/rules/ when generating code"
 ```
 
-### Method 3: Direct Remote Reference
+### Method 3 (legacy): Direct Remote Reference
 
 ```bash
 # View SKILL.md content
-curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/.claude/skills/coding-guidelines/SKILL.md
+curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/plugin/skills/coding-guidelines/SKILL.md
 
 # View specific guideline
 curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/.claude/rules/coding/general.md
@@ -145,6 +160,22 @@ Follow these patterns for API design:
 | **Review Efficiency** | Reduce review time with clear criteria |
 | **Security Enhancement** | Apply systematic security checklist |
 
+## Plugin Activation
+
+This section describes how AD-SDLC v0.1.0+ activates claude-config as a Claude Code plugin instead of relying on URL or clone-based references.
+
+```bash
+# Inside a Claude Code session
+/plugins install claude-config@2.3.0
+/plugins enable claude-config
+
+# When AD-SDLC v0.1.0+ runs, worker / pr-reviewer / ci-fixer automatically
+# preload the Skills declared as auto-preload in their frontmatter.
+ad-sdlc run
+```
+
+Once `claude-config` is enabled at the session level, every agent definition that lists matching `skills:` entries receives the plugin Skills without further configuration. Agents whose stage is marked `manual reference` in the Skills table continue to consume Skills via URL or clone (Methods 1 and 2 above).
+
 ## Cautions
 
 1. **Version Sync**: Verify reference URLs when claude-config is updated
@@ -155,5 +186,5 @@ Follow these patterns for API design:
 
 - [claude-config Repository](https://github.com/kcenon/claude-config)
 - [AD-SDLC Repository](https://github.com/kcenon/claude_code_agent)
-- [Skills List](../project/.claude/skills/)
+- [Skills List (plugin)](../plugin/skills/)
 - [Rules List](../project/.claude/rules/)


### PR DESCRIPTION
## What

Refresh `docs/ad-sdlc-integration.md` for AD-SDLC v0.1.0 and claude-config v2.3.0 (plugin runtime). Five changes:

1. Overview: agent count 27 -> 35 (Greenfield, Enhancement, Import modes); mention `claude-config@2.3.0` plugin and link to the new Plugin Activation section.
2. Skills table expanded from 6 rows to 9. New columns: AD-SDLC Stage, Adoption (`v0.1.0 auto-preload` vs `manual reference`), Notes.
3. Reference Methods reordered: a new "Recommended (v0.1.0+)" section is the primary entry point; URL, clone, and curl methods are now marked `(legacy)`.
4. New `Plugin Activation` section (between Expected Benefits and Cautions) documents `/plugins install`, `/plugins enable`, and AD-SDLC v0.1.0 auto-preload behavior.
5. Skill path migrated: `project/.claude/skills/` -> `plugin/skills/` for the curl URL and the Related Links entry.

## Why

Closes kcenon/claude_code_agent#806.

The current document predates AD-19 (plugin skill auto-preload) and AD-SDLC v0.1.0 (Greenfield/Enhancement/Import modes). Without this refresh the integration guide points readers at outdated agent counts, deprecated reference methods, and the wrong skill path.

## Where

- File: `docs/ad-sdlc-integration.md`
- Branch base: `develop`

## How

- Markdown-only edits. No code paths touched.
- Each change isolated so the diff is reviewable section by section.
- Plugin Activation uses a fenced bash block with the v0.1.0 install/enable flow plus an `ad-sdlc run` example.

## Acceptance Criteria

- [x] Overview reflects 35 agents and plugin runtime.
- [x] Skills table has 9 rows with the Adoption column populated.
- [x] Reference Methods has the plugin path as recommended; legacy methods labeled.
- [x] Plugin Activation section added at section 6.
- [x] Skill path uses `plugin/skills/` for the URLs introduced or modified by this PR.
- [ ] CI green (pending).

## Out of Scope

The pre-existing markdown contains broken or stale path references that this PR does not introduce:

- `coding-standards/` references should map to `coding/` (directory was renamed).
- `coding-standards/concurrency.md` and `coding-standards/quality.md` are absent on disk.
- `api-architecture/` references should map to `api/`.

These are unrelated to issue #806 and will be tracked in a follow-up issue.

## Test Plan

1. View the updated document on GitHub: tables render with 9 rows and 4 columns; the new `Plugin Activation` section anchor resolves.
2. Verify the new curl URL resolves to a real `SKILL.md`: https://raw.githubusercontent.com/kcenon/claude-config/main/plugin/skills/coding-guidelines/SKILL.md
3. The inline anchor link `[Plugin Activation](#plugin-activation)` jumps to the new section.

## Cross-repo Notes

- Issue lives in `kcenon/claude_code_agent#806`; this PR lives in `kcenon/claude-config`.
- The auto-close keyword may not fire across repos (claude-config squash-merges to `develop`, not `main`); the issue will be closed manually after merge.
