### PR TITLE
[codex] fix PR 705 macOS memory-write guard CI

### DIFF
--- a/global/hooks/memory-write-guard.sh
+++ b/global/hooks/memory-write-guard.sh
@@ -148,6 +148,9 @@ RESOLVED="$(resolve_path "$FILE_PATH")"
 
 # Activation gate: path must be a .md file under $HOME/.claude/memory-shared/memories/.
 MEMORY_ROOT="${HOME}/.claude/memory-shared/memories"
+if [ -d "$MEMORY_ROOT" ]; then
+    MEMORY_ROOT="$(resolve_path "$MEMORY_ROOT")"
+fi
 case "$RESOLVED" in
     "$MEMORY_ROOT"/*.md) ;;
     *) emit_allow "" ;;

--- a/tests/hooks/test-memory-write-guard.sh
+++ b/tests/hooks/test-memory-write-guard.sh
@@ -15,7 +15,14 @@ ERRORS=()
 cd "$(dirname "$0")/../.." || exit 1
 
 # Establish a test memory tree under HOME so the hook's path gate triggers.
-TEST_HOME="$(mktemp -d -t mwg-home.XXXXXX)"
+# Use a symlinked HOME to exercise macOS-style realpath normalization
+# (/var/... -> /private/var/...), where the file path and memory root must be
+# normalized before comparing.
+TEST_HOME_REAL="$(mktemp -d -t mwg-home.XXXXXX)"
+TEST_HOME="${TEST_HOME_REAL}.link"
+if ! ln -s "$TEST_HOME_REAL" "$TEST_HOME" 2>/dev/null; then
+    TEST_HOME="$TEST_HOME_REAL"
+fi
 export HOME="$TEST_HOME"
 MEM="$HOME/.claude/memory-shared/memories"
 mkdir -p "$MEM"
@@ -35,7 +42,10 @@ ln -sf "$(pwd)/scripts/memory/secret-check.sh"    "$HOME/.claude/scripts/memory/
 ln -sf "$(pwd)/scripts/memory/injection-check.sh" "$HOME/.claude/scripts/memory/injection-check.sh"
 
 cleanup() {
-    rm -rf "$TEST_HOME" 2>/dev/null || true
+    if [ "$TEST_HOME" != "$TEST_HOME_REAL" ]; then
+        rm -f "$TEST_HOME" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_HOME_REAL" 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## What
- Normalize `MEMORY_ROOT` with the same resolver used for target file paths in `memory-write-guard.sh`.
- Update the memory-write guard test to use a symlinked `HOME`, reproducing macOS `/var` -> `/private/var` realpath behavior on Linux too.

## Why
PR #705 is now blocked by `Validate Hooks / test (macos-latest)`. The failing suite is `memory-write-guard` with 3 secret-write assertions allowing instead of denying.

On macOS, temp paths can be created under `/var/...` while `realpath` returns `/private/var/...`. The hook normalized the target file path but compared it to an unnormalized `$HOME/.claude/memory-shared/memories` root, so the path gate missed memory files and allowed writes without validator checks.

## Scope
- `global/hooks/memory-write-guard.sh`
- `tests/hooks/test-memory-write-guard.sh`

## Verification
- `bash tests/hooks/test-memory-write-guard.sh` using a temporary native-style jq wrapper in WSL: 13 passed, 0 failed
- `shellcheck -S warning -e SC2086 global/hooks/memory-write-guard.sh tests/hooks/test-memory-write-guard.sh`
- `git diff --check`

## Risk
Low. The behavior change only normalizes an existing memory root before comparing it to the already-normalized target path; non-memory paths still pass through unchanged.