### PR TITLE
fix(hooks): rename Ensure-Directory to approved verb to stop stdout leak

### DIFF
--- a/global/hooks/lib/CommonHelpers.psm1
+++ b/global/hooks/lib/CommonHelpers.psm1
@@ -401,7 +401,7 @@ function Test-Administrator {
 # Replaces bash mkdir -p
 # ──────────────────────────────────────────────────────────────
 
-function Ensure-Directory {
+function New-DirectoryIfMissing {
     <#
     .SYNOPSIS
         Creates a directory if it does not exist. Returns the path.
@@ -412,6 +412,11 @@ function Ensure-Directory {
     }
     return $Path
 }
+
+# Back-compat: existing hooks/scripts call 'Ensure-Directory'. Aliases are
+# exempt from PowerShell's approved-verb check, so this preserves the call
+# name without re-introducing the module-import warning. See issue #696.
+Set-Alias -Name Ensure-Directory -Value New-DirectoryIfMissing
 
 # ──────────────────────────────────────────────────────────────
 # Export all functions
@@ -437,5 +442,5 @@ Export-ModuleMember -Function @(
     'Test-Prerequisites'
     'Get-GitHubRepo'
     'Test-Administrator'
-    'Ensure-Directory'
-)
+    'New-DirectoryIfMissing'
+) -Alias @('Ensure-Directory')


### PR DESCRIPTION
Closes #696

## What
Rename `Ensure-Directory` (unapproved PowerShell verb `Ensure`) to `New-DirectoryIfMissing` in `CommonHelpers.psm1`, and re-export `Ensure-Directory` as a back-compat alias.

## Why
The unapproved verb made every `.ps1` hook's `Import-Module ... -Force` emit a module-load warning on the PowerShell warning stream. When a child `pwsh` process is captured, that stream is folded into stdout, so the warning prepended each hook's JSON decision. Claude Code requires the entire hook stdout to be valid JSON, so parsing failed, `permissionDecision` was ignored, and the normal permission flow prompted on every command (the blanket `allow` from `dangerous-command-guard` was silently lost). This degraded all 18 decision-emitting PowerShell hooks on Windows.

## How
- `function Ensure-Directory` -> `function New-DirectoryIfMissing` (approved verb)
- `Set-Alias -Name Ensure-Directory -Value New-DirectoryIfMissing` (aliases are exempt from the verb check)
- Export the new function name plus the alias

Zero call-site changes: all existing `Ensure-Directory` callers (~44) resolve through the alias.

## Where
- `global/hooks/lib/CommonHelpers.psm1` (function definition + `Export-ModuleMember`)

## Verification
- `Import-Module CommonHelpers.psm1 -Force` now emits no warning to stdout.
- `dangerous-command-guard.ps1` on a benign command outputs only valid JSON (single object).
- `Ensure-Directory` (alias) and `New-DirectoryIfMissing` (function) both create directories correctly.
- `tests/hooks` PowerShell suite: 197 passed. The 3 `team-limit-guard` failures are **pre-existing on develop** (a Windows-only test-isolation defect: the test sets `$env:HOME` but the hook reads the `$HOME` automatic variable, which Windows does not derive from `$env:HOME`) and are unrelated to this change. This fix actually removes the warning that previously also polluted those test outputs.
