### PR TITLE
feat(governance): constrain MCP server enablement (#677)

### DIFF
--- a/global/settings.json
+++ b/global/settings.json
@@ -18,6 +18,8 @@
     "commit": "",
     "pr": ""
   },
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [],
   "permissions": {
     "defaultMode": "default",
     "disableBypassPermissionsMode": "disable",

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -22,6 +22,9 @@
     "pr": ""
   },
 
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [],
+
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,

--- a/project/.mcp.json
+++ b/project/.mcp.json
@@ -44,6 +44,8 @@
     "usage": "Copy this file to your project root and configure the servers you need",
     "security": "Never commit this file with actual tokens - use environment variables",
     "customization": "Remove unused servers and update paths for your project",
+    "governance": "MCP enablement is constrained at the user tier: global/settings.json sets enableAllProjectMcpServers:false with an empty enabledMcpjsonServers allowlist, so a project-supplied .mcp.json is never auto-enabled - each server must be approved explicitly. Consistent with the repo's secret-blocking posture (#677).",
+    "successor-migration": "Intentionally deferred (#677): this template keeps the @modelcontextprotocol namespace rather than migrating github/postgres/slack to third-party successors, to avoid endorsing third parties. The successor pointers in 'servers' below are informational only.",
     "servers": "Reference servers live under the @modelcontextprotocol namespace (NOT @anthropic). filesystem and memory are actively maintained. github, postgres, and slack reference servers are deprecated upstream; the maintained successors are GitHub's official HTTP server (https://api.githubcopilot.com/mcp/ - see .mcp.json.example for the http transport shape), @bytebase/dbhub for PostgreSQL, and the community slack-mcp-server. Verify the current package before relying on it in production."
   }
 }

--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -17,6 +17,9 @@
         "baseRef": { "type": "string", "enum": ["fresh", "head"] }
       }
     },
+    "enableAllProjectMcpServers": { "type": "boolean" },
+    "enabledMcpjsonServers":  { "type": "array", "items": { "type": "string" } },
+    "disabledMcpjsonServers": { "type": "array", "items": { "type": "string" } },
     "env": {
       "type": "object",
       "additionalProperties": { "type": ["string", "number", "boolean"] }


### PR DESCRIPTION
Closes #677

## Summary
Minimal-scope MCP improvement. The third-party successor migration (github -> HTTP, postgres -> dbhub, slack -> community server) was **intentionally not done** to avoid endorsing third parties; only the governance posture is added.

### Governance keys
- `global/settings.json` + `global/settings.windows.json`: `enableAllProjectMcpServers: false` with an empty `enabledMcpjsonServers` allowlist. A project-supplied `.mcp.json` is never auto-enabled — each server must be approved explicitly, consistent with the repo's secret-blocking stance.
- `settings-json.schema.json`: documents `enableAllProjectMcpServers`, `enabledMcpjsonServers`, `disabledMcpjsonServers`.

### Template
- `project/.mcp.json`: `_comments` gains `governance` and `successor-migration` notes recording the explicit-enablement posture and the deferral decision. The `@modelcontextprotocol` namespace is kept; the successor pointers remain informational only.

## Out of scope (deferred)
- Migrating github/postgres/slack to third-party successors.
- A policy-tier `managed-mcp.json` allowlist (belongs to enterprise/policy scope, not user-tier global settings).

## Test Plan
- All four changed files parse as valid JSON.
- Governance keys added to the schema's documented surface (additionalProperties already accepted them; now explicit).