### PR TITLE
docs(governance): add ADR frontmatter schema and backfill (#624)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -21,6 +21,10 @@ on:
       - 'scripts/schemas/**'
       - 'scripts/fleet_orchestrator/**'
       - 'tests/fleet_orchestrator/**'
+      - 'docs/design/**'
+      - 'docs/tier2-benchmark-results.md'
+      - 'docs/batch-drift-regression.md'
+      - 'scripts/validate-adr-headers.sh'
       - 'VERSION_MAP.yml'
       - 'scripts/check_versions.sh'
       - 'scripts/sync_versions.sh'
@@ -78,3 +82,10 @@ jobs:
         # counts at every level. Catches "added a section in English, forgot
         # to translate" drift before it accrues into multi-version debt.
         run: bash scripts/diff-readme.sh
+
+      - name: Verify ADR frontmatter on docs/design (#624)
+        # docs/design/*.md (plus tier2-benchmark-results.md and
+        # batch-drift-regression.md) must carry the five-field ADR
+        # frontmatter so readers can tell at a glance whether a design
+        # document is still load-bearing.
+        run: bash scripts/validate-adr-headers.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Phase 3 ADR metadata headers (#624). The eight `docs/design/*.md`
+  files plus the two long-lived performance/regression docs
+  (`docs/tier2-benchmark-results.md`, `docs/batch-drift-regression.md`)
+  now carry a five-field YAML frontmatter (`status`, `audience`,
+  `last_reviewed`, `supersedes`, `superseded_by`). Status assignments
+  reflect implementation reality: `Active` for shipped systems,
+  `Draft` for proposals or design concepts not yet implemented. The
+  new `scripts/validate-adr-headers.sh` lint enforces presence and
+  basic shape on every PR via `validate-skills.yml`. Schema documented
+  in `docs/CUSTOM_EXTENSIONS.md`.
 - Phase 3 README.ko.md sync (#623). Korean README brought back into
   shape parity with English:
   - Translated v1.8.0 and v1.9.0 changelog entries (the v1.7.0 — v1.10.0

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -336,6 +336,50 @@ For authoritative information on Claude Code features:
 
 > **2026 URL migration**: Claude Code documentation moved from `docs.anthropic.com/en/docs/claude-code/*` (and legacy `docs.claude.com/en/docs/claude-code/*`) to `code.claude.com/docs/en/*`. Old URLs 301-redirect but search rankings suffer; all links in this repo should use `code.claude.com`. See [issue #336](https://github.com/kcenon/claude-config/issues/336).
 
+## ADR / Design Doc Frontmatter (#624)
+
+Files in `docs/design/` and the long-lived performance / regression docs
+(`docs/tier2-benchmark-results.md`, `docs/batch-drift-regression.md`) carry a
+small YAML frontmatter so a reader can tell at a glance whether the document
+is still load-bearing without reading the body. The format is intentionally
+narrow — five fields, all required:
+
+```yaml
+---
+status: Active             # one of: Active | Superseded | Draft
+audience: maintainer       # one of: maintainer | contributor | user
+last_reviewed: 2026-05-09  # ISO date the doc was last confirmed accurate
+supersedes: []             # list of relative paths this doc replaces
+superseded_by: null        # relative path of the doc that replaces this one, or null
+---
+```
+
+Field semantics:
+
+- `status`: `Active` for current, `Draft` for proposals or design concepts
+  not yet implemented, `Superseded` for documents kept for historical context
+  but no longer authoritative.
+- `audience`: who the document is for. `maintainer` for internal design,
+  `contributor` for outside-PR explanations, `user` for end-user-visible
+  docs (rare in `docs/design/`).
+- `last_reviewed`: bumped whenever a maintainer confirms the doc still
+  reflects reality. A future `/doc-index` extension will flag entries older
+  than six months for re-review.
+- `supersedes` / `superseded_by`: builds a forward / backward chain so the
+  index can render "this design was replaced by …" links without prose
+  authors having to add cross-references manually.
+
+Validator: `scripts/validate-adr-headers.sh` is wired into
+`validate-skills.yml` and rejects any `docs/design/` file (plus the two
+named perf / regression docs) that is missing the frontmatter or has an
+out-of-range value. When you create a new design document, copy the
+five-field block from the nearest existing file as a starting point.
+
+This is a custom extension — Claude Code itself does not consume these
+fields. The doc-index skill (`/doc-index`) will eventually surface them in
+`docs/.index/manifest.yaml` so router and bundle recommendations can filter
+on `status: Active` and `audience`.
+
 ## Reporting Issues
 
 If a feature from this configuration doesn't work:
@@ -346,4 +390,4 @@ If a feature from this configuration doesn't work:
 
 ---
 
-*Version: 1.3.0 | Last updated: 2026-04-17*
+*Version: 1.4.0 | Last updated: 2026-05-09*

--- a/docs/batch-drift-regression.md
+++ b/docs/batch-drift-regression.md
@@ -1,3 +1,11 @@
+---
+status: Active
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Batch Drift Regression Test
 
 Automated regression test that verifies batch workflows retain rule compliance

--- a/docs/design/command-optimization.md
+++ b/docs/design/command-optimization.md
@@ -1,3 +1,11 @@
+---
+status: Active
+audience: contributor
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Command-Specific Token Optimization
 
 > **Version**: 1.2.0

--- a/docs/design/intelligent-prefetching.md
+++ b/docs/design/intelligent-prefetching.md
@@ -1,3 +1,11 @@
+---
+status: Draft
+audience: contributor
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Intelligent Pre-fetching System
 
 > ⚠️ **CUSTOM EXTENSION / DESIGN CONCEPT**

--- a/docs/design/module-caching.md
+++ b/docs/design/module-caching.md
@@ -1,3 +1,11 @@
+---
+status: Draft
+audience: contributor
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Module Caching Strategy
 
 > ⚠️ **CUSTOM EXTENSION / DESIGN CONCEPT**

--- a/docs/design/module-priority.md
+++ b/docs/design/module-priority.md
@@ -1,3 +1,11 @@
+---
+status: Draft
+audience: contributor
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Module Priority and Loading Strategy
 
 > ⚠️ **CUSTOM EXTENSION / DESIGN CONCEPT**

--- a/docs/design/monitors-migration.md
+++ b/docs/design/monitors-migration.md
@@ -1,3 +1,11 @@
+---
+status: Draft
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Design Proposal: monitors.json Migration
 
 > **Status**: Proposal (no implementation)

--- a/docs/design/optimization-discoveries.md
+++ b/docs/design/optimization-discoveries.md
@@ -1,3 +1,11 @@
+---
+status: Active
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Token Optimization Discoveries
 
 > **Date**: 2026-01-27

--- a/docs/design/optimization-phases.md
+++ b/docs/design/optimization-phases.md
@@ -1,3 +1,11 @@
+---
+status: Active
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Complete Token Optimization System
 
 > **Version**: 1.5.0 (All Phases Implemented)

--- a/docs/design/permission-event-hooks.md
+++ b/docs/design/permission-event-hooks.md
@@ -1,3 +1,11 @@
+---
+status: Draft
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Design Proposal: PermissionRequest / PermissionDenied Hooks
 
 > **Status**: Proposal (no implementation)

--- a/docs/tier2-benchmark-results.md
+++ b/docs/tier2-benchmark-results.md
@@ -1,3 +1,11 @@
+---
+status: Active
+audience: maintainer
+last_reviewed: 2026-05-09
+supersedes: []
+superseded_by: null
+---
+
 # Tier 2 Benchmark Results
 
 Quantitative comparison of Tier 2 isolation strategies against the

--- a/scripts/validate-adr-headers.sh
+++ b/scripts/validate-adr-headers.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# validate-adr-headers.sh — enforce ADR frontmatter on docs/design/*.md (#624).
+#
+# Schema (YAML at top of file):
+#   ---
+#   status: Active           # Active | Superseded | Draft
+#   audience: maintainer     # maintainer | contributor | user
+#   last_reviewed: YYYY-MM-DD
+#   supersedes: []
+#   superseded_by: null
+#   ---
+#
+# The check is intentionally lightweight — it verifies presence and basic
+# shape of each required field, not deep YAML correctness. Deeper schema
+# validation can layer on later (e.g. via the doc-index skill once the
+# extractor knows about ADR fields).
+#
+# Exit codes:
+#   0  every targeted file passes
+#   1  one or more files missing or malformed
+#   2  no files matched the glob (configuration error)
+#
+# Usage:
+#   bash scripts/validate-adr-headers.sh                # docs/design/*.md
+#   bash scripts/validate-adr-headers.sh path/...       # explicit list
+
+set -uo pipefail
+
+if [[ $# -gt 0 ]]; then
+    files=("$@")
+else
+    shopt -s nullglob
+    files=(docs/design/*.md docs/tier2-benchmark-results.md docs/batch-drift-regression.md)
+    shopt -u nullglob
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "validate-adr-headers: no files matched" >&2
+    exit 2
+fi
+
+required_keys=(status audience last_reviewed supersedes superseded_by)
+status_values_re='^(Active|Superseded|Draft)$'
+audience_values_re='^(maintainer|contributor|user)$'
+date_re='^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+
+failures=0
+total=0
+
+for f in "${files[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        printf 'MISSING %s\n' "$f"
+        failures=$((failures + 1))
+        continue
+    fi
+    total=$((total + 1))
+    file_failed=0
+
+    # Frontmatter must start at line 1 with literal '---' and end at the
+    # next '---'. Capture only those lines.
+    if ! head -1 "$f" | grep -qx '\-\-\-'; then
+        printf 'NO-FRONTMATTER %s\n' "$f"
+        failures=$((failures + 1))
+        continue
+    fi
+    block=$(awk 'NR==1 && /^---$/ {flag=1; next} flag && /^---$/ {exit} flag' "$f")
+    if [[ -z "$block" ]]; then
+        printf 'EMPTY-FRONTMATTER %s\n' "$f"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    # Required-key presence
+    for key in "${required_keys[@]}"; do
+        if ! grep -qE "^${key}:" <<<"$block"; then
+            printf 'MISSING-KEY %s: %s\n' "$f" "$key"
+            file_failed=1
+        fi
+    done
+
+    # Value sanity for the three free-form-ish keys (status, audience, date)
+    status_v=$(grep -E '^status:' <<<"$block" | head -1 | sed -E 's/^status:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]+$//')
+    audience_v=$(grep -E '^audience:' <<<"$block" | head -1 | sed -E 's/^audience:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]+$//')
+    date_v=$(grep -E '^last_reviewed:' <<<"$block" | head -1 | sed -E 's/^last_reviewed:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]+$//')
+
+    if [[ -n "$status_v" ]] && ! [[ "$status_v" =~ $status_values_re ]]; then
+        printf 'BAD-STATUS %s: "%s" (expected Active|Superseded|Draft)\n' "$f" "$status_v"
+        file_failed=1
+    fi
+    if [[ -n "$audience_v" ]] && ! [[ "$audience_v" =~ $audience_values_re ]]; then
+        printf 'BAD-AUDIENCE %s: "%s" (expected maintainer|contributor|user)\n' "$f" "$audience_v"
+        file_failed=1
+    fi
+    if [[ -n "$date_v" ]] && ! [[ "$date_v" =~ $date_re ]]; then
+        printf 'BAD-DATE %s: "%s" (expected YYYY-MM-DD)\n' "$f" "$date_v"
+        file_failed=1
+    fi
+
+    if (( file_failed )); then
+        failures=$((failures + 1))
+    else
+        printf 'OK %s\n' "$f"
+    fi
+done
+
+echo
+if (( failures == 0 )); then
+    echo "validate-adr-headers: ${total} files OK"
+    exit 0
+else
+    echo "validate-adr-headers: ${failures} of ${total} files failed"
+    exit 1
+fi


### PR DESCRIPTION
## What

Phase 3.b of the post-audit roadmap (epic #626). Add a machine-readable freshness/intent signal to every long-lived design and performance document so readers — and tooling — can tell at a glance whether a file is still load-bearing.

Closes #624

## Why

`docs/design/*.md` and the two long-lived performance/regression docs (`tier2-benchmark-results.md`, `batch-drift-regression.md`) had no consistent metadata. New contributors had to skim each document to figure out whether it described shipped behavior, an unimplemented proposal, or stale data. As `docs/` grows, that triage cost compounds.

## How

| File | Change |
|------|--------|
| `docs/design/*.md` (8 files) + `docs/tier2-benchmark-results.md` + `docs/batch-drift-regression.md` (2 files) | Five-field YAML frontmatter prepended at the top of each file. Status assigned per implementation reality: `Active` (6 files) for shipped systems, `Draft` (4 files) for design concepts and proposals not yet implemented. `audience` reflects who the document is for: `maintainer` for internal design, `contributor` for outside-PR explanations. `last_reviewed: 2026-05-09` for every file (initial backfill date — bump on next maintainer review). `supersedes: []` and `superseded_by: null` are the no-op defaults; future supersession chains land here. |
| `scripts/validate-adr-headers.sh` (new) | Bash lint that enforces presence and value ranges of every required field. Defaults to the 8+2 files above; accepts an explicit list to validate ad hoc. Exit codes: 0 OK, 1 mismatch/missing field, 2 no files matched. |
| `.github/workflows/validate-skills.yml` | Path filter expanded with `docs/design/**`, the two named perf/regression docs, and the lint script itself. New step `Verify ADR frontmatter on docs/design (#624)` runs the lint on every PR that touches those paths. |
| `docs/CUSTOM_EXTENSIONS.md` | New section `## ADR / Design Doc Frontmatter (#624)` documents the schema, field semantics, and the validator wiring. Copy-paste-ready YAML block included. |
| `CHANGELOG.md` | New entry under `[Unreleased] / Changed` describes the schema, backfill split, and lint wiring. |

## Test plan

```
$ bash scripts/validate-adr-headers.sh
OK docs/design/command-optimization.md
OK docs/design/intelligent-prefetching.md
OK docs/design/module-caching.md
OK docs/design/module-priority.md
OK docs/design/monitors-migration.md
OK docs/design/optimization-discoveries.md
OK docs/design/optimization-phases.md
OK docs/design/permission-event-hooks.md
OK docs/tier2-benchmark-results.md
OK docs/batch-drift-regression.md

validate-adr-headers: 10 files OK
```

Negative test: dropping any required key (e.g. `last_reviewed`) reproduces the expected `MISSING-KEY` line and exits 1. Out-of-range values (e.g. `status: Stable`) reproduce `BAD-STATUS` and exit 1. Both confirmed manually before the validator was wired into CI.

## Per-file status assignment

| File | status | audience | Reason |
|------|--------|----------|--------|
| `command-optimization.md` | Active | contributor | Shipped token-optimization implementation (v1.2.0) |
| `intelligent-prefetching.md` | Draft | contributor | "CUSTOM EXTENSION / DESIGN CONCEPT" warning |
| `module-caching.md` | Draft | contributor | "CUSTOM EXTENSION / DESIGN CONCEPT" warning |
| `module-priority.md` | Draft | contributor | "CUSTOM EXTENSION / DESIGN CONCEPT" warning |
| `monitors-migration.md` | Draft | maintainer | "Proposal (no implementation)" |
| `optimization-discoveries.md` | Active | maintainer | Findings document referenced by tier-2 work |
| `optimization-phases.md` | Active | maintainer | "All Phases Implemented" (v1.5.0) |
| `permission-event-hooks.md` | Draft | maintainer | "Proposal (no implementation)" |
| `tier2-benchmark-results.md` | Active | maintainer | Live benchmark numbers consumed by drift regression |
| `batch-drift-regression.md` | Active | maintainer | Active CI workflow described |

A maintainer pass to refine these (e.g., promote a `Draft` whose body has been quietly implemented, or downgrade an `Active` whose data is stale) is suggested as a follow-up — the lint enforces shape, not editorial accuracy.

## Acceptance status (per #624)

- [x] Define ADR YAML frontmatter schema (status, audience, last_reviewed, supersedes, superseded_by)
- [x] Add headers to all current `docs/design/*.md` files (initial backfill: per-file status with `last_reviewed: 2026-05-09`)
- [x] Add headers to long-lived perf/regression docs as well (`tier2-benchmark-results.md`, `batch-drift-regression.md`)
- [x] Document the schema in `docs/CUSTOM_EXTENSIONS.md`
- [x] Add lint check in `validate-skills.yml` (existing workflow already triggered on `docs/` indirectly via README paths; explicit `docs/design/**` path was added)
- [ ] **Deferred**: Extend `/doc-index` skill to extract ADR fields into `manifest.yaml` `tags`. Reasonable follow-up — out of scope for this PR's governance goal.
- [ ] **Deferred**: Stale-doc detection (`last_reviewed > 6 months → warn`). Same follow-up — needs a place to surface warnings (probably the doc-index extension).

## Phase mapping

This PR realises Phase 3.b of epic #626. Phase 3.c (#625 manifest.yaml HTML extraction) follows.
