### PR TITLE
fix(hooks): powershell guard parity follow-ups

### DIFF
--- a/global/hooks/bash-write-guard.ps1
+++ b/global/hooks/bash-write-guard.ps1
@@ -3,14 +3,21 @@ $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
 
 # bash-write-guard.ps1
-# Detects file-mutation patterns in Bash commands and enforces that the
-# target was Read first this session, mirroring bash-write-guard.sh.
+# Detects file-mutation patterns in Bash commands. Partial mirror of
+# bash-write-guard.sh (Issue #477).
 #
-# Whitelist approach (Issue #477): the script flags any command whose argv
-# matches a known write tool OR contains a redirection to a file. If the
-# write target cannot be statically extracted (e.g. `python -c "..."`,
-# awk script bodies, sed command-line scripts), the call is denied with a
-# message asking the agent to use the Edit/Write tool instead.
+# Coverage on PowerShell hosts:
+#   - Sensitive-target blocking: enforced for BOTH redirection targets and
+#     write-tool argv targets (cp/mv/tee/install/sed -i/...) via pattern
+#     match — the security-relevant cases are covered on every host.
+#   - Uninspectable mutations (python/node/perl/ruby -c|-e, awk bodies):
+#     denied with a message to use the Edit/Write tool instead.
+#   - Read-before-Edit: enforced for redirection targets ONLY. Unlike
+#     bash-write-guard.sh it is NOT applied to argv write-tool destinations
+#     (e.g. `cp src existing.py`), because faithful per-tool argv target
+#     extraction needs the shell tokenizer the .sh sources from hooks/lib
+#     (tokenize-shell.sh). Closing that soft-guard gap is tracked as a
+#     follow-up; it does not affect the sensitive-target protection above.
 
 $json = Read-HookInput
 if (-not $json) {

--- a/global/hooks/commit-message-guard.ps1
+++ b/global/hooks/commit-message-guard.ps1
@@ -62,9 +62,11 @@ if (-not $msg) {
     exit 0
 }
 
-# Rule 1: Conventional Commits format
+# Rule 1: Conventional Commits format. Use -cnotmatch (case-SENSITIVE) to
+# match validate-commit-message.sh's `grep -qE` — `Feat:`/`FIX:` must be
+# rejected, not silently accepted as on a case-insensitive -notmatch.
 $ccRegex = '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|security)(\([a-z0-9._-]+\))?: .+'
-if ($msg -notmatch $ccRegex) {
+if ($msg -cnotmatch $ccRegex) {
     New-HookDenyResponse -Reason "Commit message must follow Conventional Commits: 'type(scope): description' or 'type: description'. Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security."
     exit 0
 }

--- a/tests/hooks/test-commit-message-guard.ps1
+++ b/tests/hooks/test-commit-message-guard.ps1
@@ -59,6 +59,8 @@ Assert-Deny 'docs: created by Anthropic'     'prose created by Anthropic -> deny
 Write-Host ''
 Write-Host '[Other rules still enforced]'
 Assert-Deny 'random text without a type prefix' 'non-conventional format -> deny'
+Assert-Deny 'Feat: capitalized conventional type' 'capitalized type -> deny (case-sensitive, parity with .sh)'
+Assert-Deny 'FIX: uppercase type'                 'uppercase type -> deny (case-sensitive)'
 Assert-Deny 'feat: trailing period.'            'trailing period -> deny'
 
 Write-Host ''


### PR DESCRIPTION
## What
Two remaining `.ps1`↔`.sh` guard parity items deferred from #657 (deep-audit-2026-05-29 P1 follow-ups).

| Hook | Fix |
|------|-----|
| commit-message-guard.ps1 | Conventional-Commits type check used `-notmatch` (case-insensitive) → accepted `Feat:`/`FIX:`; `validate-commit-message.sh` (`grep -qE`) rejects them. Switched to `-cnotmatch` (case-sensitive parity). |
| bash-write-guard.ps1 | Header corrected to document the actual scope: Read-before-Edit is enforced for **redirection targets only**, not argv write-tool destinations (`cp`/`tee`/...). |

## Why
- The case-insensitive type match was an undocumented behavioral divergence — capitalized conventional types pass on Windows but fail on POSIX.
- The bash-write-guard header overstated coverage ("enforces that the target was Read first ... mirroring bash-write-guard.sh"). Faithful per-tool argv extraction needs the shell tokenizer the `.sh` sources from `hooks/lib/tokenize-shell.sh`; a regex reimplementation would risk false denials (blocking legitimate commands). The **sensitive-target** block already covers both redirection and argv channels on every host, so the remaining gap is a soft Read-before-Edit nudge — documented here rather than left implicit. Full tokenizer-based parity is a tracked follow-up.

## How (verification)
- `test-commit-message-guard.ps1`: 10/10 (adds `Feat:`/`FIX:` deny cases; lowercase types still allowed).
- `bash-write-guard.ps1` parses cleanly; comment-only change, behavior unchanged (verified redirect-target path).

Refs: docs/deep-audit-2026-05-29.md
