### PR TITLE
fix(hooks): make team-limit-guard teams dir overridable for test isolation

### DIFF
--- a/global/hooks/team-limit-guard.ps1
+++ b/global/hooks/team-limit-guard.ps1
@@ -23,7 +23,11 @@ $json = Read-HookInput
 
 # Configurable limit via environment variable (default: 3)
 $maxTeams = if ($env:MAX_TEAMS) { [int]$env:MAX_TEAMS } else { 3 }
-$teamsDir = Join-Path $HOME '.claude' 'teams'
+$teamsDir = if (-not [string]::IsNullOrWhiteSpace($env:CLAUDE_TEAMS_DIR)) {
+    $env:CLAUDE_TEAMS_DIR
+} else {
+    Join-Path $HOME '.claude' 'teams'
+}
 
 # Skip check if teams directory does not exist
 if (-not (Test-Path -LiteralPath $teamsDir -PathType Container)) {

--- a/global/hooks/team-limit-guard.sh
+++ b/global/hooks/team-limit-guard.sh
@@ -23,7 +23,7 @@ cat > /dev/null
 
 # Configurable limit via environment variable (default: 3)
 MAX_TEAMS="${MAX_TEAMS:-3}"
-TEAMS_DIR="$HOME/.claude/teams"
+TEAMS_DIR="${CLAUDE_TEAMS_DIR:-$HOME/.claude/teams}"
 
 # Use jq -nc --arg reason ... so the JSON library handles all escaping
 # (quotes, backslashes, newlines, tabs, carriage returns, etc.). This closes

--- a/tests/hooks/test-team-limit-guard.ps1
+++ b/tests/hooks/test-team-limit-guard.ps1
@@ -24,7 +24,7 @@ try {
 
     function Assert-Deny {
         param([string]$InputJson, [string]$Label)
-        $result = $InputJson | & pwsh -NoProfile -Command "& { `$env:HOME = '$TestHome'; & '$($script:HookPath)' }" 2>$null
+        $result = $InputJson | & pwsh -NoProfile -Command "& { `$env:CLAUDE_TEAMS_DIR = '$teamsDir'; & '$($script:HookPath)' }" 2>$null
         if ($result -match '"deny"') {
             $script:Passed++
             Write-Host "  PASS: $Label" -ForegroundColor Green
@@ -37,7 +37,7 @@ try {
 
     function Assert-Allow {
         param([string]$InputJson, [string]$Label)
-        $result = $InputJson | & pwsh -NoProfile -Command "& { `$env:HOME = '$TestHome'; & '$($script:HookPath)' }" 2>$null
+        $result = $InputJson | & pwsh -NoProfile -Command "& { `$env:CLAUDE_TEAMS_DIR = '$teamsDir'; & '$($script:HookPath)' }" 2>$null
         if ($result -match '"allow"' -or [string]::IsNullOrEmpty($result)) {
             $script:Passed++
             Write-Host "  PASS: $Label" -ForegroundColor Green
@@ -86,7 +86,7 @@ try {
     Write-Host ''
     Write-Host '[MAX_TEAMS env override]'
     # With 4 teams and MAX_TEAMS=5, should allow
-    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:HOME = '$TestHome'; `$env:MAX_TEAMS = '5'; & '$($script:HookPath)' }" 2>$null
+    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:CLAUDE_TEAMS_DIR = '$teamsDir'; `$env:MAX_TEAMS = '5'; & '$($script:HookPath)' }" 2>$null
     if ($result -match '"allow"') {
         $script:Passed++
         Write-Host '  PASS: 4 teams with MAX_TEAMS=5 -> allow' -ForegroundColor Green
@@ -97,7 +97,7 @@ try {
     }
 
     # With 4 teams and MAX_TEAMS=4, should deny
-    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:HOME = '$TestHome'; `$env:MAX_TEAMS = '4'; & '$($script:HookPath)' }" 2>$null
+    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:CLAUDE_TEAMS_DIR = '$teamsDir'; `$env:MAX_TEAMS = '4'; & '$($script:HookPath)' }" 2>$null
     if ($result -match '"deny"') {
         $script:Passed++
         Write-Host '  PASS: 4 teams with MAX_TEAMS=4 -> deny' -ForegroundColor Green
@@ -108,7 +108,7 @@ try {
     }
 
     # With 4 teams and MAX_TEAMS=1, should deny
-    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:HOME = '$TestHome'; `$env:MAX_TEAMS = '1'; & '$($script:HookPath)' }" 2>$null
+    $result = '{}' | & pwsh -NoProfile -Command "& { `$env:CLAUDE_TEAMS_DIR = '$teamsDir'; `$env:MAX_TEAMS = '1'; & '$($script:HookPath)' }" 2>$null
     if ($result -match '"deny"') {
         $script:Passed++
         Write-Host '  PASS: 4 teams with MAX_TEAMS=1 -> deny' -ForegroundColor Green


### PR DESCRIPTION
Closes #702

## What
Add a `CLAUDE_TEAMS_DIR` environment override to `team-limit-guard.{ps1,sh}` (falls back to `$HOME/.claude/teams` when unset) and isolate the PowerShell test through it.

## Why
The PowerShell test injected `$env:HOME` to redirect the hook to a temp teams dir, but the hook reads the `$HOME` **automatic variable**, which on Windows derives from `$env:USERPROFILE` and ignores `$env:HOME` (bash makes them identical, so `.sh` was unaffected). The hook counted the real `~/.claude/teams`, so 3 "at/above limit -> deny" assertions returned `allow`. Hook logic was correct; only test isolation was broken on Windows.

## Where
- `global/hooks/team-limit-guard.ps1`, `global/hooks/team-limit-guard.sh`
- `tests/hooks/test-team-limit-guard.ps1`

## Verification
- PowerShell: `test-team-limit-guard.ps1` now 10/10; full `tests/hooks` suite **200 passed, 0 failed** (was 197/3).
- Default behavior unchanged when `CLAUDE_TEAMS_DIR` is unset (fallback identical to prior `$HOME/.claude/teams`).
- `.sh` change is a standard `${VAR:-default}` parameter expansion (logically a no-op when the override is unset). The `.sh` test suite is validated by CI on ubuntu (`validate-hooks.yml`); local Windows bash cannot run it cleanly (pre-existing environment issue, reproduced on develop without this change).