### PR TITLE
feat(sonar-fix): pr-work and release gate

### DIFF
--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -10,6 +10,7 @@ halt_conditions:
   - { type: success, expr: "All PR checks pass" }
   - { type: user,    expr: "user aborts" }
   - { type: limit,   expr: "3 identical CI failures in a row" }
+  - { type: limit,   expr: "sonar-fix exhausted max_iterations and Quality Gate still FAIL" }
 on_halt: "Report failing checks with gh pr checks output, do not merge"
 loop_safe: false
 tiers:
@@ -634,6 +635,39 @@ and the gate enforces the checks above.
 > per-iso-class evidence requirement matrix, the formal "within the last
 > 24h" definition, the full failure-message format, and the override-flag
 > contract.
+
+### 10a. Sonar Gate (sonarcloud[bot] PR Decoration)
+
+After CI passes (Step 9) and before the ABSOLUTE CI GATE merge (Step 10),
+check for a SonarCloud Quality Gate verdict on the PR. SonarCloud reports
+via PR comment from `sonarcloud[bot]`, not via a GitHub Check — so the
+`gh pr checks` gate in Step 10 does not see it.
+
+```bash
+# Fetch sonarcloud[bot] summary comment
+SONAR_COMMENT=$(gh pr view $PR_NUMBER --repo $ORG/$PROJECT \
+  --comments --json comments \
+  -q '.comments[] | select(.author.login == "sonarcloud[bot]") | .body' | tail -1)
+```
+
+If no `sonarcloud[bot]` comment is present, the project is not Sonar-attached —
+**skip** this step and proceed to Step 10.
+
+If a comment is present:
+
+- Extract the Quality Gate verdict from the comment body (look for
+  `Quality Gate passed` or `Quality Gate failed`).
+- If `PASS` -> proceed to Step 10.
+- If `FAIL` -> invoke the `sonar-fix` skill:
+  - Sub-agent: `sonar-fix $PR_NUMBER` (the skill is user-invocable per
+    its frontmatter).
+  - After `sonar-fix` completes, re-poll the `sonarcloud[bot]` summary
+    comment until the verdict flips to PASS or `sonar-fix` reaches its
+    own `max_iterations` (3).
+- If still `FAIL` after `sonar-fix` exhausts `max_iterations` -> halt
+  per pr-work's `halt_conditions` (`sonar-fix exhausted max_iterations
+  and Quality Gate still FAIL`) and exit without merging. Convert the
+  PR to draft and report the final verdict to the user.
 
 ### 10. Auto-Merge on Success
 

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -365,6 +365,18 @@ gh pr merge $PR_NUMBER --repo $ORG/$PROJECT --squash
 
 If CI fails, diagnose and fix on `develop`, push, and re-poll. Max 3 attempts.
 
+#### Sonar Gate on Release PR
+
+The release skill creates a `develop -> main` PR. Apply the same Sonar
+gate that `pr-work` uses (Step 10a) to release PRs as well — Quality Gate
+regressions accumulated on `develop` must not slip into `main`.
+
+Procedure: identical to `pr-work` Step 10a (fetch the `sonarcloud[bot]`
+summary comment, parse the Quality Gate verdict, invoke `sonar-fix` on
+FAIL, re-poll, halt if `sonar-fix` exhausts its `max_iterations`).
+
+See: `~/.claude/skills/_internal/pr-work/SKILL.md` Step 10a.
+
 ### 7. Create Git Tag on main
 
 ```bash

--- a/global/skills/_internal/sonar-fix/SKILL.md
+++ b/global/skills/_internal/sonar-fix/SKILL.md
@@ -124,14 +124,16 @@ Refer to parent epic #635 for the full rationale.
 
 ## Out of Scope
 
-- Codified fix logic for the six whitelisted rules: deferred to P2
-  (S1481, S1128) and P4 (S1854, S1192, S125, S1116).
-- Integration with the `pr-work` and `release` skills: deferred to P3.
+- Codified fix logic for the remaining whitelisted rules: deferred to P4
+  (S1854, S1192, S125, S1116).
 - Registration in the global `Skill Aliases` table in
   `global/CLAUDE.md`: deferred to P5.
 - SonarQube REST API access, token management, or non-PR sources of
   findings: out of scope by design (the bot comment channel is
   authoritative).
+- Auto-fix for `security_hotspot` or `vulnerability` findings: out of
+  scope by policy — these require human review and never qualify for
+  codified auto-fixes.
 
 ## References
 


### PR DESCRIPTION
## Summary
Wires `sonar-fix` into the existing PR lifecycle:

- `pr-work` gains **Step 10a** between CI monitoring (Step 9) and the
  ABSOLUTE CI GATE (Step 10). It fetches the sonarcloud[bot] PR comment,
  parses the Quality Gate verdict, and invokes `sonar-fix` on FAIL.
- `release` applies the same gate to develop -> main release PRs by
  cross-referencing `pr-work` Step 10a (DRY).
- `sonar-fix` Out of Scope drops the `pr-work` / `release` deferral
  since P3 resolves it.

## Why
P3 closes the gap where SonarCloud Quality Gate FAIL -- reported only via
PR comment, not via a GitHub Check -- was invisible to the merge gate.
Without this PR, `sonar-fix` from P1/P2 exists on disk but never runs
during the normal PR flow.

## Test Plan
- `validate-skills.yml` (and any other CI check) must pass
- Manual: `grep -n "Sonar Gate" global/skills/_internal/pr-work/SKILL.md`
  shows the new Step 10a heading positioned before "Squash Merge"
- Manual: `grep -n "Sonar Gate" global/skills/_internal/release/SKILL.md`
  shows the release-side gate that references pr-work Step 10a
- Manual: `grep "pr-work" global/skills/_internal/sonar-fix/SKILL.md`
  no longer matches inside Out of Scope (only inside Apply/Halt prose)

## Sub-issue
Closes #638

## Parent epic
Part of #635
