### PR TITLE
feat(settings): add skill governance keys

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -19,5 +19,5 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.13.1
+settings-schema: 1.14.0
 hooks: 1.0.0

--- a/global/settings.json
+++ b/global/settings.json
@@ -496,8 +496,10 @@
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
   "includeGitInstructions": false,
+  "skillListingBudgetFraction": 0.02,
+  "disableSkillShellExecution": true,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "showTurnDuration": true,
   "teammateMode": "in-process",
   "harness_policies": {

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.13.1",
+  "version": "1.14.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -60,6 +60,8 @@
   "skipDangerousModePermissionPrompt": true,
   "effortLevel": "high",
   "includeGitInstructions": false,
+  "skillListingBudgetFraction": 0.02,
+  "disableSkillShellExecution": true,
 
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## What

Backlog follow-up from `docs/official-spec-review-2026-05.md` — adopt official
skill-governance `settings.json` keys that were previously unused. Applied to both
`global/settings.json` and `global/settings.windows.json`.

| Key | Value | Default | Rationale |
|-----|-------|---------|-----------|
| `skillListingBudgetFraction` | `0.02` | 0.01 | Repo ships **27 skills**; default 1% budget can truncate listing descriptions |
| `disableSkillShellExecution` | `true` | false | Hardens against inline shell injection in user/project/plugin skills |

Change type: **feat** (new config policy; `settings-schema` minor bump).

## Why

- **Budget**: 27 skills' descriptions (max observed 863 chars each) can exceed the 1% listing
  budget on smaller context windows, truncating the text Claude uses to decide auto-invocation.
  0.02 restores headroom at negligible context cost.
- **Shell exec**: Verified the repo's own skills use **zero** `` !`...` `` / ` ```! ` blocks, and
  the policy exempts built-in skills, so enabling it loses no functionality while closing an
  injection vector — consistent with the existing `permissions.deny` / `sensitive-file-guard`
  posture.

`maxSkillDescriptionChars` and `skillOverrides` are intentionally **unset**: no skill exceeds
the 1536 default, and nothing needs hiding.

## Where

- `global/settings.json`, `global/settings.windows.json` — 2 keys each
- `VERSION_MAP.yml` + both settings `version` — `settings-schema` 1.13.1 → 1.14.0

## How / Verification

- Both settings files pass `json.load` validation.
- `scripts/check_versions.sh` → `OK (settings-schema=1.14.0)`.
- Skill inline-shell scan: `grep -rln -e '!` + backtick `-e '```!'` → 0 matches.
