### PR TITLE
feat(sonar-fix): expand whitelist with 4 rules

### DIFF
--- a/global/skills/_internal/sonar-fix/SKILL.md
+++ b/global/skills/_internal/sonar-fix/SKILL.md
@@ -77,8 +77,8 @@ The skill stops in three cases, paraphrased from the frontmatter:
 
 After classification, each finding is routed by whitelist match:
 
-- **Whitelist match** (rule ∈ {S1481, S1128} in P2; full whitelist
-  in P4): read the rule's entry in
+- **Whitelist match** (rule ∈ {S1481, S1128, S1854, S1192, S125,
+  S1116}): read the rule's entry in
   `reference/auto-fixable-rules.md` and apply the codified fix
   exactly as specified in its Before/After section.
 - **Whitelist miss**: render the finding into the body in
@@ -88,8 +88,10 @@ After classification, each finding is routed by whitelist match:
 All fixes must be **idempotent** — running the skill twice on the same
 PR must produce the same tree on the second run as on the first. Rules
 that declare a `Safety` section (S1481 RHS side-effect, S1128
-side-effect import) MUST escalate rather than auto-fix when the safety
-predicate cannot be evaluated with certainty. When in doubt, escalate.
+side-effect import, S1854 RHS side-effect, S1192 semantic divergence /
+naming ambiguity, S125 intentional-marker comments, S1116 intentional
+empty body) MUST escalate rather than auto-fix when the safety predicate
+cannot be evaluated with certainty. When in doubt, escalate.
 
 ## Dry-run mode
 
@@ -124,8 +126,6 @@ Refer to parent epic #635 for the full rationale.
 
 ## Out of Scope
 
-- Codified fix logic for the remaining whitelisted rules: deferred to P4
-  (S1854, S1192, S125, S1116).
 - Registration in the global `Skill Aliases` table in
   `global/CLAUDE.md`: deferred to P5.
 - SonarQube REST API access, token management, or non-PR sources of

--- a/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
+++ b/global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md
@@ -4,10 +4,10 @@
 |-------|---------------------|--------|--------------|
 | S1481 | Unused local        | **P2** | **See § S1481** |
 | S1128 | Unused import       | **P2** | **See § S1128** |
-| S1854 | Dead assignment     | P4     | TODO: P4 |
-| S1192 | Literal duplication | P4     | TODO: P4 |
-| S125  | Commented-out code  | P4     | TODO: P4 |
-| S1116 | Empty statement     | P4     | TODO: P4 |
+| S1854 | Dead assignment     | **P4** | **See § S1854** |
+| S1192 | Literal duplication | **P4** | **See § S1192** |
+| S125  | Commented-out code  | **P4** | **See § S125**  |
+| S1116 | Empty statement     | **P4** | **See § S1116** |
 
 ## Excluded (never auto-fixed)
 - `security_hotspot` (type): manual security review required
@@ -86,3 +86,172 @@ def load(path):
 ### Safety
 - Side-effect imports (e.g., `import django.setup`, `import warnings; warnings.filterwarnings(...)`) must be preserved. Detect by checking for top-level statements other than `import` in the imported module — if unsure, escalate.
 - Preserve import grouping (stdlib / third-party / local), preserve blank-line separators between groups.
+
+---
+
+## S1854 — Dead assignment
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S1854` (or message text contains "Remove this useless assignment")
+- severity ∈ {MINOR, MAJOR}
+- target file extension ∈ {.py, .js, .ts, .go, .java, .cs, .cpp, .c}
+
+### Root cause
+A value is assigned to a variable, but before that variable is read the assignment is overwritten by a later one (or the variable's scope ends). The first assignment is therefore dead.
+
+### Before
+```python
+def pick(items):
+    chosen = items[0]   # ← S1854 warns here: chosen is overwritten before any read
+    chosen = items[-1]
+    return chosen
+```
+
+### After
+```python
+def pick(items):
+    chosen = items[-1]
+    return chosen
+```
+
+### Verify
+- The line carrying the original `file:line` from the finding no longer exists, and the function still parses
+- The variable on the surviving line is still read at least once in the same scope (otherwise it has degenerated into an S1481 finding and must be handled there)
+- Re-run sonarcloud[bot] scan: the S1854 finding on the original `file:line` is gone
+
+### Safety
+- Side-effect risk: if the RHS of the dead assignment is a function call, a `print`/`logger.*` invocation, an `assert`, an `await`, or a `yield`, do **not** auto-fix — escalate. Only literal/identifier RHS values are eligible.
+- Debug-trace risk: if the dead assignment matches a temporary-variable convention (`tmp_*`, `_dbg_*`, `_unused_*`) the developer may be intentionally probing — escalate.
+- Idempotent: applying twice yields the same tree.
+
+---
+
+## S1192 — String literal duplication
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S1192` (or message text contains "Define a constant instead of duplicating this literal")
+- severity ∈ {MAJOR, CRITICAL}
+- target file extension ∈ {.py, .js, .ts, .java, .cs}
+
+### Root cause
+The same string literal appears three or more times in the same file, suggesting it should be extracted into a named constant so a future rename is a one-line change.
+
+### Before
+```python
+def has_admin(user):
+    return user.role == "administrator"
+
+def grant_admin(user):
+    user.role = "administrator"
+    save(user)
+
+def is_admin_email(email):
+    return email.endswith("@administrator.example.com") and "administrator" in email
+```
+
+### After
+```python
+ADMINISTRATOR_ROLE = "administrator"
+
+
+def has_admin(user):
+    return user.role == ADMINISTRATOR_ROLE
+
+def grant_admin(user):
+    user.role = ADMINISTRATOR_ROLE
+    save(user)
+
+def is_admin_email(email):
+    return email.endswith("@administrator.example.com") and ADMINISTRATOR_ROLE in email
+```
+
+### Verify
+- The original literal no longer appears as a bare string at the three (or more) sites flagged by the finding — every occurrence in those sites is now a constant reference
+- The new constant is defined exactly once at module scope (or class scope when all occurrences share a class)
+- The existing test suite for the affected module passes — a misclassified literal (different semantics per site) will fail a test that compared the constant's identity to a string of a different role
+- Re-run sonarcloud[bot] scan: the S1192 finding on the original `file:line` is gone
+
+### Safety
+- Semantic divergence: if any of the duplicated occurrences serves a different role (e.g., one is a format-string token like `"%s"`, another is a user-facing label), **escalate** — they only look the same.
+- Security-sensitive literals: SQL fragments, HTML tags, URL paths, regex patterns, secrets/keys — **escalate**. Extracting a constant changes how reviewers reason about injection surface.
+- Naming ambiguity: if no obvious constant name covers all sites' semantics (e.g., `"admin"` used both as a role name and as a URL segment), **escalate** rather than pick a name.
+- Length floor: literals shorter than 5 characters are **not** auto-fixed even when duplicated — a constant indirection costs more readability than it saves.
+
+---
+
+## S125 — Commented-out code
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S125` (or message text contains "Remove this commented out code")
+- severity ∈ {MAJOR, MINOR}
+- target file extension ∈ any source file the skill is configured for
+
+### Root cause
+A comment block contains code that could be uncommented and run, rather than prose explaining intent. Version control already preserves the prior code, so the comment is noise.
+
+### Before
+```python
+def parse(payload):
+    data = json.loads(payload)
+    # result = legacy_parser(payload)
+    # if result is None:
+    #     result = data
+    return data
+```
+
+### After
+```python
+def parse(payload):
+    data = json.loads(payload)
+    return data
+```
+
+### Verify
+- The exact comment line(s) flagged by the finding are removed; the surrounding prose comments (rationale, TODOs, license headers) remain untouched
+- The file still parses
+- Re-run sonarcloud[bot] scan: the S125 finding on the original `file:line` is gone
+
+### Safety
+- Intentional-marker comments: if the comment line contains `TODO`, `FIXME`, `NOTE`, `XXX`, or `HACK` (case-insensitive), **escalate** — the line is documentation, not dead code, regardless of what the SonarQube parser thinks.
+- Fresh authorship: if `git blame` for the comment line is ≤30 days old, **escalate** — the author may still be iterating and uncomment the block soon.
+- Block size: a contiguous commented-code block of three or more lines is intentional often enough that the skill **escalates** rather than deletes. Only single-line or two-line commented-out fragments are auto-fixed.
+- Idempotent: applying twice yields the same tree.
+
+---
+
+## S1116 — Empty statement
+
+### Classifier
+- sonarcloud[bot] inline comment matches `rule=S1116` (or message text contains "Remove this empty statement")
+- severity ∈ {MINOR}
+- target file extension ∈ any source file the skill is configured for
+
+### Root cause
+A bare `;` (in C-family languages) or a redundant statement separator produces a statement with no effect. The most common cause is a typo at the end of an `if`, `for`, or `while` header.
+
+### Before
+```c
+if (cond);
+{
+    do_thing();
+}
+```
+
+### After
+```c
+if (cond)
+{
+    do_thing();
+}
+```
+
+### Verify
+- The bare `;` flagged by the finding is removed; the control-flow structure that follows is now correctly attached to its header
+- The file still parses and the surrounding control-flow semantics are intact (the block now executes conditionally, not unconditionally)
+- Re-run sonarcloud[bot] scan: the S1116 finding on the original `file:line` is gone
+
+### Safety
+- Intentional empty body: if the `;` follows an `if`/`while`/`for`/`switch` header and is paired with a comment that asserts intent (`/* intentional */`, `// empty on purpose`, `# nop`), **escalate** — the empty body is deliberate.
+- Timing-loop idiom: in C/C++, constructs such as `while (*p++) ;` or `for (volatile int i = 0; i < N; i++) ;` are intentional spin loops. If the `;` body is the sole body of a loop and the loop header has side-effects, **escalate**.
+- Function-body fallthrough: an empty `;` inside a function body (not following a control header) is the only configuration auto-fixed.
+- Language-specific replacement: Python flags an empty block as a `SyntaxError` rather than S1116; if a Python `pass` is being targeted as "empty," it must be preserved (it is the only legal empty body in Python).

--- a/tests/sonar-fix/README.md
+++ b/tests/sonar-fix/README.md
@@ -1,0 +1,66 @@
+# sonar-fix fixtures
+
+Reproduction fixtures for each whitelisted SonarQube rule codified in
+`global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md`.
+
+Each rule has a `<rule_id>_before.<ext>` (input as it would arrive on a
+PR) and a `<rule_id>_after.<ext>` (expected file state after sonar-fix
+applies the codified fix). The before/after pair mirrors the Before/After
+code block of the corresponding Pattern entry so the documented fix and
+the test fixture cannot drift apart silently.
+
+| Rule  | Before                | After                |
+|-------|-----------------------|----------------------|
+| S1481 | `S1481_before.py`     | `S1481_after.py`     |
+| S1128 | `S1128_before.py`     | `S1128_after.py`     |
+| S1854 | `S1854_before.py`     | `S1854_after.py`     |
+| S1192 | `S1192_before.py`     | `S1192_after.py`     |
+| S125  | `S125_before.py`      | `S125_after.py`      |
+| S1116 | `S1116_before.c`      | `S1116_after.c`      |
+
+## Validation
+
+The driver script `test-fixtures.sh` enforces two invariants for every
+rule:
+
+1. The fixture's `<rule>_after.<ext>` file matches, byte-for-byte, the
+   "After" code block in the Pattern entry of
+   `auto-fixable-rules.md` (after stripping the surrounding fence).
+2. The fixture's `<rule>_before.<ext>` file matches the "Before" code
+   block of the same Pattern entry under the same rules.
+
+Both files exist on disk so a future automated fix engine can read the
+"Before" fixture, apply the codified transformation, and assert that
+the result is byte-identical to the "After" fixture.
+
+Run the driver from the repository root:
+
+```bash
+bash tests/sonar-fix/test-fixtures.sh
+```
+
+The driver exits non-zero whenever a Pattern entry's Before/After block
+is edited without the matching fixture being updated (or vice versa).
+For now the gate is manual — wiring the driver into
+`.github/workflows/validate-skills.yml` is deferred to a follow-up PR
+because the OAuth app creating this directory does not have the
+`workflow` scope. Reviewers should run the driver locally as part of
+PR review until that wiring lands.
+
+## Extending
+
+When adding a new rule to the whitelist:
+
+1. Append a Pattern entry to `auto-fixable-rules.md` following the
+   six-heading layout (Classifier / Root cause / Before / After /
+   Verify / Safety).
+2. Add `<rule>_before.<ext>` and `<rule>_after.<ext>` files to this
+   directory whose contents match the Before/After code blocks
+   verbatim.
+3. Append a row to the table above and to the `RULES` array in
+   `test-fixtures.sh`.
+
+The driver auto-discovers any rule listed in its `RULES` array. Once
+the follow-up PR wires `test-fixtures.sh` into the
+`validate-skills.yml` workflow, no further CI wiring is required for
+subsequent rule additions.

--- a/tests/sonar-fix/fixtures/S1116_after.c
+++ b/tests/sonar-fix/fixtures/S1116_after.c
@@ -1,0 +1,4 @@
+if (cond)
+{
+    do_thing();
+}

--- a/tests/sonar-fix/fixtures/S1116_before.c
+++ b/tests/sonar-fix/fixtures/S1116_before.c
@@ -1,0 +1,4 @@
+if (cond);
+{
+    do_thing();
+}

--- a/tests/sonar-fix/fixtures/S1128_after.py
+++ b/tests/sonar-fix/fixtures/S1128_after.py
@@ -1,0 +1,4 @@
+import json
+
+def load(path):
+    return json.load(open(path))

--- a/tests/sonar-fix/fixtures/S1128_before.py
+++ b/tests/sonar-fix/fixtures/S1128_before.py
@@ -1,0 +1,5 @@
+import os
+import json
+
+def load(path):
+    return json.load(open(path))

--- a/tests/sonar-fix/fixtures/S1192_after.py
+++ b/tests/sonar-fix/fixtures/S1192_after.py
@@ -1,0 +1,12 @@
+ADMINISTRATOR_ROLE = "administrator"
+
+
+def has_admin(user):
+    return user.role == ADMINISTRATOR_ROLE
+
+def grant_admin(user):
+    user.role = ADMINISTRATOR_ROLE
+    save(user)
+
+def is_admin_email(email):
+    return email.endswith("@administrator.example.com") and ADMINISTRATOR_ROLE in email

--- a/tests/sonar-fix/fixtures/S1192_before.py
+++ b/tests/sonar-fix/fixtures/S1192_before.py
@@ -1,0 +1,9 @@
+def has_admin(user):
+    return user.role == "administrator"
+
+def grant_admin(user):
+    user.role = "administrator"
+    save(user)
+
+def is_admin_email(email):
+    return email.endswith("@administrator.example.com") and "administrator" in email

--- a/tests/sonar-fix/fixtures/S125_after.py
+++ b/tests/sonar-fix/fixtures/S125_after.py
@@ -1,0 +1,3 @@
+def parse(payload):
+    data = json.loads(payload)
+    return data

--- a/tests/sonar-fix/fixtures/S125_before.py
+++ b/tests/sonar-fix/fixtures/S125_before.py
@@ -1,0 +1,6 @@
+def parse(payload):
+    data = json.loads(payload)
+    # result = legacy_parser(payload)
+    # if result is None:
+    #     result = data
+    return data

--- a/tests/sonar-fix/fixtures/S1481_after.py
+++ b/tests/sonar-fix/fixtures/S1481_after.py
@@ -1,0 +1,2 @@
+def calculate(x, y):
+    return x * y

--- a/tests/sonar-fix/fixtures/S1481_before.py
+++ b/tests/sonar-fix/fixtures/S1481_before.py
@@ -1,0 +1,3 @@
+def calculate(x, y):
+    result = x + y   # noqa  ← S1481 warns here
+    return x * y

--- a/tests/sonar-fix/fixtures/S1854_after.py
+++ b/tests/sonar-fix/fixtures/S1854_after.py
@@ -1,0 +1,3 @@
+def pick(items):
+    chosen = items[-1]
+    return chosen

--- a/tests/sonar-fix/fixtures/S1854_before.py
+++ b/tests/sonar-fix/fixtures/S1854_before.py
@@ -1,0 +1,4 @@
+def pick(items):
+    chosen = items[0]   # ← S1854 warns here: chosen is overwritten before any read
+    chosen = items[-1]
+    return chosen

--- a/tests/sonar-fix/test-fixtures.sh
+++ b/tests/sonar-fix/test-fixtures.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Test suite for tests/sonar-fix/fixtures/ (#639).
+#
+# Verifies that every whitelisted SonarQube rule has a before/after
+# fixture pair on disk AND that those fixtures match, byte-for-byte,
+# the Before/After code blocks in the corresponding Pattern entry of
+# global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md.
+#
+# This prevents silent drift where someone edits the Pattern entry
+# without updating the fixture (or vice versa). The automated fix
+# engine that will eventually consume these fixtures relies on the
+# Pattern entry being the single source of truth.
+#
+# Run: bash tests/sonar-fix/test-fixtures.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+RULES_DOC="global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md"
+FIX="tests/sonar-fix/fixtures"
+PASS=0
+FAIL=0
+ERRORS=()
+
+# rule_id:ext pairs. When a new whitelisted rule is codified, append
+# its row here AND drop the matching fixture files into $FIX/.
+RULES=(
+    "S1481:py"
+    "S1128:py"
+    "S1854:py"
+    "S1192:py"
+    "S125:py"
+    "S1116:c"
+)
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        ((PASS++))
+        echo "  PASS: $label"
+    else
+        ((FAIL++))
+        ERRORS+=("FAIL: $label")
+        ERRORS+=("  expected (from $RULES_DOC):")
+        while IFS= read -r line; do ERRORS+=("    | $line"); done <<< "$expected"
+        ERRORS+=("  actual (from fixture):")
+        while IFS= read -r line; do ERRORS+=("    | $line"); done <<< "$actual"
+        echo "  FAIL: $label"
+    fi
+}
+
+# Extract the contents of the first fenced code block under a heading
+# (`### Before` or `### After`) inside a specific rule's Pattern entry.
+#
+# Args:
+#   $1 — rule id (e.g. S1481)
+#   $2 — heading (Before or After)
+extract_block() {
+    local rule="$1" heading="$2"
+    awk -v r="$rule" -v h="$heading" '
+        BEGIN { in_rule = 0; in_heading = 0; in_fence = 0 }
+        /^## / {
+            in_rule = ($0 ~ ("^## " r " "))
+            in_heading = 0
+            in_fence = 0
+            next
+        }
+        in_rule && /^### / {
+            in_heading = ($0 == ("### " h))
+            in_fence = 0
+            next
+        }
+        in_rule && in_heading && /^```/ {
+            if (in_fence == 0) { in_fence = 1; next }
+            else { in_fence = 0; in_heading = 0; exit }
+        }
+        in_rule && in_heading && in_fence { print }
+    ' "$RULES_DOC"
+}
+
+echo "=== sonar-fix fixture parity tests (#639) ==="
+echo ""
+
+for entry in "${RULES[@]}"; do
+    rule="${entry%%:*}"
+    ext="${entry##*:}"
+
+    echo "[$rule]"
+
+    before_fixture="$FIX/${rule}_before.${ext}"
+    after_fixture="$FIX/${rule}_after.${ext}"
+
+    if [[ ! -f "$before_fixture" ]]; then
+        ((FAIL++))
+        ERRORS+=("FAIL: $before_fixture missing")
+        echo "  FAIL: before fixture missing"
+        continue
+    fi
+    if [[ ! -f "$after_fixture" ]]; then
+        ((FAIL++))
+        ERRORS+=("FAIL: $after_fixture missing")
+        echo "  FAIL: after fixture missing"
+        continue
+    fi
+
+    before_doc=$(extract_block "$rule" "Before")
+    after_doc=$(extract_block "$rule" "After")
+
+    if [[ -z "$before_doc" ]]; then
+        ((FAIL++))
+        ERRORS+=("FAIL: $rule Before block missing in $RULES_DOC")
+        echo "  FAIL: Before block missing in doc"
+        continue
+    fi
+    if [[ -z "$after_doc" ]]; then
+        ((FAIL++))
+        ERRORS+=("FAIL: $rule After block missing in $RULES_DOC")
+        echo "  FAIL: After block missing in doc"
+        continue
+    fi
+
+    before_actual=$(cat "$before_fixture")
+    after_actual=$(cat "$after_fixture")
+
+    assert_eq "$rule before fixture matches doc" "$before_doc" "$before_actual"
+    assert_eq "$rule after fixture matches doc"  "$after_doc"  "$after_actual"
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if (( FAIL > 0 )); then
+    echo ""
+    echo "=== Errors ==="
+    for err in "${ERRORS[@]}"; do
+        echo "$err"
+    done
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
Codifies auto-fix instructions for the remaining 4 whitelisted SonarQube
rules and adds per-rule reproduction fixtures:

- **S1854** — Dead assignment removal
- **S1192** — String literal duplication → extract constant
- **S125**  — Commented-out code block removal
- **S1116** — Empty statement removal

Adds `tests/sonar-fix/fixtures/` with `<rule>_before.<ext>` /
`<rule>_after.<ext>` pairs for all 6 whitelisted rules (including P2's
S1481 and S1128 so the fixture corpus is complete from day one). Adds
`tests/sonar-fix/test-fixtures.sh`, a driver that asserts each fixture
matches its Pattern entry's Before/After code block byte-for-byte —
preventing silent drift between the documented fix and the test
corpus.

## Why
P4 of the 5-phase plan in #635. After this PR the whitelist's full 6
rules are codified with the same 6-heading Pattern format that P2
established (Classifier / Root cause / Before / After / Verify /
Safety). Fixtures provide a test corpus that the future auto-fix
engine can consume.

## Coverage
| Rule  | Codified | Fixture |
|-------|----------|---------|
| S1481 | P2       | this PR |
| S1128 | P2       | this PR |
| S1854 | this PR  | this PR |
| S1192 | this PR  | this PR |
| S125  | this PR  | this PR |
| S1116 | this PR  | this PR |

## Test Plan
- `validate-skills.yml` and all other repository CI checks must pass
  (Pattern entry edits trigger the workflow via `global/skills/**`).
- Manual: run `bash tests/sonar-fix/test-fixtures.sh` from the
  repository root. Expected output: `Passed: 12 / Failed: 0`. This
  asserts that every Before/After fixture matches the corresponding
  code block in `auto-fixable-rules.md`.
- Manual: `grep -cE "^## S(1481|1128|1854|1192|125|1116) " \
  global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md`
  returns `6`.
- Manual: each new Pattern entry exposes 6 headings —
  `awk -v r=S1854 '/^## /{p=($0~("^## "r" "))} p && /^### /' \
  global/skills/_internal/sonar-fix/reference/auto-fixable-rules.md`
  prints the Classifier / Root cause / Before / After / Verify /
  Safety set (repeat for S1192 / S125 / S1116).

## Out of Scope
- Wiring `tests/sonar-fix/test-fixtures.sh` into
  `.github/workflows/validate-skills.yml` so the parity check runs on
  every PR. The OAuth app pushing this branch does not have the
  `workflow` scope, so the wiring is deferred to a follow-up PR. Until
  then, reviewers should run the driver locally as part of PR review —
  the driver is non-zero on drift, so a single local invocation is the
  gate.
- Registration of the skill in `global/CLAUDE.md` Skill Aliases — P5.

## Sub-issue
Closes #639

## Parent epic
Part of #635
