### PR TITLE
feat(security): disable bypass and auto permission modes (#674)

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -16,6 +16,8 @@
   },
   "permissions": {
     "defaultMode": "default",
+    "disableBypassPermissionsMode": "disable",
+    "disableAutoMode": "disable",
     "allow": [
       "Bash(git status:*)",
       "Bash(git log:*)",

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -410,6 +410,8 @@
 
   "permissions": {
     "defaultMode": "default",
+    "disableBypassPermissionsMode": "disable",
+    "disableAutoMode": "disable",
     "allow": [
       "Bash(git status:*)",
       "Bash(git log:*)",


### PR DESCRIPTION
Closes #674

## Summary
- Set `permissions.disableBypassPermissionsMode: "disable"` and `permissions.disableAutoMode: "disable"` in the user-tier `global/settings.json` and the Windows parity file `global/settings.windows.json`.
- Closes the `bypassPermissions` and `auto` mode escalation paths, making the repo's trust posture explicit and consistent with its secret-blocking stance.

## Decisions
- **Tier**: user-tier global settings (the repo ships no policy file); applied in both global settings variants for parity.
- **Scope**: both keys disabled.
- **skipDangerousModePermissionPrompt**: unchanged. With bypass mode disabled it is inert for the bypass path; the keys are otherwise independent.

## Test Plan
- `scripts/schemas/settings-json.schema.json` already declares both keys with `enum: ["disable"]` (2026-05 schema sync) — values conform.
- Both settings files parse as valid JSON; only the two permission keys added.