### PR TITLE
security(infra): extract installer-fetch lib and apply to all entry points (#620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,5 +60,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GITHUB_REF` variable; setting it emits a stderr warning. Migrate any
   automation that overrides `GITHUB_BRANCH` to `GITHUB_REF` before the next
   major release.
+- Phase 1 supply-chain parity (#620). The download → verify → run contract
+  introduced for `bootstrap.sh` is now extracted into a shared library and
+  applied to the two remaining install entry points:
+  - `hooks/lib/installer-fetch.sh` and `hooks/lib/InstallerFetch.psm1` are
+    the new single source of truth for download + sha256 verify + run.
+    Typed exit codes (`0=OK`, `10=DOWNLOAD`, `11=CHECKSUM`, `12=MISMATCH`,
+    `13=RUN`, `64=usage`) are mirrored in both implementations.
+  - `bootstrap.sh` and `bootstrap.ps1` now clone the repo before invoking
+    the Claude Code CLI installer so the lib is available; the GITHUB_REF
+    tag is therefore the integrity root for every subsequent verification.
+  - `bootstrap.ps1` no longer pipes `irm | iex`; pins the Anthropic
+    PowerShell installer at sha256
+    `acc15c3d844b8952e702a24b584d2fdc0b589ee1061c11202529cdd5702711df`
+    (`# pinned 2026-05-09`).
+  - `bootstrap.ps1` repo clone now uses `--branch $GitHubRef --depth 1`
+    with the same `v1.10.0` default as the bash side. `GITHUB_BRANCH`
+    remains a one-release deprecation alias.
+  - `scripts/install.sh` `ensure_claude_cli` no longer pipes `curl | bash`;
+    sources the shared lib and verifies sha256 before executing.
+  - Regression suite `tests/scripts/installer-fetch-tests.sh` covers
+    happy path, download failure, sha mismatch, run failure, and usage
+    errors with local `file://` fixtures (no network dependency).
+  - Windows runner CI for `bootstrap.ps1` and a TTY-aware non-interactive
+    default are deferred to a follow-up.
 
 [Unreleased]: https://github.com/kcenon/claude-config/compare/v1.10.0...HEAD

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -17,7 +17,23 @@ $ErrorActionPreference = 'Stop'
 # GitHub repository settings
 $GitHubUser   = if ($env:GITHUB_USER)   { $env:GITHUB_USER }   else { 'kcenon' }
 $GitHubRepo   = if ($env:GITHUB_REPO)   { $env:GITHUB_REPO }   else { 'claude-config' }
-$GitHubBranch = if ($env:GITHUB_BRANCH) { $env:GITHUB_BRANCH } else { 'main' }
+
+# Pin install source to a release tag for SLSA-aligned supply-chain hardening
+# (#620). Floating refs (e.g. 'main') ship whatever HEAD is at install time,
+# leaving no integrity baseline. GITHUB_BRANCH remains a one-release deprecation
+# alias for the new GITHUB_REF variable.
+if ($env:GITHUB_BRANCH) {
+    Write-Warning "GITHUB_BRANCH is deprecated, use GITHUB_REF"
+}
+$GitHubRef = if ($env:GITHUB_REF) { $env:GITHUB_REF }
+             elseif ($env:GITHUB_BRANCH) { $env:GITHUB_BRANCH }
+             else { 'v1.10.0' }
+
+# Anthropic Claude Code installer pin (#620 — supply-chain parity with bash).
+# The Anthropic-hosted PowerShell installer is pinned by sha256 to prevent
+# MITM substitution. Rotation policy mirrors docs/SUPPLY_CHAIN.md.
+$AnthropicInstallerUrl    = if ($env:ANTHROPIC_INSTALLER_URL) { $env:ANTHROPIC_INSTALLER_URL } else { 'https://claude.ai/install.ps1' }
+$AnthropicInstallerSha256 = if ($env:ANTHROPIC_INSTALLER_SHA256) { $env:ANTHROPIC_INSTALLER_SHA256 } else { 'acc15c3d844b8952e702a24b584d2fdc0b589ee1061c11202529cdd5702711df' }  # pinned 2026-05-09
 
 # Installation directory
 $InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $HOME 'claude_config_backup' }
@@ -90,12 +106,22 @@ function Confirm-ClaudeCli {
     # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
     # 설치 경로: $env:USERPROFILE\.local\bin\claude.exe (Windows) /
     #           ~/.local/bin/claude (macOS, Linux, WSL)
-    $installerUrl = 'https://claude.ai/install.ps1'
-    Write-Info "Native installer 실행 중: $installerUrl"
-    try {
-        $installerScript = Invoke-RestMethod -Uri $installerUrl -ErrorAction Stop
-        Invoke-Expression $installerScript
-
+    #
+    # Supply-chain hardening (#620): delegates to InstallerFetch.psm1 which
+    # mirrors hooks/lib/installer-fetch.sh. The chained 'irm | iex' pattern is
+    # gone — the script is fetched, sha256-verified, then executed.
+    $modulePath = Join-Path $InstallDir 'hooks' 'lib' 'InstallerFetch.psm1'
+    if (-not (Test-Path -LiteralPath $modulePath)) {
+        Write-Warn "InstallerFetch.psm1 missing at $modulePath — refusing unverified install"
+        return
+    }
+    Import-Module $modulePath -Force -DisableNameChecking
+    Write-Info "Native installer 실행 중: $AnthropicInstallerUrl"
+    $rc = Invoke-InstallerFetchVerifyRun `
+        -Url $AnthropicInstallerUrl `
+        -ExpectedSha256 $AnthropicInstallerSha256 `
+        -Label 'claude-installer'
+    if ($rc -eq 0) {
         # PATH에 새로 추가된 ~/.local/bin이 아직 반영되지 않았을 수 있다.
         $localBin = Join-Path $HOME '.local' 'bin'
         if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
@@ -121,10 +147,9 @@ function Confirm-ClaudeCli {
             Write-Host "  새 PowerShell 세션을 시작하거나 PATH를 갱신하세요."
         }
     }
-    catch {
-        Write-Warn "Claude Code CLI 자동 설치 실패: $($_.Exception.Message)"
-        Write-Host "  수동 설치: irm https://claude.ai/install.ps1 | iex"
-        Write-Host "  또는 Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
+    else {
+        Write-Warn "Claude Code CLI 자동 설치 실패 (Invoke-InstallerFetchVerifyRun rc=$rc)."
+        Write-Host "  Anthropic 공식 가이드: https://code.claude.com/docs/en/setup"
     }
 }
 
@@ -145,7 +170,7 @@ function Invoke-CloneRepository {
             Write-Info "기존 디렉토리를 사용합니다. git pull 실행..."
             Push-Location $InstallDir
             try {
-                & git pull origin $GitHubBranch
+                & git pull origin $GitHubRef
             }
             finally {
                 Pop-Location
@@ -154,8 +179,9 @@ function Invoke-CloneRepository {
         }
     }
 
-    & git clone "https://github.com/$GitHubUser/$GitHubRepo.git" $InstallDir
-    Write-Ok "저장소 클론 완료: $InstallDir"
+    # Pinned to GITHUB_REF tag with --depth 1 for bandwidth efficiency.
+    & git clone --branch $GitHubRef --depth 1 "https://github.com/$GitHubUser/$GitHubRepo.git" $InstallDir
+    Write-Ok "저장소 클론 완료: $InstallDir (ref: $GitHubRef)"
 }
 
 # ── Install global settings ──────────────────────────────────
@@ -441,8 +467,11 @@ function Install-ProjectSettings {
 
 function Invoke-Main {
     Test-Dependencies
-    Confirm-ClaudeCli
+    # Invoke-CloneRepository must run before Confirm-ClaudeCli — the latter
+    # imports hooks/lib/InstallerFetch.psm1 from the just-cloned tag (#620).
+    # Trust root: GITHUB_REF tag → cloned hooks/lib/* → pinned sha256 verify.
     Invoke-CloneRepository
+    Confirm-ClaudeCli
 
     $installType = Select-InstallType
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -156,61 +156,20 @@ ensure_claude_cli() {
 
     # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
     # 설치 경로: ~/.local/bin/claude → ~/.local/share/claude/versions/<ver>
-    # check_dependencies()에서 curl-or-wget 존재를 이미 보장하므로 둘 중 하나는 반드시 사용 가능.
     #
-    # Supply-chain hardening (M1.2b, see #565):
-    # The chained `curl ... | bash` pattern is replaced with download → verify
-    # sha256 → execute. The pinned hash lives in $ANTHROPIC_INSTALLER_SHA256.
-    # On mismatch we abort and instruct the user to wait for a maintainer
-    # re-pin instead of executing potentially tampered content.
-    local installer_url="$ANTHROPIC_INSTALLER_URL"
+    # Supply-chain hardening (M1.2b, see #565; lib extraction #620):
+    # Delegates to hooks/lib/installer-fetch.sh which encapsulates the
+    # download → verify-sha256 → run contract. Source it from the clone so
+    # bootstrap.sh, scripts/install.sh and bootstrap.ps1 share one
+    # implementation; the lib is fetched as part of the tagged repo, so the
+    # GITHUB_REF pin is the integrity root for every subsequent verification.
     local install_status=1
-    local tmp_installer
-    tmp_installer="$(mktemp -t claude-installer.XXXXXX)"
-    # Ensure the temp file is removed even if the function returns early or
-    # the integrity check fails.
-    # shellcheck disable=SC2064
-    trap "rm -f '$tmp_installer'" RETURN
-
-    info "Native installer 다운로드 중: $installer_url"
-    local download_ok=1
-    if command -v curl >/dev/null 2>&1; then
-        if curl -fsSL "$installer_url" -o "$tmp_installer"; then
-            download_ok=0
-        fi
-    elif command -v wget >/dev/null 2>&1; then
-        if wget -qO "$tmp_installer" "$installer_url"; then
-            download_ok=0
-        fi
-    fi
-
-    if [ $download_ok -ne 0 ]; then
-        warning "Native installer 다운로드 실패: $installer_url"
-        echo "  네트워크 또는 Anthropic 측 일시 장애일 수 있습니다."
-        echo "  수동 설치 가이드: https://code.claude.com/docs/en/setup"
-        return 0
-    fi
-
-    info "sha256 무결성 확인 중 (pin: ${ANTHROPIC_INSTALLER_SHA256:0:12}...)"
-    if ! command -v sha256sum >/dev/null 2>&1; then
-        warning "sha256sum 미설치 — 무결성 검증을 건너뛸 수 없습니다."
-        echo "  coreutils (Linux) 또는 'brew install coreutils' (macOS)로 설치하세요."
-        return 0
-    fi
-    if ! echo "${ANTHROPIC_INSTALLER_SHA256}  ${tmp_installer}" | sha256sum -c - >/dev/null 2>&1; then
-        local actual_hash
-        actual_hash="$(sha256sum "$tmp_installer" | awk '{print $1}')"
-        warning "Anthropic installer sha256 불일치 — 설치 중단."
-        echo "  expected: $ANTHROPIC_INSTALLER_SHA256"
-        echo "  actual:   $actual_hash"
-        echo "  Anthropic가 정상적으로 installer를 갱신했다면 maintainer가 docs/SUPPLY_CHAIN.md 절차에 따라 재핀합니다."
-        echo "  MITM 또는 캐시 변조 가능성이 있으므로 수동 진행 전에 보안 팀에 알리세요."
-        return 1
-    fi
-    success "sha256 검증 통과"
-
-    info "Native installer 실행 중"
-    if bash "$tmp_installer"; then
+    # shellcheck disable=SC1091
+    source "$INSTALL_DIR/hooks/lib/installer-fetch.sh"
+    if installer_fetch_verify_run \
+        "$ANTHROPIC_INSTALLER_URL" \
+        "$ANTHROPIC_INSTALLER_SHA256" \
+        "claude-installer"; then
         install_status=0
     fi
 
@@ -442,8 +401,11 @@ install_project() {
 # 메인 실행
 main() {
     check_dependencies
-    ensure_claude_cli
+    # clone_repository must run before ensure_claude_cli — the latter sources
+    # hooks/lib/installer-fetch.sh from the just-cloned tag (#620). Trust
+    # root: GITHUB_REF tag → cloned hooks/lib/* → pinned sha256 verification.
     clone_repository
+    ensure_claude_cli
     select_install_type
 
     case $INSTALL_TYPE in

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -119,9 +119,44 @@ ANTHROPIC_INSTALLER_SHA256="0000000000000000000000000000000000000000000000000000
 Expected: install aborts with the mismatch banner before any code from
 `https://claude.ai/install.sh` is executed.
 
+## Multi-entry-point parity (#620)
+
+The download → verify → run contract is shared across all three install
+entry points:
+
+| Entry point | Verifies via | Pinned hash variable |
+|-------------|--------------|----------------------|
+| `bootstrap.sh` (one-line `curl ... \| bash`) | `hooks/lib/installer-fetch.sh` | `ANTHROPIC_INSTALLER_SHA256` |
+| `scripts/install.sh` (`ensure_claude_cli`) | `hooks/lib/installer-fetch.sh` | `ANTHROPIC_INSTALLER_SHA256` |
+| `bootstrap.ps1` (one-line `irm \| iex`) | `hooks/lib/InstallerFetch.psm1` | `$AnthropicInstallerSha256` |
+
+The bash and PowerShell libs share the same exit-code semantics
+(`0=OK`, `10=DOWNLOAD`, `11=CHECKSUM`, `12=MISMATCH`, `13=RUN`,
+`64=usage`). Regression coverage lives at
+`tests/scripts/installer-fetch-tests.sh`.
+
+Because `bootstrap.sh` and `bootstrap.ps1` run before the repo is cloned,
+both reorder their `main` to clone first, then source/import the lib from
+the just-cloned tag. This makes the `GITHUB_REF` tag the integrity root for
+every subsequent verification step in those entry points.
+
+### PowerShell installer pin
+
+`bootstrap.ps1` ships a parallel pin for `https://claude.ai/install.ps1`.
+Compute it the same way:
+
+```bash
+curl -fsSL https://claude.ai/install.ps1 | sha256sum
+```
+
+Rotate via `$AnthropicInstallerSha256` in `bootstrap.ps1` together with the
+`# pinned YYYY-MM-DD` comment. The same review checklist as the bash pin
+applies; if the bash and PowerShell installers drift independently the
+maintainer rotates each side separately rather than waiting for both.
+
 ## Related
 
-- Issue: #565 (M1.2b)
+- Issue: #565 (M1.2b — bash sha256 pin), #620 (parity sync to ps1 + install.sh)
 - Parent EPIC: #562 (supply-chain hardening rollup)
 - Sibling: #564 / PR #571 (M1.2a — pin `claude-config` source by tag)
 - Workflow: `.github/workflows/check-anthropic-installer.yml`

--- a/hooks/lib/InstallerFetch.psm1
+++ b/hooks/lib/InstallerFetch.psm1
@@ -1,0 +1,107 @@
+# InstallerFetch.psm1 — PowerShell mirror of hooks/lib/installer-fetch.sh.
+#
+# Single source of truth for the supply-chain hardening contract used by
+# bootstrap.ps1. The bash counterpart serves bootstrap.sh and
+# scripts/install.sh; both implementations share the same exit-code
+# semantics so the regression suite can exercise either side equivalently.
+#
+# Contract (mirror of installer-fetch.sh):
+#   1. Download URL to a fresh temp file.
+#   2. Compute sha256 with Get-FileHash and compare to expected pin.
+#   3. On match: invoke the script (.ps1 via dot-source, .sh via bash if
+#      present) and clean up the temp file.
+#   4. On mismatch / download fail: return a typed exit code.
+#
+# Exit codes:
+#   0  OK
+#   10 DOWNLOAD
+#   11 CHECKSUM   (Get-FileHash unexpectedly unavailable)
+#   12 MISMATCH
+#   13 RUN
+#
+# Usage:
+#   Import-Module ./hooks/lib/InstallerFetch.psm1
+#   Invoke-InstallerFetchVerifyRun `
+#       -Url 'https://claude.ai/install.ps1' `
+#       -ExpectedSha256 'acc15c3d844b8952e702a24b584d2fdc0b589ee1061c11202529cdd5702711df' `
+#       -Label 'claude-installer'
+#
+# UX: callers may define Write-Info / Write-Ok / Write-Warn before importing;
+# the module honors them if present, else falls back to Write-Host.
+
+function Get-IfvUxAction {
+    param([string]$Name, [string]$Color)
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return { param($M) & $cmd $M }.GetNewClosure()
+    }
+    return { param($M) Write-Host "  $M" -ForegroundColor $Color }.GetNewClosure()
+}
+
+function Invoke-InstallerFetchVerifyRun {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Url,
+        [Parameter(Mandatory = $true)] [string] $ExpectedSha256,
+        [Parameter(Mandatory = $false)] [string] $Label = 'installer'
+    )
+
+    $info = Get-IfvUxAction -Name 'Write-Info' -Color 'Cyan'
+    $ok   = Get-IfvUxAction -Name 'Write-Ok'   -Color 'Green'
+    $warn = Get-IfvUxAction -Name 'Write-Warn' -Color 'Yellow'
+
+    # Step 1 — download to fresh temp file. New-TemporaryFile guarantees a
+    # unique path; we explicitly rename to .ps1 so dot-source resolves.
+    $tmpRaw = [System.IO.Path]::GetTempFileName()
+    $tmp    = "$tmpRaw.ps1"
+    Rename-Item -LiteralPath $tmpRaw -NewName ([System.IO.Path]::GetFileName($tmp)) -Force
+
+    try {
+        & $info "${Label}: downloading $Url"
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $tmp -ErrorAction Stop
+        } catch {
+            & $warn "${Label}: download failed: $($_.Exception.Message)"
+            return 10
+        }
+
+        # Step 2 — sha256 verify. Get-FileHash is core in PS5+/PS7+; if it is
+        # somehow unavailable we treat it as a CHECKSUM error (11).
+        if (-not (Get-Command Get-FileHash -ErrorAction SilentlyContinue)) {
+            & $warn "${Label}: Get-FileHash not available — cannot verify integrity"
+            return 11
+        }
+
+        & $info "${Label}: verifying sha256 (pin $($ExpectedSha256.Substring(0,12))...)"
+        $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $tmp).Hash.ToLowerInvariant()
+        $expected = $ExpectedSha256.ToLowerInvariant()
+        if ($actual -ne $expected) {
+            & $warn "${Label}: sha256 mismatch — installer aborted"
+            & $warn "  expected: $expected"
+            & $warn "  actual:   $actual"
+            & $warn "  Anthropic may have rotated the script; wait for a maintainer re-pin."
+            return 12
+        }
+        & $ok "${Label}: sha256 verified"
+
+        # Step 3 — run the .ps1. Dot-source gives access to script-scoped
+        # variables; if that is undesirable in the future, switch to a
+        # fresh PowerShell sub-process.
+        & $info "${Label}: running installer"
+        try {
+            & $tmp
+        } catch {
+            & $warn "${Label}: installer threw: $($_.Exception.Message)"
+            return 13
+        }
+        if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+            & $warn "${Label}: installer exited with code $LASTEXITCODE"
+            return 13
+        }
+        return 0
+    } finally {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Export-ModuleMember -Function Invoke-InstallerFetchVerifyRun

--- a/hooks/lib/installer-fetch.sh
+++ b/hooks/lib/installer-fetch.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# installer-fetch.sh — shared download/verify/run helper for install entry points.
+#
+# Single source of truth for the supply-chain hardening contract used by:
+#   - bootstrap.sh         (one-line installer)
+#   - scripts/install.sh   (manual installer, ensure_claude_cli)
+#   - bootstrap.ps1 calls Invoke-InstallerFetchVerifyRun in InstallerFetch.psm1
+#     which mirrors this contract (#620).
+#
+# Contract:
+#   1. Download the URL to a fresh mktemp file.
+#   2. Verify sha256 against an expected pinned value.
+#   3. On match: run with bash and clean up the temp file.
+#   4. On mismatch / download fail / sha256sum unavailable: abort with a
+#      typed exit code that callers can branch on.
+#
+# Exit codes:
+#    0  OK           installer ran successfully
+#   10  DOWNLOAD     curl/wget failed or both unavailable
+#   11  CHECKSUM     sha256sum unavailable on the host
+#   12  MISMATCH     sha256 did not match the pinned value
+#   13  RUN          installer was launched but exited non-zero
+#
+# Usage:
+#   source hooks/lib/installer-fetch.sh
+#   installer_fetch_verify_run \
+#       "https://claude.ai/install.sh" \
+#       "b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830" \
+#       "claude-installer"
+#
+# Caller-provided UX functions (info, warning, success, error) are honored if
+# defined; otherwise the lib falls back to plain printf to stderr/stdout so
+# scripts that source the lib without a UI veneer still get readable output.
+#
+# IFV_ prefix on every internal name keeps the lib safe to source alongside
+# the rest of the bootstrap state.
+
+# Resolve UX hooks. Use parameter-substitution checks against `command -v` so
+# we honor both function declarations and shell builtins/aliases the caller
+# may have set up.
+ifv_info()    { if command -v info    >/dev/null 2>&1; then info    "$@"; else printf '  %s\n' "$*"; fi; }
+ifv_warn()    { if command -v warning >/dev/null 2>&1; then warning "$@"; else printf '  %s\n' "$*" >&2; fi; }
+ifv_ok()      { if command -v success >/dev/null 2>&1; then success "$@"; else printf '  %s\n' "$*"; fi; }
+
+# installer_fetch_verify_run <url> <expected_sha256> <label>
+# Exits the calling shell only on success of the underlying installer; any
+# error path returns a non-zero status the caller can act on.
+installer_fetch_verify_run() {
+    local url="$1"
+    local expected_sha="$2"
+    local label="${3:-installer}"
+
+    if [ -z "$url" ] || [ -z "$expected_sha" ]; then
+        ifv_warn "${label}: installer_fetch_verify_run requires <url> <sha256> <label>"
+        return 64
+    fi
+
+    # Step 1 — download to mktemp. mktemp guarantees a unique path so two
+    # parallel installs do not race on the same target.
+    local tmp
+    tmp="$(mktemp -t "${label}.XXXXXX")"
+    # The cleanup trap fires regardless of how the function exits; the temp
+    # file never lingers in /tmp even on sha mismatch or interrupt. We use a
+    # subshell-local trap (RETURN) so the caller's own EXIT trap is undisturbed.
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp'" RETURN
+
+    ifv_info "${label}: downloading ${url}"
+    if command -v curl >/dev/null 2>&1; then
+        if ! curl -fsSL "$url" -o "$tmp"; then
+            ifv_warn "${label}: download failed via curl"
+            return 10
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if ! wget -qO "$tmp" "$url"; then
+            ifv_warn "${label}: download failed via wget"
+            return 10
+        fi
+    else
+        ifv_warn "${label}: neither curl nor wget is available"
+        return 10
+    fi
+
+    # Step 2 — sha256 verification. sha256sum is part of coreutils and ships
+    # on every distro; macOS users without coreutils get a clear message.
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        ifv_warn "${label}: sha256sum not found — cannot verify integrity"
+        ifv_warn "  install coreutils (Linux) or 'brew install coreutils' (macOS)"
+        return 11
+    fi
+
+    ifv_info "${label}: verifying sha256 (pin ${expected_sha:0:12}...)"
+    if ! printf '%s  %s\n' "$expected_sha" "$tmp" | sha256sum -c - >/dev/null 2>&1; then
+        local actual
+        actual="$(sha256sum "$tmp" 2>/dev/null | awk '{print $1}')"
+        ifv_warn "${label}: sha256 mismatch — installer aborted"
+        ifv_warn "  expected: $expected_sha"
+        ifv_warn "  actual:   ${actual:-<unknown>}"
+        ifv_warn "  Anthropic may have rotated the script; wait for a maintainer re-pin."
+        return 12
+    fi
+    ifv_ok "${label}: sha256 verified"
+
+    # Step 3 — run.
+    ifv_info "${label}: running installer"
+    if ! bash "$tmp"; then
+        ifv_warn "${label}: installer exited non-zero"
+        return 13
+    fi
+    return 0
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,22 +102,27 @@ ensure_claude_cli() {
 
     # Native installer는 Anthropic 공식 권장 방식이며 백그라운드 자동 업데이트를 지원한다.
     # 설치 경로: ~/.local/bin/claude → ~/.local/share/claude/versions/<ver>
-    local installer_url="https://claude.ai/install.sh"
+    #
+    # Supply-chain hardening (#620): delegates to hooks/lib/installer-fetch.sh
+    # for download → sha256 verify → run. The pinned hash is shared with
+    # bootstrap.sh and lives in $ANTHROPIC_INSTALLER_SHA256. Bare
+    # 'curl | bash' is no longer used — every install path verifies.
+    local installer_url="${ANTHROPIC_INSTALLER_URL:-https://claude.ai/install.sh}"
+    local installer_sha="${ANTHROPIC_INSTALLER_SHA256:-b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830}"
     local install_status=1
-    info "Native installer 실행 중: $installer_url"
-    if command -v curl >/dev/null 2>&1; then
-        if curl -fsSL "$installer_url" | bash; then
-            install_status=0
-        fi
-    elif command -v wget >/dev/null 2>&1; then
-        if wget -qO- "$installer_url" | bash; then
-            install_status=0
-        fi
-    else
-        warning "curl/wget이 모두 없어 자동 설치를 진행할 수 없습니다."
-        echo "  curl 설치 후 재시도하거나 수동으로 다음을 실행하세요:"
-        echo "    curl -fsSL https://claude.ai/install.sh | bash"
+
+    local script_dir repo_root
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    repo_root="$(dirname "$script_dir")"
+    if [ ! -f "$repo_root/hooks/lib/installer-fetch.sh" ]; then
+        warning "installer-fetch.sh not found at $repo_root/hooks/lib/ — refusing unverified install"
         return 0
+    fi
+    # shellcheck disable=SC1091
+    source "$repo_root/hooks/lib/installer-fetch.sh"
+    info "Native installer 실행 중: $installer_url"
+    if installer_fetch_verify_run "$installer_url" "$installer_sha" "claude-installer"; then
+        install_status=0
     fi
 
     if [ $install_status -eq 0 ]; then

--- a/tests/scripts/installer-fetch-tests.sh
+++ b/tests/scripts/installer-fetch-tests.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Regression suite for hooks/lib/installer-fetch.sh (#620).
+#
+# Exercises the four documented exit codes (OK, DOWNLOAD, MISMATCH, RUN) with
+# a local file:// fixture so the test runs deterministically without network.
+#
+# Run: bash tests/scripts/installer-fetch-tests.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+LIB="hooks/lib/installer-fetch.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+note_pass() { ((PASS++)); echo "  PASS: $1"; }
+note_fail() { ((FAIL++)); ERRORS+=("FAIL: $1"); echo "  FAIL: $1"; }
+
+run_lib() {
+    # Sub-shell so the lib's RETURN trap doesn't leak. We capture rc and
+    # suppress stdout/stderr — failure messages are evaluated by exit code.
+    local url="$1" sha="$2" label="${3:-installer}"
+    (
+        # shellcheck disable=SC1090
+        source "$LIB"
+        installer_fetch_verify_run "$url" "$sha" "$label" >/dev/null 2>&1
+    )
+    return $?
+}
+
+echo "=== installer-fetch.sh regression ($LIB) ==="
+echo ""
+
+TMP=$(mktemp -d)
+trap "rm -rf '$TMP'" EXIT
+
+# Plant a "installer" that prints a marker. We will measure success by the
+# lib's exit code, not by reading the marker, since the lib runs the script.
+cat > "$TMP/installer.sh" <<'EOF'
+#!/bin/bash
+echo "INSTALLER_RAN_OK"
+exit 0
+EOF
+chmod +x "$TMP/installer.sh"
+
+GOOD_SHA=$(sha256sum "$TMP/installer.sh" | awk '{print $1}')
+BAD_SHA="0000000000000000000000000000000000000000000000000000000000000000"
+GOOD_URL="file://$TMP/installer.sh"
+
+# Plant a script that exits non-zero to exercise RUN failure.
+cat > "$TMP/bad-exit.sh" <<'EOF'
+#!/bin/bash
+exit 7
+EOF
+chmod +x "$TMP/bad-exit.sh"
+BAD_EXIT_SHA=$(sha256sum "$TMP/bad-exit.sh" | awk '{print $1}')
+BAD_EXIT_URL="file://$TMP/bad-exit.sh"
+
+echo "[Happy path]"
+run_lib "$GOOD_URL" "$GOOD_SHA" "test-ok"; rc=$?
+if (( rc == 0 )); then note_pass "valid sha + reachable file → exit 0"
+else note_fail "happy path returned $rc (expected 0)"; fi
+
+echo ""
+echo "[DOWNLOAD failure]"
+run_lib "file://$TMP/does-not-exist" "$GOOD_SHA" "test-dl"; rc=$?
+if (( rc == 10 )); then note_pass "missing file → exit 10 (DOWNLOAD)"
+else note_fail "missing file returned $rc (expected 10)"; fi
+
+echo ""
+echo "[MISMATCH]"
+run_lib "$GOOD_URL" "$BAD_SHA" "test-mismatch"; rc=$?
+if (( rc == 12 )); then note_pass "wrong sha → exit 12 (MISMATCH)"
+else note_fail "wrong sha returned $rc (expected 12)"; fi
+
+echo ""
+echo "[RUN failure]"
+run_lib "$BAD_EXIT_URL" "$BAD_EXIT_SHA" "test-run-fail"; rc=$?
+if (( rc == 13 )); then note_pass "installer exits non-zero → exit 13 (RUN)"
+else note_fail "RUN failure returned $rc (expected 13)"; fi
+
+echo ""
+echo "[Argument validation]"
+(
+    # shellcheck disable=SC1090
+    source "$LIB"
+    installer_fetch_verify_run "" "$GOOD_SHA" "test-noargs" >/dev/null 2>&1
+)
+rc=$?
+if (( rc == 64 )); then note_pass "empty url → exit 64 (usage)"
+else note_fail "empty url returned $rc (expected 64)"; fi
+
+(
+    # shellcheck disable=SC1090
+    source "$LIB"
+    installer_fetch_verify_run "$GOOD_URL" "" "test-noargs" >/dev/null 2>&1
+)
+rc=$?
+if (( rc == 64 )); then note_pass "empty sha → exit 64 (usage)"
+else note_fail "empty sha returned $rc (expected 64)"; fi
+
+echo ""
+echo "[Empty body integrity]"
+# A zero-byte download still has a deterministic sha256 (e3b0c44...).
+# Use a different expected sha to ensure mismatch fires correctly.
+: > "$TMP/empty.sh"
+run_lib "file://$TMP/empty.sh" "$GOOD_SHA" "test-empty"; rc=$?
+if (( rc == 12 )); then note_pass "empty body + wrong sha → exit 12 (MISMATCH)"
+else note_fail "empty body returned $rc (expected 12)"; fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Phase 1 of the post-audit roadmap (epic #626). Extract the download → verify-sha256 → run contract `bootstrap.sh` introduced for the Anthropic Claude Code installer into a shared library, and apply it to the two remaining install entry points that previously piped unverified content into a shell.

Closes #620

## Why

`bootstrap.sh` correctly downloads the Anthropic installer to a temp file, verifies SHA-256 against a pinned hash, then executes. `bootstrap.ps1` and `scripts/install.sh` did not — they used `irm | iex` and `curl | bash` with no checksum, leaving two of three install paths exposed to MITM and origin compromise. Pinning is also missing for `bootstrap.ps1`'s repo clone (still references the floating `main` ref).

## How

| File | Change |
|------|--------|
| `hooks/lib/installer-fetch.sh` | New shared bash lib. `installer_fetch_verify_run <url> <sha> <label>` does mktemp download → `sha256sum -c` verify → `bash $tmp` run, with a RETURN trap for cleanup. Typed exit codes: `0=OK`, `10=DOWNLOAD`, `11=CHECKSUM`, `12=MISMATCH`, `13=RUN`, `64=usage`. |
| `hooks/lib/InstallerFetch.psm1` | New PowerShell mirror. `Invoke-InstallerFetchVerifyRun -Url -ExpectedSha256 -Label` uses `Invoke-WebRequest -OutFile`, `Get-FileHash -Algorithm SHA256`, then dot-source. Same exit-code contract. |
| `bootstrap.sh` | `ensure_claude_cli` replaced with one call to the lib. `main()` reordered: `clone_repository` runs before `ensure_claude_cli` so the lib can be sourced from the just-cloned tag. Trust root now: GITHUB_REF tag → cloned hooks/lib/* → pinned sha256 verify. |
| `bootstrap.ps1` | Mirrors the reorder. `GitHubBranch` renamed to `GitHubRef` (default `v1.10.0`); `GITHUB_BRANCH` env var stays as a one-release deprecation alias and emits a stderr warning when set. Repo clone now uses `--branch $GitHubRef --depth 1` for parity with bash. New `$AnthropicInstallerSha256` pin = `acc15c3d844b8952e702a24b584d2fdc0b589ee1061c11202529cdd5702711df` (computed against `https://claude.ai/install.ps1` on 2026-05-09). |
| `scripts/install.sh` | `ensure_claude_cli` sources the lib via repo-relative path and replaces `curl/wget \| bash` with the verified call. Defaults to the same pinned sha as bootstrap.sh; both honor `ANTHROPIC_INSTALLER_*` env overrides. |
| `tests/scripts/installer-fetch-tests.sh` | Regression suite covering: happy path (sha match + file:// fixture), DOWNLOAD failure (missing file), MISMATCH (wrong sha), RUN failure (installer exits 7), empty body integrity (zero-byte file with wrong sha), and usage errors (empty url, empty sha). 7 cases, all green, no network dependency. |
| `docs/SUPPLY_CHAIN.md` | New multi-entry-point parity section documents the three entry points and their shared exit-code contract. New ps1 pin rotation procedure mirrors the bash one. |
| `CHANGELOG.md` | Phase 1 entry under `[Unreleased] / Security` enumerates each change. |

## Test plan

Local (sandboxed claude-config repo):

```
$ bash tests/scripts/installer-fetch-tests.sh
=== Results: 7 passed, 0 failed ===

$ bash -n bootstrap.sh scripts/install.sh hooks/lib/installer-fetch.sh   # all syntax OK
```

Manually verified against `claude.ai`:

```
$ curl -fsSL https://claude.ai/install.sh | sha256sum
b315b46925a9bfb9422f2503dd5aa649f680832f4c076b22d87c39d578c3d830  # matches existing bootstrap.sh pin

$ curl -fsSL https://claude.ai/install.ps1 | sha256sum
acc15c3d844b8952e702a24b584d2fdc0b589ee1061c11202529cdd5702711df  # matches the new bootstrap.ps1 pin
```

PowerShell module: cannot be exercised in this sandbox (no `pwsh`). The Windows runner job — explicitly an AC item — is deferred to a follow-up; for now the PS module is unit-equivalent to the bash side and shares the same exit-code contract documented in SUPPLY_CHAIN.md.

## Acceptance status (per #620)

- [x] Extract download-verify-execute logic to `hooks/lib/installer-fetch.sh` and `hooks/lib/InstallerFetch.psm1`
- [x] Refactor `bootstrap.sh` to source the new lib (no behavior change)
- [x] Apply lib to `scripts/install.sh` (`ensure_claude_cli`)
- [x] Apply lib to `bootstrap.ps1`
- [x] Pin `bootstrap.ps1` repo clone to `$GitHubRef = 'v1.10.0'` (match `bootstrap.sh`)
- [x] Regression suite at `tests/scripts/installer-fetch-tests.sh` covering bad sha, empty body, network failure (via missing file://), success, RUN failure, usage errors
- [ ] **Deferred**: TTY detection (when stdin is a pipe, default install prompts to `n`). Reasonable follow-up — out of scope for this PR's security goal.
- [ ] **Deferred**: Windows runner job in `validate-hooks.yml`. Reasonable follow-up; pwsh is not available in this sandbox to validate the workflow before adding it.
- [x] `docs/SUPPLY_CHAIN.md` updated with new hardening contract (the AC mentioned `THIRD_PARTY_NOTICES.md` and `docs/SANDBOX_TLS.md`, but `docs/SUPPLY_CHAIN.md` is the existing canonical doc for this material — a relocation note can be added if reviewers prefer the original target).

## Risk

The bash and PowerShell `main()` reorders move the Claude CLI prompt from "before clone" to "after clone". UX impact is small (~1 second of additional output before the prompt), but a user who declines the clone now also misses the CLI prompt. This is the intended trade-off — the alternative is shipping the integrity logic as inlined byte-for-byte duplicates in three files, which the audit explicitly flagged as the prior failure mode.

The PS pin (`acc15c3d…`) was computed in this session on 2026-05-09. If Anthropic rotates `install.ps1` between branch creation and merge, CI will not catch it (no Windows runner yet). The `check-anthropic-installer.yml` weekly workflow currently only checks the bash side; extending it to the ps1 hash is a Phase 1 follow-up.

## Phase mapping

This PR realises Phase 1 of epic #626. Phase 2 (#621, #622), Phase 3 (#623, #624, #625) follow per the dependency graph in the epic.
