### PR TITLE
feat(governance): adopt minimumVersion and worktree settings keys (#676)

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -2,6 +2,10 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
+  "minimumVersion": "2.2.0",
+  "worktree": {
+    "baseRef": "head"
+  },
   "env": {
     "MAX_MCP_OUTPUT_TOKENS": "50000",
     "ENABLE_TOOL_SEARCH": "auto:10",

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -6,6 +6,11 @@
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
 
+  "minimumVersion": "2.2.0",
+  "worktree": {
+    "baseRef": "head"
+  },
+
   "language": "korean",
 
   "outputStyle": "Explanatory",

--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -9,6 +9,14 @@
     "$schema": { "type": "string" },
     "respectGitignore": { "type": "boolean" },
     "cleanupPeriodDays": { "type": "integer", "minimum": 0 },
+    "minimumVersion": { "type": "string" },
+    "worktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseRef": { "type": "string", "enum": ["fresh", "head"] }
+      }
+    },
     "env": {
       "type": "object",
       "additionalProperties": { "type": ["string", "number", "boolean"] }


### PR DESCRIPTION
Closes #676

## Summary
- **minimumVersion: "2.2.0"** in `global/settings.json` + `global/settings.windows.json`, aligned with `known-issues.json` `minimum_recommended` (above the 2.1.69-2.1.81 cache-bug band that `version-check.sh` warns on). Turns the advisory version check into a hard floor for the newer wired events (WorktreeCreate/Remove, SubagentStart).
- **worktree.baseRef: "head"** so session/agent worktrees branch from the local develop HEAD instead of `origin/main` (the default branch), matching the repo's develop-based model.
- **settings-json.schema.json**: documents `minimumVersion` (string) and the `worktree` object with `baseRef` enum `[fresh, head]`.

## Note on baseRef value
The issue suggested `baseRef: develop`, but the official value space is **`fresh | head` only** (added in v2.1.133, [docs](https://code.claude.com/docs/en/worktrees)) — a branch name is not accepted. `head` is the valid value that realizes the develop-based intent: with develop checked out, head-based worktrees carry develop state, whereas `fresh` would branch from `origin/main`.

## Test Plan
- All three files parse as valid JSON.
- Schema declares both keys; `worktree.baseRef` constrained to `[fresh, head]`; settings values conform.