### PR TITLE
chore(release): bump hooks to 1.1.1

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -22,4 +22,4 @@ suite: 1.10.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
 settings-schema: 1.17.0
-hooks: 1.1.0
+hooks: 1.1.1


### PR DESCRIPTION
Bump the VERSION_MAP `hooks` track 1.1.0 -> 1.1.1 ahead of the `hooks-v1.1.1` release.

This rolls up the PowerShell hook fixes merged to develop: #696 (Ensure-Directory verb / stdout leak), #698 (Read-HookInput empty-stdin hardening), #700 (suppress import warnings), #702 (team-limit-guard test isolation).

The `hooks` track has no consumer file to mirror; `check_versions` validates only that the value is well-formed SemVer (verified locally: OK).