### PR TITLE
ci: wire hook-wiring parity and regression gates into validate-hooks

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -24,6 +24,11 @@ on:
       - 'tests/scripts/test-language-policy-drift.sh'
       - 'tests/scripts/test-installer-prompt-drift.sh'
       - 'scripts/lib/**'
+      - 'global/settings.json'
+      - 'global/settings.windows.json'
+      - 'tests/scripts/test-windows-hooks-parity.sh'
+      - 'tests/scripts/test-hook-ordering.sh'
+      - 'tests/scripts/test-severity-enum.sh'
 
 jobs:
   test:
@@ -109,6 +114,21 @@ jobs:
         # scripts/lib/InstallPrompts.psm1 (PowerShell) - the single source
         # of truth for installer prompts and the policy phrase table.
         run: bash tests/scripts/test-installer-prompt-drift.sh
+
+      - name: Run hook-wiring parity test (settings.json <-> settings.windows.json)
+        # Catches dormant guards: a .ps1 hook present in global/hooks/ but not
+        # wired into settings.windows.json (or POSIX-only drift). This is the
+        # gate the 7 unwired Windows security guards (#655) would have tripped.
+        run: bash tests/scripts/test-windows-hooks-parity.sh
+
+      - name: Run hook ordering test
+        # Asserts the load-bearing PreToolUse hook order (sensitive-file-guard
+        # before pre-edit-read-guard, etc.) is preserved across both settings.
+        run: bash tests/scripts/test-hook-ordering.sh
+
+      - name: Run skill severity enum test
+        # Validates code-review skill frontmatter severity/finding_levels enums.
+        run: bash tests/scripts/test-severity-enum.sh
 
   shellcheck:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What

P0 follow-up from `docs/deep-audit-2026-05-29.md` — close the CI gap that let the dormant
Windows guards (#655) ship undetected.

Change type: **ci**.

## Why

The parity audit only checked that a same-basename `.ps1` file **exists** — never that it is
**wired** into `settings.windows.json` or behaves correctly. `test-windows-hooks-parity.sh`
already encodes the correct wiring assertion and fails when guards are dormant, but it ran in
**no workflow** (one of ~17 orphaned suites).

## How

Wires three existing, environment-independent, locally-passing suites into `validate-hooks.yml`
(main-targeted — the develop CI skip is intentional per the audit):

| Suite | Catches |
|-------|---------|
| `test-windows-hooks-parity.sh` | per-event hook set / permission allowlist drift between the two settings files (the dormant-guard gate) |
| `test-hook-ordering.sh` | load-bearing PreToolUse hook order |
| `test-severity-enum.sh` | code-review skill severity/finding_levels enums |

Also adds `global/settings.json`, `global/settings.windows.json`, and the three suites to the
workflow path filter so a settings change triggers the parity check.

## Verification

- All three suites pass locally; `test-windows-hooks-parity.sh` now PASSES post-#655.
- `validate-hooks.yml` parses as valid YAML; `test` job now has 19 steps (3 new).

## Out of scope (backlog in the audit report)

- `hook-json-escape*.sh` and `test-killswitch.sh` fail locally on Windows (CR handling /
  `spec_lint` PYTHONPATH) — need an ubuntu shim before wiring.
- A `windows-latest` pwsh leg running `test-runner.ps1` for behavioral `.ps1` execution is a
  larger follow-up (the structural reason behavioral parity can diverge).
