### PR TITLE
fix(doc-index): strip HTML and frontmatter when extracting description (#625)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -25,6 +25,9 @@ on:
       - 'docs/tier2-benchmark-results.md'
       - 'docs/batch-drift-regression.md'
       - 'scripts/validate-adr-headers.sh'
+      - 'scripts/extract-doc-description.sh'
+      - 'tests/doc-index/**'
+      - 'docs/.index/manifest.yaml'
       - 'VERSION_MAP.yml'
       - 'scripts/check_versions.sh'
       - 'scripts/sync_versions.sh'
@@ -89,3 +92,9 @@ jobs:
         # frontmatter so readers can tell at a glance whether a design
         # document is still load-bearing.
         run: bash scripts/validate-adr-headers.sh
+
+      - name: Run doc-index description extractor tests (#625)
+        # Pin extract-doc-description.sh behavior. The pre-#625
+        # heuristic took the first non-empty line, producing literal
+        # '<p align="center">' descriptions for HTML-headed READMEs.
+        run: bash tests/doc-index/test-extract-doc-description.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Phase 3 doc-index description extraction (#625). The /doc-index
+  manifest.yaml stored `'<p align="center">'` as the description for
+  files that opened with a centered badge block (most prominently
+  `README.ko.md`, the Korean entry point). New
+  `scripts/extract-doc-description.sh` skips frontmatter, headings, and
+  pure-HTML structural lines, then strips inline tags from mixed prose
+  and truncates to 200 characters. The doc-index SKILL.md flat-mode
+  Phase 3F now references the helper as the canonical extraction path.
+  Both `README.md` and `README.ko.md` entries in
+  `docs/.index/manifest.yaml` were regenerated with meaningful prose
+  descriptions. New `tests/doc-index/` directory contains 4 fixtures
+  (normal, html-only, frontmatter-only, empty) and a 10-case test
+  suite wired into `validate-skills.yml`.
 - Phase 3 ADR metadata headers (#624). The eight `docs/design/*.md`
   files plus the two long-lived performance/regression docs
   (`docs/tier2-benchmark-results.md`, `docs/batch-drift-regression.md`)

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -52,7 +52,7 @@ documents:
       - {h: "What's Next", l: 170, e: 201}
   - path: "README.ko.md"
     title: "Claude Configuration Backup & Deployment System"
-    description: "<p align=\"center\">"
+    description: "여러 시스템 간에 CLAUDE.md 설정을 쉽게 공유하고 동기화하는 도구"
     category: root
     scope: root
     size: 34108
@@ -82,7 +82,7 @@ documents:
       - {h: "License", l: 909, e: 917}
   - path: "README.md"
     title: "Claude Configuration Backup & Deployment System"
-    description: "<p align=\"center\">"
+    description: "Easily share and sync CLAUDE.md settings across multiple systems"
     category: root
     scope: root
     size: 35565

--- a/global/skills/_internal/doc-index/SKILL.md
+++ b/global/skills/_internal/doc-index/SKILL.md
@@ -84,6 +84,7 @@ For flat mode projects, generate all 4 files using path-based classification:
 2. Group into bundles by classification (core, coding, api, workflow, security, etc.)
 3. Build cross-reference graph from markdown links between files
 4. Generate keyword-based router from bundle categories
+5. **Description extraction (#625)**: for each file's `description:` field in `manifest.yaml`, call `bash scripts/extract-doc-description.sh <path>` rather than taking the first non-empty line directly. The helper skips frontmatter, headings, and pure-HTML structural lines, strips inline tags from mixed prose, and truncates to 200 characters. This avoids the historical bug where READMEs that opened with a centered badge block produced literal `<p align="center">` descriptions.
 
 Then proceed to Phase 4 (Write) and Phase 5 (Report).
 

--- a/scripts/extract-doc-description.sh
+++ b/scripts/extract-doc-description.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# extract-doc-description.sh — derive the manifest.yaml description for a
+# markdown document (#625).
+#
+# The /doc-index skill stores a one-line description per file in
+# docs/.index/manifest.yaml. The pre-#625 heuristic took the first
+# non-empty line, which produced literal HTML tags ('<p align="center">')
+# for documents that begin with a centered badge block — exactly the case
+# in README.ko.md, the Korean entry point.
+#
+# This helper implements the corrected extraction:
+#   1. Skip a YAML frontmatter block at the top (between two '---' lines).
+#   2. Skip ATX headings ('# ', '## ', etc).
+#   3. Skip lines that are pure HTML structural tags (open/close, opening
+#      tags whose content runs into other lines) — recognized by the line
+#      not containing any non-whitespace, non-tag content.
+#   4. For lines that mix HTML and prose (e.g. '<strong>여러 시스템…</strong>'),
+#      strip the tags and use the remaining text.
+#   5. Return the first non-empty result, trimmed and truncated to 200
+#      characters.
+#
+# Output: the extracted description on stdout. Empty stdout + non-zero
+# exit if no description could be derived.
+#
+# Exit codes:
+#   0  description emitted on stdout
+#   1  no description found
+#   2  usage error (missing arg / unreadable file)
+#
+# Usage:
+#   bash scripts/extract-doc-description.sh path/to/file.md
+
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: extract-doc-description.sh <markdown-file>" >&2
+    exit 2
+fi
+
+f="$1"
+if [[ ! -r "$f" ]]; then
+    echo "extract-doc-description: cannot read $f" >&2
+    exit 2
+fi
+
+# strip_html: remove tags from a single line and collapse whitespace.
+strip_html() {
+    # 1. Remove '<...>' tags greedily but non-spanningly. Use sed; the
+    #    pattern intentionally allows attributes and self-closing forms.
+    # 2. Collapse runs of whitespace (incl. NBSP) to single ASCII space.
+    # 3. Trim leading/trailing whitespace.
+    sed -E 's/<[^>]+>//g' \
+        | tr -s '[:space:]' ' ' \
+        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+# Single-pass scan: for each non-frontmatter, non-heading, non-blank line,
+# strip HTML tags. Return the first line that has prose content after the
+# stripping. Truncate to 200 chars.
+in_fm=0
+fm_seen=0
+while IFS= read -r line; do
+    if [[ "$fm_seen" == 0 && "$line" == "---" ]]; then
+        in_fm=1; fm_seen=1; continue
+    fi
+    if [[ "$in_fm" == 1 ]]; then
+        if [[ "$line" == "---" ]]; then in_fm=0; fi
+        continue
+    fi
+    # Skip ATX headings (any line starting with one or more '#' then space).
+    case "$line" in
+        '#'*' '*) continue ;;
+        '#'*) continue ;;
+    esac
+    # Skip blank lines.
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    cleaned=$(printf '%s' "$line" | strip_html)
+    if [[ -n "$cleaned" ]]; then
+        printf '%s\n' "${cleaned:0:200}"
+        exit 0
+    fi
+done < "$f"
+
+exit 1

--- a/tests/doc-index/fixtures/empty.md
+++ b/tests/doc-index/fixtures/empty.md
@@ -1,0 +1,4 @@
+# Heading Only
+
+
+

--- a/tests/doc-index/fixtures/frontmatter-only.md
+++ b/tests/doc-index/fixtures/frontmatter-only.md
@@ -1,0 +1,9 @@
+---
+status: Active
+audience: maintainer
+last_reviewed: 2026-05-09
+---
+
+# Frontmatter-Headed Doc
+
+The first prose line that the extractor should pick up.

--- a/tests/doc-index/fixtures/html-only.md
+++ b/tests/doc-index/fixtures/html-only.md
@@ -1,0 +1,13 @@
+# HTML Badge Header
+
+<p align="center">
+  <a href="https://example.com/release"><img src="badge.svg" alt="version"></a>
+</p>
+
+<p align="center">
+  <strong>Real description hidden inside an HTML strong tag</strong>
+</p>
+
+---
+
+The body starts here.

--- a/tests/doc-index/fixtures/normal.md
+++ b/tests/doc-index/fixtures/normal.md
@@ -1,0 +1,5 @@
+# Normal Document
+
+This is the first prose paragraph and should be returned as the description.
+
+A second paragraph the extractor should not reach.

--- a/tests/doc-index/test-extract-doc-description.sh
+++ b/tests/doc-index/test-extract-doc-description.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Test suite for scripts/extract-doc-description.sh (#625).
+#
+# Run: bash tests/doc-index/test-extract-doc-description.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+SCRIPT="scripts/extract-doc-description.sh"
+FIX="tests/doc-index/fixtures"
+PASS=0
+FAIL=0
+ERRORS=()
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected '$expected', got '$actual'")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_exit() {
+    local label="$1" expected_rc="$2" actual_rc="$3"
+    if (( actual_rc == expected_rc )); then
+        ((PASS++))
+        echo "  PASS: $label (rc=$actual_rc)"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label — expected rc=$expected_rc, got rc=$actual_rc")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== extract-doc-description.sh tests (#625) ==="
+echo ""
+
+echo "[Plain prose document]"
+out=$(bash "$SCRIPT" "$FIX/normal.md")
+rc=$?
+assert_exit "normal.md exits 0" 0 "$rc"
+assert_eq "normal.md returns first prose paragraph" \
+    "This is the first prose paragraph and should be returned as the description." \
+    "$out"
+
+echo ""
+echo "[Document opening with HTML badges]"
+out=$(bash "$SCRIPT" "$FIX/html-only.md")
+rc=$?
+assert_exit "html-only.md exits 0" 0 "$rc"
+assert_eq "html-only.md strips tags and returns prose inside <strong>" \
+    "Real description hidden inside an HTML strong tag" \
+    "$out"
+
+echo ""
+echo "[Document with YAML frontmatter]"
+out=$(bash "$SCRIPT" "$FIX/frontmatter-only.md")
+rc=$?
+assert_exit "frontmatter-only.md exits 0" 0 "$rc"
+assert_eq "frontmatter-only.md skips frontmatter + heading and returns prose" \
+    "The first prose line that the extractor should pick up." \
+    "$out"
+
+echo ""
+echo "[Document with no prose body]"
+out=$(bash "$SCRIPT" "$FIX/empty.md")
+rc=$?
+assert_exit "empty.md exits 1 (no description)" 1 "$rc"
+assert_eq "empty.md emits empty stdout" "" "$out"
+
+echo ""
+echo "[Real READMEs (regression for the original bug)]"
+out=$(bash "$SCRIPT" "README.ko.md")
+rc=$?
+assert_exit "README.ko.md exits 0" 0 "$rc"
+case "$out" in
+    '<p align'*)
+        ((FAIL++))
+        ERRORS+=("FAIL: README.ko.md returned the bug's HTML tag")
+        echo "  FAIL: README.ko.md still returns HTML tag"
+        ;;
+    '')
+        ((FAIL++))
+        ERRORS+=("FAIL: README.ko.md returned empty")
+        echo "  FAIL: README.ko.md returned empty"
+        ;;
+    *)
+        ((PASS++))
+        echo "  PASS: README.ko.md returns meaningful prose: $out"
+        ;;
+esac
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Phase 3.c of the post-audit roadmap (epic #626). Fix the `/doc-index` description heuristic that produced literal HTML markup for files opening with a centered badge block.

Closes #625

## Why

`docs/.index/manifest.yaml` stored `description: '<p align="center">'` for both `README.md` and `README.ko.md`. The descriptions feed router and bundle recommendations; HTML markup as a description degraded retrieval accuracy for the documents users are most likely to query — most prominently the Korean entry point.

## How

| File | Change |
|------|--------|
| `scripts/extract-doc-description.sh` (new) | Implements the corrected extraction. Skips frontmatter, ATX headings, blank lines, and pure-HTML structural lines (`<p>`, `<a>`, etc.); strips inline tags from mixed prose so `<strong>실제 설명</strong>` resolves to `실제 설명`. Truncates to 200 chars. Exit 0 with description on stdout, 1 if no description found, 2 on usage error. |
| `docs/.index/manifest.yaml` | `README.md` description corrected to `Easily share and sync CLAUDE.md settings across multiple systems`. `README.ko.md` description corrected to `여러 시스템 간에 CLAUDE.md 설정을 쉽게 공유하고 동기화하는 도구`. Both lines extracted by the new helper from the existing centered-tagline `<strong>` blocks. |
| `global/skills/_internal/doc-index/SKILL.md` | Phase 3F (flat-mode) gains an explicit step 5 directing the skill to call `bash scripts/extract-doc-description.sh <path>` instead of taking the first non-empty line directly. Captures the WHY (the historical bug) so future maintainers don't re-introduce it. |
| `tests/doc-index/fixtures/` (new) | Four fixtures matching the issue spec: `normal.md` (plain prose), `html-only.md` (badge block + tagline inside `<strong>`), `frontmatter-only.md` (YAML frontmatter + heading + prose), `empty.md` (heading only, no body). |
| `tests/doc-index/test-extract-doc-description.sh` (new) | 10-case suite covering the four fixtures plus a regression assertion that `README.ko.md` no longer returns `<p align`-prefixed output. All 10 pass on develop. |
| `.github/workflows/validate-skills.yml` | Path filter expanded with the new script, fixtures, and `docs/.index/manifest.yaml`. New step `Run doc-index description extractor tests (#625)` runs the suite on every PR. |
| `CHANGELOG.md` | New entry under `[Unreleased] / Changed` describes the bug, the fix, the manifest correction, and the test wiring. |

## Test plan

```
$ bash tests/doc-index/test-extract-doc-description.sh
=== Results: 10 passed, 0 failed ===

$ bash scripts/extract-doc-description.sh README.md
Easily share and sync CLAUDE.md settings across multiple systems

$ bash scripts/extract-doc-description.sh README.ko.md
여러 시스템 간에 CLAUDE.md 설정을 쉽게 공유하고 동기화하는 도구

$ bash scripts/extract-doc-description.sh tests/doc-index/fixtures/empty.md ; echo $?
1
```

The pre-fix description for both READMEs was the literal string `<p align="center">` (verified directly in `docs/.index/manifest.yaml` before this PR). After the fix, the same files surface meaningful prose descriptions.

## Acceptance status (per #625)

- [x] Update extraction logic to skip lines starting with HTML tag pattern (and strip inline tags from mixed prose so `<strong>...</strong>` lines remain useful)
- [x] Skip frontmatter blocks (delimited by `---`)
- [x] Skip heading lines (`#`)
- [x] Use the first non-empty plain prose paragraph; truncate to 200 chars
- [x] Regenerate `docs/.index/manifest.yaml` and verify `README.ko.md` description is meaningful prose (also corrects `README.md` which had the same bug)
- [x] Add unit test fixture (new `tests/doc-index/` directory) covering: HTML-only file, frontmatter-only file, normal file (plus `empty.md` for the negative-result path)
- [x] Update `docs/.index/router.yaml` and `bundles.yaml` if their content depended on the bad description — neither file referenced the `<p align` string, so no propagation was needed (verified via `grep`)

## Phase mapping

This PR realises Phase 3.c of epic #626 and completes the audit follow-up roadmap. With #620, #621, #622, #623, #624, and #625 all merged, every Major-severity finding from the 2026-05-08 audit is addressed.
