### PR TITLE
feat(skills): apply arguments/disallowed-tools to automation skills

### DIFF
--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[project-name] [issue-number] [--solo|--team] [--limit N] [--dry
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
+disallowed-tools: [WebSearch, WebFetch, NotebookEdit]
 max_iterations: 10
 halt_conditions:
   - { type: success, expr: "CI all-green and PR merged" }

--- a/global/skills/_internal/pr-work/SKILL.md
+++ b/global/skills/_internal/pr-work/SKILL.md
@@ -5,6 +5,7 @@ argument-hint: "[project-name] [pr-number] [--solo|--team] [--limit N] [--dry-ru
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: "Bash(gh *)"
+disallowed-tools: [WebSearch, WebFetch, NotebookEdit]
 max_iterations: 5
 halt_conditions:
   - { type: success, expr: "All PR checks pass" }

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -6,6 +6,7 @@ user-invocable: true
 disable-model-invocation: true
 context: fork
 allowed-tools: "Bash(git *) Bash(gh *)"
+disallowed-tools: [WebSearch, WebFetch, NotebookEdit]
 max_iterations: 5
 halt_conditions:
   - { type: success, expr: "Release PR merged and tag published" }


### PR DESCRIPTION
## Summary

Part of #688 (Component 3). Closes #689.

The strict and lenient schemas already define both `arguments` and
`disallowed-tools` (see `scripts/schemas/skill-md.schema.strict.json` L85
and L107); this PR only applies `disallowed-tools` to the three automation
skills. No schema files were touched.

## Per-skill decisions

| Skill | disallowed-tools | arguments |
|-------|------------------|-----------|
| `issue-work` | `[WebSearch, WebFetch, NotebookEdit]` | omitted |
| `pr-work` | `[WebSearch, WebFetch, NotebookEdit]` | omitted |
| `release` | `[WebSearch, WebFetch, NotebookEdit]` | omitted |

### Why these `disallowed-tools`

- All three are `loop_safe: false` autonomous git/gh automations. They
  never browse the web or edit notebooks. `WebSearch`, `WebFetch`, and
  `NotebookEdit` are removed so they cannot fire mid-loop and stall or
  derail the run. Non-use was confirmed by grepping each `SKILL.md` and
  every file under its `reference/` directory -- zero matches in the three
  target skills (the only hits in the repo are in the `research` and
  `harness` skills, which are out of scope here).

### Why `AskUserQuestion` is NOT disallowed

- The official spec example removes `AskUserQuestion` from background
  loops, but all three of these skills genuinely call it: `issue-work`
  Phase 0 mode selection (`SKILL.md`), `pr-work` mode selection
  (`SKILL.md`), `release` mode selection (`SKILL.md`), and the batch-gate
  prompts in `reference/batch-mode.md` for `issue-work`/`pr-work`.
  Disallowing it would break interactive mode selection and the batch
  approval gate, so it is deliberately left available.

### Why `arguments` is omitted (all three)

- `arguments` is a semantic key that maps positional `$name` substitutions.
  All three skills parse the entire `$ARGUMENTS` string with `awk`/`grep`/
  `sed` (e.g. `ARGS="$ARGUMENTS"; PROJECT=$(echo "$ARGS" | awk '{print $1}')`)
  and never reference positional `$name` tokens. Adding an `arguments` list
  without matching body wiring would create an inert, misleading field that
  also duplicates the existing `argument-hint`. Per issue #689 non-goals
  ("Do NOT add an inert arguments field without corresponding body usage")
  and the acceptance criteria allowing per-skill decline with rationale,
  `arguments` is omitted. Body rewiring to positional `$name` is out of
  scope for this change.

## Test Plan

Ran locally on the feature branch after the edits:

- `STRICT_SCHEMA=1 ./scripts/spec_lint.sh --strict`
  -> exit 0; `spec_lint: mode=skill files=38 violations=0` (plugin and
  settings modes also 0 violations).
- `./scripts/validate_skills.sh`
  -> exit 0; summary `360 checks, 360 pass, 0 fail, 5 warnings`. All 5
  warnings are pre-existing file-length / reference-directory advisories
  unrelated to this change; the three edited skills report valid YAML.
