### PR TITLE
docs(skills): add loop-safety sections and soften tier wording

### DIFF
--- a/global/skills/_internal/branch-cleanup/SKILL.md
+++ b/global/skills/_internal/branch-cleanup/SKILL.md
@@ -235,3 +235,7 @@ After completion, provide summary:
 | Protected branch in list | Skip automatically with warning | No action needed |
 | Current branch selected | Skip automatically | Checkout different branch first |
 | Network error (remote) | Report "Cannot reach remote - check connection" | Verify internet connection |
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It deletes merged and stale local/remote branches. Repeated invocation is a destructive cascade with nothing left to do after the first pass, and could race against concurrent branch creation. Run it once per cleanup; do not wrap it in `/loop`.

--- a/global/skills/_internal/fleet-orchestrator/SKILL.md
+++ b/global/skills/_internal/fleet-orchestrator/SKILL.md
@@ -468,3 +468,7 @@ After a fleet run, confirm:
 `--reanchor-interval N` (default 5, `0` disables) controls how often the Core invariants block from `global/skills/_internal/_shared/invariants.md` is emitted during the supervisor's status-polling loop.
 
 Loop bind point: every N manifest-poll cycles. A fleet run covering 20+ repos produces enough accumulated worker outputs that the supervisor's attention drifts from the canonical rules; re-anchoring keeps the English-only, squash-merge, and CI-gate invariants in the recent context when aggregating results and deciding per-repo terminal state.
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It spawns a fleet of worker agents that create branches, PRs, and commits across many repositories. Re-running would duplicate fleet work and re-open already-handled units. Resume an interrupted fleet via `--resume <fleet-id>`, never by re-invoking from the start. (The supervisor's internal status-polling loop above is bounded by `--max-parallel` / `--reanchor-interval`; that is distinct from the non-idempotent external side effects described here.)

--- a/global/skills/_internal/harness/SKILL.md
+++ b/global/skills/_internal/harness/SKILL.md
@@ -265,3 +265,7 @@ After generation, confirm:
 - **Skill writing guide**: `reference/skill-writing-guide.md` -- writing patterns, examples, data schema standards
 - **Skill testing guide**: `reference/skill-testing-guide.md` -- testing/evaluation/iterative improvement methodology
 - **QA agent guide**: `reference/qa-agent-guide.md` -- for including a QA agent in build harnesses; covers integration coherence verification, boundary bug patterns, and QA agent definition templates based on 7 real-world bug cases
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It scaffolds skills/agents and may spawn agent teams. Re-running for the same target would overwrite generated artifacts or spawn duplicate teams. Treat each invocation as a single design/build pass, not an idempotent retry.

--- a/global/skills/_internal/implement-all-levels/SKILL.md
+++ b/global/skills/_internal/implement-all-levels/SKILL.md
@@ -281,3 +281,7 @@ See `reference/team-mode.md` for the complete team mode workflow with per-tier d
 | Team mode: teammate failure | Fallback to Solo Mode from next incomplete tier |
 | Team mode: review loop exceeded | Approve tier with remaining items noted (max 2 rounds) |
 | Agent Teams not enabled | Fall back to Solo Mode with warning |
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It writes code across multiple implementation tiers and may spawn teammate agents. Re-running would re-edit files already implemented or duplicate teammate work, risking conflicting changes. Resume from the first incomplete tier rather than re-invoking the whole skill.

--- a/global/skills/_internal/issue-create/SKILL.md
+++ b/global/skills/_internal/issue-create/SKILL.md
@@ -310,3 +310,7 @@ After completion, provide summary:
 | Issue creation failed | Report GitHub API error with details | Check repository permissions |
 | Network timeout | Report "Cannot reach GitHub - check connection" | Verify internet connection |
 | Label not found | Create issue without label, warn user | Labels may need to be created in repository |
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. Each invocation opens one or more GitHub issues. Wrapping it in `/loop` would create duplicate issues. The exit contract is "one issue (or planned set) per invocation"; re-run only with a new, distinct specification.

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -601,3 +601,7 @@ In batch mode, use the summary format from **Phase B-5** instead. Include per-it
 ## Error Handling
 
 See `reference/error-handling.md` for prerequisite checks, runtime errors, and batch mode errors.
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. Each invocation creates branches, opens or advances pull requests, and posts comments against live GitHub issues. Wrapping it in `/loop` would re-trigger work on already-handled issues and create duplicate branches/PRs. The exit contract is "one resolved issue (or batch) per invocation," not a no-side-effect retry — resume an interrupted run from the documented session-resume state rather than re-running blindly.

--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -789,3 +789,7 @@ Loop bind points for pr-work:
 ## Error Handling
 
 See `reference/error-handling.md` for prerequisite checks, runtime errors, batch mode errors, and common CI failure patterns.
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It pushes commits, opens/updates pull requests, and merges them once CI passes. Re-running under `/loop` would push duplicate commits or re-attempt merges on already-handled PRs. Resume an interrupted run from its last phase via session-resume state rather than re-invoking from scratch.

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -532,3 +532,7 @@ Loop bind point: between each CI retry and each merge-gate verification. For a t
 ## Error Handling
 
 See `reference/error-handling.md` for prerequisite checks and runtime error handling.
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It bumps versions, creates git tags, and publishes GitHub releases. Repeated invocation would create duplicate or conflicting tags/releases for the same version. The idempotency contract is "one release per version bump"; never wrap it in `/loop`.

--- a/global/skills/_internal/sonar-fix/SKILL.md
+++ b/global/skills/_internal/sonar-fix/SKILL.md
@@ -140,3 +140,7 @@ Refer to parent epic #635 for the full rationale.
 - [reference/auto-fixable-rules.md](reference/auto-fixable-rules.md)
 - [reference/comment-format.md](reference/comment-format.md)
 - [reference/escalation-template.md](reference/escalation-template.md)
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: false`. It pushes fix commits to live PRs and replies to SonarCloud bot comments. Re-running would push duplicate commits or re-process already-handled findings. Run it once per PR review cycle; resume rather than re-invoke.

--- a/global/skills/_internal/traceability/SKILL.md
+++ b/global/skills/_internal/traceability/SKILL.md
@@ -247,3 +247,7 @@ or `router.yaml`. Those remain `doc-index`'s responsibility.
 - Validation rules and exit codes: `reference/validation-rules.md`
 - Catalogue producer: `global/skills/_internal/doc-index/SKILL.md`
 - Parent epic: `kcenon/claude-config#588`
+
+## Side Effects and Loop-Safety
+
+This skill is `loop_safe: true`. It is a single-pass (`max_iterations: 1`) read-mostly operation: it consumes `docs/.index/{manifest,bundles,graph,router}.yaml` and writes only `docs/.index/traceability.{yaml,md}`, never mutating source documents. Re-running is idempotent — it regenerates the same two artifacts from current inputs, so wrapping it in a `/loop` is safe (and a no-op when `graph.yaml` is absent). The `max_iterations: 1` / `halt_conditions` metadata expresses single-pass exit semantics, not a polling loop.

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -132,7 +132,7 @@ default_tier: standard        # Tier used when caller omits --tier
 
 ### When to Apply
 
-Required for skills whose `SKILL.md` body exceeds 5 KB (current examples: `issue-work`, `pr-work`). Optional for smaller skills, where a single loading mode suffices.
+Recommended for skills whose `SKILL.md` body exceeds 5 KB; adopted incrementally rather than all at once (current tiered skills: `issue-work`, `pr-work` — see the phased-rollout note under "Tiered Skills" in `docs/TOKEN_OPTIMIZATION.md`). Optional for smaller skills, where a single loading mode suffices.
 
 ### Invocation
 


### PR DESCRIPTION
## What

Add the self-documenting loop-safety body section the validator checks for, and align the tier-preset policy wording with the documented phased rollout.

- Add a `## Side Effects and Loop-Safety` section to the 9 `loop_safe: false` skills that lacked one: `issue-work`, `pr-work`, `release`, `harness`, `branch-cleanup`, `issue-create`, `implement-all-levels`, `fleet-orchestrator`, `sonar-fix`. Each names the concrete external side effect (branches/PRs/commits/tags/issues/agent spawns/branch deletion) and why repeated `/loop` invocation is unsafe.
- Add a `## Side Effects and Loop-Safety` section to `traceability` (`loop_safe: true`) documenting its single-pass, idempotent regenerate-only behavior — this also gives its `max_iterations`/`halt_conditions` drift check genuine body content instead of being satisfied only by the frontmatter keys.
- `_policy.md`: soften the tier-preset "When to Apply" from "**Required** for skills > 5 KB" to "**Recommended**; adopted incrementally", cross-linking the `docs/TOKEN_OPTIMIZATION.md` phased-rollout note — so the normative text matches practice (only `issue-work`/`pr-work` are tiered today).

## Why

The `loop_safe: false` non-idempotency contract lived only in a frontmatter boolean; the validator already warns when the body lacks a side-effect section. The `_policy.md` "Required" wording made a strict reader conclude ~10 skills were non-conformant while `TOKEN_OPTIMIZATION.md` documents the rollout as phased — a normative-vs-practice contradiction.

Findings: `loop-safe-false-missing-side-effect-section`, `traceability-loop-metadata-no-loop-body`, `tier-presets-missing-on-oversized-skills`.

## How

`scripts/validate_skills.sh` passes 360/0 with all `loop_safe: false 본문 일관성` and `loop 메타데이터 본문 일관성` checks green (the pre-commit hook validated the changed SKILL.md files on commit). The 5 remaining warnings are pre-existing file-length advisories, unrelated to this change.

Scope note: the optional validator hardening (scan body-only for the drift check) is deferred — it would surface new warnings on three unrelated skills (`doc-index`, `doc-review`, `preflight`) and is left as a follow-up; the named `traceability` finding is resolved here by the content addition.

Part of the deep-audit P2 backlog (`docs/deep-audit-2026-05-29.md`).
