### PR TITLE
docs(memory): adopt autoMemoryDirectory as primary memory redirection (#673)

### DIFF
--- a/docs/MEMORY_MIGRATION.md
+++ b/docs/MEMORY_MIGRATION.md
@@ -16,7 +16,7 @@
 4. [Phase 2 — Backfill Local Frontmatter](#4-phase-2--backfill-local-frontmatter)
 5. [Phase 3 — Trust-Level Baseline Review](#5-phase-3--trust-level-baseline-review)
 6. [Phase 4 — Clone claude-memory and Install Hooks](#6-phase-4--clone-claude-memory-and-install-hooks)
-7. [Phase 5 — Symlink Project Memory to the Shared Clone](#7-phase-5--symlink-project-memory-to-the-shared-clone)
+7. [Phase 5 — Redirect Project Memory to the Shared Clone](#7-phase-5--redirect-project-memory-to-the-shared-clone)
 8. [Phase 6 — Verify the Write-Guard Hook](#8-phase-6--verify-the-write-guard-hook)
 9. [Phase 7 — First Manual Sync](#9-phase-7--first-manual-sync)
 10. [Phase 8 — Post-Migration Validation](#10-phase-8--post-migration-validation)
@@ -299,10 +299,29 @@ local `settings.json` before continuing.
 
 ---
 
-## 7. Phase 5 — Symlink Project Memory to the Shared Clone
+## 7. Phase 5 — Redirect Project Memory to the Shared Clone
 
 **Goal**: Redirect Claude Code's memory reads/writes from the per-project
 directory to the shared clone, transparently and reversibly.
+
+### Primary: redirect via `autoMemoryDirectory` (recommended)
+
+Set the official redirection setting in **user-tier** settings so the
+per-project path never has to be enumerated or symlinked:
+
+```jsonc
+// ~/.claude/settings.json
+{ "autoMemoryDirectory": "~/.claude/memory-shared/memories" }
+```
+
+It accepts an absolute or `~/`-prefixed path and is honored only from
+user/policy settings and `--settings` (rejected from project/local — see
+[`THREAT_MODEL.md`](./THREAT_MODEL.md) Section 4, so a cloned repo cannot
+redirect memory writes). You still migrate your existing files into the
+clone (**Stage the swap** and **Move classified files** below), but skip
+**Create the symlink** — the setting replaces it. The symlink path that
+follows remains the fallback for harness versions that predate
+`autoMemoryDirectory`.
 
 ### Stage the swap
 
@@ -320,7 +339,10 @@ Copy your reviewed files (excluding any that you quarantined in
 `-n` (no-clobber) ensures we never overwrite a seeded file accidentally.
 Compare counts and resolve any collisions manually before continuing.
 
-### Create the symlink
+### Create the symlink (fallback only)
+
+Skip this step if you set `autoMemoryDirectory` above; it is needed only on
+harness versions that predate the setting.
 
     ln -s ~/.claude/memory-shared/memories memory
 
@@ -582,7 +604,7 @@ the system as production-stable or onboarding a second machine
 ## 13. Rollback Procedure
 
 **Goal**: Restore the original layout in under one minute. This procedure
-is the safety net for any failure between [Phase 5](#7-phase-5--symlink-project-memory-to-the-shared-clone)
+is the safety net for any failure between [Phase 5](#7-phase-5--redirect-project-memory-to-the-shared-clone)
 and [Phase 8](#10-phase-8--post-migration-validation).
 
 ### Commands

--- a/docs/MEMORY_SYNC.md
+++ b/docs/MEMORY_SYNC.md
@@ -395,10 +395,39 @@ If the write-guard rejects the file, consult
 [`MEMORY_VALIDATION_SPEC.md`](./MEMORY_VALIDATION_SPEC.md) for the
 authoritative contract.
 
-### 5.7 Phase 6 — Symlink the project memory directory
+### 5.7 Phase 6 — Redirect the project memory directory
 
 Claude Code stores per-project memory under a git-repo-derived path such as
-`~/.claude/projects/-Users-<user>-Sources/memory/`. Replace it with a
+`~/.claude/projects/-Users-<user>-Sources/memory/`. This phase points that
+storage at the shared store so memories written in this project flow
+through the sync engine.
+
+**Primary: `autoMemoryDirectory` (recommended).** Rather than enumerate the
+git-repo-derived path per machine, set the official `autoMemoryDirectory`
+setting to redirect auto-memory storage straight at the shared store:
+
+```jsonc
+// ~/.claude/settings.json  (user tier)
+{
+  "autoMemoryDirectory": "~/.claude/memory-shared/memories"
+}
+```
+
+`autoMemoryDirectory` accepts an absolute or `~/`-prefixed path and is
+honored **only from user/policy settings and `--settings`** — it is
+rejected from project/local settings, so a cloned repository cannot
+redirect memory writes (see
+[`THREAT_MODEL.md`](./THREAT_MODEL.md) Section 4). The redirected target is
+the synced clone, so auto-memory writes flow through the sync engine
+exactly as the symlink approach intends, without depending on the
+per-machine git-repo-derived path and without any `mv` / `ln -s` step. If a
+project memory directory already exists it is simply no longer used once
+the setting is in place; move it aside as `memory.deprecated` first if you
+want to migrate its files into the clone (`cp -n memory.deprecated/*.md
+~/.claude/memory-shared/memories/`).
+
+**Fallback: symlink the project memory directory.** On harness versions
+without `autoMemoryDirectory`, replace the per-project directory with a
 symlink to the shared store so memories written in this project flow
 through the sync engine. This mirrors `MEMORY_MIGRATION.md` Phase 5 but
 the new machine may not have an existing project memory directory yet.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -125,6 +125,7 @@ Five primary layers form the core defense, plus orthogonal layers:
 | Monthly semantic review | `semantic-review.sh` ([#530](https://github.com/kcenon/claude-config/issues/530)), opt-in | Catches subtle injection that heuristic checks miss (self-reinforcing instructions, compositional injection) |
 | Access logging | [`memory-access-logger.sh`](../global/hooks/memory-access-logger.sh) ([#531](https://github.com/kcenon/claude-config/issues/531)) | Path-only record; feeds unused-memory check; supports forensic review |
 | Trust tiers | `verified` / `inferred` / `quarantined` ([`MEMORY_TRUST_MODEL.md`](./MEMORY_TRUST_MODEL.md)) | Auto-application gate: only `verified` is auto-applied; `inferred` is shown with marker; `quarantined` never auto-applied |
+| Settings-tier redirection | `autoMemoryDirectory` user/policy-only ([#673](https://github.com/kcenon/claude-config/issues/673)) | When auto-memory storage is redirected to the shared clone via `autoMemoryDirectory`, the setting is honored only from user/policy settings and `--settings`; project/local settings are rejected, so a cloned repository cannot point memory writes at an attacker-controlled path. Strictly stronger than the filesystem symlink it replaces, which any process with write access could repoint |
 
 ---
 


### PR DESCRIPTION
Closes #673

## Summary
- Documents the official `autoMemoryDirectory` setting as the **primary** mechanism for redirecting per-project auto-memory to the shared sync clone, keeping the filesystem symlink as a **fallback**.
- `MEMORY_SYNC.md` Phase 6 and `MEMORY_MIGRATION.md` Phase 5: primary/fallback split. The setting is user/policy-tier (rejected from project/local), needs no per-machine path enumeration, and composes with the sync engine because the redirect target is the synced clone.
- `THREAT_MODEL.md` Section 4: new settings-tier redirection layer — project/local rejection means a cloned repo cannot repoint memory writes (strictly stronger than the symlink).
- Renamed Migration Phase 5 heading (Symlink -> Redirect) and updated its two internal anchor references.

## Test Plan
- `bash scripts/check_references.sh` -> OK (mirrors untouched)
- Internal anchors verified: TOC + body links resolve to the renamed heading; no stale `symlink` anchors remain
- Docs-only change; no scripts or hooks touched