### PR TITLE
chore(hooks): silence pass-time additionalContext in PreToolUse guards

### DIFF
--- a/global/hooks/dangerous-command-guard.ps1
+++ b/global/hooks/dangerous-command-guard.ps1
@@ -13,6 +13,11 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -Warni
 #   ${env:CLAUDE_LOG_DIR}/dangerous-command-guard.log (defaults to
 #   ~/.claude/logs) so an operator can verify whether the hook returned
 #   allow/deny for a specific command.
+#
+# Allow-path output (issue #715): plain allows emit the minimal allow JSON
+# with no additionalContext (pass-path context is token noise on every Bash
+# call); the allow reason goes to the file log only. Only the coarse-scan
+# allow (degraded inspection warning) keeps additionalContext.
 
 $logDir = if ($env:CLAUDE_LOG_DIR) { $env:CLAUDE_LOG_DIR } else { Join-Path $HOME '.claude/logs' }
 $logFile = Join-Path $logDir 'dangerous-command-guard.log'
@@ -48,6 +53,18 @@ function Respond-Deny {
 
 function Respond-Allow {
     param([string]$Reason = 'dangerous-command-guard: no dangerous pattern matched')
+    Write-Decision -Decision 'allow' -Reason $Reason -Command $CMD
+    # Plain allow stays silent on stdout (issue #715): pass-path
+    # additionalContext is token noise for the model. The allow reason is
+    # preserved in the file log above for operator debugging.
+    New-HookAllowResponse
+    exit 0
+}
+
+function Respond-AllowWithContext {
+    # Warning-class allow: the context has decision value for the model
+    # (e.g. degraded coarse-scan inspection), so it stays on stdout.
+    param([string]$Reason)
     Write-Decision -Decision 'allow' -Reason $Reason -Command $CMD
     New-HookAllowResponse -AdditionalContext $Reason
     exit 0
@@ -88,7 +105,7 @@ if ($CMD.Length -gt $maxBytes) {
     if ($CMD -match '(curl|wget)\s.*\|\s*(sh|bash|zsh|dash|python[23]?|perl|ruby|node)\b') {
         Respond-Deny 'Remote script execution via pipe blocked for security'
     }
-    Respond-Allow "Coarse-scan allow (input exceeds tokenizer budget of $maxBytes bytes)"
+    Respond-AllowWithContext "Coarse-scan allow (input exceeds tokenizer budget of $maxBytes bytes)"
 }
 
 function Split-Subcommands {
@@ -373,8 +390,8 @@ foreach ($sub in (Flatten-Subcommands -Cmd $CMD)) {
     $prev = $sub
 }
 
-# Tag well-known safe read-only compound patterns so the reason line explains
-# why a pipe-bearing command was auto-allowed.
+# Tag well-known safe read-only compound patterns so the logged reason
+# explains why a pipe-bearing command was auto-allowed.
 $safeHead = '^(git\s+(status|log|diff|show|branch|tag|remote|ls-files|rev-parse|describe|for-each-ref|worktree|fetch)|gh\s+(pr|issue|run|workflow|repo|release|auth)\s+(view|list|status|diff|checks))\b'
 if (($CMD -match '\|') -or ($CMD -match '2>&1') -or ($CMD -match '>\s*/dev/null')) {
     if ($CMD -match $safeHead) {

--- a/global/hooks/dangerous-command-guard.sh
+++ b/global/hooks/dangerous-command-guard.sh
@@ -14,6 +14,11 @@
 #   If a prompt was presented despite an "allow" log entry, the root
 #   cause is upstream of this hook (e.g. unsandboxed path, multi-hook
 #   merge, permission mode), not the guard.
+#
+# Allow-path output (issue #715): plain allows emit the minimal allow JSON
+# with no additionalContext (pass-path context is token noise on every Bash
+# call); the allow reason goes to the file log only. Only the coarse-scan
+# allow (degraded inspection warning) keeps additionalContext.
 
 set -euo pipefail
 
@@ -66,9 +71,20 @@ deny_response() {
 allow_response() {
     local reason="${1:-dangerous-command-guard: no dangerous pattern matched}"
     log_decision "allow" "$reason" "${CMD:-}"
-    # Allow-path diagnostic goes under additionalContext (the model-visible
-    # allow channel), matching the .ps1 New-HookAllowResponse and the rest of
-    # the suite; permissionDecisionReason is reserved for deny decisions.
+    # Plain allow stays silent on stdout (issue #715): pass-path
+    # additionalContext is token noise for the model. The allow reason is
+    # preserved in the file log above for operator debugging.
+    jq -nc \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
+    exit 0
+}
+
+allow_with_context() {
+    # Warning-class allow: the context has decision value for the model
+    # (e.g. degraded coarse-scan inspection), so it stays on stdout under
+    # additionalContext; permissionDecisionReason is reserved for deny.
+    local reason="$1"
+    log_decision "allow" "$reason" "${CMD:-}"
     jq -nc \
         --arg reason "$reason" \
         '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", additionalContext: $reason}}'
@@ -112,7 +128,7 @@ if [ "${#CMD}" -gt "$DCG_TOKENIZER_MAX_BYTES" ]; then
     if echo "$CMD" | grep -qE '(curl|wget)\s.*\|\s*(sh|bash|zsh|dash|python[23]?|perl|ruby|node)\b'; then
         deny_response "Remote script execution via pipe blocked for security"
     fi
-    allow_response "Coarse-scan allow (input exceeds tokenizer budget of ${DCG_TOKENIZER_MAX_BYTES} bytes)"
+    allow_with_context "Coarse-scan allow (input exceeds tokenizer budget of ${DCG_TOKENIZER_MAX_BYTES} bytes)"
 fi
 
 # --- Tokenizer-based inspection ----------------------------------------------
@@ -362,9 +378,9 @@ inspect_command() {
     return 0
 }
 
-# Tag well-known safe read-only compound patterns so the reason line explains
-# why a pipe-bearing command was auto-allowed. This is a label, not an
-# exception: the inspection above has already cleared every sub-command.
+# Tag well-known safe read-only compound patterns so the logged reason
+# explains why a pipe-bearing command was auto-allowed. This is a label, not
+# an exception: the inspection above has already cleared every sub-command.
 SAFE_READ_ONLY_HEAD='^(git\s+(status|log|diff|show|branch|tag|remote|ls-files|rev-parse|describe|for-each-ref|worktree|fetch)|gh\s+(pr|issue|run|workflow|repo|release|auth)\s+(view|list|status|diff|checks))\b'
 
 if reason=$(inspect_command "$CMD"); then

--- a/global/hooks/gh-write-verb-guard.ps1
+++ b/global/hooks/gh-write-verb-guard.ps1
@@ -11,6 +11,10 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -Warni
 # via additionalContext on in-scope state changes) but uses regex over
 # the raw command string instead of the bash tokenizer. Substitution-aware
 # splitting is therefore weaker on Windows. The bash variant is canonical.
+#
+# Allow-path output (issue #715 audit): plain passes already emit the minimal
+# allow JSON with no additionalContext; the state-change warning intentionally
+# keeps additionalContext because it carries decision value.
 
 $json = Read-HookInput
 if (-not $json) { New-HookAllowResponse; exit 0 }

--- a/global/hooks/gh-write-verb-guard.sh
+++ b/global/hooks/gh-write-verb-guard.sh
@@ -20,6 +20,10 @@
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always — decision is in JSON)
 #
+# Allow-path output (issue #715 audit): plain passes already emit the minimal
+# allow JSON with no additionalContext; the state-change warning (point 3)
+# intentionally keeps additionalContext because it carries decision value.
+#
 # Reuses lib/tokenize-shell.sh so quote/substitution-aware sub-command
 # splitting matches the rest of the Bash hook chain (PR #483 / #484).
 #

--- a/global/hooks/github-api-preflight.ps1
+++ b/global/hooks/github-api-preflight.ps1
@@ -7,6 +7,10 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -Warni
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always - decision is in JSON, warning only)
 # Response format: hookSpecificOutput with hookEventName
+#
+# Allow-path output (issue #715 audit): plain passes already emit the minimal
+# allow JSON with no additionalContext; only connectivity/auth warnings
+# intentionally attach context (actionable degraded-environment signals).
 
 # Read input from stdin (Claude Code passes JSON via stdin)
 $json = Read-HookInput

--- a/global/hooks/github-api-preflight.sh
+++ b/global/hooks/github-api-preflight.sh
@@ -4,6 +4,10 @@
 # Hook Type: PreToolUse (Bash)
 # Exit codes: 0 (always — decision is in JSON, warning only)
 # Response format: hookSpecificOutput with hookEventName
+#
+# Allow-path output (issue #715 audit): plain passes already emit the minimal
+# allow JSON with no additionalContext; only connectivity/auth warnings
+# intentionally attach context (actionable degraded-environment signals).
 
 set -euo pipefail
 

--- a/global/hooks/memory-write-guard.ps1
+++ b/global/hooks/memory-write-guard.ps1
@@ -10,6 +10,10 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -Warni
 # Path gate: only acts when the resolved path is under
 # "$HOME/.claude/memory-shared/memories/" and ends with ".md".
 #
+# Allow-path output (issue #715 audit): plain allows already emit the minimal
+# allow JSON with no additionalContext; only warn-only validator findings and
+# internal-failure diagnostics intentionally attach context.
+#
 # See memory-write-guard.sh for full design notes.
 
 # ----- read input ------------------------------------------------------------

--- a/global/hooks/memory-write-guard.sh
+++ b/global/hooks/memory-write-guard.sh
@@ -32,6 +32,10 @@
 #   anything that slips through; this hook must NOT block legitimate work
 #   because of its own bug.
 #
+# Allow-path output (issue #715 audit): plain allows already emit the minimal
+# allow JSON with no additionalContext; only warn-only validator findings and
+# internal-failure diagnostics intentionally attach context.
+#
 # Bash 3.2 compatible (macOS default).
 
 set -euo pipefail

--- a/tests/hooks/test-dangerous-command-guard.ps1
+++ b/tests/hooks/test-dangerous-command-guard.ps1
@@ -80,6 +80,39 @@ Assert-Allow -InputJson '{"tool_input":{"command":"git status"}}' -Label 'git st
 Assert-Allow -InputJson '{"tool_input":{"command":"npm install"}}' -Label 'npm install -> allow'
 
 Write-Host ''
+Write-Host '[allow response shape - issue #715: plain allow is silent]'
+$plainSample = '{"tool_input":{"command":"ls -la"}}' | & pwsh -NoProfile -File $script:HookPath 2>$null
+if ($plainSample -match 'additionalContext') {
+    $script:Failed++
+    $script:Errors.Add("FAIL: plain allow must not carry additionalContext - got: $plainSample")
+    Write-Host '  FAIL: plain allow carries additionalContext' -ForegroundColor Red
+} else {
+    $script:Passed++
+    Write-Host '  PASS: plain allow has no additionalContext' -ForegroundColor Green
+}
+$compoundSample = '{"tool_input":{"command":"git status 2>&1 | head -20"}}' | & pwsh -NoProfile -File $script:HookPath 2>$null
+if ($compoundSample -match 'additionalContext') {
+    $script:Failed++
+    $script:Errors.Add("FAIL: compound allow must not carry additionalContext - got: $compoundSample")
+    Write-Host '  FAIL: compound allow carries additionalContext' -ForegroundColor Red
+} else {
+    $script:Passed++
+    Write-Host '  PASS: compound allow has no additionalContext' -ForegroundColor Green
+}
+# Warning-class allow (coarse-scan fallback) must keep additionalContext.
+$env:DCG_TOKENIZER_MAX_BYTES = '10'
+$coarseSample = '{"tool_input":{"command":"echo aaaaaaaaaaaaaaaaaaaaaaaa"}}' | & pwsh -NoProfile -File $script:HookPath 2>$null
+Remove-Item Env:DCG_TOKENIZER_MAX_BYTES -ErrorAction SilentlyContinue
+if ($coarseSample -match 'additionalContext' -and $coarseSample -match 'Coarse-scan allow') {
+    $script:Passed++
+    Write-Host '  PASS: coarse-scan warning keeps additionalContext' -ForegroundColor Green
+} else {
+    $script:Failed++
+    $script:Errors.Add("FAIL: coarse-scan warning lost additionalContext - got: $coarseSample")
+    Write-Host '  FAIL: coarse-scan warning lost additionalContext' -ForegroundColor Red
+}
+
+Write-Host ''
 Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
 if ($script:Errors.Count -gt 0) {
     Write-Host ''

--- a/tests/hooks/test-dangerous-command-guard.sh
+++ b/tests/hooks/test-dangerous-command-guard.sh
@@ -97,17 +97,31 @@ assert_allow '{"tool_input":{"command":"gh pr checks 123 | cat"}}' "gh pr checks
 assert_allow '{"tool_input":{"command":"git diff >/dev/null 2>&1"}}' "git diff >/dev/null → allow"
 
 echo ""
-echo "[allow response shape]"
+echo "[allow response shape — issue #715: plain allow is silent]"
 allow_sample=$(echo '{"tool_input":{"command":"git status 2>&1 | head -20"}}' | bash "$HOOK" 2>/dev/null)
 if echo "$allow_sample" | grep -q '"additionalContext"'; then
-    ((PASS++)); echo "  PASS: allow response includes additionalContext"
+    ((FAIL++)); ERRORS+=("FAIL: compound allow must not carry additionalContext — got: $allow_sample"); echo "  FAIL: compound allow carries additionalContext"
 else
-    ((FAIL++)); ERRORS+=("FAIL: allow response missing additionalContext — got: $allow_sample"); echo "  FAIL: allow response missing additionalContext"
+    ((PASS++)); echo "  PASS: compound allow has no additionalContext"
 fi
-if echo "$allow_sample" | grep -q 'Safe read-only compound command'; then
-    ((PASS++)); echo "  PASS: compound pattern emits dedicated reason"
+plain_sample=$(echo '{"tool_input":{"command":"ls -la"}}' | bash "$HOOK" 2>/dev/null)
+if echo "$plain_sample" | grep -q '"additionalContext"'; then
+    ((FAIL++)); ERRORS+=("FAIL: plain allow must not carry additionalContext — got: $plain_sample"); echo "  FAIL: plain allow carries additionalContext"
 else
-    ((FAIL++)); ERRORS+=("FAIL: compound pattern reason missing — got: $allow_sample"); echo "  FAIL: compound pattern reason missing"
+    ((PASS++)); echo "  PASS: plain allow has no additionalContext"
+fi
+# The dedicated compound reason now lands in the file log, not stdout.
+if grep -q 'Safe read-only compound command' "$LOG_FILE"; then
+    ((PASS++)); echo "  PASS: compound pattern reason recorded in log"
+else
+    ((FAIL++)); ERRORS+=("FAIL: compound pattern reason missing from log: $(cat "$LOG_FILE")"); echo "  FAIL: compound pattern reason missing from log"
+fi
+# Warning-class allow (coarse-scan fallback) must keep additionalContext.
+coarse_sample=$(echo '{"tool_input":{"command":"echo aaaaaaaaaaaaaaaaaaaaaaaa"}}' | DCG_TOKENIZER_MAX_BYTES=10 bash "$HOOK" 2>/dev/null)
+if echo "$coarse_sample" | grep -q '"additionalContext"' && echo "$coarse_sample" | grep -q 'Coarse-scan allow'; then
+    ((PASS++)); echo "  PASS: coarse-scan warning keeps additionalContext"
+else
+    ((FAIL++)); ERRORS+=("FAIL: coarse-scan warning lost additionalContext — got: $coarse_sample"); echo "  FAIL: coarse-scan warning lost additionalContext"
 fi
 
 echo ""

--- a/tests/hooks/test-gh-write-verb-guard.sh
+++ b/tests/hooks/test-gh-write-verb-guard.sh
@@ -115,6 +115,28 @@ for f in "$CORPUS_ROOT"/edge/*.json; do
 done
 
 echo ""
+echo "[plain-pass silence — issue #715]"
+plain_sample=$(echo '{"tool_input":{"command":"gh pr view 123"}}' | bash "$HOOK" 2>/dev/null)
+if echo "$plain_sample" | grep -q '"allow"' && ! echo "$plain_sample" | grep -q '"additionalContext"'; then
+    ((PASS++)); echo "  PASS: read-only gh pass emits no additionalContext"
+else
+    ((FAIL++)); ERRORS+=("FAIL: read-only gh pass shape — got: $plain_sample"); echo "  FAIL: read-only gh pass emits additionalContext"
+fi
+nongh_sample=$(echo '{"tool_input":{"command":"ls -la"}}' | bash "$HOOK" 2>/dev/null)
+if echo "$nongh_sample" | grep -q '"allow"' && ! echo "$nongh_sample" | grep -q '"additionalContext"'; then
+    ((PASS++)); echo "  PASS: non-gh pass emits no additionalContext"
+else
+    ((FAIL++)); ERRORS+=("FAIL: non-gh pass shape — got: $nongh_sample"); echo "  FAIL: non-gh pass emits additionalContext"
+fi
+# State-change warning must keep its additionalContext (decision value).
+warn_sample=$(echo '{"tool_input":{"command":"gh issue comment 1 --body hi"}}' | bash "$HOOK" 2>/dev/null)
+if echo "$warn_sample" | grep -q '"additionalContext"' && echo "$warn_sample" | grep -q 'state-changing gh operation'; then
+    ((PASS++)); echo "  PASS: state-change warning keeps additionalContext"
+else
+    ((FAIL++)); ERRORS+=("FAIL: state-change warning lost additionalContext — got: $warn_sample"); echo "  FAIL: state-change warning lost additionalContext"
+fi
+
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [ ${#ERRORS[@]} -gt 0 ]; then
     echo ""

--- a/tests/hooks/test-github-api-preflight.sh
+++ b/tests/hooks/test-github-api-preflight.sh
@@ -71,6 +71,8 @@ echo "[Scope: non-gh commands always pass without warnings]"
 result=$(run_hook "$INPUT_NONGH" "")
 assert_contains "$result" '"allow"' "ls -la → allow"
 assert_not_contains "$result" "not authenticated" "ls -la → no auth warning"
+# Issue #715: plain pass must not carry additionalContext at all.
+assert_not_contains "$result" "additionalContext" "ls -la → no additionalContext on plain pass"
 
 echo ""
 echo "[gh command without GH_TOKEN: keyring check runs]"

--- a/tests/hooks/test-memory-write-guard.sh
+++ b/tests/hooks/test-memory-write-guard.sh
@@ -125,6 +125,29 @@ assert_decision "$(build_payload Write "$MEM/MEMORY.md" 'index')" 'allow' 'MEMOR
 assert_decision '{"tool_name":"Write","tool_input":{"content":"x"}}' 'allow' 'Missing file_path -> allow (fail-open)'
 
 echo ""
+echo "[Plain-pass silence -- issue #715]"
+plain_sample=$(printf '%s' "$(build_payload Write /tmp/non-memory.txt 'hello')" | bash "$HOOK" 2>/dev/null)
+if printf '%s' "$plain_sample" | grep -q '"additionalContext"'; then
+    FAIL=$((FAIL + 1)); ERRORS+=("FAIL: non-memory plain allow must not carry additionalContext -- got: $plain_sample"); echo "  FAIL: non-memory plain allow carries additionalContext"
+else
+    PASS=$((PASS + 1)); echo "  PASS: non-memory plain allow has no additionalContext"
+fi
+# Warn-only validator findings must keep their additionalContext feedback.
+# Build this payload with pure-bash printf (not jq --arg / env): on
+# MSYS/Git Bash, path-like arguments and env values handed to a native
+# jq.exe get converted to Windows paths, which would dodge the hook's
+# path gate. The body contains no quotes/backslashes, so escaping
+# newlines is sufficient for valid JSON.
+warn_payload=$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"%s"}}' \
+    "$MEM/feedback_strict_ctx.md" "${INJECTION_BODY//$'\n'/\\n}")
+warn_sample=$(printf '%s' "$warn_payload" | bash "$HOOK" 2>/dev/null)
+if printf '%s' "$warn_sample" | grep -q '"additionalContext"'; then
+    PASS=$((PASS + 1)); echo "  PASS: warn-only finding keeps additionalContext"
+else
+    FAIL=$((FAIL + 1)); ERRORS+=("FAIL: warn-only finding lost additionalContext -- got: $warn_sample"); echo "  FAIL: warn-only finding lost additionalContext"
+fi
+
+echo ""
 echo "[Memory write decisions]"
 assert_decision "$(build_payload Write "$MEM/feedback_clean.md" "$CLEAN_BODY")" 'allow' 'Clean memory write -> allow'
 assert_decision "$(build_payload Write "$MEM/feedback_leak.md" "$SECRET_BODY")" 'deny'  'Secret in memory -> deny'


### PR DESCRIPTION
Closes #715

## What

Silences the `additionalContext` emission on the plain-allow path of PreToolUse guard hooks, and completes the audit of the four guards listed in the issue. Warning and deny paths are byte-identical.

| Hook (.sh + .ps1) | Verdict |
|-------------------|---------|
| `dangerous-command-guard` | Behavior change: plain allow now returns the minimal allow JSON without `additionalContext`; the allow-reason diagnostic moved to the hook's file log. Coarse-scan warning allow keeps its context. |
| `gh-write-verb-guard` | Already silent on plain pass; the state-change warning intentionally keeps `additionalContext` (decision value). Header rationale added. |
| `github-api-preflight` | Already silent on plain pass; only connectivity/auth warnings emit. Header rationale added. |
| `memory-write-guard` | Already silent on plain pass; only warn-only validation and degraded-mode diagnostics emit. Header rationale added. |

`post-compact-restore` (context restore is its purpose) and `prompt-validator` (warning-only reference pattern) are untouched per the issue table. `instructions-loaded-reinforcer` is out of scope (#716).

## Why

Every allowed Bash call previously injected a model-visible system-reminder ("no dangerous pattern matched") worth ~25-30 tokens, in the main loop and in every subagent. A 60-agent orchestration run averaging 20 Bash calls each burns ~35K tokens per run on this string. Relates to #714 (same per-agent token-overhead reduction effort).

## How

- `allow_response()` / `Respond-Allow` emit `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}` only; `allow_with_context` / `Respond-AllowWithContext` remain for the warning path.
- Regression tests added per silenced hook asserting no `additionalContext` key on plain allow (sh + ps1 parity).

## Testing

| Suite | Result |
|-------|--------|
| test-dangerous-command-guard.sh | 36 pass / 0 fail |
| test-dangerous-command-guard.ps1 | 28 pass / 0 fail (3 new #715 cases) |
| test-dangerous-command-guard-golden.sh | 43 pass / 0 fail |
| test-gh-write-verb-guard.sh | 27 pass / 2 fail (pre-existing, reproduced on develop baseline 24/2; branch adds 3 passing cases) |
| test-github-api-preflight.sh | 11 pass / 0 fail |
| test-memory-write-guard.sh | 12 pass / 3 fail (pre-existing, reproduced on develop baseline 10/3; branch adds 2 passing cases) |

Manual spot-check: benign command -> minimal allow JSON without `additionalContext`; `rm -rf /` -> deny with `permissionDecisionReason` unchanged.

## Rollback

Revert this PR; no data or schema changes.
