### PR TITLE
fix(release): correct non-suite tags, govern hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ claude-config does **not** carry a single repo-wide version. Each shipped artifa
 | `plugin` | Marketplace plugin version | `plugin/.claude-plugin/plugin.json` |
 | `plugin-lite` | Lite plugin (behavioral guardrails) | `plugin-lite/.claude-plugin/plugin.json` |
 | `settings-schema` | Hook-emitting `settings.json` schema | `global/settings.json`, `global/settings.windows.json` |
-| `hooks` | Shipping hook bundle (bumped per rollout) | Surfaced via `HOOKS.md` and `ENFORCEMENT.md` |
+| `hooks` | Shipping hook-bundle label (bumped per rollout) | _none — SemVer-validated by `check_versions`, no consumer file; bump via `/release --target hooks` (tag `hooks-v<version>`)_ |
 
 `scripts/check_versions.sh` verifies each consumer file matches the field declared in `VERSION_MAP.yml`. Use `/release <field> <new-version>` (or `scripts/sync_versions.sh`) to bump exactly one field at a time — synchronizing all five fields would defeat the design and produce noisy "compatible-with-X.Y" badges that change for unrelated reasons. See [`docs/CLAUDE_DOCKER_CONTRACT.md`](docs/CLAUDE_DOCKER_CONTRACT.md) for how `suite` couples to claude-docker's tag line.
 

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -9,9 +9,11 @@
 #   plugin          -> plugin/.claude-plugin/plugin.json (version)
 #   plugin-lite     -> plugin-lite/.claude-plugin/plugin.json (version)
 #   settings-schema -> global/settings.json, global/settings.windows.json (version)
-#   hooks           -> global/hooks/* shipping bundle; bumped per rollout
-#                      (e.g. P4 timeline, attribution-guard scope changes).
-#                      Surfaced to operators via HOOKS.md and ENFORCEMENT.md.
+#   hooks           -> shipping hook-bundle label; bumped per rollout (e.g. P4
+#                      timeline, attribution-guard scope changes). No consumer
+#                      file to mirror — check_versions only validates that the
+#                      value is well-formed SemVer. Bumpable/taggable via
+#                      `/release --target hooks` (tag: hooks-v<version>).
 #
 # To bump a version: edit the field here, then run scripts/sync_versions.sh
 # (or /release <field> <new-version>) to propagate to consumers.

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -42,7 +42,7 @@ Create a release with automated changelog generation from commits since last rel
 `$ARGUMENTS` format: `<version> [options]` or `<organization>/<project-name> <version> [options]`
 
 - **version**: Semantic version (e.g., 1.2.0, 2.0.0-beta.1)
-- **--target**: Which version track to bump. One of: `suite` (default), `plugin`, `plugin-lite`, `settings-schema`. See "Version Source" below.
+- **--target**: Which version track to bump. One of: `suite` (default), `plugin`, `plugin-lite`, `settings-schema`, `hooks`. See "Version Source" below.
 - **--draft**: Create as draft release (not published)
 - **--prerelease**: Mark as pre-release
 - **--solo**: Force solo mode — single agent handles all steps sequentially
@@ -61,6 +61,7 @@ When this skill runs in the claude-config repository (or any repo that declares 
 | `plugin`          | `plugin/.claude-plugin/plugin.json`                        |
 | `plugin-lite`     | `plugin-lite/.claude-plugin/plugin.json`                   |
 | `settings-schema` | `global/settings.json`, `global/settings.windows.json`     |
+| `hooks`           | _`VERSION_MAP.yml` field only — SemVer-validated by `check_versions`, no consumer file to mirror; bumpable and taggable per hook-bundle rollout_ |
 
 Each field moves on its own SemVer track — bumping `plugin` does NOT bump the others.
 `--target <field>` selects which field to update; default is `suite`.
@@ -108,6 +109,7 @@ fi
 |--------|--------|---------|-------------|
 | `--draft` | flag | false | Create release as draft (not published) |
 | `--prerelease` | flag | false | Mark release as pre-release |
+| `--target` | suite\|plugin\|plugin-lite\|settings-schema\|hooks | suite | Independent SemVer track to bump |
 | `--org` | string | auto-detect | GitHub organization or user |
 
 ## Instructions
@@ -208,7 +210,7 @@ update the map, and propagate to consumers before cutting the release PR:
 if [ -f VERSION_MAP.yml ]; then
     # Parse --target flag (default: suite)
     TARGET="suite"
-    if [[ "$ARGUMENTS" =~ --target[[:space:]]+(suite|plugin|plugin-lite|settings-schema) ]]; then
+    if [[ "$ARGUMENTS" =~ --target[[:space:]]+(suite|plugin|plugin-lite|settings-schema|hooks) ]]; then
         TARGET="${BASH_REMATCH[1]}"
     fi
 
@@ -431,8 +433,14 @@ PROTECTION
 ### 8. Create GitHub Release
 
 ```bash
-# Build release command
-RELEASE_CMD="gh release create v$VERSION --repo $ORG/$PROJECT --title \"v$VERSION\""
+# Build release command. Re-derive TAG_NAME here (Step 7 may run in a
+# separate shell) so non-suite tracks publish against the tag that was
+# actually pushed (<target>-v$VERSION), not a mismatched v$VERSION.
+TAG_NAME="v$VERSION"
+if [ -f VERSION_MAP.yml ] && [ "${TARGET:-suite}" != "suite" ]; then
+    TAG_NAME="${TARGET}-v$VERSION"
+fi
+RELEASE_CMD="gh release create $TAG_NAME --repo $ORG/$PROJECT --title \"$TAG_NAME\""
 
 # Add draft flag if specified
 if [[ "$ARGUMENTS" == *"--draft"* ]]; then
@@ -499,8 +507,8 @@ After completion, provide summary:
 | Version | vVERSION |
 | Type | Release / Draft / Pre-release |
 | Execution mode | Solo / Team |
-| Tag | vVERSION |
-| URL | https://github.com/ORG/PROJECT/releases/tag/vVERSION |
+| Tag | TAG_NAME (`v$VERSION`, or `<target>-v$VERSION` for non-suite tracks) |
+| URL | https://github.com/ORG/PROJECT/releases/tag/TAG_NAME |
 
 ### Changelog Summary
 | Category | Count |

--- a/scripts/check_versions.ps1
+++ b/scripts/check_versions.ps1
@@ -38,6 +38,7 @@ $Suite          = Read-MapField 'suite'
 $Plugin         = Read-MapField 'plugin'
 $PluginLite     = Read-MapField 'plugin-lite'
 $SettingsSchema = Read-MapField 'settings-schema'
+$Hooks          = Read-MapField 'hooks'
 
 $drift = 0
 
@@ -90,9 +91,16 @@ Test-JsonVersion 'global/settings.windows.json'           $SettingsSchema 'setti
 Test-ReadmeBadge 'README.md'    $Suite
 Test-ReadmeBadge 'README.ko.md' $Suite
 
+# hooks has no consumer file to mirror; validate only that the declared value
+# is well-formed SemVer so the field cannot silently rot (deep-audit P1).
+if ($Hooks -notmatch '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$') {
+    Write-Host "FAIL: hooks=$Hooks is not valid SemVer in VERSION_MAP.yml" -ForegroundColor Red
+    $drift = 1
+}
+
 if ($drift -eq 0) {
     Write-Host "check_versions: OK"
-    Write-Host "  suite=$Suite  plugin=$Plugin  plugin-lite=$PluginLite  settings-schema=$SettingsSchema"
+    Write-Host "  suite=$Suite  plugin=$Plugin  plugin-lite=$PluginLite  settings-schema=$SettingsSchema  hooks=$Hooks"
     exit 0
 }
 

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -38,6 +38,7 @@ SUITE=$(read_map_field "suite")
 PLUGIN=$(read_map_field "plugin")
 PLUGIN_LITE=$(read_map_field "plugin-lite")
 SETTINGS_SCHEMA=$(read_map_field "settings-schema")
+HOOKS=$(read_map_field "hooks")
 
 drift=0
 
@@ -88,9 +89,16 @@ check_json_version "global/settings.windows.json"            "$SETTINGS_SCHEMA" 
 check_readme_badge "README.md"    "$SUITE"
 check_readme_badge "README.ko.md" "$SUITE"
 
+# hooks has no consumer file to mirror; validate only that the declared value
+# is well-formed SemVer so the field cannot silently rot (deep-audit P1).
+if ! printf '%s' "$HOOKS" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+    echo "FAIL: hooks=$HOOKS is not valid SemVer in VERSION_MAP.yml" >&2
+    drift=1
+fi
+
 if [ "$drift" -eq 0 ]; then
     echo "check_versions: OK"
-    echo "  suite=$SUITE  plugin=$PLUGIN  plugin-lite=$PLUGIN_LITE  settings-schema=$SETTINGS_SCHEMA"
+    echo "  suite=$SUITE  plugin=$PLUGIN  plugin-lite=$PLUGIN_LITE  settings-schema=$SETTINGS_SCHEMA  hooks=$HOOKS"
     exit 0
 fi
 


### PR DESCRIPTION
## What
/release multi-track defects + hooks version-track governance (deep-audit-2026-05-29, P1 group E).

| Area | Fix |
|------|-----|
| Step 8 tag | `gh release create` re-derives `TAG_NAME` (shell-scope-safe) and uses it for the ref + title, instead of hardcoding `v$VERSION` — non-suite tracks (plugin/plugin-lite/settings-schema/hooks) were publishing against a tag that was never pushed |
| `--target hooks` | added to the argument-hint, Options table, Version Source table, and parse alternation (was silently falling back to `suite`) |
| hooks governance | `check_versions.{sh,ps1}` now SemVer-validate the `hooks` field; `VERSION_MAP.yml` + `README.md` drop the false "surfaced via HOOKS.md/ENFORCEMENT.md" claim and document it accurately as a reference-only, bumpable/taggable label with no consumer file |

## Why
Step 7 computes `<target>-v$VERSION` for non-suite tracks but Step 8 ignored it and published `v$VERSION` — a mismatched/unpushed tag for every plugin/settings-schema/hooks release. The `hooks` field was declared a governed track yet read by no checker/syncer/release path and carried a false consumer claim.

## Approach (doc-only for hooks)
Chosen the minimal, non-speculative path: validate `hooks` as SemVer (so the field cannot silently rot) and document it truthfully, rather than build a new HOOKS.md consumer line. `sync_versions` is intentionally untouched (hooks has no consumer to propagate to).

## Where
`global/skills/_internal/release/SKILL.md`, `VERSION_MAP.yml`, `scripts/check_versions.{sh,ps1}`, `README.md`.

## How (verification)
- `check_versions.sh` and `check_versions.ps1` → OK (`hooks=1.1.0`).
- SemVer assertion correctly fails on a malformed `hooks` value (manual negative test).
- `--target hooks` matches the parse alternation.
- `validate_skills.sh` passes on the edited `release/SKILL.md` (requires #660).

Depends on: #660 (validate_skills cross-platform paths).
Refs: docs/deep-audit-2026-05-29.md
