### PR TITLE
feat(sonar-fix): S1481/S1128 auto-fix + dry-run

### DIFF
--- a/global/skills/_internal/sonar-fix/SKILL.md
+++ b/global/skills/_internal/sonar-fix/SKILL.md
@@ -73,6 +73,55 @@ The skill stops in three cases, paraphrased from the frontmatter:
   rule + same location) indicate the codified fix is not converging,
   so the skill stops to avoid a tight loop.
 
+## Apply
+
+After classification, each finding is routed by whitelist match:
+
+- **Whitelist match** (rule ∈ {S1481, S1128} in P2; full whitelist
+  in P4): read the rule's entry in
+  `reference/auto-fixable-rules.md` and apply the codified fix
+  exactly as specified in its Before/After section.
+- **Whitelist miss**: render the finding into the body in
+  `reference/escalation-template.md` and accumulate it for the single
+  consolidated escalation comment.
+
+All fixes must be **idempotent** — running the skill twice on the same
+PR must produce the same tree on the second run as on the first. Rules
+that declare a `Safety` section (S1481 RHS side-effect, S1128
+side-effect import) MUST escalate rather than auto-fix when the safety
+predicate cannot be evaluated with certainty. When in doubt, escalate.
+
+## Dry-run mode
+
+When the skill is invoked with `--dry-run`:
+
+- No file edits are written and no commit is created.
+- The skill emits a unified diff (`git diff` style) of the fixes it
+  *would* apply to stdout so the operator can review the change set
+  before re-running without `--dry-run`.
+- The same diff may also be posted as a PR comment with the HTML
+  marker `<!-- sonar-fix:dry-run -->` so subsequent dry-run invocations
+  replace the prior preview comment rather than stacking.
+- Escalation comments are still posted in dry-run mode so the manual
+  review path is visible alongside the auto-fix preview.
+
+After review, re-invoke the skill on the same PR without `--dry-run`
+to apply the previewed diff.
+
+## Commit Convention
+
+Auto-fix commits authored by this skill follow:
+
+```
+fix(sonar): <rule-id> -- <short reason>
+```
+
+Examples:
+- `fix(sonar): S1481 -- remove unused local in cli/main.py`
+- `fix(sonar): S1128 -- remove unused import in api/handlers.py`
+
+Refer to parent epic #635 for the full rationale.
+
 ## Out of Scope
 
 - Codified fix logic for the six whitelisted rules: deferred to P2

--- a/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
+++ b/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
@@ -1,16 +1,88 @@
 # Auto-Fixable SonarQube Rules (whitelist)
 
-| Rule  | Type                | Phase | Codified Fix |
-|-------|---------------------|-------|--------------|
-| S1481 | Unused local        | P2    | TODO: P2     |
-| S1128 | Unused import       | P2    | TODO: P2     |
-| S1854 | Dead assignment     | P4    | TODO: P4     |
-| S1192 | Literal duplication | P4    | TODO: P4     |
-| S125  | Commented-out code  | P4    | TODO: P4     |
-| S1116 | Empty statement     | P4    | TODO: P4     |
+| Rule  | Type                | Phase  | Codified Fix |
+|-------|---------------------|--------|--------------|
+| S1481 | Unused local        | **P2** | **See § S1481** |
+| S1128 | Unused import       | **P2** | **See § S1128** |
+| S1854 | Dead assignment     | P4     | TODO: P4 |
+| S1192 | Literal duplication | P4     | TODO: P4 |
+| S125  | Commented-out code  | P4     | TODO: P4 |
+| S1116 | Empty statement     | P4     | TODO: P4 |
 
 ## Excluded (never auto-fixed)
 - `security_hotspot` (type): manual security review required
 - `vulnerability` (type): manual security review required
 - Complexity rules (cognitive/cyclomatic): architectural decisions
 - Naming rules: cascade-heavy renames, risk of breaking external callers
+
+---
+
+## S1481 — Unused local variable
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S1481` (or message text contains "Remove this unused")
+- severity ∈ {MINOR, MAJOR}
+- target file extension ∈ {.py, .js, .ts, .go, .java, .cs, .cpp, .c} (skill is language-aware)
+
+### Root cause
+A local variable is declared and assigned but never read.
+
+### Before
+```python
+def calculate(x, y):
+    result = x + y   # noqa  ← S1481 warns here
+    return x * y
+```
+
+### After
+```python
+def calculate(x, y):
+    return x * y
+```
+
+### Verify
+- After applying the fix, the surrounding function still parses (run language's syntax check)
+- Re-run sonarcloud[bot] scan: the S1481 finding on the original `file:line` is gone
+- No other diagnostic appears on the affected line
+
+### Safety
+- Idempotent: applying twice yields the same tree
+- Side-effect risk: if the RHS of the assignment has side-effects (function call), do **not** auto-fix — escalate via `escalation-template.md`. Detect by parsing the AST; if not available, conservatively escalate when RHS contains `(` or `await` or `yield`.
+
+---
+
+## S1128 — Unused import
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S1128`
+- severity ∈ {MINOR, MAJOR}
+- target file extension ∈ {.py, .js, .ts, .java}
+
+### Root cause
+An import statement is present but the imported symbol is never used in the file.
+
+### Before
+```python
+import os
+import json
+
+def load(path):
+    return json.load(open(path))
+```
+
+### After
+```python
+import json
+
+def load(path):
+    return json.load(open(path))
+```
+
+### Verify
+- After applying the fix, the file still parses
+- Re-run sonarcloud[bot] scan: the S1128 finding on the original `file:line` is gone
+- Run the test suite for the affected module — if a side-effect import was misclassified, tests catch it
+
+### Safety
+- Side-effect imports (e.g., `import django.setup`, `import warnings; warnings.filterwarnings(...)`) must be preserved. Detect by checking for top-level statements other than `import` in the imported module — if unsure, escalate.
+- Preserve import grouping (stdlib / third-party / local), preserve blank-line separators between groups.

--- a/global/skills/_internal/sonar-fix/reference/comment-format.md
+++ b/global/skills/_internal/sonar-fix/reference/comment-format.md
@@ -22,5 +22,5 @@ Parser must extract: `rule_id`, `severity`, `file:line`, `message`.
 section as a chronological list of `(date, comment_url, verdict, rules[])`
 tuples so future parser tweaks have a regression corpus)
 
-### TODO entries from P2
-- (date) `<url>` — verdict, rule_ids encountered
+### Codified rules (P2)
+- S1481, S1128 — codified in `auto-fixable-rules.md` as of this PR. Sample sonarcloud[bot] comments that triggered these will be archived here in their first real-PR encounter.


### PR DESCRIPTION
## Summary
Codifies auto-fix instructions for the two safest SonarQube whitelist rules:

- **S1481** — Unused local variable removal
- **S1128** — Unused import removal

Adds `Apply` and `Dry-run mode` sections to `SKILL.md` so the skill body
now describes the full classify → fix → escalate pipeline (with `--dry-run`
preview).

## Why
P2 of the 5-phase plan in #635. S1481 and S1128 are language-agnostic,
mechanical, and idempotent — ideal first rules to validate the pipeline
shape before P4 expands to the remaining 4 whitelist rules. The
`--dry-run` flag is an explicit acceptance criterion in the parent epic
and a safety rail for P4.

## Test Plan
- `validate-skills.yml` and any other CI checks must pass
- Manual: `head -3 global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md`
  shows the updated table where S1481 and S1128 reference `§ S1481` / `§ S1128`
- Manual: `grep -A 5 "## Dry-run mode" global/skills/_internal/sonar-fix/SKILL.md`
  shows the dry-run spec
- Manual: each Pattern entry contains the four canonical headings
  (Classifier / Root cause / Before / After / Verify / Safety)

## Sub-issue
Closes #637

## Parent epic
Part of #635
