### PR TITLE
feat(scripts): guard plugin/project agent drift

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -15,6 +15,11 @@ on:
       - 'scripts/validate_skills.sh'
       - 'scripts/check_references.sh'
       - 'scripts/sync_references.sh'
+      - 'scripts/check_agents.sh'
+      - 'scripts/check_agents.ps1'
+      - 'tests/scripts/test-check-agents.sh'
+      - 'plugin/agents/**'
+      - 'project/.claude/agents/**'
       - 'scripts/spec_lint.sh'
       - 'scripts/spec_lint.ps1'
       - 'scripts/spec_lint.py'
@@ -62,6 +67,15 @@ jobs:
 
       - name: Check workflow reference mirrors match canonical
         run: ./scripts/check_references.sh
+
+      - name: Check plugin/project agent bodies in sync
+        # plugin/agents and project/.claude/agents are near-duplicate copies;
+        # this guard strips per-layer frontmatter and the one genericized
+        # rules-path sentence, then fails if the bodies otherwise diverge.
+        run: ./scripts/check_agents.sh
+
+      - name: Run agent drift guard test suite
+        run: bash tests/scripts/test-check-agents.sh
 
       - name: Check VERSION_MAP consumers match declared values
         run: ./scripts/check_versions.sh

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -206,6 +206,16 @@ pwsh scripts/sync_references.ps1   # Windows
 
 **Why this pattern**: Symlinks do not round-trip reliably through `git clone` on default Windows configurations. Build-time sync keeps all three files byte-identical without requiring platform-specific filesystem features.
 
+### Agent Definitions (drift guard)
+
+**Type**: Repository-internal convention
+
+The eight agent definitions exist in two layers — `project/.claude/agents/` and the standalone `plugin/agents/` bundle. They are near-duplicates but **not** byte-identical by design: frontmatter differs per layer (the project copy carries `color:`; neither carries the non-canonical `temperature:` field), and the body genericizes exactly one repo-specific "language-specific rules" sentence in the plugin copy.
+
+**CI enforcement**: `.github/workflows/validate-skills.yml` runs `scripts/check_agents.sh` (PowerShell twin: `scripts/check_agents.ps1`). It strips frontmatter and normalizes that single sentence, then fails (exit 2) if the agent **bodies** otherwise diverge — so a behavioral instruction edited in one layer but not the other cannot ship silently.
+
+**Skill reference files are intentionally NOT guarded this way.** Beyond the four workflow references above, the `plugin/skills/*/reference/` tree is a curated *re-structuring* of `project/.claude/rules/` — content is split and recombined across files (e.g. `rules/api/observability.md` becomes `observability.md` + `logging.md`; `rules/coding/` standards fan out into `general.md`/`quality.md`/`concurrency.md`/`memory.md`). A per-file 1:1 drift check would false-positive on that reorganization, so the plugin reference bundle is maintained as an independent curated distribution.
+
 ### Version Declarations (VERSION_MAP SSOT)
 
 **Type**: Repository-internal convention

--- a/scripts/check_agents.ps1
+++ b/scripts/check_agents.ps1
@@ -1,0 +1,61 @@
+#Requires -Version 7.0
+# check_agents.ps1 — PowerShell twin of check_agents.sh.
+# Drift guard for the 8 agent definitions duplicated across plugin/agents/
+# and project/.claude/agents/. See check_agents.sh for the full rationale:
+# frontmatter differs per layer and one repo-path sentence is genericized in
+# the plugin copy; the bodies must otherwise stay identical.
+# Exit: 0 = in sync, 2 = drift.
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir   = Split-Path -Parent $ScriptDir
+
+$Agents = @(
+    'code-reviewer'
+    'codebase-analyzer'
+    'dependency-auditor'
+    'documentation-writer'
+    'qa-reviewer'
+    'refactor-assistant'
+    'structure-explorer'
+    'test-strategist'
+)
+
+function Get-NormalizedBody {
+    param([string]$Path)
+    $dashes = 0
+    $body = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in (Get-Content -LiteralPath $Path -Encoding utf8)) {
+        if ($dashes -lt 2 -and $line -eq '---') { $dashes++; continue }
+        if ($dashes -ge 2) {
+            if ($line -match '^If .*language-specific rules.*read them before starting\.$') {
+                $body.Add('<RULES_PATH_NOTE>')
+            } else {
+                $body.Add($line)
+            }
+        }
+    }
+    return ($body -join "`n")
+}
+
+$drift = 0
+foreach ($a in $Agents) {
+    $p = Join-Path $RootDir "plugin/agents/$a.md"
+    $c = Join-Path $RootDir "project/.claude/agents/$a.md"
+    if (-not (Test-Path -LiteralPath $p)) { Write-Host "FAIL: missing plugin/agents/$a.md"; $drift = 1; continue }
+    if (-not (Test-Path -LiteralPath $c)) { Write-Host "FAIL: missing project/.claude/agents/$a.md"; $drift = 1; continue }
+    if ((Get-NormalizedBody $p) -ne (Get-NormalizedBody $c)) {
+        Write-Host "FAIL: agent body drift: plugin/agents/$a.md vs project/.claude/agents/$a.md"
+        $drift = 1
+    }
+}
+
+if ($drift -eq 0) {
+    Write-Host "check_agents: OK ($($Agents.Count) agent pairs in sync)"
+    exit 0
+}
+
+Write-Host ""
+Write-Host "check_agents: drift detected between plugin/agents and project/.claude/agents."
+exit 2

--- a/scripts/check_agents.sh
+++ b/scripts/check_agents.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check_agents.sh — Drift guard for the 8 agent definitions that are
+# duplicated across plugin/agents/ and project/.claude/agents/.
+#
+# plugin/ is a standalone distribution, so the two copies of each agent are
+# NOT byte-identical by design:
+#   - YAML frontmatter differs per layer (project carries `color:`; neither
+#     carries the non-canonical `temperature:` field anymore — see #648/#662).
+#   - The body genericizes exactly one repo-specific sentence (the
+#     "language-specific rules" note that names rules/coding/cpp-specifics.md
+#     in the project copy and a generic phrasing in the plugin copy).
+#
+# This guard strips the frontmatter and normalizes that single known
+# sentence, then requires the agent BODIES to be otherwise identical, so the
+# near-duplicate pair cannot silently diverge (e.g. a behavioral instruction
+# edited in one copy but not the other).
+#
+# Reference drift is intentionally NOT guarded here: the plugin skill
+# reference tree is a curated RE-STRUCTURING of rules/ (content is split and
+# recombined across files, e.g. observability -> observability + logging), so
+# a per-file 1:1 comparison would false-positive. The 4 byte-identical
+# project-workflow references remain covered by check_references.sh.
+#
+# Exit: 0 = in sync, 2 = drift.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+AGENTS=(
+    code-reviewer
+    codebase-analyzer
+    dependency-auditor
+    documentation-writer
+    qa-reviewer
+    refactor-assistant
+    structure-explorer
+    test-strategist
+)
+
+# Strip YAML frontmatter (through the second '---') and collapse the single
+# intentional repo-path sentence to a placeholder so it is not flagged.
+strip_and_norm() {
+    awk 'BEGIN{f=0} /^---$/{f++; next} f>=2{print}' "$1" \
+        | sed -E 's/^If .*language-specific rules.*read them before starting\.$/<RULES_PATH_NOTE>/'
+}
+
+drift=0
+for a in "${AGENTS[@]}"; do
+    p="$ROOT_DIR/plugin/agents/$a.md"
+    c="$ROOT_DIR/project/.claude/agents/$a.md"
+    if [ ! -f "$p" ]; then echo "FAIL: missing plugin/agents/$a.md" >&2; drift=1; continue; fi
+    if [ ! -f "$c" ]; then echo "FAIL: missing project/.claude/agents/$a.md" >&2; drift=1; continue; fi
+    if ! diff -q <(strip_and_norm "$p") <(strip_and_norm "$c") >/dev/null 2>&1; then
+        echo "FAIL: agent body drift: plugin/agents/$a.md vs project/.claude/agents/$a.md" >&2
+        # `|| true`: diff exits 1 on differences; without it set -e/pipefail
+        # would abort the loop before checking the remaining agents.
+        diff <(strip_and_norm "$p") <(strip_and_norm "$c") 2>/dev/null | sed 's/^/    /' >&2 || true
+        drift=1
+    fi
+done
+
+if [ "$drift" -eq 0 ]; then
+    echo "check_agents: OK (${#AGENTS[@]} agent pairs in sync)"
+    exit 0
+fi
+
+echo "" >&2
+echo "check_agents: drift detected between plugin/agents and project/.claude/agents." >&2
+echo "The body content must match (frontmatter and the single rules-path" >&2
+echo "sentence may differ by design). Reconcile the divergent lines above." >&2
+exit 2

--- a/tests/scripts/test-check-agents.sh
+++ b/tests/scripts/test-check-agents.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# test-check-agents.sh — tests for scripts/check_agents.sh (deep-audit P1-B).
+# Verifies the plugin<->project agent drift guard: in-sync passes, a body
+# divergence fails (exit 2), and frontmatter-only / rules-path-sentence
+# differences are tolerated by design.
+# Run: bash tests/scripts/test-check-agents.sh
+
+set -u
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT="$(pwd)"
+
+# Build an isolated sandbox repo containing all 8 agent pairs plus a copy of
+# the guard, so mutations never touch the real tree. The guard derives its
+# root from its own location, so it inspects the sandbox.
+mk_sandbox() {
+    local d="$1"
+    mkdir -p "$d/scripts" "$d/plugin/agents" "$d/project/.claude/agents"
+    cp "$ROOT/scripts/check_agents.sh" "$d/scripts/"
+    cp "$ROOT"/plugin/agents/*.md "$d/plugin/agents/"
+    cp "$ROOT"/project/.claude/agents/*.md "$d/project/.claude/agents/"
+}
+
+assert_exit() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$actual" -eq "$expected" ]; then
+        PASS=$((PASS + 1)); echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $label — expected exit $expected, got $actual")
+        echo "  FAIL: $label (exit $actual)"
+    fi
+}
+
+echo "=== check_agents.sh tests ==="
+echo ""
+
+# 1. The real repository is in sync.
+bash scripts/check_agents.sh >/dev/null 2>&1
+assert_exit 0 $? "real tree in sync -> exit 0"
+
+# 2. A body divergence is flagged.
+sb=$(mktemp -d); mk_sandbox "$sb"
+printf '\nEXTRA BODY LINE\n' >> "$sb/plugin/agents/qa-reviewer.md"
+( cd "$sb" && bash scripts/check_agents.sh >/dev/null 2>&1 ); rc=$?
+assert_exit 2 $rc "body divergence -> exit 2"
+rm -rf "$sb"
+
+# 3. A frontmatter-only difference is tolerated (frontmatter is stripped).
+sb=$(mktemp -d); mk_sandbox "$sb"
+sed -i '1a color: teal' "$sb/plugin/agents/test-strategist.md"
+( cd "$sb" && bash scripts/check_agents.sh >/dev/null 2>&1 ); rc=$?
+assert_exit 0 $rc "frontmatter-only diff -> exit 0"
+rm -rf "$sb"
+
+# 4. The intentional rules-path sentence variant is normalized (tolerated).
+sb=$(mktemp -d); mk_sandbox "$sb"
+sed -i 's|^If .*language-specific rules.*read them before starting\.$|If any language-specific rules exist, read them before starting.|' \
+    "$sb/plugin/agents/code-reviewer.md"
+( cd "$sb" && bash scripts/check_agents.sh >/dev/null 2>&1 ); rc=$?
+assert_exit 0 $rc "rules-path sentence variant -> exit 0"
+rm -rf "$sb"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do echo "  $err"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## What
Add `check_agents.{sh,ps1}` — a transform-aware drift guard for the 8 agent definitions duplicated across `plugin/agents/` and `project/.claude/agents/` (deep-audit-2026-05-29, P1-B `plugin-agents-near-duplicate-unguarded`). This is the chosen "transform-aware drift guard" approach, applied to the scope where it is feasible.

## Why
The two copies are near-duplicates but not byte-identical by design: per-layer frontmatter (`color:` in project; no `temperature:` in either after #648/#662) and one repo-specific "language-specific rules" sentence that the plugin copy genericizes. Without a guard, a behavioral instruction can be edited in one layer and silently diverge.

## How
- Strip YAML frontmatter, normalize the single known rules-path sentence to a placeholder, then `diff` the bodies. Fail (exit 2) on any other divergence.
- 5 of 8 bodies are already byte-identical; 3 differ only by that one normalized sentence — the guard passes today on both `.sh` and `.ps1`.
- Wired into `validate-skills.yml`; covered by `tests/scripts/test-check-agents.sh` (4/4: in-sync pass, body-divergence fail, frontmatter-only tolerated, sentence-variant tolerated).

## Scope decision (refs)
Per-file reference drift is **intentionally not guarded**. The `plugin/skills/*/reference/` tree is a curated *re-structuring* of `rules/` (content split/recombined across files — e.g. `rules/api/observability.md` → `observability.md` + `logging.md`; `rules/coding/` standards fan out into `general/quality/concurrency/memory`). A per-file 1:1 comparison would false-positive on that reorganization, so the plugin reference bundle stays an independently-maintained curated distribution (the 4 byte-identical workflow refs remain covered by `check_references.sh`). Documented in `docs/CUSTOM_EXTENSIONS.md`. The existing docs already scope SSOT correctly (the audit's "must match canonical" premise applied only to the hook lib + 4 workflow refs, not all ~33 references).

Refs: docs/deep-audit-2026-05-29.md
