### PR TITLE
[codex] fix PR 705 Validate Hooks CI

### DIFF
--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -198,7 +198,7 @@ function Update-ClaudeSettingsJson {
                     $settingsObj.env.PSObject.Properties.Remove('CLAUDE_CONTENT_LANGUAGE')
                     
                     # If env is now empty, remove it entirely to keep settings.json clean
-                    if ($settingsObj.env.PSObject.Properties.Count -eq 0) {
+                    if (@($settingsObj.env.PSObject.Properties).Count -eq 0) {
                         $settingsObj.PSObject.Properties.Remove('env')
                     }
                 }

--- a/tests/scripts/test-install-manifest-helpers.ps1
+++ b/tests/scripts/test-install-manifest-helpers.ps1
@@ -16,7 +16,7 @@ try {
     New-Item -ItemType Directory -Path $claudeDir | Out-Null
     
     $manifestPath = Join-Path $claudeDir ".install-manifest.json"
-    Set-ManifestPath $manifestPath
+    $env:MANIFEST_PATH = $manifestPath
 
     # Test Update-ClaudeSettingsJson
     $settingsPath = Join-Path $testDir "settings.json"


### PR DESCRIPTION
## What
- Replace the PowerShell helper test's removed `Set-ManifestPath` call with the supported `MANIFEST_PATH` override.
- Make `Update-ClaudeSettingsJson` prune an empty `.env` object reliably after removing `CLAUDE_CONTENT_LANGUAGE`.

## Why
PR #705 is blocked by `Validate Hooks / test (ubuntu-latest)`. The failing log shows `tests/scripts/test-install-manifest-helpers.ps1` calling `Set-ManifestPath`, which no longer exists in `scripts/install-manifest.ps1`. After switching to the documented env override locally, the same test exposed the pending empty `.env` reset assertion, so this fixes both failures in the same helper path.

## Scope
- `scripts/install-manifest.ps1`
- `tests/scripts/test-install-manifest-helpers.ps1`

## Verification
- `pwsh tests/scripts/test-install-manifest-helpers.ps1`
- `git diff --check`

Note: `bash tests/scripts/test-install-manifest-helpers.sh` could not be validated in the local WSL bash because `jq` is missing there; the CI job installs `jq` before running this test.

## Risk
Low. The production change only changes empty-property detection after removing a single settings env key, and keeps existing manifest path behavior unchanged.