### PR TITLE
docs(i18n): sync README.ko.md to English structure (#623)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -72,3 +72,9 @@ jobs:
         # depends on. Silent breakage here means consumers route work to the
         # wrong agent type.
         run: python -m pytest tests/fleet_orchestrator/ -q
+
+      - name: Verify README.md / README.ko.md heading skeleton (#623)
+        # Bilingual contract: the two READMEs must share the same heading
+        # counts at every level. Catches "added a section in English, forgot
+        # to translate" drift before it accrues into multi-version debt.
+        run: bash scripts/diff-readme.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,4 +114,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docs/PLUGIN_BUILD.md` and the fleet-orchestrator SKILL.md cross-
     reference the new CI lanes.
 
+### Changed
+
+- Phase 3 README.ko.md sync (#623). Korean README brought back into
+  shape parity with English:
+  - Translated v1.8.0 and v1.9.0 changelog entries (the v1.7.0 — v1.10.0
+    gap noted in the audit). v1.10.0 has no changelog body in either
+    README yet; both will be filled at the next release.
+  - Added 시나리오 D (Use Case D — batch-issue-work / batch-pr-work) and
+    the matching quickstart-table rows. Externally-orchestrated batch
+    flows are now visible to Korean readers without bouncing through
+    the English README.
+  - Added "Memory sync (다중 머신)" and "Related Projects" sections that
+    were English-only. With these the two READMEs now have matching
+    heading counts at every level.
+  - Removed the hardcoded "현재: 1.7.0" line in favor of pointing at
+    `VERSION_MAP.yml` as the single source of truth (mirrors the
+    English approach added in v1.9-era).
+  - New `scripts/diff-readme.sh` compares ATX heading counts at every
+    level between the two files. Awareness of fenced code blocks
+    avoids false positives on `# 1.` style comments. Wired into
+    `validate-skills.yml` (which already triggered on README changes)
+    and added to the `/release` skill checklist between the version
+    drift check and the staging step.
+
 [Unreleased]: https://github.com/kcenon/claude-config/compare/v1.10.0...HEAD

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,6 +45,8 @@ vi ~/.claude/git-identity.md
 | 설정 백업 | `./scripts/backup.sh` | `.\scripts\backup.ps1` |
 | 설정 동기화 | `./scripts/sync.sh` | `.\scripts\sync.ps1` |
 | 백업 검증 | `./scripts/verify.sh` | `.\scripts\verify.ps1` |
+| 열린 이슈 일괄 처리 | `./scripts/batch-issue-work.sh <org/repo>` | `.\scripts\batch-issue-work.ps1 -OrgProject <org/repo>` |
+| 실패 PR 일괄 처리 | `./scripts/batch-pr-work.sh <org/repo>` | `.\scripts\batch-pr-work.ps1 -OrgProject <org/repo>` |
 
 상세 시나리오는 [사용 시나리오](#사용-시나리오)를 참조하세요.
 
@@ -766,6 +768,43 @@ vi ~/.claude/git-identity.md
 
 ---
 
+### 시나리오 D: 열린 이슈 또는 실패 PR 일괄 처리
+
+각 항목마다 새 `claude` 프로세스를 띄우는 외부 오케스트레이터입니다. 한 프로세스가 정확히 하나의 이슈(또는 PR)를 처리하므로 항목 사이에 컨텍스트 상태가 누출될 수 없습니다 — 항목 N+1은 항목 1과 동일한 CLAUDE.md / 스킬 attention pool로 시작합니다. `/issue-work`와 `/pr-work`의 in-session 배치 모드를 보완하며, 격리를 OS 프로세스 경계로 끌어올립니다.
+
+다음 상황에서 사용하세요:
+
+- 배치가 in-session 안전 캡(기본 5, `--force-large` 없을 때 하드 캡 10)을 초과할 것으로 예상되고 항목별로 더 엄격한 격리를 원할 때
+- 무인 운영(cron, CI, 야간) 중이며 배치가 얼마나 길게 돌아가든 각 항목이 깨끗한 상태에서 시작하기를 원할 때
+- 라이브 터미널의 단일 스크롤백이 아닌 사후 분석용 항목별 디스크 로그가 필요할 때
+
+```bash
+# 저장소에서 최대 5개의 열린 이슈 처리 (기본 limit)
+./scripts/batch-issue-work.sh kcenon/claude-config
+
+# 최대 3개 이슈 처리
+./scripts/batch-issue-work.sh kcenon/claude-config 3
+
+# 실패한 PR을 대신 처리
+./scripts/batch-pr-work.sh kcenon/claude-config
+```
+
+```powershell
+# PowerShell 동등 명령
+.\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config
+.\scripts\batch-issue-work.ps1 -OrgProject kcenon/claude-config -Limit 3
+.\scripts\batch-pr-work.ps1    -OrgProject kcenon/claude-config
+```
+
+항목별 로그는 `~/.claude/batch-logs/<timestamp>/`에 기록됩니다:
+
+- `issue-<번호>.log`: `batch-issue-work`이 처리한 각 이슈
+- `pr-<번호>.log`: `batch-pr-work`이 처리한 각 PR
+
+항목 실패 시 배치는 **일시 중지하고 비-0 코드로 종료**합니다. 성공한 항목은 롤백되지 않습니다. 실패한 항목의 로그를 확인해 근본 원인을 수정한 뒤 오케스트레이터를 다시 실행하세요 — 이미 머지된 항목은 더 이상 열린 목록에 없으므로 자동으로 건너뜁니다.
+
+---
+
 <details>
 <summary><strong>고급 사용법</strong> (GitHub Actions, 환경 변수)</summary>
 
@@ -886,6 +925,17 @@ curl -sSL -H "Authorization: token YOUR_TOKEN" \
 
 ---
 
+## Memory sync (다중 머신)
+
+Memory sync는 Claude Code의 auto-memory를 비공개 git 저장소를 통해 모든 머신 간에 일관되게 유지합니다. 다음 문서를 참조하세요:
+
+- [운영 가이드](docs/MEMORY_SYNC.md) — 일상 운영, 문제 해결, 롤백, 충돌 해결
+- [위협 모델](docs/THREAT_MODEL.md) — 보안 분석, 7가지 위협 카테고리, 5층 방어
+- [검증 명세](docs/MEMORY_VALIDATION_SPEC.md) — 검증기 계약과 frontmatter 스키마
+- [신뢰 모델](docs/MEMORY_TRUST_MODEL.md) — 신뢰 계층과 라이프사이클
+
+---
+
 ## 추가 리소스
 
 - **설정 예제**: `global/` 및 `project/` 디렉토리 참조
@@ -900,10 +950,24 @@ curl -sSL -H "Authorization: token YOUR_TOKEN" \
 
 ## 버전
 
-**현재**: 1.7.0 (2026-04-06)
+**현재**: [`VERSION_MAP.yml`](VERSION_MAP.yml)에서 추적 (단일 진실의 출처 — `suite` 필드). 이 README 상단의 shields.io 뱃지는 동일한 필드로부터 `scripts/sync_versions.sh`가 생성합니다. 이 문서에 버전 번호를 하드코딩하지 마세요. 대신 `/release <field> <new-version>`으로 bump하세요.
 
 <details>
 <summary>변경 이력</summary>
+
+#### v1.9.0 (2026-04-13)
+- **다층 브랜치 방어**: `main`으로의 비-release 머지를 막는 4중 강제 계층
+  - PreToolUse 훅 (`pr-target-guard`): `--head develop` 없는 `gh pr create --base main` 차단
+  - GitHub Actions (`validate-pr-target.yml`): non-develop 브랜치에서 `main`을 타겟하는 PR 자동 폐쇄
+  - Release 스킬 무결성 검사: release 전 main/develop 분기 감지
+  - 문서: `branching-strategy.md`의 강제 계층 표
+- **CI 수정**: `validate-skills.yml`의 인라인 Python heredoc 블록 제거 (모든 워크플로우 실행이 YAML 파싱 오류로 실패하던 문제 해결)
+- **README 업데이트**: "PR 생성 시" 섹션 추가, 누락된 hooks 및 워크플로우를 디렉토리 트리에 반영
+
+#### v1.8.0 (2026-04-13)
+- **간소화된 git-flow 브랜칭 전략**: `develop`이 기본 브랜치, `main`을 타겟하는 PR에서만 CI 실행
+- **Pre-push 훅**: 보호 브랜치(`main`, `develop`)로의 직접 push 차단
+- **브랜칭 문서**: 브랜치 모델, CI 정책, release 워크플로우 종합 가이드
 
 #### v1.7.0 (2026-04-06)
 - **Windows PowerShell 완전 지원**: 모든 42개 bash 스크립트에 PowerShell (.ps1) 대응 파일 추가
@@ -991,6 +1055,17 @@ curl -sSL -H "Authorization: token YOUR_TOKEN" \
 3. Commit your changes (`git commit -m 'Add amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
+
+---
+
+## Related Projects
+
+### AD-SDLC (Agent-Driven Software Development Lifecycle)
+
+AI 에이전트 기반 소프트웨어 개발 자동화 플랫폼입니다. AD-SDLC 에이전트는 본 프로젝트의 스킬과 가이드라인을 참조해 코드 품질을 향상시킬 수 있습니다.
+
+- **저장소**: [kcenon/claude_code_agent](https://github.com/kcenon/claude_code_agent)
+- **통합 가이드**: [docs/ad-sdlc-integration.md](docs/ad-sdlc-integration.md)
 
 ---
 

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -226,6 +226,14 @@ if [ -f VERSION_MAP.yml ]; then
         bash scripts/check_versions.sh
     fi
 
+    # Verify README.md and README.ko.md still share the same heading skeleton
+    # (#623). A failure here means a section was added or removed in one
+    # README without mirroring in the other; resolve the divergence before
+    # the release ships rather than letting i18n debt accrue.
+    if [ -x scripts/diff-readme.sh ]; then
+        bash scripts/diff-readme.sh
+    fi
+
     # Stage the changes so they land in the release PR
     git add VERSION_MAP.yml
     git add plugin/.claude-plugin/plugin.json plugin-lite/.claude-plugin/plugin.json 2>/dev/null || true

--- a/scripts/diff-readme.sh
+++ b/scripts/diff-readme.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# diff-readme.sh — guard the bilingual README contract (#623).
+#
+# README.md is canonical; README.ko.md is a full translation. The two must
+# stay in shape parity: same section heading counts at each level, same
+# ordered list of headings (Korean prose for the heading text, but matched
+# 1:1 by position).
+#
+# Strategy:
+#   1. Extract heading lines (lines beginning with #, ##, ### …) from each
+#      file.
+#   2. Compare per-level counts. A divergence means a section was added or
+#      removed in one file but not mirrored in the other.
+#   3. Diff the ordered title sequences after stripping leading hash marks
+#      and whitespace; matching translations are not validated, only the
+#      structural skeleton is.
+#
+# Exit codes:
+#   0  shape match
+#   1  count mismatch at one or more levels
+#   2  files missing or unreadable
+#
+# Usage:
+#   bash scripts/diff-readme.sh                       # use repo paths
+#   bash scripts/diff-readme.sh path/a.md path/b.md   # explicit pair
+
+set -uo pipefail
+
+EN="${1:-README.md}"
+KO="${2:-README.ko.md}"
+
+if [[ ! -f "$EN" ]]; then
+    echo "diff-readme: $EN not found" >&2
+    exit 2
+fi
+if [[ ! -f "$KO" ]]; then
+    echo "diff-readme: $KO not found" >&2
+    exit 2
+fi
+
+# Capture only ATX-style headings outside fenced code blocks. Lines inside
+# ``` ... ``` are skipped to avoid false positives on '# 1. comment'-style
+# bash/python comment markers in install instructions.
+extract_headings() {
+    awk '
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        /^#{1,6} .+$/ { print }
+    ' "$1"
+}
+
+en_headings="$(extract_headings "$EN")"
+ko_headings="$(extract_headings "$KO")"
+
+count_at_level() {
+    local content="$1" level="$2"
+    printf '%s\n' "$content" | awk -v lvl="$level" 'NF>0 {
+        n = 0
+        for (i = 1; i <= length($0); i++) {
+            c = substr($0, i, 1)
+            if (c == "#") n++
+            else break
+        }
+        if (n == lvl) count++
+    } END { print count + 0 }'
+}
+
+mismatch=0
+for level in 1 2 3 4 5; do
+    en_n=$(count_at_level "$en_headings" "$level")
+    ko_n=$(count_at_level "$ko_headings" "$level")
+    if [[ "$en_n" != "$ko_n" ]]; then
+        printf 'level %d: %s=%d, %s=%d\n' "$level" "$EN" "$en_n" "$KO" "$ko_n"
+        mismatch=1
+    fi
+done
+
+if (( mismatch )); then
+    echo
+    echo "diff-readme: structural skeleton diverges between $EN and $KO."
+    echo "Re-sync README.ko.md to match README.md or update README.md if the"
+    echo "Korean side intentionally added a section."
+    exit 1
+fi
+
+echo "diff-readme: OK ($EN and $KO have matching heading counts at every level)"
+exit 0


### PR DESCRIPTION
## What

Phase 3 of the post-audit roadmap (epic #626). Bring `README.ko.md` back to the same structural shape as `README.md` and add a tooling guard that prevents future drift.

Closes #623

## Why

The Korean README had stayed at the v1.7-era skeleton while the English README advanced to v1.9. Korean is the project's primary working language per `global/conversation-language.md`, so the divergence breaks user trust and violates the "fully translated" bilingual contract. Every release that adds a section in English without mirroring it in Korean compounds the gap; a CI-enforced shape check is the only way to keep parity from rotting.

## How

| File | Change |
|------|--------|
| `README.ko.md` | Translated v1.8.0 and v1.9.0 changelog entries. Added 시나리오 D (Use Case D — batch-issue-work / batch-pr-work) plus the matching quickstart-table rows. Added "Memory sync (다중 머신)" and "Related Projects" sections that were English-only. Replaced the hardcoded `현재: 1.7.0 (2026-04-06)` line with a pointer to `VERSION_MAP.yml`, matching the v1.9-era English README pattern. |
| `scripts/diff-readme.sh` (new) | Compares ATX heading counts at every level (h1–h5) between two markdown files. Skips fenced code blocks so `# 1.` style comments in install instructions don't show up as headings. Exit codes: 0 OK, 1 mismatch, 2 file missing. Defaults to `README.md` / `README.ko.md` but accepts `<en> <ko>` overrides. |
| `.github/workflows/validate-skills.yml` | New step `Verify README.md / README.ko.md heading skeleton (#623)` runs `bash scripts/diff-readme.sh`. The path filter already triggered on `README.md` / `README.ko.md`, so no trigger expansion is needed. |
| `global/skills/_internal/release/SKILL.md` | `/release` checklist gains a `bash scripts/diff-readme.sh` invocation between the version-drift check and the file-staging step. A divergence at release time blocks the version bump until the readme is synced. |
| `CHANGELOG.md` | New `Changed` entry under `[Unreleased]` describes each piece. |

## Test plan

After every change:

```
$ bash scripts/diff-readme.sh
diff-readme: OK (README.md and README.ko.md have matching heading counts at every level)
```

Pre-fix run (recorded for the record): the script reported 7 missing headings split across h1/h2/h3/h4. The h1 false-positives turned out to be `# 1. Run …` comments inside fenced code blocks; the awk fence-tracking fix for that is part of this PR. The h2 + h3 + h4 actual gaps are closed by the translation work above.

Manual visual check:
- The Korean version badge already pointed at `v1.10.0` (set by an earlier `/release` invocation); the body of the README now matches.
- New "Memory sync (다중 머신)" section links to the four canonical memory docs in Korean (`MEMORY_SYNC.md`, `THREAT_MODEL.md`, `MEMORY_VALIDATION_SPEC.md`, `MEMORY_TRUST_MODEL.md`).
- New "Related Projects" section mirrors the English AD-SDLC entry verbatim with Korean prose.
- 시나리오 D is fully bilingual: prose translated, `bash`/`powershell` fenced blocks copied unchanged so the commands stay literal.

## Acceptance status (per #623)

- [x] Sync changelog v1.8.0 / v1.9.0 entries (translated, not machine-summarized). v1.10.0 has no body in either README yet — to be filled at next release.
- [x] Add Use Case D (batch processing) translation
- [x] Add quickstart table rows for `batch-issue-work.sh`, `batch-pr-work.sh`
- [x] Update version badge URL to v1.10.0 (already done by earlier `/release`; verified during this PR)
- [x] Create `scripts/diff-readme.sh` that compares section heading counts and ordered titles between `README.md` and `README.ko.md`
- [x] Add the diff-readme step to `/release` skill release checklist
- [x] Add CI step (in `validate-skills.yml`, which already triggered on README changes — no need to spin up a new `validate-docs.yml` for one step)
- [ ] **Deferred**: Verify `docs/.index/manifest.yaml` description for `README.ko.md` is regenerated. The bug that produced `'<p align="center">'` as the description is filed as #625 and will be addressed in that PR; running the regeneration before the bug is fixed would re-introduce the bad description.

## Phase mapping

This PR realises Phase 3.a of epic #626. Phase 3.b (#624 ADR metadata headers) and Phase 3.c (#625 manifest.yaml HTML extraction) follow.
