### PR TITLE
fix(scripts): validate_skills windows-bash paths

### DIFF
--- a/scripts/validate_skills.sh
+++ b/scripts/validate_skills.sh
@@ -401,12 +401,21 @@ if python3 -c "import yaml" 2>/dev/null; then
     for skill_file in "${SKILL_FILES[@]}"; do
         relative_path="${skill_file#$BACKUP_DIR/}"
 
+        # A native (non-cygwin) python3 — common on Windows Git Bash / Cygwin —
+        # cannot open a /x/... POSIX-style absolute path. Convert to a mixed
+        # Windows path (D:/...) via cygpath when available; on Linux/macOS
+        # cygpath is absent and the path is used as-is.
+        py_skill_file="$skill_file"
+        if command -v cygpath >/dev/null 2>&1; then
+            py_skill_file="$(cygpath -m "$skill_file")"
+        fi
+
         # 파일에서 직접 frontmatter 추출 및 YAML 검증
         if python3 -c "
 import yaml
 import sys
 
-with open('$skill_file', 'r') as f:
+with open('$py_skill_file', 'r', encoding='utf-8') as f:
     content = f.read()
 
 # frontmatter 추출


### PR DESCRIPTION
## What
Make `validate_skills.sh` work on Windows Git Bash / Cygwin (deep-audit-2026-05-29, discovered during P1 group E).

## Why
The script built POSIX-style absolute paths (`/d/...`) and passed them to a **native Windows `python3`**, which cannot open them. Every non-trivial `SKILL.md` failed YAML validation with `FileNotFoundError`, so the installed **pre-commit hook blocked all `SKILL.md` commits** in that environment (351 → 38 failed locally). CI (Linux) was unaffected.

## How
- Convert each skill path to a mixed Windows path (`D:/...`) via `cygpath -m` when `cygpath` is present; Linux/macOS use the path as-is (no-op).
- Open with explicit `encoding='utf-8'` so non-ASCII (Korean, em-dash) content does not trip a cp949 default-locale decode.

## Verification
`validate_skills.sh` now reports **351 passed, 0 failed** locally (was 38 failed). Guarded on `command -v cygpath`, so it is a no-op on Linux/macOS CI.

Refs: docs/deep-audit-2026-05-29.md
