### PR TITLE
fix(test): use mktemp -d in plugin-fallback test (invalid -t template)

### DIFF
--- a/tests/scripts/test-plugin-fallback.sh
+++ b/tests/scripts/test-plugin-fallback.sh
@@ -54,7 +54,7 @@ PY
 SENSITIVE_CMD="$(extract_command 0)"
 BASH_CMD="$(extract_command 1)"
 
-WORK="$(mktemp -d -t claude-plugin-fallback)"
+WORK="$(mktemp -d)"
 trap 'rm -rf -- "$WORK" 2>/dev/null || true' EXIT
 export HOME="$WORK"
 mkdir -p "$HOME/.claude"


### PR DESCRIPTION
Relates to #709. Final test-job blocker on the release PR: `test-plugin-fallback.sh` used `mktemp -d -t <prefix>` (no X placeholders) which GNU mktemp rejects on CI, leaving HOME empty. Switched to plain `mktemp -d` (matches other test scripts). Local: all test-plugin-*.sh + smoke-test.sh + install-manifest-helpers.sh pass.