### PR TITLE
ci(memory): gate PRs on validate-memory.yml workflow (#621)

### DIFF
--- a/.github/workflows/validate-memory.yml
+++ b/.github/workflows/validate-memory.yml
@@ -1,0 +1,105 @@
+name: validate-memory
+
+# Memory subsystem CI gate (#621). Closes the gap where
+# tests/memory/run-*.sh runners only existed for manual invocation. The memory
+# system has the highest blast radius in the project — regressions here corrupt
+# user memory across machines — so it deserves the same automated coverage as
+# hooks/skills.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'scripts/memory-sync.sh'
+      - 'scripts/memory/**'
+      - 'tests/memory/**'
+      - 'global/hooks/memory-write-guard.sh'
+      - '.github/workflows/validate-memory.yml'
+  schedule:
+    # Nightly at 04:17 UTC (13:17 KST). Off-minute to avoid fleet congestion
+    # (batch-drift-regression runs at 03:17 UTC).
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+# Cancel in-progress runs of the same PR / schedule so a fast follow-up commit
+# does not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-tests:
+    name: sync (T1-T11 incl. #617 auto-quarantine reproducer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync tests
+        env:
+          # Required by secret-check.sh as of #618. Test owner is decoupled
+          # from the maintainer's identity.
+          OWNER_EMAILS: 'test-owner@example.com'
+          OWNER_GITHUB_HANDLE: 'test-owner'
+          OWNER_HOME_USER: 'test-owner'
+        run: bash tests/memory/run-sync-tests.sh
+
+  validation-tests:
+    name: validators (validate.sh / secret-check.sh / injection-check.sh)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validation tests
+        env:
+          OWNER_EMAILS: 'test-owner@example.com'
+          OWNER_GITHUB_HANDLE: 'test-owner'
+          OWNER_HOME_USER: 'test-owner'
+        run: bash tests/memory/run-validation-tests.sh
+
+  semantic-review:
+    name: semantic-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semantic review tests
+        env:
+          OWNER_EMAILS: 'test-owner@example.com'
+          OWNER_GITHUB_HANDLE: 'test-owner'
+          OWNER_HOME_USER: 'test-owner'
+        run: bash tests/memory/run-semantic-review-tests.sh
+
+  notify:
+    name: notify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify tests
+        env:
+          OWNER_EMAILS: 'test-owner@example.com'
+          OWNER_GITHUB_HANDLE: 'test-owner'
+          OWNER_HOME_USER: 'test-owner'
+        run: bash tests/memory/run-notify-tests.sh
+
+  multi-machine:
+    # Multi-machine simulation runs only on schedule and manual dispatch — its
+    # synthetic-git harness builds full bare-repo conflict scenarios and is
+    # heavier than the per-PR sync-tests above. PR runs would amortize poorly.
+    # Skipped in fork PRs even when manually triggered (defense-in-depth: the
+    # harness is read-only against the test sandbox today, but secrets that
+    # land here in future must not leak via fork PRs).
+    name: multi-machine simulation (S1-S5)
+    if: |
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Multi-machine tests
+        env:
+          OWNER_EMAILS: 'test-owner@example.com'
+          OWNER_GITHUB_HANDLE: 'test-owner'
+          OWNER_HOME_USER: 'test-owner'
+        run: bash tests/memory/multi-machine/run-multi-machine-tests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,4 +85,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Windows runner CI for `bootstrap.ps1` and a TTY-aware non-interactive
     default are deferred to a follow-up.
 
+### Added
+
+- Phase 2 memory CI workflow (#621). Adds
+  `.github/workflows/validate-memory.yml`, gating PRs that touch
+  `scripts/memory-sync.sh`, `scripts/memory/`, or `tests/memory/` on the four
+  existing test runners (`run-sync-tests.sh`, `run-validation-tests.sh`,
+  `run-semantic-review-tests.sh`, `run-notify-tests.sh`). The sync-tests job
+  exercises the T5 auto-quarantine reproducer that the #617 `set -e` fix
+  restored. A nightly schedule (`17 4 * * *` UTC) additionally runs the
+  multi-machine simulation harness; the multi-machine job is skipped on fork
+  PRs. Workflow exports `OWNER_EMAILS` so tests run cleanly under the
+  post-#618 fail-closed contract. `docs/MEMORY_SYNC.md` Section 7 cross-
+  references the workflow.
+
 [Unreleased]: https://github.com/kcenon/claude-config/compare/v1.10.0...HEAD

--- a/docs/MEMORY_SYNC.md
+++ b/docs/MEMORY_SYNC.md
@@ -673,7 +673,7 @@ pre-commit, sync, and audit pipelines.
 | Validator | Purpose | Blocking exit codes |
 |-----------|---------|---------------------|
 | `validate.sh` | Structural and format validity (frontmatter schema, body rules, filename pattern) | 1 (FAIL-STRUCT), 2 (FAIL-FORMAT) |
-| `secret-check.sh` | PII and credential pattern scan | 1 (SECRET-DETECTED) |
+| `secret-check.sh` | PII and credential pattern scan; requires `OWNER_EMAILS` env (#618) | 1 (SECRET-DETECTED), 2 (OWNER_EMAILS unset — fail-closed) |
 | `injection-check.sh` | Suspicious-pattern flagger | None — warn-only (exit 3 = allow with feedback) |
 
 The authoritative contract for all three — including frontmatter schema,
@@ -685,6 +685,21 @@ pattern matching against natural language has an inherent false-positive
 rate, and blocking on it would make legitimate documentation about
 prompt-injection patterns impossible to write. Genuine injection content
 is caught by the monthly semantic review and surfaced to `/memory-review`.
+
+### Continuous integration
+
+Validator and end-to-end memory-sync regressions are gated by
+[`.github/workflows/validate-memory.yml`](../.github/workflows/validate-memory.yml)
+(#621). The workflow mirrors `validate-hooks.yml` but covers the memory
+subsystem: it runs `tests/memory/run-sync-tests.sh`, `run-validation-tests.sh`,
+`run-semantic-review-tests.sh`, and `run-notify-tests.sh` on every PR that
+touches `scripts/memory-sync.sh`, `scripts/memory/`, or `tests/memory/`. The
+sync-tests job exercises T5 (remote commit with secret → exit 2 + auto-
+quarantine), which is the reproducer scenario for the `set -e` bug fixed in
+#617 — the original issue manifested as silent quarantine bypass and would
+now fail this job. A nightly schedule (`17 4 * * *` UTC) additionally runs
+the multi-machine simulation harness; the multi-machine job is skipped on
+fork PRs to keep future secrets contained.
 
 ---
 


### PR DESCRIPTION
## What

Phase 2 of the post-audit roadmap (epic #626). Connect the four memory test runners under `tests/memory/` to GitHub Actions so the highest-blast-radius subsystem in the project gets the same automated coverage as hooks and skills.

Closes #621

## Why

The memory subsystem already had a healthy test corpus (`run-sync-tests.sh`, `run-validation-tests.sh`, `run-semantic-review-tests.sh`, `run-notify-tests.sh`) but only ran when a developer remembered to invoke it. Memory regressions corrupt user state across machines and are harder to recover from than any other subsystem failure. The `validate-hooks.yml` precedent showed CI-gated suites prevent silent regressions; this PR mirrors that for memory.

## How

| File | Change |
|------|--------|
| `.github/workflows/validate-memory.yml` | New workflow. Triggers on PR to `main`/`develop` when memory paths change, plus nightly at `17 4 * * *` UTC. Jobs: `sync-tests`, `validation-tests`, `semantic-review`, `notify` (all per-PR, 10 min cap each), and `multi-machine` (schedule + workflow_dispatch only, skipped on fork PRs). Each job exports `OWNER_EMAILS` so tests run under the post-#618 fail-closed contract. `concurrency` cancels stale runs of the same ref. |
| `docs/MEMORY_SYNC.md` | Section 7 (Validators) gets a `### Continuous integration` subsection cross-referencing the workflow and explaining the T5 auto-quarantine reproducer relationship. Validator table updated to record `secret-check.sh` exit code 2 (#618). |
| `CHANGELOG.md` | New `Added` entry under `[Unreleased]` enumerates the workflow's coverage, the schedule, and the OWNER_EMAILS handling. |

## Test plan

Local sanity check (current branch, develop-equivalent state):

```
$ OWNER_EMAILS=test-owner@example.com OWNER_GITHUB_HANDLE=test-owner OWNER_HOME_USER=test-owner \
    bash tests/memory/run-sync-tests.sh
[…] Summary: 17 pass, 0 fail

$ OWNER_EMAILS=… bash tests/memory/run-validation-tests.sh
Total: 25 pass, 0 fail

$ OWNER_EMAILS=… bash tests/memory/run-semantic-review-tests.sh
Passed: 10

$ OWNER_EMAILS=… bash tests/memory/run-notify-tests.sh
Summary: 26 pass, 0 fail
```

Total: **78 tests, all passing** with the new env-var contract from #618.

The workflow itself cannot be exercised before merge (PR-triggered workflows need to land on the default branch first to re-trigger reliably). The trigger paths are scoped tightly enough that a workflow-only PR doesn't induce false positives on unrelated changes.

## Acceptance status (per #621)

- [x] Create `.github/workflows/validate-memory.yml`
- [x] PR trigger: paths matching `scripts/memory/**`, `scripts/memory-sync.sh`, `tests/memory/**`. Also added `global/hooks/memory-write-guard.sh` (downstream consumer) and the workflow file itself (so trigger config can be exercised in PRs that touch it).
- [x] Nightly schedule (`17 4 * * *` UTC) for full multi-machine simulation
- [x] Jobs: `sync-tests`, `multi-machine`, `semantic-review`, `notify` (matrix-style — independent jobs run in parallel via the implicit `runs-on` fan-out, no explicit matrix block needed since each runner has different env requirements)
- [x] `validation-tests` added as a fifth job to surface validator regressions distinct from sync-tests (validate.sh / secret-check.sh / injection-check.sh)
- [x] `concurrency` group cancels stale runs to keep wall time bounded
- [x] Update `docs/MEMORY_SYNC.md` to reference the new workflow
- [ ] **Deferred**: Block merges on validate-memory failure (branch protection rule — repository-admin action, not a code change). Recommend toggling on after the first nightly run lands and verifies stability.
- [x] Skip in fork PRs (multi-machine job has explicit head-repo guard; per-PR jobs do not currently use secrets so they intentionally remain available to fork contributors)

## Phase mapping

This PR realises Phase 2.a of epic #626. Phase 2.b (#622 plugin/fleet pytest CI wiring) follows; Phase 3 (#623, #624, #625) depends on this Phase 2 infrastructure.
