### PR TITLE
fix(ci): align attribution fixture and skill schema (release CI debt, batch 2)

### DIFF
--- a/scripts/schemas/skill-md.schema.json
+++ b/scripts/schemas/skill-md.schema.json
@@ -4,7 +4,7 @@
   "title": "Claude Code SKILL.md Frontmatter (Deprecated Alias)",
   "description": "DEPRECATED ALIAS: this URL is preserved for backward compatibility with external plugin authors who already reference it. Its content matches skill-md.schema.lenient.json. New consumers should pick the variant explicitly: .strict.json for global/skills/_internal/ skills, .lenient.json otherwise. The Kill Switch (harness_policies.p4_strict_schema / STRICT_SCHEMA env) can force lenient across all paths.",
   "type": "object",
-  "required": ["description"],
+  "required": ["name", "description"],
   "additionalProperties": true,
   "properties": {
     "name": {

--- a/scripts/schemas/skill-md.schema.lenient.json
+++ b/scripts/schemas/skill-md.schema.lenient.json
@@ -4,7 +4,7 @@
   "title": "Claude Code SKILL.md Frontmatter (Lenient)",
   "description": "Lenient variant for plugin/, plugin-lite/, and external author skills. Validates only core required fields (name, description). additionalProperties is true so unknown fields do NOT fail; P1-c halt_conditions enforcement is omitted. External plugin authors who want stricter validation may opt in by placing skills under global/skills/_internal/ which dispatches to the strict variant. The strict-mode Kill Switch (harness_policies.p4_strict_schema or STRICT_SCHEMA env var) can also force lenient validation across all paths.",
   "type": "object",
-  "required": ["description"],
+  "required": ["name", "description"],
   "additionalProperties": true,
   "properties": {
     "name": {

--- a/scripts/schemas/skill-md.schema.strict.json
+++ b/scripts/schemas/skill-md.schema.strict.json
@@ -4,7 +4,7 @@
   "title": "Claude Code SKILL.md Frontmatter (Strict)",
   "description": "Strict variant for global/skills/_internal/* skills (claude-config-owned). Same fields as the canonical schema but all rules including P1-c halt_conditions enforcement are required. External plugin/plugin-lite skills validate against the lenient variant.",
   "type": "object",
-  "required": ["description"],
+  "required": ["name", "description"],
   "additionalProperties": false,
   "allOf": [
     {

--- a/tests/batch_drift_benchmark/fixtures/aggregator-drifted/06-106.json
+++ b/tests/batch_drift_benchmark/fixtures/aggregator-drifted/06-106.json
@@ -1,7 +1,7 @@
 {
   "issue_number": 0,
   "pr_number": 106,
-  "pr_body": "한글 본문. AI-assisted change. No closing keyword.",
+  "pr_body": "한글 본문. Generated with Claude. No closing keyword.",
   "pr_json": {
     "mergedAt": "2026-04-15T10:05:00Z",
     "statusCheckRollup": [{"conclusion": "FAILURE"}]

--- a/tests/scripts/test-spec-lint.sh
+++ b/tests/scripts/test-spec-lint.sh
@@ -177,7 +177,7 @@ assert_output_contains "'warp' is not one of" "$out" "context enum error"
 assert_output_contains "'zsh' is not one of" "$out" "shell enum error"
 
 # ── Fixture: description too long ────────────────────────────
-LONG_DESC="$(printf 'x%.0s' {1..1100})"
+LONG_DESC="$(printf 'x%.0s' {1..1600})"
 LONG_SKILL="$WORK/long-desc-skill.md"
 write_file "$LONG_SKILL" "---
 name: long-desc
@@ -188,9 +188,9 @@ content
 "
 
 echo ""
-echo "[case 5: description >1024 chars rejected]"
+echo "[case 5: description >1536 chars rejected]"
 out=$(run_lint skill "$LONG_SKILL" 2>&1); rc=$?
-assert_exit 1 "$rc" "1100-char description -> exit 1"
+assert_exit 1 "$rc" "1600-char description -> exit 1"
 assert_output_contains "is too long" "$out" "max length error"
 
 # ── Fixture: missing required name/description ───────────────


### PR DESCRIPTION
Relates to #706

Second batch of release-blocking CI debt cleared (code/schema only):
- aggregator-drifted fixture item 6 -> real prose attribution leak ("Generated with Claude")
- skill-md schemas (base/lenient/strict): add "name" to required (matches the schema comments; array had drifted to description-only)
- test-spec-lint: over-length description fixture bumped past the 1536 official maxLength (was 1100)

## Verification (local, jq + python)
- batch_drift_benchmark: all 4 test suites pass (test-aggregate now 40/0).
- test-spec-lint.sh: 48/0.
- spec_lint.sh --strict + validate_skills.sh: pass (real skills unaffected by name-required).
- shellcheck CI-scope: clean.

Note: remaining release-blockers (README.md<->ko i18n skeleton, test-job steps not yet enumerated) are tracked separately; main release deferred until develop is fully green.