### PR TITLE
feat(hooks): add permission-denial-logger (PermissionDenied audit)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,6 +47,7 @@ Each hook event type requires a Claude Code version that supports it. If your Cl
 | `CwdChanged` | cwd-change-logger | Log working-directory changes (observation only) |
 | `InstructionsLoaded` | instructions-loaded-reinforcer | Reinforce core instructions when context is (re)loaded |
 | `TeammateIdle` | session-logger | Log teammate idle events (Agent Teams) |
+| `PermissionDenied` | permission-denial-logger | Append a redacted JSONL audit record of denied tool calls (observation only) |
 
 > This table lists only the events **this config wires**. The full official catalog is larger (~30 events as of 2026-05; see `code.claude.com/docs/en/hooks`). Unwired official events are not defects -- see `docs/official-spec-rereview-2026-05-29.md`.
 
@@ -228,9 +229,9 @@ The README v1.7.0 changelog originally claimed "All 42 bash scripts now have Pow
 
 | Surface | Bash count | PowerShell count | Coverage |
 |---|---:|---:|---:|
-| `global/hooks/*.sh` | 35 | 35 | 35/35 (100%) |
+| `global/hooks/*.sh` | 36 | 36 | 36/36 (100%) |
 
-The `*.sh` ↔ `*.ps1` mapping is 1:1; the parity audit job in `.github/workflows/validate-hooks-doc.yml` fails the PR if the counts diverge. (The count dropped from 37 to 35 when the expired P4 rollout-timeline hooks — `p4-timeline-guard` and `p4-timeline-reminder` — were retired; see the strict-schema kill-switch note above.)
+The `*.sh` ↔ `*.ps1` mapping is 1:1; the parity audit job in `.github/workflows/validate-hooks-doc.yml` fails the PR if the counts diverge. (The count dropped from 37 to 35 when the expired P4 rollout-timeline hooks — `p4-timeline-guard` and `p4-timeline-reminder` — were retired; see the strict-schema kill-switch note above. It rose to 36 when `permission-denial-logger` was added for the `PermissionDenied` audit event.)
 
 The script that produces the live count: `bash -c 'b=$(ls global/hooks/*.sh | wc -l); p=$(ls global/hooks/*.ps1 | wc -l); echo "$p/$b"'`.
 

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1025,6 +1025,7 @@ this catalog for the canonical hook inventory.
 | [`memory-integrity-check.sh`](#memory-integrity-check) | SessionStart (sync) | yes |
 | [`memory-write-guard.sh`](#memory-write-guard) | PreToolUse (Edit|Write) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
+| [`permission-denial-logger.sh`](#permission-denial-logger) | PermissionDenied | yes |
 | [`post-compact-restore.sh`](#post-compact-restore) | PostCompact (sync) | yes |
 | [`post-task-checkpoint.sh`](#post-task-checkpoint) | PostToolUse | yes |
 | [`pr-language-guard.sh`](#pr-language-guard) | PreToolUse (Bash) | yes |
@@ -1044,7 +1045,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 35 bash hooks, 35 with PowerShell counterparts._
+_Total: 36 bash hooks, 36 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1337,6 +1338,24 @@ Blocks gh pr merge commands when any PR check is not passing.
 | Fail policy | FAIL-OPEN on gh CLI errors. If gh is missing, unauthenticated, |
 | PowerShell counterpart | present (`merge-gate-guard.ps1`) |
 | Source | `global/hooks/merge-gate-guard.sh` |
+
+### permission-denial-logger
+
+_File:_ `permission-denial-logger.sh`
+
+_Anchor:_ `#permission-denial-logger`
+
+Appends a redacted JSONL audit record for every denied tool call.
+
+| Field | Value |
+|---|---|
+| Hook Type | PermissionDenied |
+| Trigger / Matcher | — |
+| Exit codes | 0 (always — passive logger, never alters the permission decision) |
+| Response format | none (observation-only event; no JSON emitted, never blocks) |
+| Fail policy | best-effort; logging failures are swallowed and never surface |
+| PowerShell counterpart | present (`permission-denial-logger.ps1`) |
+| Source | `global/hooks/permission-denial-logger.sh` |
 
 ### post-compact-restore
 

--- a/docs/official-spec-rereview-2026-05-29.md
+++ b/docs/official-spec-rereview-2026-05-29.md
@@ -79,7 +79,7 @@ files. Recording them so future reviews do not re-flag them:
 | D2 | high | plugins | README install commands use **non-existent** flags `--source/--url/--subdir` and there is no `marketplace.json`, so the plugins are not installable as documented | `plugin/README.md:10-15`, `plugin-lite/README.md:19-21` |
 | D3 | high | skills | strict skill schema rejects the repo's **own** `iso_class`/`safety_class`/`applies_at_or_above` extension fields, blocking the `p4_strict_schema` flip (internal contradiction) | `scripts/schemas/skill-md.schema.strict.json:8` vs `global/skills/_internal/pr-work/SKILL.md:27` |
 | D4 | high | memory | memory-sync docs assume a cwd-encoded per-worktree path; official auto-memory is now git-repo-derived and shared across worktrees, so the user-facing migration instructions are wrong | `docs/MEMORY_MIGRATION.md:77`, `docs/MEMORY_SYNC.md:400` |
-| D5 | med | settings/perms | local `settings-json.schema.json` lags official: `defaultMode` enum missing `auto`/`dontAsk`; hook handler `type` enum locked to `command`; permissions object missing `disableBypassPermissionsMode`/`disableAutoMode`/`additionalDirectories` | `scripts/schemas/settings-json.schema.json:29,54,25-37` |
+| D5 | ~~med~~ **RESOLVED** | settings/perms | ~~local `settings-json.schema.json` lags official~~ — **fixed**: `defaultMode` enum now includes `auto`/`dontAsk`; the hook handler `type` is no longer locked to `command` (all 5 official handler types — `command`, `http`, `mcp_tool`, `prompt`, `agent` — plus the `if` conditional and `once` flag are modeled via the `anyOf` branch set); the permissions object now declares `disableBypassPermissionsMode`/`disableAutoMode`/`additionalDirectories` | `scripts/schemas/settings-json.schema.json` (`defaultMode` enum; `hooks` `anyOf` handler-type branches with `if`/`once`; `permissions` properties) |
 | D6 | med | plugins | both manifests ship a non-official `compatibility.minClaudeCodeVersion` field (trips `--strict`); neither declares `$schema` | `plugin/.claude-plugin/plugin.json:12`, `plugin-lite/.claude-plugin/plugin.json:12` |
 | D7 | med | skills | skill schemas mark `name` as required (official: optional, defaults to directory name); description `maxLength` 1024 vs official 1536 | `scripts/schemas/skill-md.schema.*.json` |
 | D8 | med | hooks | `tool-failure-logger` header + `HOOKS.md` name a phantom event `ToolFailure` (actual wiring correctly uses `PostToolUseFailure`) | `global/hooks/tool-failure-logger.sh:4`, `HOOKS.md:1041,1572` |
@@ -152,8 +152,10 @@ D1 `.mcp.json` package names; D2 plugin install flow + `marketplace.json`; D3 st
 
 ### Track C -- Validation-schema sync (backlog)
 
-D5 (settings schema enums/fields), D6 (plugin manifest `compatibility`/`$schema`), D7 (skill
-schema `name`/`maxLength`), D8 (`ToolFailure` -> `PostToolUseFailure`).
+~~D5 (settings schema enums/fields)~~ **done** (schema now models all 5 hook handler types +
+`if`/`once`, the full `defaultMode` enum, and the permissions hardening fields); D6 (plugin
+manifest `compatibility`/`$schema`), D7 (skill schema `name`/`maxLength`), D8 (`ToolFailure` ->
+`PostToolUseFailure`).
 
 ### Track D -- Opportunity backlog (GitHub issues)
 

--- a/global/hooks/permission-denial-logger.ps1
+++ b/global/hooks/permission-denial-logger.ps1
@@ -1,0 +1,124 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+
+# permission-denial-logger.ps1
+# Appends a redacted JSONL audit record for every denied tool call.
+# Hook Type: PermissionDenied
+# Exit codes: 0 (always - passive logger, never alters the permission decision)
+# Response format: none (observation-only event; no JSON emitted, never blocks)
+#
+# PowerShell parity port of permission-denial-logger.sh. Reads the official
+# PermissionDenied payload from stdin ({ tool_name, tool_input,
+# permission_suggestions }), redacts secrets from tool_input, and appends one
+# JSON line to ${env:CLAUDE_LOG_DIR} (defaults to ~/.claude/logs) /
+# permission-denials.jsonl. Purely passive: emits no permission-altering output
+# and always exits 0.
+#
+# Opt-out: set CLAUDE_PERMISSION_LOGGER=0 to disable (early no-op exit).
+#
+# Privacy: secrets in tool_input are scrubbed before the write so raw tool_input
+# never reaches disk; the log is tail-rotated at 10 MB via Invoke-LogRotation.
+
+# Opt-out switch: a single "0" disables the logger entirely.
+if ($env:CLAUDE_PERMISSION_LOGGER -eq '0') {
+    exit 0
+}
+
+$logDir = if ($env:CLAUDE_LOG_DIR) { $env:CLAUDE_LOG_DIR } else { Join-Path $HOME '.claude/logs' }
+$logFile = Join-Path $logDir 'permission-denials.jsonl'
+
+# Redact secrets from an arbitrary string. Mirrors the sed pattern set in
+# permission-denial-logger.sh: authorization/bearer, token/key/secret/password
+# assignments, URL inline credentials, AWS access keys, GitHub PATs, and PEM
+# private-key blocks. Over-redaction is preferable to leaking a credential.
+function Get-RedactedText {
+    param([string]$Text)
+    if ([string]::IsNullOrEmpty($Text)) { return $Text }
+    $t = $Text
+    $t = [regex]::Replace($t, '(authorization)([\s:=]+)(bearer|token|basic)?\s*[A-Za-z0-9._~+/=-]+', '$1$2<REDACTED>', 'IgnoreCase')
+    $t = [regex]::Replace($t, '(bearer)(\s+)[A-Za-z0-9._~+/=-]+', '$1$2<REDACTED>', 'IgnoreCase')
+    $t = [regex]::Replace($t, '((api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|client[_-]?secret|refresh[_-]?token)["'']?\s*[:=]\s*["'']?)[^"''\s,}&]+', '$1<REDACTED>', 'IgnoreCase')
+    $t = [regex]::Replace($t, '(://[^/\s:@]+):[^/\s@]+@', '$1:<REDACTED>@')
+    $t = [regex]::Replace($t, '\b(AKIA|ASIA)[A-Z0-9]{16}\b', '$1<REDACTED>')
+    $t = [regex]::Replace($t, '\b(gh[pousr]_)[A-Za-z0-9]{20,}', '$1<REDACTED>')
+    $t = [regex]::Replace($t, '-----BEGIN[^-]*PRIVATE KEY-----[^-]*-----END[^-]*PRIVATE KEY-----', '<REDACTED PRIVATE KEY>')
+    return $t
+}
+
+# Best-effort: never fail the (already-made) permission decision on a logging
+# error. Every disk touch is wrapped in try/catch.
+try {
+    if (-not (Test-Path -LiteralPath $logDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    }
+} catch {
+    exit 0
+}
+
+# Tail-rotate at 10 MB so the audit trail cannot grow unbounded.
+try { Invoke-LogRotation -FilePath $logFile -MaxMB 10 -MaxArchives 5 } catch {}
+
+$ts = (Get-Date).ToString('yyyy-MM-ddTHH:mm:sszzz')
+
+# Read raw stdin.
+$raw = ''
+try {
+    if ([Console]::IsInputRedirected) {
+        $raw = [Console]::In.ReadToEnd()
+    }
+} catch {}
+
+function Write-JsonLine {
+    param([hashtable]$Entry)
+    try {
+        ($Entry | ConvertTo-Json -Compress -Depth 10) | Out-File -FilePath $logFile -Append -Encoding utf8
+    } catch {}
+}
+
+# Empty / unparseable stdin: log a marker line and exit cleanly.
+$json = $null
+if (-not [string]::IsNullOrWhiteSpace($raw)) {
+    try { $json = $raw | ConvertFrom-Json -ErrorAction Stop } catch { $json = $null }
+}
+if ($null -eq $json) {
+    Write-JsonLine ([ordered]@{ ts = $ts; tool_name = 'unknown'; note = 'empty or unparseable hook input' })
+    exit 0
+}
+
+$toolName = if ($json.PSObject.Properties.Name -contains 'tool_name' -and $json.tool_name) { [string]$json.tool_name } else { 'unknown' }
+$sessionId = if ($json.PSObject.Properties.Name -contains 'session_id' -and $json.session_id) { [string]$json.session_id } else { '' }
+
+# Serialize tool_input to compact JSON, scrub textually, then re-parse. On
+# re-parse failure fall back to a flat redacted string so the record is always
+# valid JSON and never carries a raw secret.
+$toolInputObj = if ($json.PSObject.Properties.Name -contains 'tool_input' -and $null -ne $json.tool_input) { $json.tool_input } else { [PSCustomObject]@{} }
+$toolInputRaw = $toolInputObj | ConvertTo-Json -Compress -Depth 10
+$toolInputRedactedStr = Get-RedactedText -Text $toolInputRaw
+
+$suggestions = if ($json.PSObject.Properties.Name -contains 'permission_suggestions' -and $null -ne $json.permission_suggestions) { $json.permission_suggestions } else { @() }
+
+$toolInputRedacted = $null
+$parsedOk = $true
+try { $toolInputRedacted = $toolInputRedactedStr | ConvertFrom-Json -ErrorAction Stop } catch { $parsedOk = $false }
+
+if ($parsedOk) {
+    $entry = [ordered]@{
+        ts                     = $ts
+        session_id             = $sessionId
+        tool_name              = $toolName
+        tool_input_redacted    = $toolInputRedacted
+        permission_suggestions = $suggestions
+    }
+} else {
+    $entry = [ordered]@{
+        ts                     = $ts
+        session_id             = $sessionId
+        tool_name              = $toolName
+        tool_input_redacted    = $toolInputRedactedStr
+        permission_suggestions = $suggestions
+    }
+}
+
+Write-JsonLine $entry
+exit 0

--- a/global/hooks/permission-denial-logger.sh
+++ b/global/hooks/permission-denial-logger.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# permission-denial-logger.sh
+# Appends a redacted JSONL audit record for every denied tool call.
+# Hook Type: PermissionDenied
+# Exit codes: 0 (always — passive logger, never alters the permission decision)
+# Response format: none (observation-only event; no JSON emitted, never blocks)
+# Fail policy: best-effort; logging failures are swallowed and never surface
+#
+# Behavior:
+#   Reads the official PermissionDenied payload from stdin
+#   ({ tool_name, tool_input, permission_suggestions }), redacts secrets from
+#   tool_input, and appends one JSON line to
+#   ${CLAUDE_LOG_DIR:-$HOME/.claude/logs}/permission-denials.jsonl.
+#   The hook is purely passive: it emits no permission-altering output and
+#   always exits 0, mirroring the logging-style hooks (config-change-logger,
+#   tool-failure-logger) rather than the gating guards.
+#
+# Opt-out:
+#   Set CLAUDE_PERMISSION_LOGGER=0 to disable (early no-op exit).
+#
+# Privacy / security:
+#   Secrets in tool_input (tokens, API keys, Authorization headers, URL
+#   credentials, ~/.ssh/ key contents, etc.) are scrubbed before the write so
+#   raw tool_input never reaches disk. The log is tail-rotated at 10 MB via
+#   lib/rotate.sh to bound growth (see docs/design/permission-event-hooks.md).
+
+set -euo pipefail
+
+# Opt-out switch: a single "0" disables the logger entirely.
+if [ "${CLAUDE_PERMISSION_LOGGER:-1}" = "0" ]; then
+    exit 0
+fi
+
+LOG_DIR="${CLAUDE_LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/permission-denials.jsonl"
+
+# Redact secrets from an arbitrary string. The pattern set targets the high-risk
+# shapes that show up in tool_input: bearer/authorization headers, common
+# token/key/secret/password assignments (env-style and JSON-style), URL inline
+# credentials, AWS-style access keys, GitHub PATs, and private-key PEM blocks.
+# A self-contained scrubber is used because there is no shared redaction library
+# in the repo to reuse yet (see PR notes / issue #691); keep it conservative —
+# over-redaction is preferable to leaking a credential.
+redact_secrets() {
+    sed -E \
+        -e 's/(authorization)([[:space:]:=]+)(bearer|token|basic)?[[:space:]]*[A-Za-z0-9._~+/=-]+/\1\2<REDACTED>/Ig' \
+        -e 's/(bearer)([[:space:]]+)[A-Za-z0-9._~+/=-]+/\1\2<REDACTED>/Ig' \
+        -e 's/((api[_-]?key|access[_-]?key|secret|token|password|passwd|pwd|client[_-]?secret|refresh[_-]?token)["'"'"']?[[:space:]]*[:=][[:space:]]*["'"'"']?)[^"'"'"'[:space:],}&]+/\1<REDACTED>/Ig' \
+        -e 's#(://[^/[:space:]:@]+):[^/[:space:]@]+@#\1:<REDACTED>@#g' \
+        -e 's/\b(AKIA|ASIA)[A-Z0-9]{16}\b/\1<REDACTED>/g' \
+        -e 's/\b(gh[pousr]_)[A-Za-z0-9]{20,}/\1<REDACTED>/g' \
+        -e 's/-----BEGIN[^-]*PRIVATE KEY-----[^-]*-----END[^-]*PRIVATE KEY-----/<REDACTED PRIVATE KEY>/g'
+}
+
+# Best-effort log writer. Never fail the (already-made) permission decision on a
+# logging error — every disk touch is guarded.
+mkdir -p "$LOG_DIR" 2>/dev/null || exit 0
+
+# Tail-rotate at 10 MB so the audit trail cannot grow unbounded.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"
+if [ -f "$LIB_DIR/rotate.sh" ]; then
+    # shellcheck source=lib/rotate.sh
+    . "$LIB_DIR/rotate.sh"
+    rotate_log "$LOG_FILE" 10 5 2>/dev/null || true
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+
+TS=$(date +"%Y-%m-%dT%H:%M:%S%z")
+
+# Without jq we cannot safely parse or re-emit JSON; record a minimal marker
+# rather than risk writing a malformed or unredacted line.
+if ! command -v jq >/dev/null 2>&1; then
+    printf '{"ts":"%s","tool_name":"unknown","note":"jq unavailable — payload not parsed"}\n' \
+        "$TS" >>"$LOG_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+# Empty / unparseable stdin: log a marker line and exit cleanly.
+if [ -z "$INPUT" ] || ! echo "$INPUT" | jq -e . >/dev/null 2>&1; then
+    jq -cn --arg ts "$TS" \
+        '{ts:$ts, tool_name:"unknown", note:"empty or unparseable hook input"}' \
+        >>"$LOG_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo "unknown")
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
+
+# Redact secrets inside tool_input. The value is serialized to a compact JSON
+# string, scrubbed textually, then re-parsed. If re-parsing fails (e.g. the
+# scrub disturbed the structure), fall back to a flat redacted string so the
+# record is always valid JSON and never carries a raw secret.
+TOOL_INPUT_RAW=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null || echo '{}')
+TOOL_INPUT_REDACTED=$(printf '%s' "$TOOL_INPUT_RAW" | redact_secrets)
+
+SUGGESTIONS=$(echo "$INPUT" | jq -c '.permission_suggestions // []' 2>/dev/null || echo '[]')
+
+if echo "$TOOL_INPUT_REDACTED" | jq -e . >/dev/null 2>&1; then
+    jq -cn \
+        --arg ts "$TS" \
+        --arg session_id "$SESSION_ID" \
+        --arg tool_name "$TOOL_NAME" \
+        --argjson tool_input_redacted "$TOOL_INPUT_REDACTED" \
+        --argjson permission_suggestions "$SUGGESTIONS" \
+        '{ts:$ts, session_id:$session_id, tool_name:$tool_name, tool_input_redacted:$tool_input_redacted, permission_suggestions:$permission_suggestions}' \
+        >>"$LOG_FILE" 2>/dev/null || true
+else
+    jq -cn \
+        --arg ts "$TS" \
+        --arg session_id "$SESSION_ID" \
+        --arg tool_name "$TOOL_NAME" \
+        --arg tool_input_redacted "$TOOL_INPUT_REDACTED" \
+        --argjson permission_suggestions "$SUGGESTIONS" \
+        '{ts:$ts, session_id:$session_id, tool_name:$tool_name, tool_input_redacted:$tool_input_redacted, permission_suggestions:$permission_suggestions}' \
+        >>"$LOG_FILE" 2>/dev/null || true
+fi
+
+exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -453,6 +453,18 @@
           }
         ]
       }
+    ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/permission-denial-logger.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -406,6 +406,18 @@
           }
         ]
       }
+    ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/permission-denial-logger.ps1",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
     ]
   },
 

--- a/tests/hooks/test-permission-denial-logger.sh
+++ b/tests/hooks/test-permission-denial-logger.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Test suite for permission-denial-logger.sh
+# Run: bash tests/hooks/test-permission-denial-logger.sh
+#
+# The hook is a passive PermissionDenied logger: it must never emit
+# permission-altering output, must redact secrets before writing, and must
+# honor the CLAUDE_PERMISSION_LOGGER=0 opt-out. Tests run against an isolated
+# CLAUDE_LOG_DIR so the real ~/.claude/logs is never touched.
+
+HOOK="global/hooks/permission-denial-logger.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+# Fresh isolated log dir per invocation of the hook.
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# run_hook <env-prefix> <json-input> -> echoes the log file path; populates
+# global LAST_STDOUT and LAST_RC.
+LAST_STDOUT=""
+LAST_RC=0
+run_hook() {
+    local logdir="$TMP_ROOT/$RANDOM-$RANDOM/logs"
+    LAST_STDOUT=$(printf '%s' "$2" | env CLAUDE_LOG_DIR="$logdir" $1 bash "$HOOK" 2>/dev/null)
+    LAST_RC=$?
+    echo "$logdir/permission-denials.jsonl"
+}
+
+assert_log_contains() {
+    local logfile="$1" needle="$2" label="$3"
+    if [ -f "$logfile" ] && grep -qF "$needle" "$logfile"; then
+        ((PASS++)); echo "  PASS: $label"
+    else
+        ((FAIL++)); ERRORS+=("FAIL: $label — '$needle' not found in $(cat "$logfile" 2>/dev/null)")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_log_absent_pattern() {
+    local logfile="$1" pattern="$2" label="$3"
+    if [ -f "$logfile" ] && grep -qE "$pattern" "$logfile"; then
+        ((FAIL++)); ERRORS+=("FAIL: $label — leaked pattern '$pattern' in $(cat "$logfile")")
+        echo "  FAIL: $label"
+    else
+        ((PASS++)); echo "  PASS: $label"
+    fi
+}
+
+assert_no_logfile() {
+    local logfile="$1" label="$2"
+    if [ ! -f "$logfile" ]; then
+        ((PASS++)); echo "  PASS: $label"
+    else
+        ((FAIL++)); ERRORS+=("FAIL: $label — log file unexpectedly created")
+        echo "  FAIL: $label"
+    fi
+}
+
+assert_true() {
+    local cond="$1" label="$2"
+    if [ "$cond" = "1" ]; then
+        ((PASS++)); echo "  PASS: $label"
+    else
+        ((FAIL++)); ERRORS+=("FAIL: $label")
+        echo "  FAIL: $label"
+    fi
+}
+
+echo "=== permission-denial-logger.sh tests ==="
+echo ""
+
+echo "[Basic logging]"
+LOG=$(run_hook "" '{"session_id":"sess-1","tool_name":"Bash","tool_input":{"command":"ls /etc"},"permission_suggestions":[]}')
+assert_true "$([ "$LAST_RC" = "0" ] && echo 1)" "exit 0 on normal denial"
+assert_log_contains "$LOG" '"tool_name":"Bash"' "records tool_name"
+assert_log_contains "$LOG" '"session_id":"sess-1"' "records session_id"
+assert_log_contains "$LOG" 'tool_input_redacted' "records tool_input_redacted field"
+
+echo ""
+echo "[Passive contract — no stdout, never blocks]"
+run_hook "" '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' >/dev/null
+assert_true "$([ -z "$LAST_STDOUT" ] && echo 1)" "emits nothing on stdout (no permission output)"
+assert_true "$([ "$LAST_RC" = "0" ] && echo 1)" "exit 0 even for a dangerous command"
+
+echo ""
+echo "[Opt-out]"
+LOG=$(run_hook "CLAUDE_PERMISSION_LOGGER=0" '{"tool_name":"Bash","tool_input":{"command":"ls"}}')
+assert_true "$([ "$LAST_RC" = "0" ] && echo 1)" "CLAUDE_PERMISSION_LOGGER=0 exits 0"
+assert_no_logfile "$LOG" "CLAUDE_PERMISSION_LOGGER=0 writes nothing"
+
+echo ""
+echo "[Redaction — secrets must not reach disk]"
+# Secret-shaped fixtures are assembled at runtime via adjacent-quote
+# concatenation so no contiguous secret pattern appears in the committed
+# source (would trip secret scanners such as GitGuardian). The assembled
+# runtime values are real-shaped and exercise the hook's redaction regex.
+fake_bearer='sk-''live-SECRET12345'
+fake_urlpw='hunter2''PW'
+fake_pat='ghp_''ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+redaction_cmd=$(printf 'curl -H "Authorization: Bearer %s" https://u:%s@h.example/x?token=%s' \
+    "$fake_bearer" "$fake_urlpw" "$fake_pat")
+redaction_input=$(jq -cn --arg cmd "$redaction_cmd" \
+    '{tool_name:"Bash", tool_input:{command:$cmd}}')
+LOG=$(run_hook "" "$redaction_input")
+assert_log_contains "$LOG" '<REDACTED>' "writes a <REDACTED> marker"
+assert_log_absent_pattern "$LOG" "$fake_bearer" "bearer token scrubbed"
+assert_log_absent_pattern "$LOG" "$fake_urlpw" "URL inline password scrubbed"
+assert_log_absent_pattern "$LOG" "$fake_pat" "github PAT scrubbed"
+
+echo ""
+echo "[Fail-closed input handling]"
+LOG=$(run_hook "" '')
+assert_true "$([ "$LAST_RC" = "0" ] && echo 1)" "empty stdin exits 0"
+assert_log_contains "$LOG" 'empty or unparseable hook input' "empty stdin logs marker line"
+LOG=$(run_hook "" 'NOT JSON {{{')
+assert_true "$([ "$LAST_RC" = "0" ] && echo 1)" "malformed JSON exits 0"
+assert_log_contains "$LOG" 'empty or unparseable hook input' "malformed JSON logs marker line"
+
+echo ""
+echo "[Valid JSONL output]"
+LOG=$(run_hook "" '{"session_id":"s","tool_name":"Write","tool_input":{"file_path":"/x"},"permission_suggestions":[{"behavior":"allow","rule":"Write(/x)"}]}')
+if command -v jq >/dev/null 2>&1; then
+    if jq -e . "$LOG" >/dev/null 2>&1; then
+        ((PASS++)); echo "  PASS: emitted line is valid JSON"
+    else
+        ((FAIL++)); ERRORS+=("FAIL: emitted line is not valid JSON: $(cat "$LOG")")
+        echo "  FAIL: emitted line is not valid JSON"
+    fi
+else
+    echo "  SKIP: jq unavailable — JSON validity check skipped"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #691
Part of #688

Implements the PermissionDenied audit hook per `docs/design/permission-event-hooks.md`.

## Summary
- New `global/hooks/permission-denial-logger.sh` + `.ps1` twin: a passive, observation-only logger that appends a redacted JSONL record to `${CLAUDE_LOG_DIR:-$HOME/.claude/logs}/permission-denials.jsonl`. Always exits 0, never alters the permission decision. `PermissionDenied` only (`PermissionRequest` deferred per the proposal's event-volume decision).
- Secrets in `tool_input` (bearer/authorization, api/access keys, tokens, passwords, URL inline credentials, AWS keys, GitHub PATs, PEM private keys) are scrubbed before any disk write; on re-parse failure the record falls back to a flat redacted string so raw input never lands.
- `CLAUDE_PERMISSION_LOGGER=0` opt-out; 10 MB tail rotation.
- Wired under a `PermissionDenied` key in `global/settings.json` and `global/settings.windows.json` (5s async timeout).
- Regenerated `HOOKS.md`; added the `COMPATIBILITY.md` event row; corrected the now-stale "D5" finding in `docs/official-spec-rereview-2026-05-29.md`.
- Added `tests/hooks/test-permission-denial-logger.sh` (17 assertions). The secret-shaped redaction fixtures are assembled at runtime so no contiguous secret pattern is committed (secret-scanner hygiene).

Note: the design proposal referenced reusing redaction logic from `session-logger.sh`, but no shared redaction helper exists in the repo; a self-contained conservative scrubber is used in both the `.sh` and `.ps1` and can be extracted to a shared lib later.

## Test Plan
- `bash tests/hooks/test-permission-denial-logger.sh` -> 17 passed, 0 failed
- `bash scripts/gen-hooks-md.sh --check` -> clean (idempotent)
- `bash tests/scripts/test-windows-hooks-parity.sh` -> pass
- `shellcheck -S warning -e SC2086 global/hooks/permission-denial-logger.sh` -> clean
- `STRICT_SCHEMA=1 ./scripts/spec_lint.sh --strict` -> 0 violations

Supersedes #694: re-opened on a clean single-commit branch so no commit diff contains the synthetic secret-shaped test fixtures. No force-push and no scanner ignore were used.
