### PR TITLE
chore(skills): wire tier presets into fleet-orchestrator/harness/release

### DIFF
--- a/docs/TOKEN_OPTIMIZATION.md
+++ b/docs/TOKEN_OPTIMIZATION.md
@@ -487,10 +487,13 @@ Pass the tier as a flag when invoking a tiered skill:
 Omitting `--tier` selects the skill's declared `default_tier`. Unknown tier
 values fall back to `default_tier` with a warning.
 
-### Tiered Skills (this PR)
+### Tiered Skills
 
 - `pr-work`
 - `issue-work`
+- `fleet-orchestrator`
+- `harness`
+- `release`
 
 Additional skills will adopt the schema as their bodies cross the 5 KB
 threshold or as workflow demand justifies differentiated loading.

--- a/global/skills/_internal/fleet-orchestrator/SKILL.md
+++ b/global/skills/_internal/fleet-orchestrator/SKILL.md
@@ -11,7 +11,22 @@ halt_conditions:
   - { type: limit,   expr: "--max-parallel worker pool drains with no pending items" }
 on_halt: "Render final fleet-status table with per-repo outcome and exit"
 loop_safe: false
+tiers:
+  light:
+    ref_docs: []
+    deep_checks: false
+  standard:
+    ref_docs: [core]
+    deep_checks: false
+  deep:
+    ref_docs: [core]
+    deep_checks: true
+default_tier: standard
 iso_class: none
+# ref_docs keys:
+#   core -> reference/worker-template.md
+#   (reference/manifest-schema.json is a JSON Schema, not a prose ref_doc;
+#    it is cited in-body and loaded directly when rendering fleet-status.json)
 ---
 
 # Fleet Orchestrator -- Parallel Multi-Repo Directive Executor

--- a/global/skills/_internal/harness/SKILL.md
+++ b/global/skills/_internal/harness/SKILL.md
@@ -5,7 +5,23 @@ argument-hint: "[domain-or-project-description]"
 user-invocable: true
 disable-model-invocation: true
 loop_safe: false
+tiers:
+  light:
+    ref_docs: []
+    deep_checks: false
+  standard:
+    ref_docs: [core]
+    deep_checks: false
+  deep:
+    ref_docs: [core, advanced]
+    deep_checks: true
+default_tier: standard
 iso_class: none
+# ref_docs keys:
+#   core     -> reference/agent-design-patterns.md, reference/agent-frontmatter-spec.md
+#   advanced -> reference/orchestrator-template.md, reference/team-examples.md,
+#               reference/skill-writing-guide.md, reference/skill-testing-guide.md,
+#               reference/qa-agent-guide.md, reference/long-running-harness-guide.md
 ---
 
 # Harness -- Agent Team & Skill Architect

--- a/global/skills/_internal/release/SKILL.md
+++ b/global/skills/_internal/release/SKILL.md
@@ -14,7 +14,21 @@ halt_conditions:
   - { type: failure, expr: "integrity check fails" }
 on_halt: "Report incomplete release state, leave tag/PR in whatever state they are in, do not force-publish"
 loop_safe: false
+tiers:
+  light:
+    ref_docs: []
+    deep_checks: false
+  standard:
+    ref_docs: [core]
+    deep_checks: true
+  deep:
+    ref_docs: [core, advanced]
+    deep_checks: true
+default_tier: standard
 iso_class: none
+# ref_docs keys:
+#   core     -> reference/error-handling.md
+#   advanced -> reference/team-mode.md
 ---
 
 # Release Command

--- a/global/skills/_policy.md
+++ b/global/skills/_policy.md
@@ -132,7 +132,7 @@ default_tier: standard        # Tier used when caller omits --tier
 
 ### When to Apply
 
-Recommended for skills whose `SKILL.md` body exceeds 5 KB; adopted incrementally rather than all at once (current tiered skills: `issue-work`, `pr-work` — see the phased-rollout note under "Tiered Skills" in `docs/TOKEN_OPTIMIZATION.md`). Optional for smaller skills, where a single loading mode suffices.
+Recommended for skills whose `SKILL.md` body exceeds 5 KB; adopted incrementally rather than all at once (current tiered skills: `issue-work`, `pr-work`, `fleet-orchestrator`, `harness`, `release` — see the phased-rollout note under "Tiered Skills" in `docs/TOKEN_OPTIMIZATION.md`). Optional for smaller skills, where a single loading mode suffices.
 
 ### Invocation
 


### PR DESCRIPTION
## Summary

Wires the repo's tier-preset convention into the frontmatter of three skills
that already ship `reference/` directories but did not declare the
`tiers:` / `ref_docs:` / `default_tier:` preset block. Only `issue-work` and
`pr-work` were tiered before this change. The reference docs already exist and
are cited in-body; this PR only adds the preset wiring so the harness can load
each skill at `light` / `standard` / `deep` depth.

The blocks follow the `issue-work` / `pr-work` pattern exactly: `tiers` with
`light` / `standard` / `deep` each carrying a `ref_docs` alias list and a
`deep_checks` flag, `default_tier: standard`, and a trailing `# ref_docs keys:`
comment that maps each alias to its `reference/*.md` file. They are inserted
after the `loop_safe` key and before `iso_class` / the closing `---`, matching
the existing frontmatter style.

Part of #688
Closes #690

## Per-skill tiers design

### fleet-orchestrator
- `light`: `ref_docs: []`, `deep_checks: false`
- `standard`: `ref_docs: [core]`, `deep_checks: false`
- `deep`: `ref_docs: [core]`, `deep_checks: true`
- `default_tier: standard`
- Alias map: `core -> reference/worker-template.md`
- `reference/manifest-schema.json` is intentionally left out of `ref_docs`: it
  is a JSON Schema (Draft 2020-12), not a prose ref_doc. It is cited in-body and
  loaded directly when rendering `fleet-status.json`. The `# ref_docs keys:`
  comment documents this. `worker-template.md` is the only `.md` reference, so
  `deep` reuses `core` and distinguishes itself via `deep_checks: true`.

### harness
- `light`: `ref_docs: []`, `deep_checks: false`
- `standard`: `ref_docs: [core]`, `deep_checks: false`
- `deep`: `ref_docs: [core, advanced]`, `deep_checks: true`
- `default_tier: standard`
- Alias map:
  - `core -> reference/agent-design-patterns.md, reference/agent-frontmatter-spec.md`
    (foundational design + frontmatter spec cited throughout Phases 1-3)
  - `advanced -> reference/orchestrator-template.md, reference/team-examples.md,`
    `reference/skill-writing-guide.md, reference/skill-testing-guide.md,`
    `reference/qa-agent-guide.md, reference/long-running-harness-guide.md`
    (deep build/validate/long-running material)

### release
- `light`: `ref_docs: []`, `deep_checks: false`
- `standard`: `ref_docs: [core]`, `deep_checks: true`
- `deep`: `ref_docs: [core, advanced]`, `deep_checks: true`
- `default_tier: standard`
- Alias map (mirrors `issue-work`):
  - `core -> reference/error-handling.md` (prerequisite + runtime error handling)
  - `advanced -> reference/team-mode.md` (team coordination workflow)

## release body slimming

Not done. `release/SKILL.md` trips the `validate_skills` >500-line WARNING (553
lines after this change, 539 before). This is a WARNING, not a FAIL, and is
pre-existing. Body slimming was skipped to avoid any risk to the in-body
`reference/error-handling.md` and `reference/team-mode.md` citations and the
section anchors. Correctness was prioritized over the line count, per the
issue's conservative guidance. The same length WARNING already applies to
`issue-work` (608) and `pr-work` (796).

## Doc-list updates

- `global/skills/_policy.md` (Tier Preset Schema, "When to Apply"): the
  "current tiered skills" list now reads
  `issue-work, pr-work, fleet-orchestrator, harness, release`.
- `docs/TOKEN_OPTIMIZATION.md`: the "Tiered Skills (this PR)" heading was
  renamed to "Tiered Skills" (the original `(this PR)` qualifier was stale) and
  the list now includes `fleet-orchestrator`, `harness`, and `release`.

## Non-goals (per issue)

- Did not create reference splits from scratch (they already exist).
- Did not modify `pr-work` or `issue-work` (already tiered).

## Test Plan

All commands run from the repo root on the feature branch.

- `STRICT_SCHEMA=1 ./scripts/spec_lint.sh --strict` -> exit 0
  - `mode=skill files=38 violations=0`
  - `mode=plugin files=2 violations=0`
  - `mode=settings files=3 violations=0`
- `./scripts/validate_skills.sh` -> exit 0
  - `360 checks, 360 pass, 0 fail, 5 warnings`
  - The 5 warnings are exactly the pre-existing baseline (doc-index no-reference,
    memory-review no-reference, issue-work length, pr-work length, release
    length). No NEW failures and no new orphan/reference warnings were
    introduced. `fleet-orchestrator` (489 lines) and `harness` (287 lines) raise
    zero warnings.
- Frontmatter YAML for all three edited skills parses with `yaml.safe_load`;
  `tiers` keys and `default_tier` resolve as designed.
- `grep "reference/"` on each edited `SKILL.md` confirms in-body reference
  citations are intact (fleet-orchestrator 9, harness 23, release 4 mentions),
  so no orphan-reference warning is raised.
