### PR TITLE
chore(agents): add color and explicit permissionMode to project agents

### DIFF
--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 30
 effort: high
+color: purple
 memory: project
 initialPrompt: "Check your memory for established project patterns and past review findings before starting."
 applies_to:

--- a/project/.claude/agents/codebase-analyzer.md
+++ b/project/.claude/agents/codebase-analyzer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Glob, Grep
 maxTurns: 25
 effort: high
+color: blue
 memory: project
 initialPrompt: "Check your memory for previously identified architecture patterns and conventions in this project."
 applies_to:

--- a/project/.claude/agents/dependency-auditor.md
+++ b/project/.claude/agents/dependency-auditor.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 20
 effort: high
+color: yellow
 memory: project
 initialPrompt: "Check your memory for known dependency issues and prior audit results in this project."
 applies_to:

--- a/project/.claude/agents/documentation-writer.md
+++ b/project/.claude/agents/documentation-writer.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Write, Edit, Glob
 maxTurns: 30
 effort: high
+permissionMode: acceptEdits
+color: pink
 memory: project
 initialPrompt: "Check your memory for established documentation patterns and style conventions in this project."
 applies_to:

--- a/project/.claude/agents/qa-reviewer.md
+++ b/project/.claude/agents/qa-reviewer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 30
 effort: high
+color: orange
 memory: project
 initialPrompt: "Check your memory for known boundary mismatches and integration patterns in this project."
 applies_to:

--- a/project/.claude/agents/refactor-assistant.md
+++ b/project/.claude/agents/refactor-assistant.md
@@ -5,6 +5,8 @@ model: sonnet
 tools: Read, Edit, Glob, Grep
 maxTurns: 25
 effort: high
+permissionMode: acceptEdits
+color: red
 memory: project
 initialPrompt: "Check your memory for past refactoring decisions and established patterns in this project."
 applies_to:

--- a/project/.claude/agents/structure-explorer.md
+++ b/project/.claude/agents/structure-explorer.md
@@ -5,6 +5,7 @@ model: haiku
 tools: Glob, Read
 maxTurns: 15
 effort: medium
+color: cyan
 memory: local
 applies_to:
   - "**/Makefile"

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 25
 effort: high
+color: green
 memory: project
 initialPrompt: "Check your memory for known test coverage gaps and established test patterns in this project."
 applies_to:


### PR DESCRIPTION
## What

Backlog follow-up from `docs/official-spec-review-2026-05.md` section 4.3 (unused official
subagent fields).

- Adds a unique `color` to all 8 `project/.claude/agents/*.md` (terminal/tmux identification).
- Adds `permissionMode: acceptEdits` to the 2 edit-capable agents only.

Change type: **chore** (config; no behavior change for read-only agents).

## Why

Both `color` and `permissionMode` are official subagent frontmatter fields that were unused.
`color` aids visual identification when multiple agents run in split-pane. `acceptEdits` lets
the edit-capable agents apply file changes without a per-edit permission prompt — matching the
"implementation agent" pattern in `agent-frontmatter-spec.md`.

## Where

| Agent | tools | color | permissionMode |
|-------|-------|-------|----------------|
| code-reviewer | Read, Grep, Glob, Bash | purple | — |
| codebase-analyzer | Read, Glob, Grep | blue | — |
| dependency-auditor | Read, Grep, Glob, Bash | yellow | — |
| documentation-writer | Read, Write, Edit, Glob | pink | **acceptEdits** |
| qa-reviewer | Read, Grep, Glob, Bash | orange | — |
| refactor-assistant | Read, Edit, Glob, Grep | red | **acceptEdits** |
| structure-explorer | Glob, Read | cyan | — |
| test-strategist | Read, Grep, Glob, Bash | green | — |

## How

Read-only agents (no Edit/Write) intentionally **omit** `permissionMode`: their `tools`
allowlist already defines the trust boundary, so an explicit mode would be redundant
(Minimize & Focus). Only the two agents that can mutate files get `acceptEdits`.

### Verification
- All 8 colors unique; frontmatter field order preserved.
- `git diff --stat` → 10 insertions, no deletions.
