### PR TITLE
ci(test): wire plugin smoke and fleet_orchestrator pytest into CI (#622)

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -9,8 +9,9 @@ on:
       - 'tests/hooks/**'
       - 'tests/hooks/fixtures/**'
       - 'tests/batch_drift_benchmark/**'
-      - 'plugin/hooks/**'
-      - 'plugin-lite/hooks/**'
+      - 'plugin/**'
+      - 'plugin-lite/**'
+      - 'tests/plugin/**'
       - 'scripts/install.sh'
       - 'scripts/install.ps1'
       - 'scripts/install-manifest.sh'
@@ -75,6 +76,13 @@ jobs:
         # extracts the live command string from hooks.json via python3,
         # which is pre-installed on ubuntu-latest and macos-latest runners.
         run: bash tests/scripts/test-plugin-standalone.sh
+
+      - name: Run plugin/plugin-lite directory smoke test (#622)
+        # Catches packaging regressions (manifest mismatches, missing
+        # skills) before they ship in releases. Sh runner on Linux/macOS;
+        # PowerShell sibling smoke-test.ps1 is exercised when the
+        # InstallerFetch matrix lands a Windows runner.
+        run: bash tests/plugin/smoke-test.sh
 
       - name: Run plugin fallback regression tests
         # Validates probe-driven per-hook stand-down plus failure modes

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -19,6 +19,8 @@ on:
       - 'scripts/spec_lint.ps1'
       - 'scripts/spec_lint.py'
       - 'scripts/schemas/**'
+      - 'scripts/fleet_orchestrator/**'
+      - 'tests/fleet_orchestrator/**'
       - 'VERSION_MAP.yml'
       - 'scripts/check_versions.sh'
       - 'scripts/sync_versions.sh'
@@ -59,3 +61,14 @@ jobs:
 
       - name: Run spec linter test suite
         run: bash tests/scripts/test-spec-lint.sh
+
+      - name: Install pytest for fleet_orchestrator tests
+        # pytest is already a transitive dep of jsonschema in some envs; pin
+        # explicitly so the runner does not silently fall back to unittest.
+        run: pip install pytest
+
+      - name: Run fleet_orchestrator pytest (#622)
+        # Pins the topk_scorer routing behavior the fleet-orchestrator skill
+        # depends on. Silent breakage here means consumers route work to the
+        # wrong agent type.
+        run: python -m pytest tests/fleet_orchestrator/ -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,5 +98,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PRs. Workflow exports `OWNER_EMAILS` so tests run cleanly under the
   post-#618 fail-closed contract. `docs/MEMORY_SYNC.md` Section 7 cross-
   references the workflow.
+- Phase 2 plugin/fleet CI wiring (#622). Two test areas that had passing
+  test code but no CI integration are now connected:
+  - `tests/plugin/smoke-test.sh` runs on every PR via
+    `validate-hooks.yml`, catching plugin packaging regressions
+    (manifest mismatches, missing skills) before release. PR triggers
+    expanded from `plugin/hooks/**` to the full `plugin/**` and
+    `plugin-lite/**` plus `tests/plugin/**`.
+  - `tests/fleet_orchestrator/` pytest suite (17 cases) runs on every
+    PR via `validate-skills.yml`. Pins `topk_scorer.py` routing
+    behavior — silent breakage previously meant wrong agent
+    assignments to work items in any consumer using the
+    fleet-orchestrator skill. Path triggers expanded with
+    `scripts/fleet_orchestrator/**` and `tests/fleet_orchestrator/**`.
+  - `docs/PLUGIN_BUILD.md` and the fleet-orchestrator SKILL.md cross-
+    reference the new CI lanes.
 
 [Unreleased]: https://github.com/kcenon/claude-config/compare/v1.10.0...HEAD

--- a/docs/PLUGIN_BUILD.md
+++ b/docs/PLUGIN_BUILD.md
@@ -55,6 +55,13 @@ workflow fails and the PR cannot merge. This guarantees the invariant
 holds in `main` regardless of how the copies were produced (manual,
 script, or future build tooling).
 
+The same workflow also runs `tests/plugin/smoke-test.sh` (#622) on every
+PR that touches `plugin/`, `plugin-lite/`, or `tests/plugin/`. The smoke
+test catches packaging regressions — manifest schema mismatches, missing
+or renamed skills, broken hook references — before they ship in a release.
+Sh/PowerShell parity: the matching `tests/plugin/smoke-test.ps1` is held
+for the future Windows runner job (out of scope for #622).
+
 ## Why Copy Instead of Symlink
 
 Symlinks are not portable across the install paths the plugin supports

--- a/global/skills/_internal/fleet-orchestrator/SKILL.md
+++ b/global/skills/_internal/fleet-orchestrator/SKILL.md
@@ -232,8 +232,11 @@ file list), so it is unit-tested in isolation. Required cases:
 4. `K >= agent_count` — all agents selected, order preserved by score.
 5. Tie on score — stable alphabetical ordering.
 
-Tests live under `tests/fleet-orchestrator/test_topk_scoring.*` and run as part
-of the skill's CI lane.
+Tests live under `tests/fleet_orchestrator/test_topk_scoring.py` and
+`tests/fleet_orchestrator/test_docs_only_routing.py`. As of #622 they run
+on every PR via `.github/workflows/validate-skills.yml`
+(`python -m pytest tests/fleet_orchestrator/ -q`); silent breakage in the
+scorer would now fail CI rather than ship to consumers of this skill.
 
 #### Fallback and Compatibility
 


### PR DESCRIPTION
## What

Phase 2.b of the post-audit roadmap (epic #626). Wire two existing test areas into CI so they run on every PR instead of only when a developer remembers to invoke them.

Closes #622

## Why

Both areas already had healthy test code:

- `tests/plugin/smoke-test.sh` — directory-structure smoke tests for `plugin/` and `plugin-lite/` (manifest schema, skill presence, hook references).
- `tests/fleet_orchestrator/` — Python unittest suite covering the `topk_scorer.py` routing behavior the fleet-orchestrator skill depends on.

Neither was connected to a workflow. Plugin packaging regressions could ship in a release silently; fleet routing breakage would assign work to the wrong agent type without any signal.

## How

| File | Change |
|------|--------|
| `.github/workflows/validate-hooks.yml` | Path filter expanded from `plugin/hooks/**` to the full `plugin/**` + `plugin-lite/**` + `tests/plugin/**`. New step `Run plugin/plugin-lite directory smoke test (#622)` runs `bash tests/plugin/smoke-test.sh` on the existing `ubuntu-latest` / `macos-latest` matrix. |
| `.github/workflows/validate-skills.yml` | Path filter expanded with `scripts/fleet_orchestrator/**` and `tests/fleet_orchestrator/**`. New steps `Install pytest for fleet_orchestrator tests` and `Run fleet_orchestrator pytest (#622)` execute `python -m pytest tests/fleet_orchestrator/ -q` on the existing Python 3.x setup. pytest is pinned via `pip install pytest` to avoid silent unittest fallback. |
| `docs/PLUGIN_BUILD.md` | "CI Enforcement" section gains a note about the smoke-test step and parity status of the PowerShell sibling. |
| `global/skills/_internal/fleet-orchestrator/SKILL.md` | Test-coverage cross-reference updated to point at the actual file names (`tests/fleet_orchestrator/test_topk_scoring.py` + `test_docs_only_routing.py`) and the workflow lane that runs them. |
| `CHANGELOG.md` | New `Added` entry under `[Unreleased]` describes both lanes. |

## Test plan

Local:

```
$ bash tests/plugin/smoke-test.sh
================================
Summary: 38 passed, 0 failed
================================

$ python3 -m unittest discover -s tests/fleet_orchestrator -v
Ran 17 tests in 0.006s
OK
```

The fleet pytest cannot be exercised locally in this sandbox (no `pytest` installed, no PyPI in the sandbox); the workflow `pip install pytest` step covers it. The unittest invocation above is the structural equivalent — pytest discovers the same test cases and reports the same pass/fail counts.

## Acceptance status (per #622)

- [x] Add `tests/plugin/` runner step to `validate-hooks.yml` (sh on Linux, sh on macOS via the existing matrix; PowerShell sibling held for the Windows runner job in #620 follow-up)
- [x] Add `python -m pytest tests/fleet_orchestrator/ -q` step to `validate-skills.yml`
- [x] Document test coverage addition in `docs/PLUGIN_BUILD.md`
- [x] Document fleet test suite in `global/skills/_internal/fleet-orchestrator/SKILL.md`
- [x] Confirm pytest is available in the workflow runner image; install on demand if not (explicit `pip install pytest` step pre-empts the silent unittest fallback)

## Phase mapping

This PR realises Phase 2.b of epic #626 and completes Phase 2. Phase 3 (#623, #624, #625) follows.
