### PR TITLE
fix(hooks): markdown-anchor-validator cross-file resolution false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `markdown-anchor-validator` hook (both PowerShell and bash variants): cross-file
+  anchor resolution now works against unstaged target files via lazy parsing with
+  per-file caching (#646). Previously the anchor registry was built exclusively
+  from `git diff --cached --name-only`, so inter-file references like
+  `[text](other.md#anchor)` were reported as broken whenever `other.md` was on
+  disk but not staged in the current commit. Single-file edit PRs that
+  legitimately reference sibling documents (e.g. SDS slices referencing IDS / SRS
+  anchors) were systematically blocked. The fix preserves the staged-file
+  registry as a fast path and falls back to disk parsing only when an inter-file
+  reference misses the primary registry; results are cached per file so the same
+  target is never parsed twice.
+
 ### Security
 
 - Phase 0 audit hotfix bundle (#616, #617, #618, #619). Four critical defense

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -101,10 +101,11 @@ Hooks are user-defined commands that automatically execute during specific Claud
 **Trigger**: `git commit` commands only (all other commands pass through)
 
 **How it works**:
-1. Auto-detects markdown directory (`docs/reference/` → `docs/` → `./`)
-2. **Pass 1**: Builds anchor registry from all headings (GitHub-style slug algorithm)
-3. **Pass 2**: Checks all `](#anchor)` and `](file.md#anchor)` references against registry
-4. Blocks commit if broken anchors are found
+1. Collects staged markdown files via `git diff --cached --name-only --diff-filter=d -- '*.md'`
+2. **Pass 1**: Builds the primary anchor registry from headings in those staged files (GitHub-style slug algorithm)
+3. **Pass 2**: Checks all `](#anchor)` (intra-file) and `](file.md#anchor)` (inter-file) references against the registry
+4. **Cross-file fallback**: when an inter-file reference's target is not in the primary registry (i.e. the target file is on disk but not staged), the validator lazy-parses the target file and caches its anchors. The reference passes if and only if the target heading exists. See issue #646 for the rationale — single-file edit PRs that legitimately reference unstaged sibling files must not produce false positives.
+5. Blocks commit if broken anchors are found
 
 **Anchor generation algorithm** (matches GitHub):
 - Strip inline formatting (bold, italic, code, links)
@@ -116,6 +117,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 - Handles Korean/CJK characters in anchors
 - Validates both intra-file and inter-file references
 - Excludes external URLs (detects `:` in path)
+- Lazy cross-file anchor resolution with per-file caching (no double-parse)
 
 **Behavior**:
 - Returns JSON with `permissionDecision: "deny"` listing broken anchors

--- a/global/hooks/markdown-anchor-validator.ps1
+++ b/global/hooks/markdown-anchor-validator.ps1
@@ -160,6 +160,44 @@ foreach ($filePath in $stagedFiles) {
     }
 }
 
+# === Lazy cross-file anchor resolution + cache ===
+# Inter-file references can target files that are NOT staged in the current
+# commit. Building the registry exclusively from staged files (above) is the
+# fast path; when an inter-file check misses, fall back to parsing the target
+# file from disk. Cache results in $ResolvedFiles to avoid double-parse.
+$ResolvedFiles = @{}
+
+function Resolve-FileAnchors {
+    param([string]$FilePath)
+
+    if ($ResolvedFiles.ContainsKey($FilePath)) {
+        return $ResolvedFiles[$FilePath]
+    }
+
+    $anchors = @{}
+    if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
+        # Cache the negative result so we do not Test-Path on every reference.
+        $ResolvedFiles[$FilePath] = $anchors
+        return $anchors
+    }
+
+    $counts = @{}
+    $refs = Get-MarkdownReferences -FilePath $FilePath
+    foreach ($headingText in $refs.Headings) {
+        $anchor = ConvertTo-GitHubAnchor -Text $headingText
+        if ([string]::IsNullOrEmpty($anchor)) { continue }
+        if ($counts.ContainsKey($anchor)) {
+            $counts[$anchor]++
+            $anchors["${anchor}-$($counts[$anchor])"] = $true
+        } else {
+            $counts[$anchor] = 0
+            $anchors[$anchor] = $true
+        }
+    }
+    $ResolvedFiles[$FilePath] = $anchors
+    return $anchors
+}
+
 # === Check references ===
 $Errors = [System.Collections.Generic.List[string]]::new()
 
@@ -183,7 +221,11 @@ foreach ($filePath in $stagedFiles) {
         $target = "${dir}/$($ref.RefFile)" -replace '\\', '/' -replace '/\./', '/'
 
         $key = "${target}::$($ref.Anchor)"
-        if (-not $Anchors.ContainsKey($key)) {
+        if ($Anchors.ContainsKey($key)) { continue }
+
+        # Primary registry miss — target may be unstaged. Lazy-parse from disk.
+        $targetAnchors = Resolve-FileAnchors -FilePath $target
+        if (-not $targetAnchors.ContainsKey($ref.Anchor)) {
             $fileName = Split-Path $relPath -Leaf
             $Errors.Add("${fileName}:$($ref.LineNum): $($ref.RefFile)#$($ref.Anchor)")
         }

--- a/global/hooks/markdown-anchor-validator.sh
+++ b/global/hooks/markdown-anchor-validator.sh
@@ -159,6 +159,67 @@ if [ -n "$H_LINES" ]; then
     done < <(paste "$TMP_FILES" "$TMP_ANCHORS")
 fi
 
+# === Lazy cross-file anchor resolution + cache ===
+# Inter-file references may target files that are NOT staged. The primary
+# registry is intentionally built from staged files only (fast path). When an
+# inter-file check misses, fall back to parsing the target file from disk and
+# cache the resulting anchors per file so we never reparse.
+#
+# Cache keys:
+#   RESOLVED_FILES[<path>]=1 marks <path> as already parsed (positive OR negative)
+#   RESOLVED_ANCHORS[<path>::<anchor>]=1 records each anchor discovered in <path>
+declare -A RESOLVED_FILES
+declare -A RESOLVED_ANCHORS
+
+resolve_file_anchors() {
+    local target="$1"
+    # Cache hit (idempotent) — fall through to the lookup in the caller.
+    [[ -n "${RESOLVED_FILES[$target]+x}" ]] && return 0
+    RESOLVED_FILES["$target"]=1
+
+    # Negative cache: target file does not exist on disk.
+    [[ -f "$target" ]] || return 0
+
+    # Single-pass awk: emit one heading-text per line, no per-line metadata.
+    # The transformation pipeline below mirrors the staged-file registry
+    # build (sed/tr stages) so cross-file resolution stays algorithmically
+    # identical to the staged path.
+    local heading_lines
+    heading_lines=$(awk '
+        BEGIN { c = 0 }
+        /^[[:space:]]*(```|~~~)/ { c = !c; next }
+        c { next }
+        match($0, /^#+[[:space:]]/) {
+            h_count = RLENGTH - 1
+            if (h_count >= 1 && h_count <= 6) {
+                h = $0
+                sub(/^#+[[:space:]]+/, "", h)
+                sub(/[[:space:]#]*$/, "", h)
+                if (h != "") print h
+            }
+        }
+    ' "$target" 2>/dev/null) || return 0
+
+    [[ -z "$heading_lines" ]] && return 0
+
+    local -A counts=()
+    local anchor
+    while IFS= read -r heading; do
+        anchor=$(printf '%s' "$heading" \
+            | sed -e 's/\]([^)]*)//g' -e 's/\[//g' -e 's/\*//g' -e 's/`//g' -e 's/<[^>]*>//g' \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -e 's/[^[:alnum:]_ -]//g' -e 's/ /-/g' -e 's/^-//;s/-$//')
+        [[ -z "$anchor" ]] && continue
+        if [[ -n "${counts[$anchor]+x}" ]]; then
+            counts["$anchor"]=$(( counts["$anchor"] + 1 ))
+            RESOLVED_ANCHORS["${target}::${anchor}-${counts[$anchor]}"]=1
+        else
+            counts["$anchor"]=0
+            RESOLVED_ANCHORS["${target}::${anchor}"]=1
+        fi
+    done <<< "$heading_lines"
+}
+
 # === Check references ===
 ERRORS=()
 
@@ -182,7 +243,12 @@ while IFS=$'\t' read -r _type file line_num ref_file anchor; do
     while [[ "$target" == *"/.."* ]]; do
         target="$(echo "$target" | sed 's|[^/]*/\.\./||')"
     done
-    if [[ -z "${ANCHORS[${target}::${anchor}]+x}" ]]; then
+    if [[ -n "${ANCHORS[${target}::${anchor}]+x}" ]]; then
+        continue
+    fi
+    # Primary registry miss — target may be unstaged. Lazy-parse from disk.
+    resolve_file_anchors "$target"
+    if [[ -z "${RESOLVED_ANCHORS[${target}::${anchor}]+x}" ]]; then
         ERRORS+=("${file##*/}:${line_num}: ${ref_file}#${anchor}")
     fi
 done < <(echo "$AWK_OUTPUT" | grep '^X' || true)

--- a/tests/hooks/test-markdown-anchor-validator.ps1
+++ b/tests/hooks/test-markdown-anchor-validator.ps1
@@ -1,0 +1,249 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# Test suite for markdown-anchor-validator.ps1
+# Mirrors tests/hooks/test-markdown-anchor-validator.sh — shared fixtures live
+# under tests/markdown-anchor-validator/fixtures/. Both runners must produce
+# identical allow/deny decisions on the same fixture so the two variants stay
+# behaviorally locked together (see issue #646).
+# Run: pwsh tests/hooks/test-markdown-anchor-validator.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot     = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath     = Join-Path $script:RepoRoot 'global' 'hooks' 'markdown-anchor-validator.ps1'
+$script:FixturesDir  = Join-Path $script:RepoRoot 'tests' 'markdown-anchor-validator' 'fixtures'
+$script:Passed       = 0
+$script:Failed       = 0
+$script:Errors       = [System.Collections.Generic.List[string]]::new()
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Host 'SKIP: git not on PATH; validator tests require git'
+    exit 0
+}
+
+# Stage one fixture (and optionally drop a sidecar fixture next to it on
+# disk WITHOUT staging) inside an isolated temp git repo, then invoke the
+# hook with a synthetic `git commit` tool_input payload and capture the
+# JSON response.
+function Invoke-HookCapture {
+    param(
+        [Parameter(Mandatory)][string]$StagedFixture,
+        [string]$StagedDest = '',
+        [string]$SidecarFixture = '',
+        [string]$SidecarDest = ''
+    )
+
+    if ([string]::IsNullOrEmpty($StagedDest)) {
+        $StagedDest = "docs/$StagedFixture"
+    }
+    if ($SidecarFixture -and [string]::IsNullOrEmpty($SidecarDest)) {
+        $SidecarDest = "docs/$SidecarFixture"
+    }
+
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+    $origCwd = Get-Location
+    try {
+        Set-Location -LiteralPath $tmpDir
+        & git init -q 2>$null
+        & git config user.email 'ci@example.com'
+        & git config user.name  'CI'
+
+        $stagedFull = Join-Path $tmpDir $StagedDest
+        New-Item -ItemType Directory -Path (Split-Path -Parent $stagedFull) -Force | Out-Null
+        Copy-Item -LiteralPath (Join-Path $script:FixturesDir $StagedFixture) -Destination $stagedFull
+
+        if ($SidecarFixture) {
+            $sidecarFull = Join-Path $tmpDir $SidecarDest
+            New-Item -ItemType Directory -Path (Split-Path -Parent $sidecarFull) -Force | Out-Null
+            Copy-Item -LiteralPath (Join-Path $script:FixturesDir $SidecarFixture) -Destination $sidecarFull
+        }
+
+        # Stage ONLY the primary fixture. The sidecar (if any) stays unstaged
+        # — this is the regression scenario from issue #646.
+        & git add -- $StagedDest 2>$null
+
+        $payload = '{"tool_input":{"command":"git commit -m test"}}'
+        # Redirect stderr (2>) and the warning stream (3>) to $null so the
+        # CommonHelpers "unapproved verbs" warning does not leak into
+        # stdout and break the JSON parse in Assert-ValidJson.
+        $result  = $payload | & pwsh -NoProfile -File $script:HookPath 2>$null 3>$null
+        return [string]$result
+    } finally {
+        Set-Location -LiteralPath $origCwd
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-Deny {
+    param([string]$Label, [hashtable]$Params)
+    $out = Invoke-HookCapture @Params
+    if ($out -match '"deny"') {
+        $script:Passed++
+        Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++
+        $script:Errors.Add("FAIL: $Label - expected deny, got: $out")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+function Assert-Allow {
+    param([string]$Label, [hashtable]$Params)
+    $out = Invoke-HookCapture @Params
+    if ($out -match '"allow"') {
+        $script:Passed++
+        Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++
+        $script:Errors.Add("FAIL: $Label - expected allow, got: $out")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+function Assert-ValidJson {
+    param([string]$Label, [hashtable]$Params)
+    $out = Invoke-HookCapture @Params
+    # Strip the CommonHelpers "unapproved verbs" warning (and any ANSI escape
+    # sequences PowerShell adds when stderr/warning streams leak into stdout)
+    # before parsing. The warning is environmental noise unrelated to the
+    # hook's JSON contract.
+    $cleaned = ($out -split "`n" | Where-Object {
+        $_ -notmatch 'WARNING:' -and $_ -notmatch 'unapproved verbs'
+    }) -join "`n"
+    $cleaned = $cleaned -replace "`e\[[0-9;]*m", ''
+    $cleaned = $cleaned.Trim()
+    try {
+        $null = $cleaned | ConvertFrom-Json -ErrorAction Stop
+        $script:Passed++
+        Write-Host "  PASS: $Label" -ForegroundColor Green
+    } catch {
+        $script:Failed++
+        $script:Errors.Add("FAIL: $Label - output is not valid JSON: $cleaned")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host '=== markdown-anchor-validator.ps1 tests ==='
+Write-Host ''
+
+Write-Host '[Bug A: 7+ hashes are not headings]'
+Assert-Deny -Label 'ref to ####### line -> deny (broken anchor)' `
+    -Params @{ StagedFixture = 'bug-a-excessive-hashes.md' }
+
+Write-Host ''
+Write-Host '[Bug B: inline code spans are not live references]'
+Assert-Allow -Label '`[a](#x)` inside backticks -> allow' `
+    -Params @{ StagedFixture = 'bug-b-inline-code.md' }
+
+Write-Host ''
+Write-Host '[Bug C: JSON output remains well-formed with backslash in anchor]'
+Assert-ValidJson -Label 'anchor with backslash -> valid JSON' `
+    -Params @{ StagedFixture = 'bug-c-backslash.md' }
+
+Write-Host ''
+Write-Host '[Baseline: no false positives on well-formed markdown]'
+Assert-Allow -Label 'valid intra-file refs -> allow' `
+    -Params @{ StagedFixture = 'baseline-valid.md' }
+
+Write-Host ''
+Write-Host '[Parity: staged .md outside docs/ is also checked]'
+Assert-Deny -Label 'root-level .md with broken anchor -> deny' `
+    -Params @{ StagedFixture = 'bug-a-excessive-hashes.md'; StagedDest = 'top-level.md' }
+
+Write-Host ''
+Write-Host '[Cross-file resolution: unstaged target with valid anchor -> allow]'
+# Regression target for issue #646: staged file references an anchor in a
+# sibling file that exists on disk but is NOT staged. Lazy resolution must
+# parse the unstaged sibling and recognize the anchor.
+Assert-Allow -Label 'unstaged target heading -> allow' `
+    -Params @{
+        StagedFixture  = 'cross-file-source.md'
+        SidecarFixture = 'cross-file-target.md'
+    }
+
+Write-Host ''
+Write-Host '[Cross-file resolution: existing file but missing anchor -> deny]'
+# Negative case authored inline — committing the broken-ref fixture itself
+# would trip the validator at commit time, so we materialize the source
+# file inside the temp repo at test time instead.
+function Invoke-InlineHookCapture {
+    param(
+        [Parameter(Mandatory)][string]$SourceContent,
+        [string]$SidecarFixture = ''
+    )
+    $tmpDir  = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+    $origCwd = Get-Location
+    try {
+        Set-Location -LiteralPath $tmpDir
+        & git init -q 2>$null
+        & git config user.email 'ci@example.com'
+        & git config user.name  'CI'
+
+        $docs = Join-Path $tmpDir 'docs'
+        New-Item -ItemType Directory -Path $docs -Force | Out-Null
+        $src = Join-Path $docs 'source.md'
+        Set-Content -LiteralPath $src -Value $SourceContent -Encoding utf8 -NoNewline
+
+        if ($SidecarFixture) {
+            Copy-Item -LiteralPath (Join-Path $script:FixturesDir $SidecarFixture) `
+                      -Destination (Join-Path $docs $SidecarFixture)
+        }
+
+        & git add -- 'docs/source.md' 2>$null
+        $payload = '{"tool_input":{"command":"git commit -m test"}}'
+        $result  = $payload | & pwsh -NoProfile -File $script:HookPath 2>$null 3>$null
+        return [string]$result
+    } finally {
+        Set-Location -LiteralPath $origCwd
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$missingAnchorOut = Invoke-InlineHookCapture `
+    -SourceContent "# Source with missing anchor`n`n[missing](cross-file-target.md#definitely-missing-heading)`n" `
+    -SidecarFixture 'cross-file-target.md'
+if ($missingAnchorOut -match '"deny"') {
+    $script:Passed++
+    Write-Host '  PASS: unstaged target missing the requested anchor -> deny' -ForegroundColor Green
+} else {
+    $script:Failed++
+    $script:Errors.Add("FAIL: missing anchor inline case - expected deny, got: $missingAnchorOut")
+    Write-Host '  FAIL: unstaged target missing the requested anchor -> deny' -ForegroundColor Red
+}
+
+Write-Host ''
+Write-Host '[Cross-file resolution: target file does not exist -> deny]'
+$missingFileOut = Invoke-InlineHookCapture `
+    -SourceContent "# Source with missing file`n`n[missing](no-such-file.md#whatever)`n"
+if ($missingFileOut -match '"deny"') {
+    $script:Passed++
+    Write-Host '  PASS: missing referenced file -> deny' -ForegroundColor Green
+} else {
+    $script:Failed++
+    $script:Errors.Add("FAIL: missing referenced file - expected deny, got: $missingFileOut")
+    Write-Host '  FAIL: missing referenced file -> deny' -ForegroundColor Red
+}
+
+Write-Host ''
+Write-Host '[Non-commit commands pass through]'
+$result = '{"tool_input":{"command":"ls -la"}}' | & pwsh -NoProfile -File $script:HookPath 2>$null
+if ($result -match '"allow"') {
+    $script:Passed++; Write-Host '  PASS: ls -la -> allow' -ForegroundColor Green
+} else {
+    $script:Failed++
+    $script:Errors.Add("FAIL: ls -la - got: $result")
+    Write-Host '  FAIL: ls -la' -ForegroundColor Red
+}
+
+Write-Host ''
+if ($script:Failed -gt 0) {
+    Write-Host 'Failures:'
+    foreach ($e in $script:Errors) {
+        Write-Host "  $e"
+    }
+}
+Write-Host "=== Results: $script:Passed passed, $script:Failed failed ==="
+
+if ($script:Failed -gt 0) { exit 1 } else { exit 0 }

--- a/tests/hooks/test-markdown-anchor-validator.sh
+++ b/tests/hooks/test-markdown-anchor-validator.sh
@@ -86,6 +86,67 @@ assert_valid_json() {
     fi
 }
 
+# Cross-file scenario runner: stages one fixture as $1 (placed at docs/$1
+# by default), while ALSO copying a sidecar fixture next to it on disk
+# WITHOUT staging it. This is the exact pattern that exposes the
+# cross-file resolution false positive — the inter-file ref's target
+# exists in the working tree but is not in `git diff --cached`.
+#
+# $1: staged fixture filename
+# $2: sidecar fixture filename (copied next to staged file but unstaged)
+# $3: optional staged-path override (default: docs/$1)
+# $4: optional sidecar-path override (default: docs/$2)
+run_cross_file_hook_capture() {
+    local staged_fixture="$1"
+    local sidecar_fixture="$2"
+    local staged_dest="${3:-docs/$staged_fixture}"
+    local sidecar_dest="${4:-docs/$sidecar_fixture}"
+    local root_abs hook_abs tmpdir
+    root_abs="$(pwd)"
+    hook_abs="${root_abs}/${HOOK}"
+    tmpdir=$(mktemp -d)
+    (
+        cd "$tmpdir" && \
+        git init -q && \
+        git config user.email "ci@example.com" && \
+        git config user.name "CI" && \
+        mkdir -p "$(dirname "$staged_dest")" "$(dirname "$sidecar_dest")" && \
+        cp "${root_abs}/tests/markdown-anchor-validator/fixtures/${staged_fixture}" "${staged_dest}" && \
+        cp "${root_abs}/tests/markdown-anchor-validator/fixtures/${sidecar_fixture}" "${sidecar_dest}" && \
+        git add -- "${staged_dest}" && \
+        echo '{"tool_input":{"command":"git commit -m test"}}' | bash "$hook_abs" 2>/dev/null
+    )
+    rm -rf "$tmpdir"
+}
+
+assert_cross_file_allow() {
+    local staged="$1" sidecar="$2" label="$3"
+    local out
+    out=$(run_cross_file_hook_capture "$staged" "$sidecar")
+    if echo "$out" | grep -q '"allow"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected allow, got: $out")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_cross_file_deny() {
+    local staged="$1" sidecar="$2" label="$3"
+    local out
+    out=$(run_cross_file_hook_capture "$staged" "$sidecar")
+    if echo "$out" | grep -q '"deny"'; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label — expected deny, got: $out")
+        echo "  FAIL: $label"
+    fi
+}
+
 echo "=== markdown-anchor-validator.sh tests ==="
 echo ""
 
@@ -114,6 +175,78 @@ echo "[Parity: staged .md outside docs/ is also checked]"
 assert_deny_fixture "bug-a-excessive-hashes.md" \
     "root-level .md with broken anchor → deny" \
     "top-level.md"
+
+echo ""
+echo "[Cross-file resolution: unstaged target with valid anchor → allow]"
+# Regression target for issue #646. Staged file references an anchor in a
+# sibling file that exists on disk but is NOT staged. Before the fix, the
+# anchor registry (built from staged files only) missed the target's
+# headings and the hook denied the commit. After the fix, the validator
+# lazy-parses the unstaged sibling and recognizes the anchor.
+assert_cross_file_allow \
+    "cross-file-source.md" \
+    "cross-file-target.md" \
+    "unstaged target heading → allow"
+
+echo ""
+echo "[Cross-file resolution: existing file but missing anchor → deny]"
+# Negative case authored inline — the fixture itself would have a broken
+# inter-file reference and would fail the hook on its own commit, so we
+# materialize the file inside the temp repo at test time.
+root_abs="$(pwd)"
+hook_abs="${root_abs}/${HOOK}"
+tmpdir=$(mktemp -d)
+out=$(
+    cd "$tmpdir" && \
+    git init -q && \
+    git config user.email "ci@example.com" && \
+    git config user.name "CI" && \
+    mkdir -p docs && \
+    cp "${root_abs}/tests/markdown-anchor-validator/fixtures/cross-file-target.md" docs/cross-file-target.md && \
+    cat > docs/source.md <<'MDFILE'
+# Source with missing anchor
+
+[missing](cross-file-target.md#definitely-missing-heading)
+MDFILE
+    git add docs/source.md && \
+    echo '{"tool_input":{"command":"git commit -m test"}}' | bash "$hook_abs" 2>/dev/null
+)
+rm -rf "$tmpdir"
+if echo "$out" | grep -q '"deny"'; then
+    PASS=$((PASS + 1)); echo "  PASS: unstaged target missing the requested anchor → deny"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: missing anchor inline case — expected deny, got: $out")
+    echo "  FAIL: unstaged target missing the requested anchor → deny"
+fi
+
+echo ""
+echo "[Cross-file resolution: target file does not exist → deny]"
+# No sidecar — the referenced file is absent on disk. Lazy resolution
+# must produce an empty anchor set and the validator must deny.
+tmpdir=$(mktemp -d)
+out=$(
+    cd "$tmpdir" && \
+    git init -q && \
+    git config user.email "ci@example.com" && \
+    git config user.name "CI" && \
+    mkdir -p docs && \
+    cat > docs/source.md <<'MDFILE'
+# Source with missing file
+
+[missing](no-such-file.md#whatever)
+MDFILE
+    git add docs/source.md && \
+    echo '{"tool_input":{"command":"git commit -m test"}}' | bash "$hook_abs" 2>/dev/null
+)
+rm -rf "$tmpdir"
+if echo "$out" | grep -q '"deny"'; then
+    PASS=$((PASS + 1)); echo "  PASS: missing referenced file → deny"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: missing referenced file — expected deny, got: $out")
+    echo "  FAIL: missing referenced file → deny"
+fi
 
 echo ""
 echo "[Non-commit commands pass through]"

--- a/tests/markdown-anchor-validator/fixtures/cross-file-source.md
+++ b/tests/markdown-anchor-validator/fixtures/cross-file-source.md
@@ -1,0 +1,8 @@
+# Cross-file reference source
+
+This file contains an inter-file reference whose target is the sibling
+`cross-file-target.md`. When only this file is staged, the validator
+must lazy-resolve anchors from the unstaged sibling and allow the
+commit because the target heading exists.
+
+[valid cross-file ref](cross-file-target.md#real-target-heading)

--- a/tests/markdown-anchor-validator/fixtures/cross-file-target.md
+++ b/tests/markdown-anchor-validator/fixtures/cross-file-target.md
@@ -1,0 +1,10 @@
+# Real target heading
+
+This file is intentionally not staged in the cross-file test cases.
+It exists on disk so the validator can lazy-resolve its anchors and
+recognize the inter-file reference from `cross-file-source.md` as
+valid.
+
+## Another section
+
+Used by negative cases that target a missing anchor in this file.


### PR DESCRIPTION
## What
Fix `markdown-anchor-validator` (PowerShell + bash) so inter-file anchor
references resolve correctly against target files that are NOT staged in
the current commit. The primary anchor registry continues to be built
from `git diff --cached --name-only` (fast path, unchanged), but
inter-file checks now fall back to lazy on-disk parsing of the target
file when the primary registry misses. Parsed anchors are cached per
file to guarantee O(1) double-parse avoidance.

## Why
Closes #646.

The previous registry was built exclusively from staged files. For a
single-file edit PR that references anchors in sibling documents (e.g. a
streamliner SDS slice referencing IDS / SRS / SVMM anchors), the
referenced files are not staged, so their headings were never indexed
and every cross-file reference was reported as a false-positive broken
anchor. This systematically blocked legitimate single-file documentation
PRs.

Concrete blocked case: streamliner #715 4-way decomposition. The
sibling slice (#820) merged successfully with identical cross-file
patterns; the encoder_branch slice (#815) was blocked by 31 false
positives in its wip checkpoint, all of which are GitHub-valid per the
actual GitHub anchor algorithm. The memory feedback
`feedback_sds_broken_anchor_blocks_cascade.md` documents the recurrence.

## How
**Lazy cross-file resolution + per-file cache**

PowerShell variant (`global/hooks/markdown-anchor-validator.ps1`):
- New `Resolve-FileAnchors` function parses a target file on demand and
  stores its anchors in `$ResolvedFiles[$FilePath]`. Both positive and
  negative results are cached (missing files cache an empty set), so
  `Test-Path` runs at most once per referenced target.
- Inter-file check loop now falls through to `Resolve-FileAnchors` when
  the primary `$Anchors` registry does not contain the key. Intra-file
  refs and inter-file refs whose target IS staged continue to use the
  primary fast path with zero behavior change.

Bash variant (`global/hooks/markdown-anchor-validator.sh`):
- New `resolve_file_anchors()` function uses awk to extract headings from
  the target file, then runs the same `sed | tr | sed` pipeline that the
  staged registry uses to generate anchors. The two paths are
  algorithmically identical.
- `RESOLVED_FILES[<path>]=1` marks already-parsed paths (positive +
  negative); `RESOLVED_ANCHORS[<path>::<anchor>]=1` records discovered
  anchors. The X-line check loop falls through to `resolve_file_anchors`
  when the primary `ANCHORS` registry misses, mirroring the PowerShell
  flow exactly.

Both variants ship identical semantics — proven against a shared 9-case
fixture suite (see Validation below).

## Files Changed
- `global/hooks/markdown-anchor-validator.ps1` — `Resolve-FileAnchors`
  function (33 lines) + fallthrough at the inter-file check site
- `global/hooks/markdown-anchor-validator.sh` — `resolve_file_anchors`
  function (54 lines) + fallthrough at the X-line check loop
- `tests/hooks/test-markdown-anchor-validator.ps1` (new) — PowerShell
  test runner with the same 9 cases as the bash runner
- `tests/hooks/test-markdown-anchor-validator.sh` — extended with the
  cross-file scenario runner and 3 new cases
- `tests/markdown-anchor-validator/fixtures/cross-file-source.md` (new)
  — fixture for the unstaged-target positive case
- `tests/markdown-anchor-validator/fixtures/cross-file-target.md` (new)
  — sidecar copied into the test repo without staging
- `HOOKS.md` — Markdown Anchor Validation narrative updated to document
  the new lazy cross-file resolution semantics
- `CHANGELOG.md` — Unreleased / Fixed entry pointing at #646

Negative-case sources are authored inline inside the test runners (no
fixture file) because materializing a broken cross-file reference as a
checked-in fixture would trip the validator on this PR's own commit.

## Validation
- Bash runner: 9 passed, 0 failed
- PowerShell runner: 9 passed, 0 failed
- Both runners exercise: 6 regression cases (intra-file valid/invalid,
  inline-code spans, 7+ hashes are not headings, valid JSON output,
  root-level .md parity) + 3 new cases (unstaged target valid anchor =>
  allow, unstaged target missing anchor => deny, missing target file =>
  deny) + 1 non-commit pass-through
- Streamliner #815 wip checkpoint (`80ea822a`):
  - before fix: 31 broken-anchor false positives
  - after fix: 0 broken anchors
- `scripts/gen-hooks-md.sh --check`: no drift
- `scripts/spec_lint.sh --quiet`: passes (38 skills, 2 plugins, 3
  settings files)

## Test Plan
1. Run `bash tests/hooks/test-markdown-anchor-validator.sh` => `9 passed`
2. Run `pwsh tests/hooks/test-markdown-anchor-validator.ps1` => `9 passed`
3. (Optional) Manually verify streamliner #815 by recreating the wip
   checkpoint state and running the patched hook against it; expect 0
   broken anchors.

## Breaking Changes
None. The fix only widens what the validator accepts — every input that
previously produced `allow` still produces `allow`, and every input that
referenced a truly missing anchor still produces `deny`.

## Rollback
Revert this PR; the previous staged-only resolution behavior is restored.

Closes #646
