### PR TITLE
feat(sonar-fix): skeleton for SonarQube Cloud PR comment handling

### DIFF
--- a/global/skills/_internal/sonar-fix/SKILL.md
+++ b/global/skills/_internal/sonar-fix/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: sonar-fix
+description: Parse sonarcloud[bot] PR comments, classify findings, codify whitelisted auto-fixes, escalate the rest.
+argument-hint: "<pr-number> [--dry-run]"
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: "Bash(gh *)"
+max_iterations: 3
+halt_conditions:
+  - { type: success,  expr: "sonarcloud[bot] reports Quality Gate PASS" }
+  - { type: fallback, expr: "no rule matches whitelist after 3 attempts" }
+  - { type: limit,    expr: "3 identical re-scan failures" }
+loop_safe: false
+severity: S2
+finding_levels: [S1, S2, S3]
+iso_class: none
+---
+
+# sonar-fix
+
+## Overview
+
+The `sonar-fix` skill processes PR decoration emitted by SonarQube Cloud
+via the `sonarcloud[bot]` GitHub account. It parses the bot's summary
+and inline review comments, classifies each finding by rule and
+severity, and follows a `classify -> fix -> escalate` flow. Whitelisted
+rules (see `reference/auto-fixable-rules.md`) are eligible for codified
+auto-fixes in later phases; everything else is escalated back to the
+PR author as a single consolidated comment. No SonarQube REST API
+tokens are required; the bot's PR comments are the only data source.
+
+## Classify
+
+The skill reads two channels from the PR conversation:
+
+1. The single `sonarcloud[bot]` **summary comment**, which carries the
+   Quality Gate verdict (`PASS` or `FAIL`).
+2. The `sonarcloud[bot]` **inline review comments**, one per finding,
+   anchored to a diff line.
+
+For every inline comment, the parser extracts `rule_id`, `severity`,
+`file:line`, and `message`, producing a `(rule_id, severity)` mapping
+keyed by location. The parsing contract is captured in
+`reference/comment-format.md` and must be treated as the single source
+of truth for regex and field layout.
+
+## Summary
+
+After classification the skill posts a single comment to the PR with a
+breakdown table: total findings, count per rule, count per severity,
+and which findings are eligible for auto-fix versus escalation. The
+comment is idempotent across runs so re-scans replace rather than
+append.
+
+## Escalate
+
+Findings that do not match an entry in the auto-fix whitelist are
+reported using the body in `reference/escalation-template.md`. The
+escalation comment is also idempotent: a single HTML marker comment
+identifies prior escalations from this skill so subsequent runs update
+the existing comment instead of stacking new ones.
+
+## Halt Conditions
+
+The skill stops in three cases, paraphrased from the frontmatter:
+
+- **Success**: the latest `sonarcloud[bot]` summary reports Quality
+  Gate PASS, meaning no further action is needed.
+- **Fallback**: after three classification attempts no remaining
+  finding matches the auto-fix whitelist, so the skill escalates and
+  exits.
+- **Limit**: three identical re-scan failures in a row (same
+  rule + same location) indicate the codified fix is not converging,
+  so the skill stops to avoid a tight loop.
+
+## Out of Scope
+
+- Codified fix logic for the six whitelisted rules: deferred to P2
+  (S1481, S1128) and P4 (S1854, S1192, S125, S1116).
+- Integration with the `pr-work` and `release` skills: deferred to P3.
+- Registration in the global `Skill Aliases` table in
+  `global/CLAUDE.md`: deferred to P5.
+- SonarQube REST API access, token management, or non-PR sources of
+  findings: out of scope by design (the bot comment channel is
+  authoritative).
+
+## References
+
+- [reference/auto-fixable-rules.md](reference/auto-fixable-rules.md)
+- [reference/comment-format.md](reference/comment-format.md)
+- [reference/escalation-template.md](reference/escalation-template.md)

--- a/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
+++ b/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
@@ -1,0 +1,16 @@
+# Auto-Fixable SonarQube Rules (whitelist)
+
+| Rule  | Type                | Phase | Codified Fix |
+|-------|---------------------|-------|--------------|
+| S1481 | Unused local        | P2    | TODO: P2     |
+| S1128 | Unused import       | P2    | TODO: P2     |
+| S1854 | Dead assignment     | P4    | TODO: P4     |
+| S1192 | Literal duplication | P4    | TODO: P4     |
+| S125  | Commented-out code  | P4    | TODO: P4     |
+| S1116 | Empty statement     | P4    | TODO: P4     |
+
+## Excluded (never auto-fixed)
+- `security_hotspot` (type): manual security review required
+- `vulnerability` (type): manual security review required
+- Complexity rules (cognitive/cyclomatic): architectural decisions
+- Naming rules: cascade-heavy renames, risk of breaking external callers

--- a/global/skills/_internal/sonar-fix/reference/comment-format.md
+++ b/global/skills/_internal/sonar-fix/reference/comment-format.md
@@ -1,0 +1,26 @@
+# sonarcloud[bot] PR Comment Format
+
+## Summary comment (one per PR)
+Posted by `sonarcloud[bot]`. Contains the Quality Gate verdict in a
+heading or bolded line such as `Quality Gate passed` or `Quality Gate failed`.
+
+Parser must extract: `verdict in {PASS, FAIL}`.
+
+## Inline review comments (one per finding)
+Posted on the diff line of the finding. Body shape:
+
+> <severity> <rule-name> <message>
+> See more on [SonarQube Cloud](URL with `rule=<rule_id>` query)
+
+Parser must extract: `rule_id`, `severity`, `file:line`, `message`.
+
+## `rule_id` regex
+`\b(S\d{1,4})\b` (matches `S1481`, `S125`, etc.)
+
+## Sample Archive
+(populated by P2+ as real sonarcloud[bot] comments arrive — keep this
+section as a chronological list of `(date, comment_url, verdict, rules[])`
+tuples so future parser tweaks have a regression corpus)
+
+### TODO entries from P2
+- (date) `<url>` — verdict, rule_ids encountered

--- a/global/skills/_internal/sonar-fix/reference/escalation-template.md
+++ b/global/skills/_internal/sonar-fix/reference/escalation-template.md
@@ -1,0 +1,29 @@
+# Escalation Template
+
+Used when sonar-fix finds at least one finding outside the whitelist.
+The skill posts this body as a single PR comment, replacing any
+previous escalation comment from the same skill.
+
+```markdown
+## Sonar findings outside auto-fix whitelist
+
+The following findings require manual review and cannot be auto-fixed
+by this skill:
+
+| File:Line | Rule | Severity | Message |
+|-----------|------|----------|---------|
+| <path>:<line> | <rule_id> | <severity> | <message> |
+
+Source: <sonarcloud[bot] summary comment URL>
+
+After resolving manually, re-trigger sonar-fix or wait for the next
+sonarcloud[bot] re-scan.
+```
+
+## Idempotency
+The skill marks its comment with an HTML marker comment so subsequent
+runs replace rather than append:
+
+```html
+<!-- sonar-fix:escalation -->
+```


### PR DESCRIPTION
## Summary
Skeleton for the new `sonar-fix` skill at `global/skills/_internal/sonar-fix/`.
This PR introduces 4 files: `SKILL.md` with the frontmatter contract from
#635, plus 3 reference docs (`auto-fixable-rules.md`, `comment-format.md`,
`escalation-template.md`). All prose; no codified fix logic.

## Why
P1 of the 5-phase plan in #635. Locks the module shape and frontmatter
contract before P2 adds the first codified fixes (S1481, S1128).

## Test Plan
- `validate-skills.yml` (and any other CI checks) must pass
- Manual: `grep -rn "fix(sonar):" global/skills/_internal/sonar-fix/` returns nothing
- Manual: `head -20 global/skills/_internal/sonar-fix/SKILL.md` matches the verbatim frontmatter

## Sub-issue
Closes #636

## Parent epic
Part of #635
