### PR TITLE
chore(plugin): drop temperature from plugin agents

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -3,7 +3,6 @@ name: code-reviewer
 description: Comprehensive code review covering quality, security, performance, and maintainability. Reports findings with file:line references and severity ratings. Use when reviewing PRs, auditing code changes, or checking code quality in any language.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.3
 maxTurns: 30
 effort: high
 memory: project

--- a/plugin/agents/codebase-analyzer.md
+++ b/plugin/agents/codebase-analyzer.md
@@ -3,7 +3,6 @@ name: codebase-analyzer
 description: Analyzes codebase architecture, patterns, conventions, and dependency structure. Reports findings with file:line references and confidence scores. Use when exploring unfamiliar codebases, auditing architecture, or mapping module boundaries.
 model: sonnet
 tools: Read, Glob, Grep
-temperature: 0.2
 maxTurns: 25
 effort: high
 memory: project

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -3,7 +3,6 @@ name: dependency-auditor
 description: Audits project dependencies for CVEs, license conflicts, outdated versions, and unused packages. Runs language-specific audit tools and cross-references vulnerability databases. Use when reviewing dependency security, checking for supply chain risks, or auditing license compliance.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.1
 maxTurns: 20
 effort: high
 memory: project

--- a/plugin/agents/documentation-writer.md
+++ b/plugin/agents/documentation-writer.md
@@ -3,7 +3,6 @@ name: documentation-writer
 description: Creates and updates technical documentation including README files, API references, architecture docs, and changelogs. Matches existing documentation style and structure. Use when documentation needs creation or update after code changes.
 model: sonnet
 tools: Read, Write, Edit, Glob
-temperature: 0.5
 maxTurns: 30
 effort: high
 memory: project

--- a/plugin/agents/qa-reviewer.md
+++ b/plugin/agents/qa-reviewer.md
@@ -3,7 +3,6 @@ name: qa-reviewer
 description: Verifies integration coherence and cross-boundary contracts. Checks API response shapes vs frontend consumers, route path mappings, state transition completeness, and endpoint coverage. Use when verifying that connected components agree on contracts, shapes, and paths.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.2
 maxTurns: 30
 effort: high
 memory: project

--- a/plugin/agents/refactor-assistant.md
+++ b/plugin/agents/refactor-assistant.md
@@ -3,7 +3,6 @@ name: refactor-assistant
 description: Safely improves code structure without changing behavior. Applies extract method, rename, inline, and other refactoring techniques with test verification before and after each change. Use when reducing duplication, improving readability, or restructuring modules.
 model: sonnet
 tools: Read, Edit, Glob, Grep
-temperature: 0.2
 maxTurns: 25
 effort: high
 memory: project

--- a/plugin/agents/structure-explorer.md
+++ b/plugin/agents/structure-explorer.md
@@ -3,7 +3,6 @@ name: structure-explorer
 description: Maps project directory structure, classifies files by purpose, and identifies key entry points, build configs, and CI workflows. Reports concise structure summaries. Use when surveying unfamiliar projects or mapping file organization.
 model: haiku
 tools: Glob, Read
-temperature: 0.1
 maxTurns: 15
 effort: medium
 memory: local

--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -3,7 +3,6 @@ name: test-strategist
 description: Analyzes test coverage gaps, designs test strategies, and generates test skeletons. Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or generating test scaffolding.
 model: sonnet
 tools: Read, Grep, Glob, Bash
-temperature: 0.3
 maxTurns: 25
 effort: high
 memory: project


### PR DESCRIPTION
## What
Remove the non-canonical `temperature:` frontmatter field from all 8 `plugin/agents/*.md` (deep-audit-2026-05-29, P1 group B — the concrete, safe part).

## Why
`temperature` is not an official Claude Code agent field — agent determinism is controlled by `effort` (see `harness/reference/agent-frontmatter-spec.md` §9). The field was already removed from `project/.claude/agents` in #648; the plugin copies still carried it. Claude Code silently ignores it, so removal is behavior-neutral and restores cross-layer consistency.

## Scope decision (deferred)
The audit's broader remediation — a body-diff CI guard between `plugin/agents` and `project/.claude/agents`, and syncing the ~29 `plugin/skills/*/reference/*` files to `rules/` — is **intentionally deferred**. `plugin/` is a decoupled standalone distribution: its agents use generic wording (no repo-specific `rules/coding/cpp-specifics.md` paths) and its skill references strip YAML frontmatter and soften imperatives. A byte-identical mirror guard would fight that design and regress the distribution. Whether to canonicalize the plugin copies, build a transform-aware guard, or keep them independently maintained is a maintainer/product decision, not an autonomous change.

## Where
`plugin/agents/*.md` (8 files, 8 deletions).

## How (verification)
All 8 frontmatter blocks still parse as valid YAML; `effort: high` (etc.) remains as the determinism control.

Refs: docs/deep-audit-2026-05-29.md
