### PR TITLE
fix(hooks): emit allow JSON via jq and unify allow-path field

### DIFF
--- a/global/hooks/dangerous-command-guard.sh
+++ b/global/hooks/dangerous-command-guard.sh
@@ -66,9 +66,12 @@ deny_response() {
 allow_response() {
     local reason="${1:-dangerous-command-guard: no dangerous pattern matched}"
     log_decision "allow" "$reason" "${CMD:-}"
+    # Allow-path diagnostic goes under additionalContext (the model-visible
+    # allow channel), matching the .ps1 New-HookAllowResponse and the rest of
+    # the suite; permissionDecisionReason is reserved for deny decisions.
     jq -nc \
         --arg reason "$reason" \
-        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", permissionDecisionReason: $reason}}'
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", additionalContext: $reason}}'
     exit 0
 }
 

--- a/global/hooks/github-api-preflight.sh
+++ b/global/hooks/github-api-preflight.sh
@@ -15,28 +15,18 @@ if [ -z "$CMD" ]; then
     CMD="${CLAUDE_TOOL_INPUT:-}"
 fi
 
-# Helper function for allow response
+# Helper function for allow response.
+# Use jq -nc --arg so the JSON library handles all escaping (quotes,
+# backslashes, newlines). This closes the heredoc-interpolation injection
+# class banned elsewhere in the suite (issue #567 / #579).
 allow_response() {
     local message="${1:-}"
     if [ -n "$message" ]; then
-        cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "additionalContext": "$message"
-  }
-}
-EOF
+        jq -nc --arg ctx "$message" \
+            '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", additionalContext: $ctx}}'
     else
-        cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow"
-  }
-}
-EOF
+        jq -nc \
+            '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
     fi
     exit 0
 }

--- a/global/hooks/prompt-validator.sh
+++ b/global/hooks/prompt-validator.sh
@@ -9,17 +9,17 @@ set -euo pipefail
 
 PROMPT="${CLAUDE_USER_PROMPT:-}"
 
-# Helper function for allow response with warning
+# Helper function for allow response with warning.
+# jq -nc --arg handles all escaping, avoiding the heredoc-interpolation
+# injection class banned elsewhere in the suite (issue #567 / #579). This is an
+# advisory UserPromptSubmit hook: if jq is unavailable, emit no context rather
+# than risk a malformed payload (the prompt is still allowed).
 allow_with_warning() {
     local warning="$1"
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "$warning"
-  }
-}
-EOF
+    if command -v jq >/dev/null 2>&1; then
+        jq -nc --arg ctx "$warning" \
+            '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
+    fi
     exit 0
 }
 

--- a/tests/hook-json-escape.sh
+++ b/tests/hook-json-escape.sh
@@ -106,7 +106,10 @@ assert_decision() {
 assert_reason_roundtrip() {
     local out="$1" expected="$2" label="$3"
     local got
-    got=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)
+    # Deny carries the reason under permissionDecisionReason; allow carries it
+    # under additionalContext (suite-wide convention). Accept either so the
+    # roundtrip check works for both paths.
+    got=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // .hookSpecificOutput.additionalContext // empty' 2>/dev/null)
     if [ "$got" = "$expected" ]; then
         ((PASS++))
         echo "  PASS [reason roundtrip]: $label"

--- a/tests/hooks/test-dangerous-command-guard.sh
+++ b/tests/hooks/test-dangerous-command-guard.sh
@@ -99,10 +99,10 @@ assert_allow '{"tool_input":{"command":"git diff >/dev/null 2>&1"}}' "git diff >
 echo ""
 echo "[allow response shape]"
 allow_sample=$(echo '{"tool_input":{"command":"git status 2>&1 | head -20"}}' | bash "$HOOK" 2>/dev/null)
-if echo "$allow_sample" | grep -q '"permissionDecisionReason"'; then
-    ((PASS++)); echo "  PASS: allow response includes permissionDecisionReason"
+if echo "$allow_sample" | grep -q '"additionalContext"'; then
+    ((PASS++)); echo "  PASS: allow response includes additionalContext"
 else
-    ((FAIL++)); ERRORS+=("FAIL: allow response missing permissionDecisionReason — got: $allow_sample"); echo "  FAIL: allow response missing permissionDecisionReason"
+    ((FAIL++)); ERRORS+=("FAIL: allow response missing additionalContext — got: $allow_sample"); echo "  FAIL: allow response missing additionalContext"
 fi
 if echo "$allow_sample" | grep -q 'Safe read-only compound command'; then
     ((PASS++)); echo "  PASS: compound pattern emits dedicated reason"


### PR DESCRIPTION
## What

Harden two heredoc JSON emitters and unify the allow-path field name across the hook suite.

- `github-api-preflight.sh` `allow_response()`: heredoc → `jq -nc --arg` (both the with-message and no-message branches).
- `prompt-validator.sh` `allow_with_warning()`: heredoc → `jq -nc --arg`, guarded by `command -v jq` (advisory `UserPromptSubmit` hook — if jq is absent, emit no context rather than risk a malformed payload; the prompt is still allowed).
- `dangerous-command-guard.sh` `allow_response()`: the allow-path diagnostic moves from `permissionDecisionReason` to `additionalContext`, matching `dangerous-command-guard.ps1` (`New-HookAllowResponse -AdditionalContext`) and every other `.sh` peer. The deny path keeps `permissionDecisionReason` (unchanged).
- Tests updated to the new convention: `test-dangerous-command-guard.sh` allow-shape assertion, and `hook-json-escape.sh` `assert_reason_roundtrip` now accepts `permissionDecisionReason` (deny) **or** `additionalContext` (allow).

## Why

The two heredoc emitters are the exact interpolation class banned elsewhere (issues #567/#578/#579) — harmless today (static literals only) but a regression waiting to be reintroduced. The dangerous-command-guard allow field diverged from its `.ps1` twin and the suite convention.

Findings: `gap-heredoc-not-jq`, `dangerous-command-guard-allow-shape-mismatch`.

## How

- All three hooks verified to emit valid JSON for every branch (`jq -e` round-trip).
- `test-dangerous-command-guard.sh` 34/34, `test-github-api-preflight.sh` 10/0, `test-prompt-validator.sh` 39/0.
- `hook-json-escape.sh`: the security-critical exploit-roundtrip cases (deny **and** allow) pass. Two residual `nasty reason` failures are a pre-existing Windows-git-bash CR/LF command-substitution artifact (the **deny** case — untouched by this PR — fails identically), not caused by this change; this suite is wired into no workflow (`hook-json-escape-tests-orphaned`).
- `.ps1` counterparts unchanged — they already use the safe JSON helpers / `additionalContext`, so this restores parity rather than breaking it.

Part of the deep-audit P2 backlog (`docs/deep-audit-2026-05-29.md`).
