### PR TITLE
security(hotfix): bundle Phase 0 patches (#616-#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Phase 0 audit hotfix bundle (#616, #617, #618, #619). Four critical defense
+  layers had bypasses that the post-audit triage flagged simultaneously; this
+  release fixes them as a single coordinated patch so reviewers see all four
+  surfaces at once.
+  - `pr-target-guard.sh` (#616) — when `gh pr create` was invoked without
+    `--base`, the hook unconditionally allowed, assuming the repo's default
+    branch was `develop`. Repositories whose default branch is `main` or
+    `master` (e.g. `vcpkg-registry`) silently bypassed the branching policy.
+    The hook now resolves the default branch via
+    `gh api repos/{owner}/{repo} --jq .default_branch` and applies the same
+    develop-or-release-only protection when the resolved base is `main`/`master`.
+    `PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE` exposes the resolution to tests
+    so the new `tests/hooks/fixtures/pr-target-guard/main-default-repo.json`
+    fixture and 9 new test cases run without depending on `gh` authentication.
+  - `memory-sync.sh` (#617) — `post_pull_validate` captured `$?` after a raw
+    validator call. Under `set -euo pipefail`, a non-zero validator exit
+    terminated the whole script before the assignment ran, so the
+    auto-quarantine branch — the last line of defense in the memory sync's
+    five-layer model — never executed. Switched to the standard
+    `rc=0; cmd || rc=$?` idiom so the validator's exit code is preserved
+    without aborting on failure.
+  - `secret-check.sh` (#618) — **BREAKING**. The script shipped with
+    `DEFAULT_OWNER_EMAILS="kcenon@gmail.com"`, embedding the maintainer's
+    personal email in a public repository and giving every fresh installation
+    an owner allowlist that allow-listed the maintainer instead of the
+    operator. The default is now empty; missing `OWNER_EMAILS` exits 2 with
+    a helpful message. Migration:
+    `export OWNER_EMAILS="you@example.com"`
+    See `scripts/memory/secret-check.env.example` for the full template and
+    `docs/MEMORY_TRUST_BASELINE.md` Section 8 for the trust-model rationale.
+    Bootstrap.sh first-run integration is deferred (the memory opt-in flow
+    does not yet exist there).
+  - `install-hooks.sh` (#619) — option 2 ("병합") appended claude-config
+    validators after the existing hook content. If the existing hook called
+    `exit 0` in its primary path, the appended validators never ran and the
+    install appeared to succeed but the gate was silently disabled. Switched
+    to PREPEND so the new validators always run first; an `exit 0` downstream
+    is now dead code unless validators explicitly fall through. Added
+    `tests/hooks/test-merge-installation.sh` covering prepend ordering, the
+    new merge-order summary message, and invalid-message rejection. Users
+    who previously chose "병합" should re-run the installer and choose
+    option 1 (덮어쓰기) to clean up the legacy duplicated block.
 - `bootstrap.sh` pins the install source to a release tag instead of the floating
   `main` branch (SLSA-aligned supply-chain hardening). The default `GITHUB_REF`
   is `v1.10.0`, and `git clone` now uses `--branch "$GITHUB_REF" --depth 1`,

--- a/docs/MEMORY_TRUST_BASELINE.md
+++ b/docs/MEMORY_TRUST_BASELINE.md
@@ -132,7 +132,27 @@ grep '^trust-level:' <memories-dir>/project_steamliner_doc_approval.md
 # expected: trust-level: inferred
 ```
 
-## 8. Cross-References
+## 8. Runtime Owner Identity (OWNER_EMAILS)
+
+Per the explicit-configuration-only principle, `secret-check.sh` does not
+ship a maintainer-specific `OWNER_EMAILS` default. Every installation must
+export the variable before invoking memory-sync flows; an unset value
+yields exit code 2 with a helpful migration message rather than a silent
+"no owner" allowlist (issue #618).
+
+```bash
+export OWNER_EMAILS="you@example.com you+other@example.com"
+# Optional:
+# export OWNER_GITHUB_HANDLE="your-github-handle"
+# export OWNER_HOME_USER="your-unix-user"
+```
+
+A copy-pasteable template lives at `scripts/memory/secret-check.env.example`.
+Trust-level assignment in this document remains valid regardless of the
+runtime owner identity — owner-email matching is one of several heuristics
+applied during scanning, not the source of the per-file tier.
+
+## 9. Cross-References
 
 - `docs/MEMORY_TRUST_MODEL.md` (#511) -- trust-level taxonomy and
   lifecycle.
@@ -142,12 +162,16 @@ grep '^trust-level:' <memories-dir>/project_steamliner_doc_approval.md
   defaults this document confirms.
 - `scripts/memory/injection-check.sh` (#509) -- pre-screen that flagged
   the three CI-policy files referenced in Section 5.
+- `scripts/memory/secret-check.env.example` (#618) -- runtime owner
+  identity template.
 - Issue [#513](https://github.com/kcenon/claude-config/issues/513) --
   authoritative requirement for this decision record.
+- Issue [#618](https://github.com/kcenon/claude-config/issues/618) --
+  removal of hardcoded maintainer email; runtime requirement above.
 - Epic [#505](https://github.com/kcenon/claude-config/issues/505) --
   Phase B trust-tier rollout.
 
-## 9. Change Log
+## 10. Change Log
 
 ### v1.0.0 -- 2026-05-01
 

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -190,6 +190,8 @@ Both workflows use **path filters** — they only trigger when relevant files ch
 |-------|------|-------|
 | GitHub branch protection | Server-side | Blocks direct push to `main` and `develop` |
 | `pre-push` git hook | Client-side | Blocks direct push to `main` and `develop` locally |
+| `pr-target-guard.sh` PreToolUse hook | Client-side | Blocks `gh pr create` whose effective base is `main`/`master` unless `--head develop` or `--head release/*`. When `--base` is omitted, the hook resolves the repo's default branch via `gh api repos/{owner}/{repo} --jq .default_branch` and applies the same protection — main-default repos no longer bypass the policy by virtue of omitting `--base` (#616). |
+| `validate-pr-target.yml` workflow | Server-side | Auto-closes PRs targeting `main` from non-`develop`, non-`release/*` branches |
 | Squash merge only | Server-side | Only squash merge allowed in GitHub settings |
 | Auto-delete branches | Server-side | Cleans up feature branches after PR merge |
 

--- a/global/hooks/memory-write-guard.sh
+++ b/global/hooks/memory-write-guard.sh
@@ -20,6 +20,7 @@
 #   4. Decide:
 #        validate.sh exit 1 or 2 -> deny  (FAIL-STRUCT / FAIL-FORMAT)
 #        secret-check.sh exit 1  -> deny  (SECRET-DETECTED)
+#        secret-check.sh exit 2  -> deny  (OWNER_EMAILS not configured, #618)
 #        injection-check.sh exit 3 -> allow with feedback (warn-only, never blocks)
 #        validate.sh exit 3       -> allow with feedback (semantic warning)
 #        else                     -> allow
@@ -253,16 +254,22 @@ build_deny_reason() {
     if [ "$SECRET_RC" -eq 1 ]; then
         reason="${reason}\nsecret-check.sh blocked write:\n${SECRET_OUT}"
     fi
+    if [ "$SECRET_RC" -eq 2 ]; then
+        reason="${reason}\nsecret-check.sh requires configuration (#618):\n${SECRET_OUT}"
+    fi
     printf '%s' "$reason"
 }
 
 # Per spec: validate.sh codes 1 (FAIL-STRUCT) and 2 (FAIL-FORMAT) are blocking;
 # code 3 (WARN-SEMANTIC) is non-blocking. secret-check.sh code 1 is blocking.
+# secret-check.sh code 2 (configuration required, #618) is also blocking —
+# without OWNER_EMAILS we cannot tell owner emails from foreign emails, so
+# fail-closed is the safe choice.
 BLOCK=0
 if [ "$VALIDATE_RC" -eq 1 ] || [ "$VALIDATE_RC" -eq 2 ]; then
     BLOCK=1
 fi
-if [ "$SECRET_RC" -eq 1 ]; then
+if [ "$SECRET_RC" -eq 1 ] || [ "$SECRET_RC" -eq 2 ]; then
     BLOCK=1
 fi
 

--- a/global/hooks/pr-target-guard.sh
+++ b/global/hooks/pr-target-guard.sh
@@ -63,28 +63,46 @@ if [ -z "$BASE" ]; then
     BASE=$(echo "$CMD" | sed -nE "s/.*-B[[:space:]]*[\"']?([a-zA-Z0-9._/-]+).*/\1/p" | head -1)
 fi
 
-# If no --base flag found, the PR uses the repo default branch (develop).
-# Allow it — this is the normal feature-to-develop workflow.
+# If no --base flag found, query the repo's default branch instead of
+# blindly allowing. Repos with default_branch=main (e.g. vcpkg-registry)
+# previously bypassed the policy because the hook assumed develop-default.
+# PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE allows tests to inject without gh.
 if [ -z "$BASE" ]; then
-    allow_response
+    if [ -n "${PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE:-}" ]; then
+        BASE="$PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE"
+    else
+        REPO=$(echo "$CMD" | sed -nE "s/.*--repo[= ][\"']?([a-zA-Z0-9._/-]+).*/\1/p" | head -1)
+        if [ -z "$REPO" ]; then
+            REPO=$(echo "$CMD" | sed -nE "s/.*-R[[:space:]]+[\"']?([a-zA-Z0-9._/-]+).*/\1/p" | head -1)
+        fi
+        if [ -n "$REPO" ]; then
+            BASE=$(gh api "repos/$REPO" --jq .default_branch 2>/dev/null || true)
+        else
+            BASE=$(gh api 'repos/{owner}/{repo}' --jq .default_branch 2>/dev/null || true)
+        fi
+    fi
+    # Graceful degradation: preserve historical allow if we cannot resolve.
+    if [ -z "$BASE" ]; then
+        allow_response
+    fi
 fi
 
 # Strip surrounding quotes if present
 BASE=$(echo "$BASE" | sed -E "s/^[\"']//;s/[\"']$//")
 
-# Only block if base is exactly 'main' (not 'main-backup', 'maintain', etc.)
-if [ "$BASE" != "main" ]; then
+# Only block if base is exactly 'main' or 'master'.
+if [ "$BASE" != "main" ] && [ "$BASE" != "master" ]; then
     allow_response
 fi
 
-# Base is 'main' — check if this is a release PR (--head develop or release/*)
+# Base is 'main' or 'master' — check if this is a release PR (--head develop or release/*)
 HEAD=$(echo "$CMD" | sed -nE "s/.*(--head[= ])[\"']?([a-zA-Z0-9._/-]+).*/\2/p" | head -1)
 if [ -z "$HEAD" ]; then
     HEAD=$(echo "$CMD" | sed -nE "s/.*-H[[:space:]]*[\"']?([a-zA-Z0-9._/-]+).*/\1/p" | head -1)
 fi
 HEAD=$(echo "$HEAD" | sed -E "s/^[\"']//;s/[\"']$//")
 
-# Allow release PRs: develop → main or release/* → main
+# Allow release PRs: develop → main/master or release/* → main/master
 # (matches .github/workflows/validate-pr-target.yml server-side policy)
 if [ "$HEAD" = "develop" ]; then
     allow_response
@@ -95,5 +113,5 @@ case "$HEAD" in
         ;;
 esac
 
-# Deny: non-develop/non-release branch targeting main
-deny_response "PR targeting 'main' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into 'main'. Feature/fix branches must target 'develop'."
+# Deny: non-develop/non-release branch targeting main or master
+deny_response "PR targeting '${BASE}' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into '${BASE}'. Feature/fix branches must target 'develop'."

--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -9,8 +9,21 @@
 #   hooks/install-hooks.sh --force      # non-interactive — overwrite all
 #   hooks/install-hooks.sh -y           # alias for --force
 #
+# Merge contract (when option 2 "병합" is chosen):
+#   The new claude-config validators are PREPENDED — they run before the
+#   existing hook content. If a validator exits non-zero, git rejects the
+#   commit/push and the existing hook never runs. Pre-#619 builds appended
+#   after, which let an existing 'exit 0' silently bypass the new validators.
+#   If you previously merged with the old behavior, choose option 1
+#   (overwrite) on the next install to clean up the duplicated block.
+#
 # The non-interactive mode is intended for CI, automation sessions, and
 # scripted provisioning where no TTY is available to answer the prompt.
+#
+# Environment overrides (test/automation use):
+#   INSTALL_HOOKS_TARGET_DIR  override the install destination (default
+#                             $REPO_ROOT/.git/hooks). Used by
+#                             tests/hooks/test-merge-installation.sh.
 
 set -euo pipefail
 
@@ -21,7 +34,7 @@ for arg in "$@"; do
             FORCE_MODE=1
             ;;
         -h|--help)
-            sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -48,7 +61,7 @@ error() { echo -e "${RED}❌ $1${NC}"; }
 # 스크립트 디렉토리
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+GIT_HOOKS_DIR="${INSTALL_HOOKS_TARGET_DIR:-$REPO_ROOT/.git/hooks}"
 
 echo -e "${BLUE}"
 cat << 'EOF'
@@ -88,7 +101,7 @@ install_hook() {
             info "  --force: 덮어쓰기 선택 (비대화)"
         else
             echo "  1) 덮어쓰기 (교체)"
-            echo "  2) 병합 (기존 hook 뒤에 추가)"
+            echo "  2) 병합 (claude-config validators run BEFORE existing hook)"
             echo "  3) 건너뛰기"
             read -p "  선택 (1-3) [기본값: 3]: " choice
             choice=${choice:-3}
@@ -101,13 +114,23 @@ install_hook() {
                 success "$hook_name hook 덮어쓰기 완료!"
                 ;;
             2)
+                # PREPEND new validators before existing hook content (#619).
+                # Old behavior appended after, which let `exit 0` in the
+                # existing hook silently bypass the new validators.
+                local existing_body
+                existing_body=$(tail -n +2 "$target_file")
                 {
+                    head -n 1 "$source_file"
                     echo ""
-                    echo "# --- claude-config hooks (appended $(date +%Y-%m-%d)) ---"
+                    echo "# --- claude-config $hook_name (prepended $(date +%Y-%m-%d)) ---"
                     tail -n +2 "$source_file"
-                } >> "$target_file"
+                    echo ""
+                    echo "# --- existing $hook_name content (preserved) ---"
+                    echo "$existing_body"
+                } > "$target_file"
                 chmod +x "$target_file"
-                success "$hook_name hook 병합 완료!"
+                success "$hook_name hook 병합 완료 (claude-config validators run first)"
+                info "  merge order: 1) claude-config validators  2) existing hook content"
                 ;;
             3)
                 info "$hook_name 설치를 건너뜁니다."

--- a/scripts/memory-sync.sh
+++ b/scripts/memory-sync.sh
@@ -410,10 +410,11 @@ post_pull_validate() {
     base="$(basename "$f")"
     [[ "$base" == "MEMORY.md" ]] && continue
 
-    "$validate" "$f" >/dev/null
-    rc_v=$?
-    "$secret" "$f" >/dev/null
-    rc_s=$?
+    # `rc=0; cmd || rc=$?` preserves exit code under set -e so quarantine still runs.
+    rc_v=0
+    "$validate" "$f" >/dev/null || rc_v=$?
+    rc_s=0
+    "$secret" "$f" >/dev/null || rc_s=$?
     # injection is warn-only; do not factor into the fail count.
     if [[ -n "$injection" ]]; then
       "$injection" "$f" >/dev/null || true

--- a/scripts/memory-sync.sh
+++ b/scripts/memory-sync.sh
@@ -424,7 +424,9 @@ post_pull_validate() {
     if (( rc_v == 1 || rc_v == 2 )); then
       file_failed=1
     fi
-    if (( rc_s == 1 )); then
+    # secret-check exit 1 = SECRET-DETECTED, exit 2 = OWNER_EMAILS unset (#618).
+    # Both are fail-closed — without OWNER_EMAILS we cannot tell owner from foreign.
+    if (( rc_s == 1 || rc_s == 2 )); then
       file_failed=1
     fi
 

--- a/scripts/memory/quarantine-restore.sh
+++ b/scripts/memory/quarantine-restore.sh
@@ -57,7 +57,7 @@ EXIT CODES
 
 VALIDATORS RUN
     validate.sh         (exit 1 = FAIL-STRUCT, 2 = FAIL-FORMAT both block)
-    secret-check.sh     (exit 1 = SECRET-DETECTED blocks)
+    secret-check.sh     (exit 1 = SECRET-DETECTED, 2 = OWNER_EMAILS unset; both block)
     injection-check.sh  (warn-only; never blocks restore)
 
 NOTES
@@ -256,7 +256,7 @@ main() {
   esac
   printf '  validate.sh:    %s\n' "$val_label"
 
-  # secret-check.sh: 0 = CLEAN, 1 = SECRET-DETECTED (blocks).
+  # secret-check.sh: 0 = CLEAN, 1 = SECRET-DETECTED, 2 = OWNER_EMAILS unset (#618).
   local sec_rc=0
   local sec_label="CLEAN"
   local sec_out
@@ -264,6 +264,7 @@ main() {
   case "$sec_rc" in
     0) sec_label="CLEAN" ;;
     1) sec_label="SECRET-DETECTED" ;;
+    2) sec_label="CONFIG-REQUIRED" ;;
     *) sec_label="UNKNOWN($sec_rc)" ;;
   esac
   printf '  secret-check.sh: %s\n' "$sec_label"
@@ -283,8 +284,10 @@ main() {
   fi
 
   # Decide whether to refuse. Blocking failures: validate.sh in (1, 2),
-  # secret-check.sh == 1. injection-check.sh never blocks (per spec).
-  if (( val_rc == 1 || val_rc == 2 || sec_rc == 1 )); then
+  # secret-check.sh in (1, 2). injection-check.sh never blocks (per spec).
+  # secret-check exit 2 = OWNER_EMAILS unset; fail-closed since we cannot
+  # determine owner emails without it (#618).
+  if (( val_rc == 1 || val_rc == 2 || sec_rc == 1 || sec_rc == 2 )); then
     printf '%s\n' "$val_out"
     printf '%s\n' "$sec_out"
     if [[ -n "$inj_out" ]] && (( inj_rc != 0 )); then

--- a/scripts/memory/secret-check.env.example
+++ b/scripts/memory/secret-check.env.example
@@ -1,0 +1,26 @@
+# scripts/memory/secret-check.env.example
+#
+# Sample configuration for secret-check.sh. Copy to .env (gitignored) or
+# export the variables in your shell startup before running memory sync.
+#
+# Required:
+#   OWNER_EMAILS — space-separated email allowlist. At least one address.
+#
+# Optional:
+#   OWNER_GITHUB_HANDLE — your GitHub handle. Used to recognize the
+#     <numeric>+<HANDLE>@users.noreply.github.com and
+#     <HANDLE>@users.noreply.github.com forms as owner emails.
+#   OWNER_HOME_USER — your Unix home directory user. Used to recognize
+#     /Users/<user>/ and /home/<user>/ paths as your own (not foreign).
+#
+# Usage:
+#   1. cp scripts/memory/secret-check.env.example .env
+#   2. Edit .env with your values
+#   3. source .env
+#   4. ./scripts/memory-sync.sh
+#
+# See docs/MEMORY_TRUST_BASELINE.md for the trust model.
+
+export OWNER_EMAILS="you@example.com"
+export OWNER_GITHUB_HANDLE="your-github-handle"
+export OWNER_HOME_USER="your-unix-user"

--- a/scripts/memory/secret-check.sh
+++ b/scripts/memory/secret-check.sh
@@ -6,6 +6,7 @@
 # Exit codes:
 #   0  -- CLEAN (no findings)
 #   1  -- SECRET-DETECTED (at least one finding; blocks merge)
+#   2  -- configuration required (OWNER_EMAILS not set)
 #   64 -- usage error
 #
 # Usage:
@@ -13,23 +14,42 @@
 #   secret-check.sh --all <dir>     batch mode (skips MEMORY.md)
 #   secret-check.sh --help|-h       show usage
 #
-# Environment overrides (all optional):
-#   OWNER_EMAILS         space-separated owner email allowlist (default: kcenon@gmail.com)
-#   OWNER_GITHUB_HANDLE  GitHub handle for no-reply allowlist (default: kcenon)
-#   OWNER_HOME_USER      owner Unix home directory user (default: raphaelshin)
+# Required environment:
+#   OWNER_EMAILS         space-separated owner email allowlist (no default)
+# Optional environment overrides:
+#   OWNER_GITHUB_HANDLE  GitHub handle for no-reply allowlist
+#   OWNER_HOME_USER      owner Unix home directory user
+#
+# See scripts/memory/secret-check.env.example for a sample configuration.
 
 set -u
 
-# Default owner identity. Caller may override via env vars.
-DEFAULT_OWNER_EMAILS="kcenon@gmail.com"
+# Empty default — caller must export OWNER_EMAILS explicitly (issue #618).
+DEFAULT_OWNER_EMAILS=""
 DEFAULT_OWNER_GITHUB_HANDLE="kcenon"
 DEFAULT_OWNER_HOME_USER="raphaelshin"
 
-# Parse OWNER_EMAILS into a bash array (space-separated).
-# Use ${VAR:-default} to avoid mutating the caller's environment.
 read -r -a OWNER_EMAILS_ARR <<< "${OWNER_EMAILS:-$DEFAULT_OWNER_EMAILS}"
 OWNER_GITHUB_HANDLE="${OWNER_GITHUB_HANDLE:-$DEFAULT_OWNER_GITHUB_HANDLE}"
 OWNER_HOME_USER="${OWNER_HOME_USER:-$DEFAULT_OWNER_HOME_USER}"
+
+# Exit 2 = configuration-required (distinct from 1=finding, 64=usage).
+require_owner_emails() {
+  if (( ${#OWNER_EMAILS_ARR[@]} == 0 )) || [[ -z "${OWNER_EMAILS_ARR[0]}" ]]; then
+    cat >&2 <<'EOF'
+secret-check.sh: OWNER_EMAILS is not set.
+
+Memory validation cannot run without a configured owner email allowlist.
+Set the OWNER_EMAILS environment variable (space-separated) before invocation:
+
+    export OWNER_EMAILS="you@example.com"
+
+See scripts/memory/secret-check.env.example for the full configuration template
+and docs/MEMORY_TRUST_BASELINE.md for the trust-model rationale.
+EOF
+    exit 2
+  fi
+}
 
 usage() {
   cat <<EOF
@@ -40,12 +60,14 @@ Usage:
   $(basename "$0") --all <dir>     scan every .md in <dir> (MEMORY.md skipped)
   $(basename "$0") --help|-h       show this help
 
-Exit codes: 0=clean, 1=finding (blocks), 64=usage error.
+Exit codes: 0=clean, 1=finding (blocks), 2=OWNER_EMAILS not set, 64=usage error.
 
-Environment overrides:
-  OWNER_EMAILS          space-separated allowlist (default: ${DEFAULT_OWNER_EMAILS})
-  OWNER_GITHUB_HANDLE   GitHub handle for noreply allowlist (default: ${DEFAULT_OWNER_GITHUB_HANDLE})
-  OWNER_HOME_USER       owner Unix home dir name (default: ${DEFAULT_OWNER_HOME_USER})
+Environment:
+  OWNER_EMAILS          required, space-separated allowlist
+  OWNER_GITHUB_HANDLE   optional GitHub handle for noreply allowlist
+  OWNER_HOME_USER       optional Unix home directory user
+
+See scripts/memory/secret-check.env.example for a sample.
 EOF
 }
 
@@ -166,6 +188,7 @@ main() {
       exit 0
       ;;
     --all)
+      require_owner_emails
       if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
         echo "error: --all requires a directory argument" >&2
         usage >&2
@@ -194,6 +217,7 @@ main() {
       exit 0
       ;;
     *)
+      require_owner_emails
       if [[ ! -f "$1" ]]; then
         echo "error: file not found: $1" >&2
         exit 64

--- a/tests/hooks/fixtures/pr-target-guard/main-default-repo.json
+++ b/tests/hooks/fixtures/pr-target-guard/main-default-repo.json
@@ -1,0 +1,12 @@
+{
+  "tool_input": {
+    "command": "gh pr create --repo kcenon/vcpkg-registry --title \"chore: update manifest\" --body \"routine update\""
+  },
+  "_meta": {
+    "fixture": "pr-target-guard/main-default-repo",
+    "issue": "https://github.com/kcenon/claude-config/issues/616",
+    "scenario": "gh pr create with no --base in a repo whose default branch is main",
+    "expected": "deny — must not bypass the policy because default_branch=main",
+    "test_invocation": "PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE=main bash global/hooks/pr-target-guard.sh < tests/hooks/fixtures/pr-target-guard/main-default-repo.json"
+  }
+}

--- a/tests/hooks/test-memory-write-guard.sh
+++ b/tests/hooks/test-memory-write-guard.sh
@@ -20,6 +20,13 @@ export HOME="$TEST_HOME"
 MEM="$HOME/.claude/memory-shared/memories"
 mkdir -p "$MEM"
 
+# OWNER_EMAILS is required by secret-check.sh as of #618. Configure a test
+# owner so the secret-detection paths can run; the test suite still uses
+# validate.sh + secret-check.sh + injection-check.sh as the real chain.
+export OWNER_EMAILS="test-owner@example.com"
+export OWNER_GITHUB_HANDLE="test-owner"
+export OWNER_HOME_USER="test-owner"
+
 # Symlink validators to ${HOME}/.claude/scripts/memory/ so the hook's
 # locator finds them regardless of the user's installed claude-config.
 mkdir -p "$HOME/.claude/scripts/memory"

--- a/tests/hooks/test-merge-installation.sh
+++ b/tests/hooks/test-merge-installation.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Test suite for install-hooks.sh merge mode prepend behavior (#619).
+#
+# Verifies that when a user chooses option 2 "병합", claude-config
+# validators are PREPENDED before the existing hook content so an
+# existing `exit 0` cannot silently bypass them.
+#
+# Run: bash tests/hooks/test-merge-installation.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+INSTALLER="hooks/install-hooks.sh"
+
+note_pass() {
+    ((PASS++))
+    echo "  PASS: $1"
+}
+
+note_fail() {
+    ((FAIL++))
+    ERRORS+=("FAIL: $1")
+    echo "  FAIL: $1"
+}
+
+echo "=== install-hooks.sh merge mode tests (#619) ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 1: prepend ordering
+# ---------------------------------------------------------------------------
+echo "[Test 1: claude-config block is prepended, not appended]"
+TMP=$(mktemp -d)
+trap "rm -rf '$TMP'" EXIT
+TARGET="$TMP/git-hooks"
+mkdir -p "$TARGET"
+
+# Plant an existing commit-msg hook whose primary path exits 0.
+cat > "$TARGET/commit-msg" <<'EOF'
+#!/bin/bash
+echo "EXISTING_HOOK_RAN" >&2
+exit 0
+EOF
+chmod +x "$TARGET/commit-msg"
+
+# Feed "2" to the only prompt (commit-msg has an existing hook). The other
+# two installs (pre-commit, pre-push) write fresh and do not prompt.
+INSTALL_HOOKS_TARGET_DIR="$TARGET" \
+  bash "$INSTALLER" <<<"2" >"$TMP/install.log" 2>&1 || true
+
+if [[ ! -f "$TARGET/commit-msg" ]]; then
+    note_fail "commit-msg hook was not installed"
+else
+    content=$(cat "$TARGET/commit-msg")
+    # The claude-config prepend marker must appear before the existing marker.
+    prepend_pos=$(grep -n "claude-config commit-msg (prepended" <<<"$content" | head -1 | cut -d: -f1)
+    existing_pos=$(grep -n "EXISTING_HOOK_RAN" <<<"$content" | head -1 | cut -d: -f1)
+    if [[ -z "$prepend_pos" ]]; then
+        note_fail "claude-config prepend marker missing in merged commit-msg"
+    elif [[ -z "$existing_pos" ]]; then
+        note_fail "existing-hook content missing in merged commit-msg"
+    elif (( prepend_pos < existing_pos )); then
+        note_pass "claude-config block precedes existing content (prepend@${prepend_pos} < existing@${existing_pos})"
+    else
+        note_fail "claude-config block is not before existing (prepend@${prepend_pos} >= existing@${existing_pos}) — bug regressed"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: installer reports merge order
+# ---------------------------------------------------------------------------
+echo ""
+echo "[Test 2: installer prints merge order summary]"
+if grep -q "merge order: 1) claude-config validators  2) existing hook content" "$TMP/install.log"; then
+    note_pass "merge order summary present in installer stdout"
+else
+    note_fail "merge order summary missing — install log:"
+    sed 's/^/    /' "$TMP/install.log" | head -20 >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: claude-config validators have authority — invalid message rejected
+# ---------------------------------------------------------------------------
+# The "prepend" model means the new validators decide first and exit. An
+# existing 'exit 0' downstream cannot override unless claude-config falls
+# through. Send an invalid commit message and verify the merged hook
+# rejects it (exit non-zero) — proves new validators ran and were not
+# bypassed.
+echo ""
+echo "[Test 3: invalid message rejected (existing exit 0 cannot bypass new validators)]"
+mkdir -p "$TARGET/lib"
+cp hooks/lib/validate-commit-message.sh "$TARGET/lib/" 2>/dev/null || true
+[[ -f hooks/lib/validate-traceability.sh ]] && cp hooks/lib/validate-traceability.sh "$TARGET/lib/" 2>/dev/null || true
+
+INVALID_MSG="$TMP/invalid-commit"
+# Invalid Conventional Commits type — rejected by validate-commit-message.sh.
+# (commit-msg only inspects the first non-comment line.)
+printf 'nope: this commit type is not allowed\n' > "$INVALID_MSG"
+
+set +e
+(cd "$TARGET" && bash "./commit-msg" "$INVALID_MSG") >"$TMP/invalid.out" 2>&1
+rc=$?
+set -e
+
+if (( rc != 0 )); then
+    note_pass "claude-config validators rejected invalid commit-type message (exit $rc); existing exit 0 did not bypass"
+else
+    note_fail "merged hook returned 0 on invalid message — new validators were bypassed (regression)"
+    sed 's/^/    /' "$TMP/invalid.out" | head -10 >&2
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0

--- a/tests/hooks/test-pr-target-guard.sh
+++ b/tests/hooks/test-pr-target-guard.sh
@@ -80,7 +80,9 @@ assert_deny '{"tool_input":{"command":"gh pr create --base main --head release-c
 echo ""
 echo "[Normal workflow: allow]"
 assert_allow '{"tool_input":{"command":"gh pr create --base develop --title \"feat: new feature\""}}' "--base develop → allow"
-assert_allow '{"tool_input":{"command":"gh pr create --title \"feat: something\""}}' "no --base (defaults to develop) → allow"
+# The "no --base" case is now repository-default-dependent (#616). The
+# develop-default scenario is exercised in the [Default-branch query]
+# block below using PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE=develop.
 assert_allow '{"tool_input":{"command":"gh pr create --base develop --head feat/issue-42"}}' "--base develop --head feat/ → allow"
 
 echo ""
@@ -89,6 +91,34 @@ assert_allow '{"tool_input":{"command":"gh pr create --base main-backup --title 
 assert_allow '{"tool_input":{"command":"gh pr create --base maintain --title \"test\""}}' "--base maintain → allow (not exact main)"
 assert_deny '{"tool_input":{"command":"cd repo && gh pr create --base main --title \"fix\""}}' "chained command with --base main → deny"
 assert_deny '{"tool_input":{"command":"gh pr create --repo org/repo --base main --title \"fix\""}}' "--repo with --base main → deny"
+
+echo ""
+echo "[Default-branch query when --base missing (#616)]"
+# PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE injects the resolved branch so the
+# test does not depend on gh API authentication. Drives the new code path
+# that closes the main-default repo bypass.
+assert_with_branch() {
+    local expect="$1" branch="$2" input="$3" label="$4"
+    local result
+    result=$(echo "$input" | PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE="$branch" bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q "\"$expect\""; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected $expect, got: $result")
+        echo "  FAIL: $label"
+    fi
+}
+assert_with_branch deny  main "$(cat tests/hooks/fixtures/pr-target-guard/main-default-repo.json)" "fixture: main-default + no --base → deny"
+assert_with_branch deny  main   '{"tool_input":{"command":"gh pr create --title test"}}' "main-default + no --base + no --head → deny"
+assert_with_branch deny  main   '{"tool_input":{"command":"gh pr create --head feat/x --title test"}}' "main-default + --head feat/x → deny"
+assert_with_branch allow main   '{"tool_input":{"command":"gh pr create --head develop --title release"}}' "main-default + --head develop → allow"
+assert_with_branch allow main   '{"tool_input":{"command":"gh pr create --head release/1.0 --title release"}}' "main-default + --head release/1.0 → allow"
+assert_with_branch allow develop '{"tool_input":{"command":"gh pr create --title test"}}' "develop-default + no --base → allow (regression)"
+assert_with_branch deny  master '{"tool_input":{"command":"gh pr create --head fix/bug --title test"}}' "master-default + --head fix/x → deny"
+assert_with_branch allow master '{"tool_input":{"command":"gh pr create --head develop --title release"}}' "master-default + --head develop → allow"
+assert_with_branch allow trunk  '{"tool_input":{"command":"gh pr create --title test"}}' "non-main/master default (trunk) → allow"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## What

Phase 0 hotfix bundle from the 2026-05-08 multi-persona audit. Four critical bypass findings, fixed and reviewed together so reviewers see all bypass surfaces at once instead of in disconnected PRs (per epic #626 plan).

| Issue | Area | Severity | Acceptance status |
|-------|------|----------|-------------------|
| #616 | `pr-target-guard.sh` main-default bypass | Major (security) | 5/5 ACs met |
| #617 | `memory-sync.sh` set -e drops validator exit code | Major (correctness) | 1/1 AC met |
| #618 | `secret-check.sh` hardcoded maintainer email | Major (privacy) | 4/6 ACs met (bootstrap.sh deferred) |
| #619 | `install-hooks.sh` merge-mode bypass | Major (security) | 5/5 ACs met |

Closes #616
Closes #617
Closes #618
Closes #619

## Why

Each fix targets a defense layer that was *silently* disabled — installation succeeded, the gate looked active, but a downstream `exit 0`, a missing `--base`, an unset env var, or a `set -e` interaction made the validator inert. Bundling avoids partial mitigation: a reviewer who agrees with #616 alone could miss the related blast radius in #618's exit-code propagation.

## How

| File | Change |
|------|--------|
| `global/hooks/pr-target-guard.sh` | When `--base` missing, resolve default branch via `gh api repos/{owner}/{repo} --jq .default_branch`. Apply protection when default is `main`/`master`. `PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE` for tests. Graceful degradation on gh failure preserves historical allow. |
| `scripts/memory-sync.sh` | `post_pull_validate` switched from `cmd; rc=$?` to `rc=0; cmd \|\| rc=$?` so `set -euo pipefail` doesn't terminate before the assignment. Also extended `rc_s == 1` block check to `rc_s == 1 \|\| rc_s == 2` to honor #618's new exit code. |
| `scripts/memory/secret-check.sh` | `DEFAULT_OWNER_EMAILS=""`. Missing `OWNER_EMAILS` exits 2 with a helpful migration message (`require_owner_emails` called from `--all` and single-file paths; `--help` still works without env). Exit-code header and usage text updated. |
| `scripts/memory/secret-check.env.example` | New migration template. |
| `docs/MEMORY_TRUST_BASELINE.md` | Section 8 documents the new runtime requirement; cross-references updated. |
| `global/hooks/memory-write-guard.sh` | Treat secret-check exit 2 as block (was silently `allow`). Docstring + decision logic + reason text updated. |
| `scripts/memory/quarantine-restore.sh` | Same exit-2 propagation: case label `CONFIG-REQUIRED`, decision adds `\|\| sec_rc == 2`. |
| `hooks/install-hooks.sh` | Merge mode rewritten to **prepend** claude-config validators. Old behavior appended after, letting an existing `exit 0` bypass them. Adds `INSTALL_HOOKS_TARGET_DIR` env override for tests, prints a one-line merge-order summary, and documents the merge contract in `--help`. |
| `tests/hooks/fixtures/pr-target-guard/main-default-repo.json` | New reproducer fixture for #616. |
| `tests/hooks/test-pr-target-guard.sh` | +9 cases via `assert_with_branch` helper, covering main-default, master-default, develop-default, and trunk-default permutations. Replaces an existing test whose label assumed develop default (the bug used to mask the scenario). |
| `tests/hooks/test-merge-installation.sh` | New end-to-end test: prepend ordering, summary message, invalid-message rejection through the merged hook. |
| `tests/hooks/test-memory-write-guard.sh` | Exports `OWNER_EMAILS` so the existing assertions exercise the real validator path instead of tripping the new exit-2 short-circuit. |
| `docs/branching-strategy.md` | Enforcement-Layers table now documents `pr-target-guard.sh` and `validate-pr-target.yml` plus the new resolved-default behavior. |
| `CHANGELOG.md` | "Security" section under `[Unreleased]` enumerates the four fixes, including the **BREAKING** note for `OWNER_EMAILS` migration. |

## Test plan

Locally on this branch (gh authenticated, claude-config repo's default_branch = `main`):

```
$ bash tests/hooks/test-pr-target-guard.sh        # 38 passed, 0 failed
$ bash tests/hooks/test-merge-installation.sh     # 3 passed, 0 failed
$ bash tests/hooks/test-memory-write-guard.sh     # 13 passed, 0 failed
$ bash tests/hooks/test-runner.sh                 # 596 passed, 0 failed (full suite)
```

Manual scenarios verified:

- `secret-check.sh --help` works without `OWNER_EMAILS`.
- `secret-check.sh README.md` exits 2 with migration message when `OWNER_EMAILS` unset.
- `OWNER_EMAILS="x@y.z" secret-check.sh README.md` returns CLEAN.
- `gh pr create --title test` against this `main`-default repo would now resolve to deny (verified via `PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE=main` test fixture).

CI does not trigger on develop-targeting PRs; the hook test suite is the authoritative gate. The full suite — including unrelated tests in `tests/hooks/` — was re-run after each commit to confirm no collateral regressions.

## Deferred (out of scope, follow-up issues to be filed)

- **#618 bootstrap.sh first-run prompt** — bootstrap.sh has no memory opt-in flow today, so adding an interactive `OWNER_EMAILS` prompt is a new feature rather than a hotfix. To be raised as a follow-up issue against the v1.11 milestone.
- **#618 OWNER_GITHUB_HANDLE / OWNER_HOME_USER defaults** — these still ship with the maintainer's identity. Surgical-precision principle kept this PR's scope to the email leak (the only AC item); the broader cleanup deserves its own discussion (security vs. backward compatibility for established installs).

## Risk

- **Breaking change** for any installation that relied on the implicit `kcenon@gmail.com` default; mitigated by exit-2 message, env example, doc section, and CHANGELOG.
- The `pr-target-guard` change broadens denials in `main`-default repos. The test fixture and graceful-degradation branch (gh failure → allow) keep the change observable in tests but minimize disruption when gh is unauthenticated.
- The install-hooks prepend changes the merged-hook semantics: existing hooks no longer run after the claude-config block exits, even on success. Documented in the help output and the legacy-merge cleanup note in the CHANGELOG.

## Phase mapping

This PR realises Phase 0 of epic #626. Phase 1 (#620), Phase 2 (#621, #622), and Phase 3 (#623, #624, #625) are queued as separate work items per the dependency graph in the epic.
