### PR TITLE
fix(settings): wire 7 dormant security/memory guards into Windows settings

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -19,5 +19,5 @@
 suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.16.0
+settings-schema: 1.17.0
 hooks: 1.1.0

--- a/global/settings.json
+++ b/global/settings.json
@@ -511,7 +511,7 @@
   "skillListingBudgetFraction": 0.02,
   "disableSkillShellExecution": true,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "showTurnDuration": true,
   "teammateMode": "in-process"
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
-  "version": "1.16.0",
+  "version": "1.17.0",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -74,6 +74,11 @@
           },
           {
             "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/memory-write-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/p4-timeline-guard.ps1",
             "timeout": 5
           }
@@ -85,6 +90,21 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/dangerous-command-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/bash-sensitive-read-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/bash-write-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/gh-write-verb-guard.ps1",
             "timeout": 5
           },
           {
@@ -101,6 +121,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/commit-message-guard.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/traceability-guard.ps1",
+            "timeout": 10
           },
           {
             "type": "command",
@@ -163,6 +188,11 @@
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/p4-timeline-reminder.ps1",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/memory-integrity-check.ps1",
+            "timeout": 5
           }
         ]
       }
@@ -218,6 +248,12 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-edit-read-guard.ps1",
+            "timeout": 5,
+            "async": true
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/memory-access-logger.ps1",
             "timeout": 5,
             "async": true
           }


### PR DESCRIPTION
## What

P0 security fix from `docs/deep-audit-2026-05-29.md` (findings
`windows-bash-secret-guards-not-wired`, `win-missing-bash-tool-guards`, `win-missing-memory-hooks`).

Seven fully-implemented `.ps1` hooks existed in `global/hooks/` but were **never registered** in
`settings.windows.json`. Since `install.ps1` deploys that file as `~/.claude/settings.json`,
Windows users ran without guards the docs advertise as active.

Change type: **fix** (security).

## Why

The CI parity check only verifies a same-basename `.ps1` file *exists*, never that it is *wired*.
So these guards shipped dormant on the default branch:

| Event | Newly wired |
|-------|-------------|
| PreToolUse `Bash` | `bash-sensitive-read-guard`, `bash-write-guard`, `gh-write-verb-guard`, `traceability-guard` |
| PreToolUse `Edit\|Write\|Read` | `memory-write-guard` (after `pre-edit-read-guard`) |
| SessionStart | `memory-integrity-check` |
| PostToolUse `Read` | `memory-access-logger` (async) |

Without them, on Windows `cat .env`, `type ~/.aws/credentials`, writes to existing files, and
unscoped `gh` write verbs were unguarded, and memory writes/integrity were unprotected.

## How

Wired all seven in the **same order and timeouts as POSIX** (`settings.json`), restoring
hook-set parity. No new scripts — pure registration of existing, tested `.ps1` files.

### Verification
- `tests/scripts/test-windows-hooks-parity.sh` → **PASS** (it failed before this change).
- Bash matcher order now byte-identical across platforms (14 hooks each).
- Both settings files validate as JSON; `check_versions.sh` OK (settings-schema=1.17.0).

## Follow-up (separate PR)

P0-3 will wire `test-windows-hooks-parity.sh` and other orphaned suites into CI so this class of
"dormant guard" cannot regress (the parity test that catches this currently runs in no workflow).
