### PR TITLE
docs(hooks): fix section 12 heading level and stale pr-target logic

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -256,11 +256,11 @@ Hooks are user-defined commands that automatically execute during specific Claud
 - Advisory only (conflict prevention), not security-critical
 - Cross-platform: `conflict-guard.sh` and `conflict-guard.ps1`
 
-## 12. PR Target Guard (PreToolUse)
+### 12. PR Target Guard (PreToolUse)
 
-*Enforces branching policy: only `develop` may merge into `main`.*
+*Enforces branching policy: only `develop` or a `release/*` branch may merge into the repo default branch (`main`/`master`).*
 
-**Purpose**: Intercepts `gh pr create` commands and blocks those targeting `main` unless the source branch is `develop` (a legitimate release PR).
+**Purpose**: Intercepts `gh pr create` commands and blocks those targeting the default branch (`main`/`master`) unless the source branch is `develop` or `release/*` (a legitimate release PR).
 
 **Trigger**: `Bash` tool calls containing `gh pr create`
 
@@ -269,10 +269,11 @@ Hooks are user-defined commands that automatically execute during specific Claud
 **Logic**:
 1. Scope gate: only process `gh pr create` commands (all others pass through)
 2. Extract `--base` value (`--base main`, `--base=main`, `-B main`)
-3. If `--base main` detected:
-   - Allow if `--head develop` is also present (release PR via `/release`)
-   - Deny otherwise with guidance message
-4. If no `--base` flag: allow (defaults to `develop`)
+3. If no `--base` flag is present, resolve the repo default branch: use `PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE` if set (test injection), else query `gh api repos/{owner}/{repo} --jq .default_branch` (honoring `--repo`/`-R` when supplied). If the default branch cannot be resolved, allow (graceful degradation)
+4. If the resolved base is `main` or `master`:
+   - Allow if the head branch is `develop` or matches `release/*` (legitimate release PR via `/release`)
+   - Deny otherwise with the branching-policy guidance message
+5. Otherwise (base is neither `main` nor `master`): allow
 
 **Fail policy**: Fail-closed (deny if JSON parsing fails)
 


### PR DESCRIPTION
## What

Fix two defects in `HOOKS.md` section 12 (PR Target Guard):

1. Heading level `## 12.` → `### 12.` so it matches the H3 siblings (§11, §13) and no longer breaks the numbered hierarchy.
2. Rewrite the **Logic** block (and caption/purpose) to match the shipped #616 behavior: the guard no longer "allows by default when no `--base`" — it resolves the repo default branch (via `PR_TARGET_GUARD_DEFAULT_BRANCH_OVERRIDE` or `gh api repos/{owner}/{repo} --jq .default_branch`), blocks `main` **and** `master`, and allows `develop` or `release/*` heads.

## Why

`HOOKS.md` §12 documented the exact pre-#616 vulnerable behavior the fix removed (repos defaulting to `main`/`master` like vcpkg-registry silently bypassed the policy). The doc narrative contradicted `global/hooks/pr-target-guard.sh`.

Finding: `hooks-md-section12-h2-and-stale-content`.

## Where

`HOOKS.md` §12 only. This section sits in the hand-written narrative region (outside the auto-generated markers at lines 990/1682), so it is edited directly — `gen-hooks-md.sh --check` (verified green) is unaffected, and the hook source needs no change (it is already correct).

## How

Logic text verified line-by-line against `global/hooks/pr-target-guard.sh:58-117` (base extraction, default-branch resolution with graceful-degradation allow, main/master block, develop + release/* allow). `gen-hooks-md.sh --check` passes (auto region unchanged); headings §11/§12/§13 are now all H3.

Part of the deep-audit P2 backlog (`docs/deep-audit-2026-05-29.md`).
