### PR TITLE
feat(schemas): document claudeMd and claudeMdExcludes settings keys (#678)

### DIFF
--- a/scripts/schemas/settings-json.schema.json
+++ b/scripts/schemas/settings-json.schema.json
@@ -20,6 +20,8 @@
     "enableAllProjectMcpServers": { "type": "boolean" },
     "enabledMcpjsonServers":  { "type": "array", "items": { "type": "string" } },
     "disabledMcpjsonServers": { "type": "array", "items": { "type": "string" } },
+    "claudeMd": { "type": "string" },
+    "claudeMdExcludes": { "type": "array", "items": { "type": "string" } },
     "env": {
       "type": "object",
       "additionalProperties": { "type": ["string", "number", "boolean"] }


### PR DESCRIPTION
Closes #678

## Summary
Exploratory, low-priority evaluation of the newer official hook/settings surface. Per the issue's guidance to *pick the high-value ones rather than adopting all*, this PR adopts only the safe, authoritative slice and records what was deferred.

### Adopted (this PR)
- `settings-json.schema.json`: document `claudeMd` (string; managed-settings only) and `claudeMdExcludes` (string[] of glob patterns), verified against the official settings reference.

### Already adopted in #675
- Hook handler types `command/http/mcp_tool/prompt/agent` + the `if` conditional and `once` field → settings hook-handler `anyOf`.
- Skill `arguments` and `disallowed-tools` → skill schemas.

### Deferred (with rationale)
- **subagentStatusLine**: not documented in the official settings reference; shape unverified, so not added to the schema (would risk an over-strict regression).
- **Unused events** (FileChanged, PermissionRequest, PermissionDenied): the `hooks` object already accepts arbitrary event names via `additionalProperties`; wiring them as net-new audit/validation hooks is feature work, not a schema sync.
- **Rewriting command-substring hook guards to declarative `if`**: a behavior change to working, test-covered hooks. Those tests (validate-hooks.yml) run only on PRs to `main`, so a develop PR cannot verify them — deferred to a dedicated, verifiable change.

## Test Plan
- Schema parses as valid JSON.
- `scripts/validate_skills.sh` → 359/359 pass.