### PR TITLE
chore(settings): relocate P4 harness_policies out of settings.json

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -118,11 +118,8 @@ reference: [`code.claude.com/docs/en/settings`](https://code.claude.com/docs/en/
 | `skipDangerousModePermissionPrompt` | Stable | 2.0.0+ | Ignored in project settings (security). |
 | `showTurnDuration` | **Misplaced** | 2.1.0+ | Officially belongs in `~/.claude.json`, not `settings.json`. May trigger schema validation warning in future CC versions. Consider moving. |
 | `teammateMode` | **Misplaced** | 2.1.0+ | Same as above — belongs in `~/.claude.json`. Valid values: `auto`, `in-process`, `tmux`. |
-| `harness_policies.p4_strict_schema` | Undocumented | — | claude-config Kill Switch for P4 strict-schema dispatch (EPIC #454). Default `false`. **Bypass:** set `STRICT_SCHEMA=0` env var (env wins over settings) to force lenient schema validation across all skills. |
-| `harness_policies.p4_d1_merged_at` | Undocumented | — | ISO-8601 anchor for the D1 (#461) merge. Read by p4-timeline-guard.sh and p4-timeline-reminder.sh. |
-| `harness_policies.p4_grace_until` | Undocumented | — | ISO-8601 deadline for the lenient-only grace window. PRs touching `global/skills/_internal/` are blocked by p4-timeline-guard.sh until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
-| `harness_policies.p4_observation_until` | Undocumented | — | ISO-8601 deadline for the observation window. Edits flipping `p4_strict_schema` to `true` are blocked until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
-| `harness_policies.p4_freeze_until` | Undocumented | — | ISO-8601 deadline for the post-D2 72h freeze. SessionStart banner remains active until now() >= this timestamp. |
+
+> **Note:** The `harness_policies.*` P4 timeline fields were relocated out of `settings.json` into `~/.claude/policies/p4-timeline.json` (P4 Phase 2; the P4 hooks already read that file first). Their definitions now live in the [Skill Directory Layout (P4)](#skill-directory-layout-p4) section below.
 
 ### env fields in settings.json
 
@@ -155,7 +152,17 @@ EPIC #454 P4 introduced a strict/lenient schema split. claude-config-owned skill
 | Plugin | `plugin/skills/` | lenient |
 | Plugin-lite | `plugin-lite/skills/` | lenient |
 
-Strict mode is OFF by default during the post-D2 grace window; see `harness_policies.p4_strict_schema` and the timeline toggles (`p4_grace_until`, `p4_observation_until`, `p4_freeze_until`) in the Settings Field Inventory above. External plugin/plugin-lite installs are unaffected by the relocation; their skill paths are unchanged.
+Strict mode is OFF by default during the post-D2 grace window. The P4 timeline policy now lives in `~/.claude/policies/p4-timeline.json` (read first by `p4-timeline-guard.sh` and `p4-timeline-reminder.sh`; a deprecated `settings.json` fallback is retained in the hooks for backward compatibility and will be dropped in a later step). External plugin/plugin-lite installs are unaffected by the relocation; their skill paths are unchanged.
+
+### P4 timeline policy fields (`policies/p4-timeline.json`)
+
+| Field | Notes |
+|---|---|
+| `p4_strict_schema` | claude-config kill switch for P4 strict-schema dispatch (EPIC #454). Default `false`. **Bypass:** set `STRICT_SCHEMA=0` env var (env wins over the policy file) to force lenient schema validation across all skills. |
+| `p4_d1_merged_at` | ISO-8601 anchor for the D1 (#461) merge. Read by `p4-timeline-guard.sh` and `p4-timeline-reminder.sh`. |
+| `p4_grace_until` | ISO-8601 deadline for the lenient-only grace window. PRs touching `global/skills/_internal/` are blocked until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
+| `p4_observation_until` | ISO-8601 deadline for the observation window. Edits flipping `p4_strict_schema` to `true` are blocked until now() >= this timestamp. **Override:** `CLAUDE_P4_OVERRIDE=1` (RCA required). |
+| `p4_freeze_until` | ISO-8601 deadline for the post-D2 72h freeze. SessionStart banner remains active until now() >= this timestamp. |
 
 ---
 

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -19,5 +19,5 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.15.0
+settings-schema: 1.16.0
 hooks: 1.1.0

--- a/global/settings.json
+++ b/global/settings.json
@@ -511,14 +511,7 @@
   "skillListingBudgetFraction": 0.02,
   "disableSkillShellExecution": true,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "showTurnDuration": true,
-  "teammateMode": "in-process",
-  "harness_policies": {
-    "p4_strict_schema": false,
-    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
-    "p4_grace_until": "2026-05-03T22:15:57Z",
-    "p4_observation_until": "2026-05-17T22:15:57Z",
-    "p4_freeze_until": "2026-05-20T22:15:57Z"
-  }
+  "teammateMode": "in-process"
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.15.0",
+  "version": "1.16.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -48,13 +48,6 @@
   },
   "alwaysThinkingEnabled": true,
   "teammateMode": "in-process",
-  "harness_policies": {
-    "p4_strict_schema": false,
-    "p4_d1_merged_at": "2026-04-26T22:15:57Z",
-    "p4_grace_until": "2026-05-03T22:15:57Z",
-    "p4_observation_until": "2026-05-17T22:15:57Z",
-    "p4_freeze_until": "2026-05-20T22:15:57Z"
-  },
 
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,


### PR DESCRIPTION
## What

Backlog follow-up from `docs/official-spec-review-2026-05.md` — remove the non-schema
`harness_policies` custom key from `settings.json`, completing the **data side** of the
P4 Phase 2 migration.

Change type: **chore** (no behavior change; hooks already read the policy file first).

## Why

`global/policies/p4-timeline.json` is already the SSOT for the P4 timeline and is installed to
`~/.claude/policies/`. The P4 hooks (`p4-timeline-guard.sh`, `p4-timeline-reminder.sh`) read it
**first** (Phase 1 dual-read), with a `settings.json` fallback explicitly marked for removal:

> "Phase 2 will drop the settings.json fallback."

The `harness_policies` block in `settings.json` was therefore a **duplicate** of the policy
file — and a non-schema custom key that a strict `$schema` validator would flag. The P4
timeline windows are also all expired (latest `p4_freeze_until: 2026-05-20`).

## Where

| File | Change |
|------|--------|
| `global/settings.json`, `settings.windows.json` | Remove `harness_policies` block |
| `COMPATIBILITY.md` | Drop harness_policies rows from settings field inventory; document fields under the P4 section pointing at `policies/p4-timeline.json` |
| `VERSION_MAP.yml` + both settings | settings-schema 1.15.0 → 1.16.0 |

## How / Scope

- The hooks' `settings.json` **fallback code is intentionally retained** for backward
  compatibility — dropping it is a separate, hook-side step of Phase 2 (avoids coupling a
  data cleanup with hook-logic changes).
- `global/policies/p4-timeline.json` is **unchanged** (it remains the SSOT; the P4 timeline
  owner controls its values).

### Verification
- `p4-timeline-guard.sh` and `p4-timeline-reminder.sh` run correctly from the policy file
  alone (no settings fallback): both return `allow` / exit 0 with `harness_policies` absent.
- Both settings files pass JSON validation; `check_versions.sh` OK (settings-schema=1.16.0).
- `markdown-anchor-validator` on COMPATIBILITY.md → allow (new `#skill-directory-layout-p4` link resolves).
- `grep harness_policies` on settings files → 0 matches.
