### PR TITLE
fix(hooks): preflight scope and unicode anchors

### DIFF
--- a/global/hooks/github-api-preflight.sh
+++ b/global/hooks/github-api-preflight.sh
@@ -41,8 +41,10 @@ EOF
     exit 0
 }
 
-# Only check GitHub-related commands
-if ! echo "$CMD" | grep -qE '(gh |github\.com|api\.github\.com)'; then
+# Only check GitHub-related commands. The `gh` detection is word-bounded
+# (reusing gh-write-verb-guard's prefilter) so benign words like 'high' or
+# 'weigh' no longer trigger a network curl on every Bash call.
+if ! echo "$CMD" | grep -qE '(^|[[:space:]`(])gh[[:space:]]|github\.com|api\.github\.com'; then
     allow_response
 fi
 
@@ -59,7 +61,7 @@ fi
 # `gh auth status` may still report failure (e.g. empty keyring in containers,
 # CI runners, or sandboxed envs). Token-based auth works regardless, so skip
 # the keyring check in that case to avoid false-positive warnings.
-if echo "$CMD" | grep -qE '^gh '; then
+if echo "$CMD" | grep -qE '(^|[[:space:]`(])gh[[:space:]]'; then
     if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
         if ! gh auth status >/dev/null 2>&1; then
             allow_response "GitHub CLI not authenticated. Run 'gh auth login' or 'gh auth status' to check."

--- a/global/hooks/markdown-anchor-validator.sh
+++ b/global/hooks/markdown-anchor-validator.sh
@@ -72,6 +72,17 @@ if [ ${#MD_FILES[@]} -eq 0 ]; then
     exit 0
 fi
 
+# perl with Unicode property support generates locale-independent anchors
+# (\p{L}\p{N}\p{Pc}) so Korean/CJK headings produce byte-identical anchors to
+# markdown-anchor-validator.ps1 regardless of the installed locale. Fall open
+# if perl is absent, matching the jq/bash-4 guards above (never block on an
+# environment issue).
+if ! command -v perl >/dev/null 2>&1; then
+    echo "markdown-anchor-validator: perl not found on PATH; skipping validation" >&2
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+    exit 0
+fi
+
 # === Single-pass AWK extraction ===
 # Extract headings and references from all files in one awk invocation.
 # Output format (TSV):
@@ -139,10 +150,12 @@ if [ -n "$H_LINES" ]; then
     # Extract heading texts (field 3+) → bulk transform to GitHub-style anchors
     # Pipeline: strip formatting markers → lowercase → remove non-alnum/space/hyphen/underscore → spaces→hyphens → trim
     # NOTE: GitHub does NOT collapse consecutive hyphens (e.g., "A / B" → "a--b")
+    # Locale-independent anchor transform (Unicode-aware) matching the .ps1.
+    # perl emits exactly one line per input heading (print "$_\n") so the
+    # paste with TMP_FILES stays row-aligned.
     echo "$H_LINES" | cut -f3- | \
         sed -e 's/\]([^)]*)//g' -e 's/\[//g' -e 's/\*//g' -e 's/`//g' -e 's/<[^>]*>//g' | \
-        tr '[:upper:]' '[:lower:]' | \
-        sed -e 's/[^[:alnum:]_ -]//g' -e 's/ /-/g' -e 's/^-//;s/-$//' \
+        perl -CSAD -ne 'chomp; $_=lc; s/[^\p{L}\p{N}\p{Pc} -]//g; s/ /-/g; s/^-//; s/-$//; print "$_\n"' \
         > "$TMP_ANCHORS"
 
     # Merge file paths with generated anchors and build registry
@@ -205,10 +218,12 @@ resolve_file_anchors() {
     local -A counts=()
     local anchor
     while IFS= read -r heading; do
+        # Locale-independent anchor transform (Unicode-aware) matching the
+        # .ps1 and the bulk pipeline above; bare `print` (no trailing newline)
+        # because command substitution captures the value.
         anchor=$(printf '%s' "$heading" \
             | sed -e 's/\]([^)]*)//g' -e 's/\[//g' -e 's/\*//g' -e 's/`//g' -e 's/<[^>]*>//g' \
-            | tr '[:upper:]' '[:lower:]' \
-            | sed -e 's/[^[:alnum:]_ -]//g' -e 's/ /-/g' -e 's/^-//;s/-$//')
+            | perl -CSAD -ne 'chomp; $_=lc; s/[^\p{L}\p{N}\p{Pc} -]//g; s/ /-/g; s/^-//; s/-$//; print')
         [[ -z "$anchor" ]] && continue
         if [[ -n "${counts[$anchor]+x}" ]]; then
             counts["$anchor"]=$(( counts["$anchor"] + 1 ))

--- a/tests/hooks/test-github-api-preflight.sh
+++ b/tests/hooks/test-github-api-preflight.sh
@@ -96,6 +96,16 @@ assert_not_contains "$result" "GitHub CLI not authenticated" \
     "gh pr view (GITHUB_TOKEN) → no auth warning"
 
 echo ""
+echo "[Overmatch fix: benign 'gh' substrings skip the network/auth probe]"
+# 'high'/'weigh' contain the letters g-h but are not the gh CLI. The
+# word-bounded scope gate must skip them entirely (plain allow, no curl,
+# no auth check) instead of firing a network round-trip on every Bash call.
+result=$(run_hook '{"tool_input":{"command":"echo high and weigh in"}}' "")
+assert_contains "$result" '"allow"' "echo high and weigh → allow"
+assert_not_contains "$result" "unreachable" "benign substring → no connectivity probe"
+assert_not_contains "$result" "not authenticated" "benign substring → no auth probe"
+
+echo ""
 echo "=== Results ==="
 echo "Passed: $PASS"
 echo "Failed: $FAIL"

--- a/tests/hooks/test-markdown-anchor-validator.ps1
+++ b/tests/hooks/test-markdown-anchor-validator.ps1
@@ -227,6 +227,24 @@ if ($missingFileOut -match '"deny"') {
 }
 
 Write-Host ''
+Write-Host '[CJK/Korean anchors: locale-independent generation (deep-audit P1)]'
+Assert-Allow -Label 'Korean heading + correct Unicode ref -> allow' `
+    -Params @{ StagedFixture = 'cjk-anchor.md' }
+# Negative case authored inline (a committed broken-anchor fixture would trip
+# the markdown-anchor PreToolUse hook on its own commit). The Unicode anchor
+# is 설치-가이드-setup, so a ref to the ASCII-stripped "#-setup" must deny.
+$cjkBrokenOut = Invoke-InlineHookCapture `
+    -SourceContent "# 설치 가이드 Setup`n`n[broken](#-setup)`n"
+if ($cjkBrokenOut -match '"deny"') {
+    $script:Passed++
+    Write-Host '  PASS: Korean heading + ASCII-stripped ref -> deny' -ForegroundColor Green
+} else {
+    $script:Failed++
+    $script:Errors.Add("FAIL: korean broken anchor - expected deny, got: $cjkBrokenOut")
+    Write-Host '  FAIL: Korean heading + ASCII-stripped ref -> deny' -ForegroundColor Red
+}
+
+Write-Host ''
 Write-Host '[Non-commit commands pass through]'
 $result = '{"tool_input":{"command":"ls -la"}}' | & pwsh -NoProfile -File $script:HookPath 2>$null
 if ($result -match '"allow"') {

--- a/tests/hooks/test-markdown-anchor-validator.sh
+++ b/tests/hooks/test-markdown-anchor-validator.sh
@@ -249,6 +249,34 @@ else
 fi
 
 echo ""
+echo "[CJK/Korean anchors: locale-independent generation (deep-audit P1)]"
+assert_allow_fixture "cjk-anchor.md" "Korean heading + correct Unicode ref → allow"
+# Negative case authored inline (a committed broken-anchor fixture would trip
+# the markdown-anchor PreToolUse hook on its own commit). The heading
+# "설치 가이드 Setup" yields the Unicode anchor 설치-가이드-setup, so a ref to
+# the C-locale ASCII-stripped "#-setup" must be denied — proving the
+# validator generates the locale-independent anchor.
+tmpdir=$(mktemp -d)
+out=$(
+    cd "$tmpdir" && \
+    git init -q && \
+    git config user.email "ci@example.com" && \
+    git config user.name "CI" && \
+    mkdir -p docs && \
+    printf '# %s\n\n[broken](#-setup)\n' '설치 가이드 Setup' > docs/cjk.md && \
+    git add docs/cjk.md && \
+    echo '{"tool_input":{"command":"git commit -m test"}}' | bash "${root_abs}/${HOOK}" 2>/dev/null
+)
+rm -rf "$tmpdir"
+if echo "$out" | grep -q '"deny"'; then
+    PASS=$((PASS + 1)); echo "  PASS: Korean heading + ASCII-stripped ref → deny"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: korean broken anchor — expected deny, got: $out")
+    echo "  FAIL: Korean heading + ASCII-stripped ref → deny"
+fi
+
+echo ""
 echo "[Non-commit commands pass through]"
 # These don't need a fixture — they exit before reading any markdown.
 result=$(echo '{"tool_input":{"command":"ls -la"}}' | bash "$HOOK" 2>/dev/null)

--- a/tests/markdown-anchor-validator/fixtures/cjk-anchor.md
+++ b/tests/markdown-anchor-validator/fixtures/cjk-anchor.md
@@ -1,0 +1,7 @@
+# 설치 가이드 (Setup)
+
+See [설치 가이드](#설치-가이드-setup) below for installation.
+
+## 개요 Overview
+
+Jump to [개요 Overview](#개요-overview).


### PR DESCRIPTION
## What
Two hook correctness fixes (deep-audit-2026-05-29, P1 group D).

| Hook | Fix |
|------|-----|
| github-api-preflight.sh | word-bound the `gh` scope + auth-status detection (reuse gh-write-verb-guard's prefilter) — benign words like `high`/`weigh` no longer fire a network curl; chained `cd x && gh ...` now reaches the auth diagnostic |
| markdown-anchor-validator.sh | locale-independent perl `\p{L}\p{N}\p{Pc}` anchor transform (replacing locale-dependent `[:alnum:]` sed) so Korean/CJK headings produce byte-identical anchors to the `.ps1`; falls open if perl absent |

## Why
- The unanchored `gh ` matcher fired a `curl` (timeout 10) on every Bash command containing the letters g-h (e.g. `high`), adding latency and false "GitHub unreachable" context; the `^gh ` auth gate missed `cd x && gh ...`.
- The anchor validator built different anchor registries on the same tree when the `.sh` locale fallback landed on `C` (Hangul stripped) vs the always-Unicode `.ps1` — a real allow/deny divergence in a repo that uses Korean headings heavily.

## Where
`global/hooks/github-api-preflight.sh`, `global/hooks/markdown-anchor-validator.sh`, `tests/hooks/test-*`, `tests/markdown-anchor-validator/fixtures/cjk-anchor.md`.

## How (verification)
- `bash -n` on both hooks; `gen-hooks-md.sh --check` clean.
- New shared `cjk-anchor.md` fixture + an inline broken-anchor negative case (a committed broken fixture would trip the markdown-anchor PreToolUse hook on its own commit). Both runners now produce identical decisions: `test-markdown-anchor-validator.sh` and `.ps1` 11/11 each.
- `test-github-api-preflight.sh` extended with benign-substring cases: 10/10.

## Note
The `s/^-//; s/-$//` single-hyphen trim is preserved (matches the original `.sh`); the `.ps1` `.Trim('-')` multi-hyphen difference is pre-existing and out of scope.

Refs: docs/deep-audit-2026-05-29.md
