### PR TITLE
fix(hooks): restore PowerShell guard parity

### DIFF
--- a/global/hooks/attribution-guard.ps1
+++ b/global/hooks/attribution-guard.ps1
@@ -1,6 +1,7 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'AttributionValidator.psm1') -Force
 
 # attribution-guard.ps1
 # Blocks gh pr/issue/release commands whose user-facing text fields contain
@@ -22,24 +23,9 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 # one, update the other to keep enforcement consistent across bash and
 # PowerShell hosts.
 
-$AttributionTrailerRegex = '(?m)^\s*(Co-[Aa]uthored-[Bb]y|Co-[Aa]uthor|[Gg]enerated[- ]?[Bb]y|[Cc]reated[- ]?[Bb]y|[Aa]uthored[- ]?[Bb]y|[Ss]igned-[Oo]ff-[Bb]y|[Aa]ssisted-[Bb]y)\s*:\s*.*([Cc]laude|[Aa]nthropic|AI[- ]?[Aa]ssisted)'
-$AttributionEmojiRegex   = '🤖\s*\S*\s*([Cc]laude|[Aa]nthropic)'
-$AttributionProseRegex   = '([Gg]enerated|[Cc]reated|[Aa]uthored|[Ww]ritten)\s+(with|by|using)\s+(Claude|Anthropic|AI[- ]?[Aa]ssistant)'
-
-function Test-AttributionReason {
-    param([string]$Text)
-    if (-not $Text) { return $null }
-    if ($Text -match $AttributionTrailerRegex) {
-        return 'Text contains AI/Claude attribution trailer (Co-Authored-By: / Generated-by: / Authored-by: Claude or Anthropic). Remove the trailer before submitting.'
-    }
-    if ($Text -match $AttributionEmojiRegex) {
-        return 'Text contains AI bot emoji adjacent to Claude/Anthropic attribution. Remove the marker before submitting.'
-    }
-    if ($Text -match $AttributionProseRegex) {
-        return "Text contains AI/Claude attribution prose (e.g. 'Generated with Claude'). Remove the attribution before submitting."
-    }
-    return $null
-}
+# Attribution patterns + Test-AttributionReason now live in the shared
+# lib/AttributionValidator.psm1 (imported above; also used by
+# commit-message-guard.ps1) so the three-pattern rules stay single-sourced.
 
 # Extracts the value for a given long/short flag from a shell command string.
 function Get-FlagValue {

--- a/global/hooks/commit-message-guard.ps1
+++ b/global/hooks/commit-message-guard.ps1
@@ -2,6 +2,7 @@
 $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot 'lib' 'LanguageValidator.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'AttributionValidator.psm1') -Force
 
 # commit-message-guard.ps1
 # Deterministic git commit message validator
@@ -85,9 +86,12 @@ if ($desc.EndsWith('.')) {
     exit 0
 }
 
-# Rule 4: No AI/Claude attribution
-if ($msg -imatch '(claude|anthropic|ai-assisted|co-authored-by:\s*claude|generated\s+with)') {
-    New-HookDenyResponse -Reason 'Commit message must not contain AI/Claude attribution (claude, anthropic, ai-assisted, generated with, co-authored-by: claude).'
+# Rule 4: No AI/Claude attribution (three-pattern design via the shared
+# AttributionValidator module — casual technical mentions like 'Claude API'
+# or 'Anthropic SDK' are deliberately allowed; mirrors validate-commit-message.sh).
+$attrReason = Test-AttributionReason $msg
+if ($attrReason) {
+    New-HookDenyResponse -Reason "Commit message rejected: $attrReason"
     exit 0
 }
 

--- a/global/hooks/lib/AttributionValidator.psm1
+++ b/global/hooks/lib/AttributionValidator.psm1
@@ -1,0 +1,40 @@
+#Requires -Version 7.0
+# AttributionValidator.psm1 — Shared AI/Claude attribution detection.
+#
+# Single source of truth for the three-pattern attribution design, imported
+# by attribution-guard.ps1 (gh pr/issue/release text fields) and
+# commit-message-guard.ps1 (git commit messages). Mirrors the bash authority
+# hooks/lib/validate-commit-message.sh. When updating a pattern here, update
+# that bash library too so enforcement stays consistent across hosts.
+#
+# Three-pattern design:
+#   1. Trailer-style attribution at line start (Co-Authored-By: Claude ...)
+#   2. Bot emoji adjacent to Claude/Anthropic
+#   3. Generated|Created|Authored {with|by|using} {Claude|Anthropic} prose
+# Casual prose mentions ("Claude API", "Anthropic SDK") are deliberately
+# allowed to eliminate false positives on legitimate technical writing.
+
+$script:AttributionTrailerRegex = '(?m)^\s*(Co-[Aa]uthored-[Bb]y|Co-[Aa]uthor|[Gg]enerated[- ]?[Bb]y|[Cc]reated[- ]?[Bb]y|[Aa]uthored[- ]?[Bb]y|[Ss]igned-[Oo]ff-[Bb]y|[Aa]ssisted-[Bb]y)\s*:\s*.*([Cc]laude|[Aa]nthropic|AI[- ]?[Aa]ssisted)'
+$script:AttributionEmojiRegex   = '🤖\s*\S*\s*([Cc]laude|[Aa]nthropic)'
+$script:AttributionProseRegex   = '([Gg]enerated|[Cc]reated|[Aa]uthored|[Ww]ritten)\s+(with|by|using)\s+(Claude|Anthropic|AI[- ]?[Aa]ssistant)'
+
+# Test-AttributionReason
+# Returns a user-facing rejection reason string when $Text contains an
+# attribution marker matching one of the three patterns, or $null when the
+# text is clean (including casual technical mentions of Claude/Anthropic).
+function Test-AttributionReason {
+    param([string]$Text)
+    if (-not $Text) { return $null }
+    if ($Text -match $script:AttributionTrailerRegex) {
+        return 'Text contains AI/Claude attribution trailer (Co-Authored-By: / Generated-by: / Authored-by: Claude or Anthropic). Remove the trailer before submitting.'
+    }
+    if ($Text -match $script:AttributionEmojiRegex) {
+        return 'Text contains AI bot emoji adjacent to Claude/Anthropic attribution. Remove the marker before submitting.'
+    }
+    if ($Text -match $script:AttributionProseRegex) {
+        return "Text contains AI/Claude attribution prose (e.g. 'Generated with Claude'). Remove the attribution before submitting."
+    }
+    return $null
+}
+
+Export-ModuleMember -Function @('Test-AttributionReason')

--- a/global/hooks/lib/LanguageValidator.psm1
+++ b/global/hooks/lib/LanguageValidator.psm1
@@ -6,7 +6,9 @@
 # authoritative source of truth; keep the character sets in sync with them.
 #
 # The CLAUDE_CONTENT_LANGUAGE environment variable selects the policy:
-#   - english (default, unset, or empty) → ASCII printable + whitespace only
+#   - english (default, unset, or empty) → ASCII printable + whitespace,
+#       plus allowlisted English typographic punctuation (em/en-dash, curly
+#       quotes, ellipsis, NBSP) per issue #583
 #   - korean_plus_english → ASCII + Hangul syllables/Jamo/Compat Jamo
 #   - exclusive_bilingual → per-document: english_only when text has no
 #                           Hangul syllables, otherwise korean_with_tech_terms
@@ -51,6 +53,16 @@ function Test-CodePointAllowed {
     # ASCII printable + whitespace (shared across english and korean_plus_english)
     if (($CodePoint -ge 0x20 -and $CodePoint -le 0x7E) -or
         ($CodePoint -ge 0x09 -and $CodePoint -le 0x0D)) {
+        return $true
+    }
+    # Allowlisted English typographic punctuation (issue #583): em-dash,
+    # en-dash, curly double/single quotes, horizontal ellipsis, NBSP. Matches
+    # the strip list in hooks/lib/validate-language.sh (applied before any
+    # category check, so it holds for every policy).
+    if ($CodePoint -eq 0x2014 -or $CodePoint -eq 0x2013 -or
+        $CodePoint -eq 0x201C -or $CodePoint -eq 0x201D -or
+        $CodePoint -eq 0x2018 -or $CodePoint -eq 0x2019 -or
+        $CodePoint -eq 0x2026 -or $CodePoint -eq 0x00A0) {
         return $true
     }
     if ($Policy -eq 'korean_plus_english') {

--- a/global/hooks/memory-write-guard.ps1
+++ b/global/hooks/memory-write-guard.ps1
@@ -168,7 +168,9 @@ try {
 
     $block = $false
     if ($validateRc -eq 1 -or $validateRc -eq 2) { $block = $true }
-    if ($secretRc -eq 1) { $block = $true }
+    # Fail-closed on secret-check exit code 2 (OWNER_EMAILS not configured,
+    # #618), mirroring memory-write-guard.sh lines 272-274.
+    if ($secretRc -eq 1 -or $secretRc -eq 2) { $block = $true }
 
     if ($block) {
         $reason = "memory-write-guard rejected write to $leaf"
@@ -177,6 +179,9 @@ try {
         }
         if ($secretRc -eq 1) {
             $reason = $reason + "`nsecret-check.sh blocked write:`n" + $secretOut.TrimEnd()
+        }
+        if ($secretRc -eq 2) {
+            $reason = $reason + "`nsecret-check.sh requires configuration (#618):`n" + $secretOut.TrimEnd()
         }
         Write-Output (New-HookDenyResponse -Reason $reason)
         exit 0

--- a/global/hooks/merge-gate-guard.ps1
+++ b/global/hooks/merge-gate-guard.ps1
@@ -49,6 +49,15 @@ if ($CMD -notmatch 'gh\s+pr\s+merge') {
     exit 0
 }
 
+# --- Squash-only enforcement (Issue #478) ---
+# The branching strategy mandates squash merges to develop/main. Reject
+# --merge and --rebase so the gh CLI cannot bypass that policy. Mirrors
+# merge-gate-guard.sh lines 82-88.
+if ($CMD -match '(^|\s)--(merge|rebase)(\s|=|$)') {
+    New-HookDenyResponse -Reason 'gh pr merge --merge/--rebase blocked: branching strategy requires squash merges (use --squash). See workflow/branching-strategy.md.'
+    exit 0
+}
+
 # --- Extract PR number ---
 $prNum = $null
 

--- a/global/hooks/pr-target-guard.ps1
+++ b/global/hooks/pr-target-guard.ps1
@@ -45,23 +45,45 @@ if ($baseMatch.Success) {
     $base = $baseMatch.Groups[1].Value
 }
 
-# If no --base flag found, the PR uses the repo default branch (develop).
-# Allow it -- this is the normal feature-to-develop workflow.
+# If no --base flag found, resolve the repo's default branch instead of
+# blindly allowing. Repos with default_branch=main previously bypassed the
+# policy. PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE lets tests inject without
+# gh. Mirrors the pr-target-guard.sh #616 hardening (lines 70-88).
 if (-not $base) {
-    New-HookAllowResponse
-    exit 0
+    if ($env:PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE) {
+        $base = $env:PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE
+    } else {
+        $repo = $null
+        $rm = [regex]::Match($CMD, '(?:--repo[= ]|-R\s+)["\x27]?([a-zA-Z0-9._/-]+)')
+        if ($rm.Success) { $repo = $rm.Groups[1].Value }
+        if (Get-Command gh -ErrorAction SilentlyContinue) {
+            try {
+                if ($repo) {
+                    $base = (& gh api "repos/$repo" --jq .default_branch 2>$null)
+                } else {
+                    $base = (& gh api 'repos/{owner}/{repo}' --jq .default_branch 2>$null)
+                }
+            } catch {}
+        }
+        if ($base) { $base = ("$base").Trim() }
+    }
+    # Graceful degradation: preserve the historical allow if unresolved.
+    if (-not $base) {
+        New-HookAllowResponse
+        exit 0
+    }
 }
 
 # Strip surrounding quotes if present
 $base = $base -replace '^["\x27]|["\x27]$', ''
 
-# Only block if base is exactly 'main'
-if ($base -ne 'main') {
+# Only block if base is exactly 'main' or 'master'
+if ($base -ne 'main' -and $base -ne 'master') {
     New-HookAllowResponse
     exit 0
 }
 
-# Base is 'main' -- check if this is a release PR (--head develop)
+# Base is 'main' or 'master' -- check if this is a release PR (--head develop)
 $head = $null
 $headMatch = [regex]::Match($CMD, '(?:--head[= ]|-H\s*)["\x27]?([a-zA-Z0-9._/-]+)')
 if ($headMatch.Success) {
@@ -80,6 +102,6 @@ if ($head -like 'release/*') {
     exit 0
 }
 
-# Deny: non-develop/non-release branch targeting main
-New-HookDenyResponse -Reason "PR targeting 'main' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into 'main'. Feature/fix branches must target 'develop'."
+# Deny: non-develop/non-release branch targeting main or master
+New-HookDenyResponse -Reason "PR targeting '$base' is blocked by branching policy. Only 'develop' or 'release/*' branches may merge into '$base'. Feature/fix branches must target 'develop'."
 exit 0

--- a/global/hooks/sensitive-file-guard.ps1
+++ b/global/hooks/sensitive-file-guard.ps1
@@ -58,6 +58,21 @@ if ($FILE -match '\.(pem|key|p12|pfx)$') {
     exit 0
 }
 
+# SSH private keys (mirrors sensitive-file-guard.sh). Matches id_rsa,
+# id_ed25519, id_ecdsa, id_dsa and their suffixed variants (incl. .pub) by
+# basename. $basenameLower is computed above.
+if ($basenameLower -match '^id_(rsa|ed25519|ecdsa|dsa)(\..*)?$') {
+    New-HookDenyResponse -Reason "Access to sensitive file blocked: $FILE (SSH private key)"
+    exit 0
+}
+
+# AWS credential files: basename 'credentials' or 'config' under a .aws dir.
+if (($basenameLower -eq 'credentials' -or $basenameLower -eq 'config') -and
+    ($FILE -match '(?i)[/\\]\.aws[/\\]')) {
+    New-HookDenyResponse -Reason "Access to sensitive file blocked: $FILE (AWS credentials)"
+    exit 0
+}
+
 # Check sensitive directories
 if ($FILE -match '(?i)(secrets|credentials|passwords)[/\\]') {
     New-HookDenyResponse -Reason "Access to sensitive directory blocked: $FILE (protected path)"

--- a/tests/hooks/test-commit-message-guard.ps1
+++ b/tests/hooks/test-commit-message-guard.ps1
@@ -1,0 +1,71 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# Tests for commit-message-guard.ps1 Rule 4 (attribution) after the switch
+# from the broad substring regex to the shared AttributionValidator
+# three-pattern design. Casual technical mentions of Claude/Anthropic must
+# be allowed; only real attribution shapes are denied.
+# Run: pwsh tests/hooks/test-commit-message-guard.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'commit-message-guard.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-Commit {
+    param([string]$Message)
+    $cmd = 'git commit -m "' + $Message + '"'
+    $json = (@{ tool_input = @{ command = $cmd } } | ConvertTo-Json -Compress)
+    return ($json | & pwsh -NoProfile -File $script:HookPath 2>$null)
+}
+
+function Assert-Allow {
+    param([string]$Message, [string]$Label)
+    $r = Invoke-Commit $Message
+    if ($r -match '"allow"' -or [string]::IsNullOrEmpty($r)) {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected allow, got: $r")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+function Assert-Deny {
+    param([string]$Message, [string]$Label)
+    $r = Invoke-Commit $Message
+    if ($r -match '"deny"') {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected deny, got: $r")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host '=== commit-message-guard.ps1 attribution (Rule 4) tests ==='
+Write-Host ''
+Write-Host '[Casual technical mentions allowed - no false positives]'
+Assert-Allow 'docs: clarify Claude API behavior'        'Claude API mention -> allow'
+Assert-Allow 'feat: add Anthropic SDK integration'      'Anthropic SDK mention -> allow'
+Assert-Allow 'fix: handle ai-assisted suggestions panel' 'ai-assisted as feature noun -> allow'
+Assert-Allow 'fix: resolve null pointer in parser'      'plain commit -> allow'
+
+Write-Host ''
+Write-Host '[Real attribution shapes denied]'
+Assert-Deny 'feat: generated with Claude'   'prose generated with Claude -> deny'
+Assert-Deny 'docs: created by Anthropic'     'prose created by Anthropic -> deny'
+
+Write-Host ''
+Write-Host '[Other rules still enforced]'
+Assert-Deny 'random text without a type prefix' 'non-conventional format -> deny'
+Assert-Deny 'feat: trailing period.'            'trailing period -> deny'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-language-validator.ps1
+++ b/tests/hooks/test-language-validator.ps1
@@ -58,6 +58,9 @@ Invoke-LangCase -Name "unset policy accepts ASCII"          -ExpectedValid $true
 Invoke-LangCase -Name "english rejects Hangul"              -ExpectedValid $false -Policy 'english'   -Text "한국어"
 Invoke-LangCase -Name "english rejects accented Latin"      -ExpectedValid $false -Policy 'english'   -Text "café"
 Invoke-LangCase -Name "english rejects emoji"               -ExpectedValid $false -Policy 'english'   -Text "party 🎉"
+Invoke-LangCase -Name "english allows em-dash (#583)"       -ExpectedValid $true  -Policy 'english'   -Text ("dash" + [char]0x2014 + "here")
+Invoke-LangCase -Name "english allows curly quotes (#583)"  -ExpectedValid $true  -Policy 'english'   -Text ([char]0x201C + "quoted" + [char]0x201D)
+Invoke-LangCase -Name "english allows ellipsis+NBSP (#583)" -ExpectedValid $true  -Policy 'english'   -Text ("wait" + [char]0x2026 + [char]0x00A0 + "x")
 
 Write-Host ""
 Write-Host "[korean_plus_english policy]"

--- a/tests/hooks/test-merge-gate-squash-only.ps1
+++ b/tests/hooks/test-merge-gate-squash-only.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# PowerShell mirror of tests/hooks/test-merge-gate-squash-only.sh.
+# Validates merge-gate-guard.ps1 squash-only enforcement (Issue #478): the
+# --merge / --rebase flags must be denied before any gh pr checks call.
+# Run: pwsh tests/hooks/test-merge-gate-squash-only.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'merge-gate-guard.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Assert-SquashDeny {
+    param([string]$Cmd, [string]$Label)
+    $json = (@{ tool_input = @{ command = $Cmd } } | ConvertTo-Json -Compress)
+    $result = $json | & pwsh -NoProfile -File $script:HookPath 2>$null
+    if ($result -match '"deny"' -and $result -match 'branching strategy requires squash') {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected squash deny, got: $result")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+function Assert-NotSquashDeny {
+    param([string]$Cmd, [string]$Label)
+    # The squash-only branch must NOT fire. The downstream CI-checks branch
+    # may legitimately allow or deny depending on the (absent) gh CLI, so we
+    # only assert the squash-specific reason is not present.
+    $json = (@{ tool_input = @{ command = $Cmd } } | ConvertTo-Json -Compress)
+    $result = $json | & pwsh -NoProfile -File $script:HookPath 2>$null
+    if ($result -match 'branching strategy requires squash') {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - squash-only branch unexpectedly fired: $result")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    } else {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    }
+}
+
+Write-Host '=== merge-gate-guard.ps1 squash-only tests ==='
+Write-Host ''
+Write-Host '[deny - non-squash flags]'
+Assert-SquashDeny 'gh pr merge 1 --merge'   'long-form --merge'
+Assert-SquashDeny 'gh pr merge --merge 1'   '--merge before PR#'
+Assert-SquashDeny 'gh pr merge 1 --rebase'  'long-form --rebase'
+Assert-SquashDeny 'gh pr merge --rebase 7'  '--rebase before PR#'
+
+Write-Host ''
+Write-Host '[pass-through - squash and unrelated commands]'
+Assert-NotSquashDeny 'gh pr merge 1 --squash --delete-branch' '--squash'
+Assert-NotSquashDeny 'gh pr view 1'                            'non-merge gh'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-pr-target-guard.ps1
+++ b/tests/hooks/test-pr-target-guard.ps1
@@ -1,0 +1,86 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# PowerShell mirror of tests/hooks/test-pr-target-guard.sh.
+# Validates pr-target-guard.ps1 parity (#616 hardening): blocks both main
+# and master, and resolves the repo default branch via the
+# PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE env var when --base is absent.
+# Run: pwsh tests/hooks/test-pr-target-guard.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'pr-target-guard.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-Hook {
+    param([string]$Json, [string]$Branch)
+    if ($Branch) {
+        $env:PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE = $Branch
+        try { return ($Json | & pwsh -NoProfile -File $script:HookPath 2>$null) }
+        finally { $env:PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE = $null }
+    }
+    return ($Json | & pwsh -NoProfile -File $script:HookPath 2>$null)
+}
+
+function Assert-Decision {
+    param([string]$Expect, [string]$Json, [string]$Label, [string]$Branch)
+    $result = Invoke-Hook -Json $Json -Branch $Branch
+    if ($result -match "`"$Expect`"") {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected $Expect, got: $result")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host '=== pr-target-guard.ps1 tests ==='
+Write-Host ''
+Write-Host '[Fail-closed]'
+Assert-Decision 'deny'  ''              'Empty input -> deny'
+Assert-Decision 'deny'  'INVALID_JSON'  'Malformed JSON -> deny'
+
+Write-Host ''
+Write-Host '[Scope: non-create gh commands pass through]'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr view 123"}}'        'gh pr view -> allow'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr merge 42 --squash"}}' 'gh pr merge -> allow (not create)'
+
+Write-Host ''
+Write-Host '[gh pr create targeting main: deny]'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --base main --title t"}}'  '--base main -> deny'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --base=main --title t"}}'  '--base=main -> deny'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create -B main --title t"}}'      '-B main -> deny'
+
+Write-Host ''
+Write-Host '[gh pr create targeting master: deny (parity fix)]'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --base master --head fix/x --title t"}}'  '--base master from feature -> deny'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --base=master --title t"}}'              '--base=master -> deny'
+
+Write-Host ''
+Write-Host '[Release exceptions: develop/release/* -> main|master allowed]'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --base main --head develop --title rel"}}'      'develop -> main -> allow'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --base master --head develop --title rel"}}'    'develop -> master -> allow'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --base main --head release/1.0 --title rel"}}'  'release/1.0 -> main -> allow'
+
+Write-Host ''
+Write-Host '[Normal workflow]'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --base develop --title t"}}'  '--base develop -> allow'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --base main-backup --title t"}}' '--base main-backup -> allow (not exact main)'
+
+Write-Host ''
+Write-Host '[Default-branch resolution when --base missing (#616 parity)]'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --head fix/x --title t"}}'   'main-default + feature head -> deny'   'main'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --head develop --title rel"}}' 'main-default + develop head -> allow' 'main'
+Assert-Decision 'deny'  '{"tool_input":{"command":"gh pr create --head fix/x --title t"}}'   'master-default + feature head -> deny' 'master'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --title t"}}'                'develop-default + no base -> allow'    'develop'
+Assert-Decision 'allow' '{"tool_input":{"command":"gh pr create --title t"}}'                'trunk-default -> allow (not main/master)' 'trunk'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-sensitive-file-guard.ps1
+++ b/tests/hooks/test-sensitive-file-guard.ps1
@@ -77,6 +77,17 @@ Assert-Deny -InputJson '{"tool_input":{"file_path":"config/credentials/aws.json"
 Assert-Deny -InputJson '{"tool_input":{"file_path":"config/passwords/list.txt"}}' -Label 'passwords/ -> deny'
 
 Write-Host ''
+Write-Host '[SSH private keys + AWS credentials (parity with .sh)]'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/home/u/.ssh/id_rsa"}}' -Label 'id_rsa -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"id_ed25519"}}' -Label 'id_ed25519 -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/keys/id_ecdsa.bak"}}' -Label 'id_ecdsa.bak -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/home/u/.ssh/id_ed25519.pub"}}' -Label 'id_ed25519.pub -> deny (parity)'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/home/u/.aws/credentials"}}' -Label '.aws/credentials -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/home/u/.aws/config"}}' -Label '.aws/config -> deny'
+Assert-Allow -InputJson '{"tool_input":{"file_path":"src/config"}}' -Label 'non-.aws config -> allow'
+Assert-Allow -InputJson '{"tool_input":{"file_path":"src/identity.py"}}' -Label 'id-prefixed non-key -> allow'
+
+Write-Host ''
 Write-Host '[Allowed system paths]'
 Assert-Allow -InputJson '{"tool_input":{"file_path":"/private/tmp/claude_test"}}' -Label '/private/tmp -> allow (macOS system)'
 


### PR DESCRIPTION
## What
Restore behavioral parity between seven PowerShell guards and their canonical `.sh` siblings (deep-audit-2026-05-29, P1 group A).

| Guard | Fix |
|-------|-----|
| merge-gate-guard.ps1 | add squash-only `--merge`/`--rebase` deny (#478) |
| pr-target-guard.ps1 | block `main` AND `master`; resolve default branch when `--base` absent (#616) |
| commit-message-guard.ps1 | three-pattern attribution check (no more false-rejects of casual mentions) |
| memory-write-guard.ps1 | fail-closed on secret-check exit code 2 (#618) |
| LanguageValidator.psm1 | allowlist English typographic code points (#583) |
| sensitive-file-guard.ps1 | block SSH private keys and `.aws` credential files |

Attribution logic is factored into a shared `lib/AttributionValidator.psm1` (single source of truth) imported by both `attribution-guard.ps1` and `commit-message-guard.ps1`.

## Why
These were confirmed divergences from a stated invariant (decision parity between `.sh` and `.ps1`). On Windows: merge-gate/pr-target weakened branching enforcement; the attribution and typographic checks over-blocked legitimate commits/PRs; memory-write failed open in the common `OWNER_EMAILS`-unset state.

## Where
`global/hooks/*.ps1`, `global/hooks/lib/{AttributionValidator,LanguageValidator}.psm1`, `tests/hooks/test-*.ps1`.

## How (verification)
New/extended PowerShell parity suites; all pass locally on pwsh 7:
- merge-gate-squash-only 6/6, pr-target 19/19, commit-message 8/8, sensitive-file 38/38, language-validator 29/29.
- `gen-hooks-md.sh --check`, `test-windows-hooks-parity.sh`, `test-hook-ordering.sh` all pass.

The new module ships via `install.ps1`'s `*.psm1` glob.

## Deferred (tracked follow-ups)
- `bash-write-guard.ps1` argv read-before-edit (high-risk argv parsing).
- `commit-message-guard.ps1` Rule 1 case-insensitive type match parity.

Refs: docs/deep-audit-2026-05-29.md
