### PR TITLE
chore(hooks): suppress CommonHelpers import warnings (defense-in-depth)

### DIFF
--- a/global/hooks/attribution-guard.ps1
+++ b/global/hooks/attribution-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot 'lib' 'AttributionValidator.psm1') -Force
 
 # attribution-guard.ps1

--- a/global/hooks/bash-sensitive-read-guard.ps1
+++ b/global/hooks/bash-sensitive-read-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # bash-sensitive-read-guard.ps1
 # Blocks reading sensitive files via the Bash tool channel on Windows.

--- a/global/hooks/bash-write-guard.ps1
+++ b/global/hooks/bash-write-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # bash-write-guard.ps1
 # Detects file-mutation patterns in Bash commands. Partial mirror of

--- a/global/hooks/cleanup.ps1
+++ b/global/hooks/cleanup.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # cleanup.ps1
 # Cleans up temporary files created during session

--- a/global/hooks/commit-message-guard.ps1
+++ b/global/hooks/commit-message-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot 'lib' 'LanguageValidator.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot 'lib' 'AttributionValidator.psm1') -Force
 

--- a/global/hooks/config-change-logger.ps1
+++ b/global/hooks/config-change-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # config-change-logger.ps1
 # Logs configuration file changes during session

--- a/global/hooks/conflict-guard.ps1
+++ b/global/hooks/conflict-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # conflict-guard.ps1
 # Guards against git operations that could cause conflicts.

--- a/global/hooks/cwd-change-logger.ps1
+++ b/global/hooks/cwd-change-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # cwd-change-logger.ps1
 # Logs working-directory changes during a session for audit trails.

--- a/global/hooks/dangerous-command-guard.ps1
+++ b/global/hooks/dangerous-command-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # dangerous-command-guard.ps1
 # Blocks dangerous bash commands and records every decision.

--- a/global/hooks/gh-write-verb-guard.ps1
+++ b/global/hooks/gh-write-verb-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # gh-write-verb-guard.ps1
 # PowerShell parity for gh-write-verb-guard.sh.

--- a/global/hooks/github-api-preflight.ps1
+++ b/global/hooks/github-api-preflight.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # github-api-preflight.ps1
 # Checks GitHub API connectivity before executing GitHub-related commands

--- a/global/hooks/lib/rotate.ps1
+++ b/global/hooks/lib/rotate.ps1
@@ -7,7 +7,7 @@
 #   . (Join-Path $PSScriptRoot 'rotate.ps1')
 #   Invoke-LogRotation -FilePath $logFile -MaxMB 5 -MaxArchives 3
 
-Import-Module (Join-Path $PSScriptRoot 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # Invoke-LogRotation is already exported by CommonHelpers.psm1.
 # No additional wrapper needed — importing the module makes it available

--- a/global/hooks/markdown-anchor-validator.ps1
+++ b/global/hooks/markdown-anchor-validator.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # markdown-anchor-validator.ps1
 # Validates markdown anchor references in git-staged files before commit

--- a/global/hooks/memory-access-logger.ps1
+++ b/global/hooks/memory-access-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'SilentlyContinue'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # memory-access-logger.ps1
 # Logs Claude Code Read tool calls targeting memory files (path only).

--- a/global/hooks/memory-write-guard.ps1
+++ b/global/hooks/memory-write-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # memory-write-guard.ps1
 # Validates Claude Code Edit/Write tool calls targeting memory files BEFORE disk write.

--- a/global/hooks/merge-gate-guard.ps1
+++ b/global/hooks/merge-gate-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # merge-gate-guard.ps1
 # Blocks gh pr merge commands when any PR check is not passing.

--- a/global/hooks/permission-denial-logger.ps1
+++ b/global/hooks/permission-denial-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # permission-denial-logger.ps1
 # Appends a redacted JSONL audit record for every denied tool call.

--- a/global/hooks/pr-language-guard.ps1
+++ b/global/hooks/pr-language-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 Import-Module (Join-Path $PSScriptRoot 'lib' 'LanguageValidator.psm1') -Force
 
 # pr-language-guard.ps1

--- a/global/hooks/pr-target-guard.ps1
+++ b/global/hooks/pr-target-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # pr-target-guard.ps1
 # Blocks PRs targeting 'main' from non-develop branches

--- a/global/hooks/pre-compact-snapshot.ps1
+++ b/global/hooks/pre-compact-snapshot.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # pre-compact-snapshot.ps1
 # Captures working state before automatic context compaction

--- a/global/hooks/pre-edit-read-guard.ps1
+++ b/global/hooks/pre-edit-read-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # pre-edit-read-guard.ps1
 # Enforces the "Read before Edit/Write" tool contract.

--- a/global/hooks/prompt-validator.ps1
+++ b/global/hooks/prompt-validator.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # prompt-validator.ps1
 # Validates user prompts for dangerous operations

--- a/global/hooks/sensitive-file-guard.ps1
+++ b/global/hooks/sensitive-file-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # sensitive-file-guard.ps1
 # Blocks access to sensitive files

--- a/global/hooks/session-logger.ps1
+++ b/global/hooks/session-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # session-logger.ps1
 # Logs session start/end events

--- a/global/hooks/subagent-logger.ps1
+++ b/global/hooks/subagent-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # subagent-logger.ps1
 # Logs subagent start/stop events for monitoring

--- a/global/hooks/task-completed-logger.ps1
+++ b/global/hooks/task-completed-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # task-completed-logger.ps1
 # Logs task completion events for audit trail

--- a/global/hooks/team-limit-guard.ps1
+++ b/global/hooks/team-limit-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # team-limit-guard.ps1
 # Limits the maximum number of concurrent Agent Teams

--- a/global/hooks/tool-failure-logger.ps1
+++ b/global/hooks/tool-failure-logger.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # tool-failure-logger.ps1
 # Logs tool execution failures for debugging and analysis

--- a/global/hooks/traceability-guard.ps1
+++ b/global/hooks/traceability-guard.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # traceability-guard.ps1
 # Deterministic traceability cascade validator.

--- a/global/hooks/version-check.ps1
+++ b/global/hooks/version-check.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # version-check.ps1
 # Checks Claude Code version against known problematic versions

--- a/global/hooks/worktree-create.ps1
+++ b/global/hooks/worktree-create.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # worktree-create.ps1
 # Creates an isolated worktree directory for non-git environments

--- a/global/hooks/worktree-remove.ps1
+++ b/global/hooks/worktree-remove.ps1
@@ -1,6 +1,6 @@
 #Requires -Version 7.0
 $ErrorActionPreference = 'Stop'
-Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # worktree-remove.ps1
 # Cleans up and logs worktree removal events


### PR DESCRIPTION
Closes #700

## What
Append `-WarningAction SilentlyContinue` to every bare `Import-Module ... CommonHelpers.psm1 -Force` across the PowerShell hooks (32 files). Import-line only; no behavior change.

## Why
#696 showed that a single unapproved-verb export makes the module-load WARNING leak into hook stdout and break the JSON permission decision for every importing hook. The alias fix removed the current offender; this hardens each hook so any future import-time warning cannot re-pollute stdout. Defense-in-depth.

## Where
- 32 `global/hooks/**/*.ps1` files (excludes the 3 already using `-WarningAction`). `.sh` hooks need no change (bash has no approved-verb checker / module-import warnings).

## Verification
- `git diff --stat`: 32 files, 32 insertions / 32 deletions (exactly one import line each; line endings/encoding preserved).
- `dangerous-command-guard.ps1` still emits clean valid JSON.
- `tests/hooks` suite: 197 passed (the 3 `team-limit-guard` failures are pre-existing, tracked separately).