### PR TITLE
chore(agents): remove unsupported temperature field, document spec drift

### DIFF
--- a/docs/official-spec-review-2026-05.md
+++ b/docs/official-spec-review-2026-05.md
@@ -1,0 +1,159 @@
+# Official Spec Review — 2026-05-29
+
+Re-validation of `claude-config` against the **current Claude Code official documentation**
+(`docs.claude.com/en/docs/claude-code/{settings,hooks,skills,sub-agents}`), fetched and
+cross-checked on 2026-05-29.
+
+## Method
+
+1. Inventoried every Claude Code asset the repo ships: `settings.json` top-level keys,
+   hook events, skill / agent / command frontmatter fields, plugin manifests.
+2. Fetched the live official docs and extracted the authoritative field/event lists.
+3. Cross-checked agent output against the primary source (the docs themselves) to catch
+   model hallucination — one was found and corrected (see "Corrections" below).
+4. Classified each finding as **conformant**, **drift (fix)**, **opportunity (backlog)**,
+   or **intentional non-standard extension (no action)**.
+
+## Executive Summary
+
+`claude-config` tracks the latest official schema **very closely**. No deprecated keys are
+in use and no broken event wiring was found. The repo is unusually disciplined: it explicitly
+documents which of its frontmatter fields are *advisory metadata not enforced by the harness*
+(`global/skills/_policy.md:40`) and ships its own `agent-frontmatter-spec.md` that mirrors the
+official agent field set exactly.
+
+The single genuine drift is the `temperature` field on subagents, which is **not an official
+field and is not even listed in the repo's own agent spec** — it is silently ignored by the
+harness and duplicates the intent of the already-present `effort` field.
+
+| Severity | Finding | Action |
+|----------|---------|--------|
+| **Drift** | `temperature` on all 8 project agents | Remove (this PR) |
+| **Drift (docs)** | `keywords` / `applies_to` agent fields undocumented in repo's own spec | Document as non-standard extension (this PR) |
+| **Opportunity** | 5 new hook events unused | Backlog |
+| **Opportunity** | ~10 new `settings.json` keys unused | Backlog |
+| **Housekeeping** | `harness_policies` custom key + expired P4 timeline | Note only (team decision) |
+| **Conformant** | hook events, attribution, sandbox, skill advisory fields | No action |
+
+## Corrections to Preliminary Analysis
+
+- **`attribution` is an object, not a string.** The official schema defines
+  `attribution: {commit, pr}` with empty strings hiding attribution. `claude-config`'s
+  `{commit:"", pr:""}` is correct. (A first-pass agent claimed it had "changed to a string" —
+  that was a hallucination, refuted against the live doc.)
+- **`includeCoAuthoredBy` is deprecated** in favor of `attribution`. `claude-config` already
+  uses `attribution` and does not set the deprecated key. Conformant.
+
+## 1. Hooks — Conformant
+
+All 18 hook events wired in `global/settings.json` and `global/settings.windows.json` are
+present in the official hooks documentation:
+
+`PreToolUse, PostToolUse, PostToolUseFailure, SessionStart, SessionEnd, UserPromptSubmit,
+Stop, SubagentStart, SubagentStop, PreCompact, PostCompact, InstructionsLoaded, TaskCreated,
+TaskCompleted, ConfigChange, TeammateIdle, WorktreeCreate, WorktreeRemove.`
+
+The `async: true` and `timeout` handler fields are both officially supported. Every wired hook
+has a matching script in `global/hooks/`, and every script is wired — no orphans.
+
+### Unused official hook events (opportunity)
+
+| Event | Possible use for this repo |
+|-------|----------------------------|
+| `FileChanged` | React to edits of `settings.json` / `SKILL.md` (live-validate frontmatter) |
+| `PermissionRequest` | Audit/log permission escalations centrally |
+| `Notification` | Surface long-running batch (`issue-work`/`pr-work`) completion |
+| `CwdChanged` | Re-resolve project-scoped rules on directory switch |
+| `Setup` | One-time `init`/`maintenance` provisioning (currently done by `bootstrap.sh`) |
+
+## 2. settings.json — Conformant, with unused new keys
+
+Every key in use is officially supported: `attribution, effortLevel, autoUpdatesChannel,
+skipDangerousModePermissionPrompt, teammateMode, spinnerVerbs, alwaysThinkingEnabled,
+includeGitInstructions, outputStyle, language, sandbox, statusLine, cleanupPeriodDays,
+respectGitignore, env, permissions`.
+
+### Unused official keys (opportunity)
+
+`skillOverrides`, `skillListingBudgetFraction`, `maxSkillDescriptionChars`,
+`disableSkillShellExecution`, `forceLoginMethod`, `enabledPlugins`, `disableAllHooks`,
+`autoMemoryDirectory`, `model`, `agents`.
+
+Of these, the skill-governance keys (`skillOverrides`, `maxSkillDescriptionChars`,
+`disableSkillShellExecution`) are the most relevant to a config repo that ships many skills,
+and are worth a dedicated follow-up evaluating whether to set policy defaults.
+
+### Non-standard custom key (housekeeping)
+
+`harness_policies` (in both `global/settings.json` and `global/settings.windows.json`) is **not
+in the official schema**. Claude Code ignores unknown top-level keys, so there is no runtime
+effect, but a strict `$schema` validator will flag it. Additionally, its P4 timeline values are
+expired as of this review (`p4_freeze_until: 2026-05-20` < 2026-05-29). Recommendation: either
+move P4 timeline state out of `settings.json` into a dedicated `harness_policies.json` read by
+the P4 hooks, or prune the expired window. Left to the team that owns the P4 timeline rollout.
+
+## 3. Skills — Conformant
+
+Official frontmatter fields (`name, description, when_to_use, argument-hint, arguments,
+disable-model-invocation, user-invocable, allowed-tools, disallowed-tools, model, effort,
+context, agent, hooks, paths, shell`) are all respected. `disable-model-invocation: true` and
+`user-invocable: false` — used widely across the `_internal` skills — are confirmed official.
+
+The repo's many additional frontmatter fields (`loop_safe`, `halt_conditions`, `on_halt`,
+`max_iterations`, `iso_class`, `tiers`, `default_tier`, `applies_at_or_above`, `severity`,
+`finding_levels`) are **intentional advisory metadata**, explicitly documented as
+"LLM-advisory metadata only — Claude Code does not enforce them at runtime"
+(`global/skills/_policy.md:40`). **No action** — this is a deliberate, well-documented design.
+
+## 4. Subagents — One drift, one doc gap
+
+The repo's own `global/skills/_internal/harness/reference/agent-frontmatter-spec.md` correctly
+mirrors the official field set: `name, description, tools, disallowedTools, model, maxTurns,
+effort, background, permissionMode, memory, skills, mcpServers, hooks, isolation, color,
+initialPrompt`.
+
+### 4.1 Drift: `temperature` (FIX)
+
+All 8 agents under `project/.claude/agents/` set `temperature` (0.1–0.5). This field is:
+
+- **not** in the official subagent frontmatter spec,
+- **not** in the repo's own `agent-frontmatter-spec.md`,
+- silently ignored by Claude Code (subagents do not expose a sampling-temperature knob),
+- redundant with `effort`, which every agent already sets and which *is* official.
+
+Unlike the skill advisory fields, `temperature` cannot be honored even as prompt-level
+self-regulation (it is a sampling parameter, not a behavior the model can emulate by reading
+its own frontmatter). It is pure dead metadata. **Removed in this PR.**
+
+### 4.2 Doc gap: `keywords` / `applies_to` (DOCUMENT)
+
+Both fields appear on all 8 agents but are absent from `agent-frontmatter-spec.md`.
+`docs/architecture-review-skills-rules.md:115` already notes `keywords` is "NOT officially
+supported". These are non-standard advisory extensions (used by the repo's own routing/index
+tooling, not the harness). To keep the spec honest and consistent with the skills `_policy.md`
+pattern, a "Non-standard advisory extensions" section is added to `agent-frontmatter-spec.md`
+in this PR. No change to the agent files for these two fields (they are intentional).
+
+### 4.3 Unused official fields (opportunity)
+
+Agents set none of `color`, `permissionMode`, `disallowedTools`. Adding `color` aids tmux
+split-pane identification; `permissionMode: plan` or `acceptEdits` would make the
+implementation-capable agents' trust level explicit rather than inherited. Backlog.
+
+## 5. Plugins — Conformant
+
+`plugin/.claude-plugin/plugin.json` (`minClaudeCodeVersion: 2.2.0`) and
+`plugin-lite/.claude-plugin/plugin.json` (`2.0.0`) are well-formed. No schema issues found.
+
+## Recommended Follow-ups (Backlog)
+
+1. Evaluate skill-governance keys (`skillOverrides`, `maxSkillDescriptionChars`,
+   `disableSkillShellExecution`) for policy defaults.
+2. Resolve `harness_policies`: relocate out of `settings.json` or prune expired P4 window.
+3. Consider adopting `FileChanged` to live-validate config frontmatter on edit.
+4. Add `color` / explicit `permissionMode` to the 8 project agents.
+
+---
+
+*Generated by an official-spec re-validation pass. Source docs fetched 2026-05-29 from
+`docs.claude.com/en/docs/claude-code/`.*

--- a/global/skills/_internal/harness/reference/agent-frontmatter-spec.md
+++ b/global/skills/_internal/harness/reference/agent-frontmatter-spec.md
@@ -14,6 +14,7 @@ Complete reference for all YAML frontmatter fields available in `.claude/agents/
 6. [Lifecycle & Display](#6-lifecycle--display)
 7. [Field Resolution Order](#7-field-resolution-order)
 8. [Examples by Use Case](#8-examples-by-use-case)
+9. [Non-Standard Advisory Extensions](#9-non-standard-advisory-extensions)
 
 ---
 
@@ -316,3 +317,27 @@ model: sonnet
 mcpServers: [api-explorer]
 ---
 ```
+
+---
+
+## 9. Non-Standard Advisory Extensions
+
+The fields in sections 1-6 are the **officially supported** subagent frontmatter, verified
+against `docs.claude.com/en/docs/claude-code/sub-agents`. Some `.claude/agents/*.md` files in
+this repo carry additional keys that the Claude Code harness does **not** read. They are kept
+only as metadata for the repo's own routing/index tooling, mirroring the advisory-field pattern
+documented for skills in `global/skills/_policy.md`.
+
+| Field | Status | Consumed by | Notes |
+|-------|--------|-------------|-------|
+| `keywords` | Non-standard | repo routing/index docs | Explicitly "NOT officially supported" — see `docs/architecture-review-skills-rules.md`. Harness ignores it. |
+| `applies_to` | Non-standard | repo path-routing convention | Glob list; advisory only. The harness has no agent-side path-trigger; use `paths` on a skill instead if runtime triggering is needed. |
+
+### Removed: `temperature`
+
+`temperature` was previously set on the project agents. It is **not** an official field, is not
+listed in sections 1-6, and is silently ignored by the harness — subagents expose no
+sampling-temperature knob. Determinism/breadth is controlled by `effort` (section 3) instead.
+The field was removed in the 2026-05 official-spec review (`docs/official-spec-review-2026-05.md`).
+Do not reintroduce it: unlike skill advisory fields, a sampling parameter cannot be honored even
+as prompt-level self-regulation.

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -3,7 +3,6 @@ name: code-reviewer
 description: Comprehensive code review covering quality, security, performance, and maintainability. Reports findings with file:line references and severity ratings. Use when reviewing PRs, auditing code changes, or checking code quality in any language.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.3
 maxTurns: 30
 effort: high
 memory: project

--- a/project/.claude/agents/codebase-analyzer.md
+++ b/project/.claude/agents/codebase-analyzer.md
@@ -3,7 +3,6 @@ name: codebase-analyzer
 description: Analyzes codebase architecture, patterns, conventions, and dependency structure. Reports findings with file:line references and confidence scores. Use when exploring unfamiliar codebases, auditing architecture, or mapping module boundaries.
 model: sonnet
 tools: Read, Glob, Grep
-temperature: 0.2
 maxTurns: 25
 effort: high
 memory: project

--- a/project/.claude/agents/dependency-auditor.md
+++ b/project/.claude/agents/dependency-auditor.md
@@ -3,7 +3,6 @@ name: dependency-auditor
 description: Audits project dependencies for CVEs, license conflicts, outdated versions, and unused packages. Runs language-specific audit tools and cross-references vulnerability databases. Use when reviewing dependency security, checking for supply chain risks, or auditing license compliance.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.1
 maxTurns: 20
 effort: high
 memory: project

--- a/project/.claude/agents/documentation-writer.md
+++ b/project/.claude/agents/documentation-writer.md
@@ -3,7 +3,6 @@ name: documentation-writer
 description: Creates and updates technical documentation including README files, API references, architecture docs, and changelogs. Matches existing documentation style and structure. Use when documentation needs creation or update after code changes.
 model: sonnet
 tools: Read, Write, Edit, Glob
-temperature: 0.5
 maxTurns: 30
 effort: high
 memory: project

--- a/project/.claude/agents/qa-reviewer.md
+++ b/project/.claude/agents/qa-reviewer.md
@@ -3,7 +3,6 @@ name: qa-reviewer
 description: Verifies integration coherence and cross-boundary contracts. Checks API response shapes vs frontend consumers, route path mappings, state transition completeness, and endpoint coverage. Use when verifying that connected components agree on contracts, shapes, and paths.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.2
 maxTurns: 30
 effort: high
 memory: project

--- a/project/.claude/agents/refactor-assistant.md
+++ b/project/.claude/agents/refactor-assistant.md
@@ -3,7 +3,6 @@ name: refactor-assistant
 description: Safely improves code structure without changing behavior. Applies extract method, rename, inline, and other refactoring techniques with test verification before and after each change. Use when reducing duplication, improving readability, or restructuring modules.
 model: sonnet
 tools: Read, Edit, Glob, Grep
-temperature: 0.2
 maxTurns: 25
 effort: high
 memory: project

--- a/project/.claude/agents/structure-explorer.md
+++ b/project/.claude/agents/structure-explorer.md
@@ -3,7 +3,6 @@ name: structure-explorer
 description: Maps project directory structure, classifies files by purpose, and identifies key entry points, build configs, and CI workflows. Reports concise structure summaries. Use when surveying unfamiliar projects or mapping file organization.
 model: haiku
 tools: Glob, Read
-temperature: 0.1
 maxTurns: 15
 effort: medium
 memory: local

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -3,7 +3,6 @@ name: test-strategist
 description: Analyzes test coverage gaps, designs test strategies, and generates test skeletons. Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or generating test scaffolding.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.3
 maxTurns: 25
 effort: high
 memory: project


### PR DESCRIPTION
## What

Re-validates `claude-config` against the **current Claude Code official documentation**
(`settings`, `hooks`, `skills`, `sub-agents`, fetched 2026-05-29) and fixes the one genuine
drift found.

- Removes the `temperature` field from all 8 `project/.claude/agents/*.md` (dead metadata).
- Documents `keywords` / `applies_to` / `temperature` as non-standard advisory extensions in
  `agent-frontmatter-spec.md` (new section 9).
- Adds `docs/official-spec-review-2026-05.md` — the full review.

Change type: **chore** (docs + config hygiene; no behavior change).

## Why

`temperature` is **not** an official subagent frontmatter field, is **not** listed in the
repo's own `agent-frontmatter-spec.md`, and is **silently ignored** by the harness. Subagents
expose no sampling-temperature knob; determinism/breadth is already controlled by the official
`effort` field (every agent sets `effort: high/medium`). The field was pure dead metadata and
created a false impression that sampling was being tuned.

Verified against the live docs that all 18 wired hook events, all settings keys in use, and the
skills advisory fields are conformant — so this is the only fix needed. A first-pass agent
claim that `attribution` had "become a string" was refuted against the primary source:
`attribution: {commit, pr}` (object) is correct and already used.

## Where

| File | Change |
|------|--------|
| `project/.claude/agents/*.md` (8) | Remove `temperature` line (1 each) |
| `global/skills/_internal/harness/reference/agent-frontmatter-spec.md` | Add section 9 + ToC entry |
| `docs/official-spec-review-2026-05.md` | New review report |

## How

1. Inventoried every shipped asset; fetched live official docs; extracted authoritative field
   and event lists.
2. Cross-checked agent output against the primary source to catch hallucination.
3. Removed only `temperature` (8 deletions); preserved all other fields (`effort`, `model`,
   `maxTurns`, `memory`, `initialPrompt`, `applies_to`, `keywords`).

### Verification

- `grep -rn '^temperature:' project/.claude/agents/` → empty (removed)
- `grep -rl '^effort:' project/.claude/agents/` → 8 files (preserved)
- New ToC anchor `#9-non-standard-advisory-extensions` matches its heading.

## Backlog (not in this PR)

- Evaluate skill-governance keys (`skillOverrides`, `maxSkillDescriptionChars`,
  `disableSkillShellExecution`).
- Resolve `harness_policies`: relocate out of `settings.json` or prune expired P4 window
  (`p4_freeze_until: 2026-05-20` is past).
- Consider adopting unused hook events (`FileChanged`, `PermissionRequest`).
- Add `color` / explicit `permissionMode` to project agents.
