### PR TITLE
fix(ci): resync commit-settings template and README.ko.md i18n skeleton

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -141,6 +141,12 @@ cd ~\claude_config_backup
 > **참고**: PowerShell 7+ (`pwsh`)가 필요합니다. `winget install Microsoft.PowerShell`로 설치하세요.
 > 실행 정책 오류 시: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
+#### Docker 호환 dual-variant 설치
+
+`install.ps1`은 모든 hook 및 유틸리티 스크립트의 PowerShell(`.ps1`)·bash(`.sh`) 변종을 **둘 다** `~/.claude/hooks/`와 `~/.claude/scripts/`에 배포합니다. `.sh` 파일은 LF 줄바꿈(UTF-8, BOM 없음)으로 작성됩니다.
+
+이는 Windows 호스트의 `~/.claude/`가 Linux Claude Code 컨테이너에 bind-mount될 때(예: 동반 [claude-docker](https://github.com/kcenon/claude-docker) 프로젝트) 중요합니다: 컨테이너 entrypoint가 `pwsh ... -File foo.ps1` hook 명령을 `foo.sh`로 재작성하는데, 마운트에 대응 `.sh` 파일이 있어야만 동작합니다. 설치 스크립트는 페어링 감사를 실행해 `.sh` 짝이 없는 `.ps1`(또는 그 반대)을 경고하여 Docker 측 재작성이 누락 파일로 조용히 해석되지 않게 합니다.
+
 ### 경량 Plugin (Behavioral Guardrails Only)
 
 전체 구성 없이 핵심 동작 교정만 원하시나요?
@@ -705,18 +711,23 @@ Create a team to implement the notification system:
 
 ---
 
-## Pre-commit Hook
+## Git Hooks
 
-SKILL.md 파일을 커밋 전 자동으로 검증하려면 pre-commit hook을 설치하세요:
+SKILL.md 파일을 커밋 전 자동으로 검증하려면 git hook을 설치하세요:
 
 ```bash
 ./hooks/install-hooks.sh
 ```
 
-Hook이 수행하는 작업:
+### Pre-commit Hook
 - SKILL.md 파일 변경 감지
 - `validate_skills.sh` 자동 실행
 - 유효하지 않은 SKILL.md 파일이 있으면 커밋 차단
+
+### Pre-push Hook
+- 보호 브랜치(`main`, `develop`)로의 직접 push 차단
+- 보호 브랜치는 pull request 워크플로 필요
+- 크로스 플랫폼: `pre-push`(bash)와 `pre-push.ps1`(PowerShell)
 
 ---
 

--- a/global/commit-settings.md
+++ b/global/commit-settings.md
@@ -5,7 +5,7 @@ Enforced by `settings.json` (`attribution: ""`), the `commit-message-guard` PreT
 
 Filename references to project root config files (`CLAUDE.md`, `CLAUDE.local.md`) and narrative mentions of the config (e.g. "the CLAUDE config loader") are allowed in commit subjects — only attribution patterns (`Co-Authored-By:` trailers, bot emoji adjacent to Claude/Anthropic, "generated/created/authored {with|by|using} {Claude|Anthropic}" prose) are rejected. See the three-pattern design comment in `hooks/lib/validate-commit-message.sh` for the exact rules.
 
-All GitHub Issues and Pull Requests must follow the active `CLAUDE_CONTENT_LANGUAGE` policy. Validation is dispatched by `hooks/lib/validate-language.sh` (single source of truth — see issue #410 for the design and #447 for the `exclusive_bilingual` mode):
+All GitHub Issues and Pull Requests must follow the active `CLAUDE_CONTENT_LANGUAGE` policy (English by default). Validation is dispatched by `hooks/lib/validate-language.sh` (single source of truth — see issue #410 for the design and #447 for the `exclusive_bilingual` mode):
 
 | `CLAUDE_CONTENT_LANGUAGE` | Per-artifact rule |
 |---------------------------|-------------------|

--- a/global/commit-settings.md.tmpl
+++ b/global/commit-settings.md.tmpl
@@ -3,4 +3,17 @@
 No AI/Claude attribution in commits, issues, or PRs.
 Enforced by `settings.json` (`attribution: ""`), the `commit-message-guard` PreToolUse hook (Claude-side feedback loop), and the `commit-msg` git hook installed by `hooks/install-hooks.sh` (terminal-side gate).
 
-All GitHub Issues and Pull Requests must be written in {{CONTENT_LANGUAGE_POLICY}}.
+Filename references to project root config files (`CLAUDE.md`, `CLAUDE.local.md`) and narrative mentions of the config (e.g. "the CLAUDE config loader") are allowed in commit subjects — only attribution patterns (`Co-Authored-By:` trailers, bot emoji adjacent to Claude/Anthropic, "generated/created/authored {with|by|using} {Claude|Anthropic}" prose) are rejected. See the three-pattern design comment in `hooks/lib/validate-commit-message.sh` for the exact rules.
+
+All GitHub Issues and Pull Requests must follow the active `CLAUDE_CONTENT_LANGUAGE` policy ({{CONTENT_LANGUAGE_POLICY}} by default). Validation is dispatched by `hooks/lib/validate-language.sh` (single source of truth — see issue #410 for the design and #447 for the `exclusive_bilingual` mode):
+
+| `CLAUDE_CONTENT_LANGUAGE` | Per-artifact rule |
+|---------------------------|-------------------|
+| `english` (default, unset, or empty) | ASCII only. Allowlisted English typographic punctuation accepted: em-dash, en-dash, curly quotes, ellipsis, NBSP. |
+| `korean_plus_english`     | ASCII + Hangul (Syllables / Jamo / Compat Jamo). Mixed inline allowed. |
+| `exclusive_bilingual`     | Each artifact (title / body / comment) is **either** English-only **or** Korean-only — no inline mixing. Inside Korean artifacts, the following ASCII containers are allowed: fenced code blocks, inline code, URLs, and the `한국어(English)` translation form. |
+| `any`                     | Skip language validation. |
+
+Sub-agents, skills, and reinforcer hooks MUST resolve the runtime policy from `CLAUDE_CONTENT_LANGUAGE` rather than hard-coding "English only". When in doubt, defer to this file and the dispatcher in `validate-language.sh`.
+
+Conversation language (the language Claude uses to *talk to the user* and reason in `<thinking>`) is a separate axis governed by `conversation-language.md` and `settings.json` `language`. Artifact language ≠ conversation language: a Korean-speaking user may publish English-only PRs (or vice versa) depending on the policy above.


### PR DESCRIPTION
Closes #709

Final release-blocking CI debt for the hooks-v1.1.1 release (#705):
- **commit-settings.md drift** (validate-skills / language-policy-drift): #410/#447 expanded the .md with the content-language policy table but the template kept the old single-phrase line. Added "(English by default)" + re-rendered the template placeholder. Local: test-language-policy-drift 15/0.
- **README.ko.md i18n skeleton** (validate-skills / diff-readme): added the missing Git Hooks -> Pre-commit/Pre-push L3 sections and the Windows dual-variant install L4 section (translated from README.md). Local: diff-readme OK at every level.

With #707/#708 (code/schema) and this, all release-blockers found by #705 are resolved. check_references/test-runner perl-timeout local failures were WSL-environment artifacts (passed on CI's first #705 run).