### PR TITLE
fix(hooks): harden Read-HookInput against intermittent empty stdin

### DIFF
--- a/global/hooks/lib/CommonHelpers.psm1
+++ b/global/hooks/lib/CommonHelpers.psm1
@@ -89,20 +89,29 @@ function Read-HookInput {
     .DESCRIPTION
         Replacement for the bash pattern: INPUT=$(cat); echo "$INPUT" | jq -r '.field'
         Returns $null if stdin is empty or contains invalid JSON.
+
+        A short bounded retry guards an intermittent Windows race where the stdin
+        redirection is not yet observable at process start ([Console]::IsInputRedirected
+        momentarily false), which would otherwise yield an empty read and a
+        spurious fail-closed deny. Once stdin IS redirected, an empty payload is
+        treated as genuinely empty (the stream is consumed and not retried).
     #>
-    try {
-        if ([Console]::IsInputRedirected) {
-            $raw = [Console]::In.ReadToEnd()
-            if ([string]::IsNullOrWhiteSpace($raw)) {
-                return $null
+    for ($attempt = 0; $attempt -lt 10; $attempt++) {
+        try {
+            if ([Console]::IsInputRedirected) {
+                $raw = [Console]::In.ReadToEnd()
+                if ([string]::IsNullOrWhiteSpace($raw)) {
+                    return $null
+                }
+                return ($raw | ConvertFrom-Json)
             }
-            return ($raw | ConvertFrom-Json)
         }
-        return $null
+        catch {
+            return $null
+        }
+        Start-Sleep -Milliseconds 20
     }
-    catch {
-        return $null
-    }
+    return $null
 }
 
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #698

## What
Harden `Read-HookInput` (`CommonHelpers.psm1`) so an intermittent empty stdin read no longer causes a spurious fail-closed `deny`.

## Why
`Read-HookInput` returned `$null` on an empty stdin read; fail-closed hooks (e.g. `dangerous-command-guard.ps1:60`) then `deny`. The verb-warning fix (#696) removed the stdout pollution that previously masked this, so an intermittent empty-stdin condition on Windows surfaced as occasional spurious denials of benign commands (decision log shows `command=""`, a retry succeeds).

## How
Wrap the read in a short bounded retry (10 x 20ms) that guards the process-start race where `[Console]::IsInputRedirected` is momentarily false. Once stdin IS redirected, an empty payload is treated as genuinely empty (stream consumed, no retry). The common path reads on the first attempt - no added latency, no behavior change for normal or genuinely-empty input.

Root cause is most likely Claude Code-side intermittent stdin delivery; this is a conservative consumer-side mitigation, not a guaranteed fix for every case.

## Where
- `global/hooks/lib/CommonHelpers.psm1` - `Read-HookInput`

## Verification
- Normal piped JSON -> parsed on first attempt, `allow`, valid JSON, no warning.
- Empty stdin -> immediate `deny` (no hang; redirected-but-empty is not retried).
- `tests/hooks` suite: 197 passed. The 3 `team-limit-guard` failures are pre-existing on develop (Windows `$HOME` vs `$env:HOME` test-isolation defect) and unrelated; tracked separately.