### PR TITLE
chore(schemas): complete validation-schema sync to official surface (#675)

### DIFF
--- a/scripts/schemas/plugin-json.schema.json
+++ b/scripts/schemas/plugin-json.schema.json
@@ -7,12 +7,21 @@
   "required": ["name", "version", "description"],
   "additionalProperties": true,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema URL for editor autocomplete and validation. Claude Code ignores this field at load time."
+    },
     "name": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]*$",
       "minLength": 1,
       "maxLength": 128,
-      "description": "Plugin identifier. Lowercase letters, digits, and hyphens; cannot start with hyphen."
+      "description": "Plugin identifier. Lowercase letters, digits, and hyphens; cannot start with hyphen. Used for namespacing and lookup."
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name shown in the /plugin picker and other UI surfaces (Claude Code v2.1.143+). May contain spaces and any casing; falls back to name when omitted. Not used for namespacing or lookup."
     },
     "version": {
       "type": "string",
@@ -54,19 +63,9 @@
       ]
     },
     "license": { "type": "string", "minLength": 1 },
-    "compatibility": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "minClaudeCodeVersion": {
-          "type": "string",
-          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*).*$"
-        },
-        "maxClaudeCodeVersion": {
-          "type": "string",
-          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*).*$"
-        }
-      }
+    "defaultEnabled": {
+      "type": "boolean",
+      "description": "Whether the plugin starts in an enabled state when the user has not set one (Claude Code v2.1.154+). Defaults to true."
     },
     "keywords": {
       "type": "array",

--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -58,15 +58,81 @@
             "hooks": {
               "type": "array",
               "items": {
-                "type": "object",
-                "required": ["type"],
-                "additionalProperties": true,
-                "properties": {
-                  "type":    { "type": "string", "enum": ["command", "http", "mcp_tool", "prompt", "agent"] },
-                  "command": { "type": "string", "minLength": 1 },
-                  "timeout": { "type": "integer", "minimum": 0 },
-                  "async":   { "type": "boolean" }
-                }
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "required": ["type", "command"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type":          { "const": "command" },
+                      "command":       { "type": "string", "minLength": 1 },
+                      "args":          { "type": "array", "items": { "type": "string" } },
+                      "async":         { "type": "boolean" },
+                      "asyncRewake":   { "type": "boolean" },
+                      "shell":         { "type": "string", "enum": ["bash", "powershell"] },
+                      "timeout":       { "type": "integer", "minimum": 0 },
+                      "if":            { "type": "string" },
+                      "once":          { "type": "boolean" },
+                      "statusMessage": { "type": "string" }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["type", "url"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type":           { "const": "http" },
+                      "url":            { "type": "string" },
+                      "headers":        { "type": "object" },
+                      "allowedEnvVars": { "type": "array", "items": { "type": "string" } },
+                      "timeout":        { "type": "integer", "minimum": 0 },
+                      "if":             { "type": "string" },
+                      "once":           { "type": "boolean" },
+                      "statusMessage":  { "type": "string" }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["type", "server", "tool"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type":          { "const": "mcp_tool" },
+                      "server":        { "type": "string" },
+                      "tool":          { "type": "string" },
+                      "input":         { "type": "object" },
+                      "timeout":       { "type": "integer", "minimum": 0 },
+                      "if":            { "type": "string" },
+                      "once":          { "type": "boolean" },
+                      "statusMessage": { "type": "string" }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["type", "prompt"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type":          { "const": "prompt" },
+                      "prompt":        { "type": "string", "minLength": 1 },
+                      "model":         { "type": "string" },
+                      "timeout":       { "type": "integer", "minimum": 0 },
+                      "if":            { "type": "string" },
+                      "once":          { "type": "boolean" },
+                      "statusMessage": { "type": "string" }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["type"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "type":          { "const": "agent" },
+                      "timeout":       { "type": "integer", "minimum": 0 },
+                      "if":            { "type": "string" },
+                      "once":          { "type": "boolean" },
+                      "statusMessage": { "type": "string" }
+                    }
+                  }
+                ]
               }
             }
           }

--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -22,9 +22,21 @@
     },
     "when_to_use": { "type": "string", "minLength": 1 },
     "argument-hint": { "type": "string" },
+    "arguments": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
     "disable-model-invocation": { "type": "boolean" },
     "user-invocable": { "type": "boolean" },
     "allowed-tools": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
+    "disallowed-tools": {
       "oneOf": [
         { "type": "string" },
         { "type": "array", "items": { "type": "string" }, "minItems": 1 }

--- a/scripts/schemas/skill-md.schema.lenient.json
+++ b/scripts/schemas/skill-md.schema.lenient.json
@@ -22,9 +22,21 @@
     },
     "when_to_use": { "type": "string", "minLength": 1 },
     "argument-hint": { "type": "string" },
+    "arguments": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
     "disable-model-invocation": { "type": "boolean" },
     "user-invocable": { "type": "boolean" },
     "allowed-tools": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
+    "disallowed-tools": {
       "oneOf": [
         { "type": "string" },
         { "type": "array", "items": { "type": "string" }, "minItems": 1 }

--- a/scripts/schemas/skill-md.schema.strict.json
+++ b/scripts/schemas/skill-md.schema.strict.json
@@ -82,6 +82,13 @@
       "type": "string",
       "description": "Usage hint shown to the user, e.g., \"<file-or-directory> [--verbose]\"."
     },
+    "arguments": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "description": "Named positional arguments for $name substitution in the skill content. Space-separated string or YAML list; names map to argument positions in order."
+    },
     "disable-model-invocation": {
       "type": "boolean",
       "description": "When true, the model cannot auto-invoke this skill (user-only)."
@@ -96,6 +103,13 @@
         { "type": "array", "items": { "type": "string" }, "minItems": 1 }
       ],
       "description": "Tools the skill is allowed to call. Scalar (\"Bash(git *)\") or array form."
+    },
+    "disallowed-tools": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ],
+      "description": "Tools removed from Claude's available pool while this skill is active. Scalar or array form."
     },
     "model": {
       "type": "string",


### PR DESCRIPTION
Closes #675

## Summary
Closes the three lower-risk schema gaps deliberately deferred in the 2026-05 re-review (D5/D6/D7 follow-ups).

### 1. settings hook handlers (`settings-json.schema.json`)
Replaced the single lenient handler shape (`required: [type]`) with an **anyOf of the five typed branches** — command/http/mcp_tool/prompt/agent — each enforcing its own required fields (`command`; `url`; `server`+`tool`; `prompt`; none) via a `type` const discriminator. Each branch keeps `additionalProperties: true` for forward-compat. Verified all currently wired command handlers (38 global / 39 windows) still validate.

### 2. plugin manifest (`plugin-json.schema.json`)
- Dropped the **non-official `compatibility`** definition (still tolerated via `additionalProperties: true`; the repo's plugin.json files don't use it).
- Added the official `displayName` (v2.1.143+), `defaultEnabled` (v2.1.154+), and `$schema` fields, verified against the live plugins-reference. `name` remains the lowercase identifier; `displayName` is the separate UI name.

### 3. skill schemas (strict + lenient + base)
Added the official `arguments` and `disallowed-tools` fields, both `oneOf[string, array]` (same shape as `allowed-tools`), per the live skills frontmatter reference.

## Test Plan
- All five schema files parse as valid JSON.
- `scripts/validate_skills.sh` -> 359/359 pass (6 pre-existing warnings unchanged).
- Wired hook handlers re-checked against the new anyOf: 0 would fail.

## Note
Left the plugin manifest `required` set unchanged (`name`, `version`, `description`) — stricter than the official `name`-only requirement, but it reflects the repo's own plugin policy and all repo manifests satisfy it. Out of scope for this surgical sync.