### PR TITLE
feat(sonar-fix): register skill and close #635

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -26,6 +26,7 @@ Global settings applied every session. Routing index only — procedural detail 
 - **Lifecycle skills**: `global/skills/_internal/issue-work`, `pr-work`, `release`, `branch-cleanup`
 - **Build verification**: `global/skills/_internal/pr-work/reference/build-verification.md`
 - **Skill authoring**: `global/skills/_policy.md`, `global/skills/_internal/_shared/invariants.md`
+- **Sonar fix (SonarQube Cloud)**: `global/skills/_internal/sonar-fix`
 - **Skill aliases**: see "Skill Aliases" section below
 
 ## Skill Aliases (post-D2 relocation, see #491, #492)
@@ -39,6 +40,7 @@ When the user types one of the keywords below as a leading command (with or with
 | `release`              | `~/.claude/skills/_internal/release/SKILL.md`               |
 | `branch-cleanup`       | `~/.claude/skills/_internal/branch-cleanup/SKILL.md`        |
 | `ci-fix`               | `~/.claude/skills/_internal/ci-fix/SKILL.md`                |
+| `sonar-fix`            | `~/.claude/skills/_internal/sonar-fix/SKILL.md`             |
 | `harness`              | `~/.claude/skills/_internal/harness/SKILL.md`               |
 | `research`             | `~/.claude/skills/_internal/research/SKILL.md`              |
 | `doc-review`           | `~/.claude/skills/_internal/doc-review/SKILL.md`            |


### PR DESCRIPTION
## Summary
Registers the `sonar-fix` skill in `global/CLAUDE.md`:

- **Skill Aliases table**: adds `sonar-fix` row pointing to
  `~/.claude/skills/_internal/sonar-fix/SKILL.md`
- **Routing section**: adds `sonar-fix` next to `ci-fix` (both are
  fix-loop skills)

This is the final phase of the #635 epic — its merge unlocks the
`sonar-fix <pr>` user-invocable command pattern and closes #635 via
the auto-close workflow.

## Why
P5 of the 5-phase plan in #635. Without registration, `sonar-fix`
exists on disk and is wired into pr-work / release (per P3) but
cannot be invoked as a leading command (`sonar-fix <pr>`) like
`pr-work`, `ci-fix`, etc. P5 completes that contract.

## Coverage of #635
| Phase | PR | Status |
|-------|-----|--------|
| P1 — skeleton | #641 | merged |
| P2 — S1481/S1128 + dry-run | #642 | merged |
| P3 — pr-work/release gate | #643 | merged |
| P4 — 4 rules + fixtures | #644 | merged |
| P5 — registration + close epic | (this PR) | pending |

## Test Plan
- GitGuardian and any other CI check must pass
- Manual: `grep "sonar-fix" global/CLAUDE.md` returns 2 lines (Skill
  Aliases row + Routing entry)
- Manual: the table column alignment matches surrounding rows

## Sub-issue
Closes #640

## Parent epic
Closes #635
