### PR TITLE
feat(hooks): add CwdChanged audit logger

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1014,6 +1014,7 @@ this catalog for the canonical hook inventory.
 | [`commit-message-guard.sh`](#commit-message-guard) | PreToolUse (Bash) | yes |
 | [`config-change-logger.sh`](#config-change-logger) | ConfigChange | yes |
 | [`conflict-guard.sh`](#conflict-guard) | PreToolUse (Bash) | yes |
+| [`cwd-change-logger.sh`](#cwd-change-logger) | CwdChanged | yes |
 | [`dangerous-command-guard.sh`](#dangerous-command-guard) | PreToolUse (Bash) | yes |
 | [`gh-write-verb-guard.sh`](#gh-write-verb-guard) | PreToolUse (Bash) | yes |
 | [`github-api-preflight.sh`](#github-api-preflight) | PreToolUse (Bash) | yes |
@@ -1044,7 +1045,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 36 bash hooks, 36 with PowerShell counterparts._
+_Total: 37 bash hooks, 37 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1166,6 +1167,23 @@ Guards against git operations that could cause conflicts
 | Response format | hookSpecificOutput with hookEventName |
 | PowerShell counterpart | present (`conflict-guard.ps1`) |
 | Source | `global/hooks/conflict-guard.sh` |
+
+### cwd-change-logger
+
+_File:_ `cwd-change-logger.sh`
+
+_Anchor:_ `#cwd-change-logger`
+
+Logs working-directory changes during a session for audit trails.
+
+| Field | Value |
+|---|---|
+| Hook Type | CwdChanged |
+| Trigger / Matcher | — |
+| Exit codes | — |
+| Response format | none (observation-only event; CwdChanged cannot block, exit 2 only shows stderr) |
+| PowerShell counterpart | present (`cwd-change-logger.ps1`) |
+| Source | `global/hooks/cwd-change-logger.sh` |
 
 ### dangerous-command-guard
 

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -19,5 +19,5 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.14.0
-hooks: 1.0.0
+settings-schema: 1.15.0
+hooks: 1.1.0

--- a/global/hooks/cwd-change-logger.ps1
+++ b/global/hooks/cwd-change-logger.ps1
@@ -1,0 +1,25 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# cwd-change-logger.ps1
+# Logs working-directory changes during a session for audit trails.
+# Hook Type: CwdChanged
+# Input: JSON via stdin with session_id, cwd, transcript_path, hook_event_name
+# Response format: none (observation-only event; CwdChanged cannot block, exit 2 only shows stderr)
+
+$json = Read-HookInput
+
+$Cwd = if ($json -and $json.cwd) { $json.cwd } else { 'unknown' }
+$SessionId = if ($json -and $json.session_id) { $json.session_id } else { 'unknown' }
+
+$LogDir = Join-Path $HOME '.claude' 'logs'
+$LogFile = Join-Path $LogDir 'session.log'
+
+Ensure-Directory $LogDir | Out-Null
+
+$Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+Add-Content -Path $LogFile -Value "[$Timestamp] Session ${SessionId}: CWD_CHANGED cwd=$Cwd"
+
+exit 0

--- a/global/hooks/cwd-change-logger.sh
+++ b/global/hooks/cwd-change-logger.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Cwd Change Logger Hook
+# Logs working-directory changes during a session for audit trails.
+#
+# Hook Type: CwdChanged
+# Input: JSON via stdin with session_id, cwd, transcript_path, hook_event_name
+# Response format: none (observation-only event; CwdChanged cannot block, exit 2 only shows stderr)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // "unknown"')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/session.log"
+
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${TIMESTAMP}] Session ${SESSION_ID}: CWD_CHANGED cwd=${CWD}" >> "$LOG_FILE"
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -453,6 +453,18 @@
           }
         ]
       }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/cwd-change-logger.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
     ]
   },
   "statusLine": {
@@ -499,7 +511,7 @@
   "skillListingBudgetFraction": 0.02,
   "disableSkillShellExecution": true,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "showTurnDuration": true,
   "teammateMode": "in-process",
   "harness_policies": {

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.14.0",
+  "version": "1.15.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -367,6 +367,18 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/session-logger.ps1 teammate-idle",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/cwd-change-logger.ps1",
             "timeout": 5,
             "async": true
           }


### PR DESCRIPTION
## What

Backlog follow-up from `docs/official-spec-review-2026-05.md` — adopt the previously-unused
official `CwdChanged` hook event with a new observation-only logger.

- New `cwd-change-logger.{sh,ps1}` records working-directory changes to `~/.claude/logs/session.log`.
- Wired in both `global/settings.json` and `global/settings.windows.json`.
- `HOOKS.md` regenerated via `scripts/gen-hooks-md.sh`.

Change type: **feat** (new observability hook; cannot block anything).

## Why

`CwdChanged` was one of 5 official hook events the repo did not use. It fits the repo's existing
audit-logging pattern (session-logger, config-change-logger). Logging directory transitions
completes the session audit trail for multi-directory workflows.

`CwdChanged` is **observation-only** per the official docs (no decision control; exit 2 only
shows stderr), so this introduces zero blocking risk.

## Where

| File | Change |
|------|--------|
| `global/hooks/cwd-change-logger.sh` | New (LF, executable) |
| `global/hooks/cwd-change-logger.ps1` | New (CRLF, uses CommonHelpers) |
| `global/settings.json` / `settings.windows.json` | Wire CwdChanged (async, timeout 5) |
| `HOOKS.md` | Regenerated catalog entry |
| `VERSION_MAP.yml` + both settings | settings-schema 1.14.0→1.15.0, hooks 1.0.0→1.1.0 |

## How / Verification

- Mock-input run: valid JSON → correct log line; empty `{}` → graceful `unknown` fallback; both exit 0.
- `scripts/gen-hooks-md.sh --check` → exit 0 (HOOKS.md catalog in sync).
- `markdown-anchor-validator` on HOOKS.md → allow.
- Both settings files pass JSON validation; `check_versions.sh` OK (settings-schema=1.15.0).
- Line endings verified: `.sh`=LF, `.ps1`=CRLF (repo convention).
