### PR TITLE
chore(hooks): slim instructions-loaded-reinforcer to a short digest

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -470,16 +470,15 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 
 *Re-asserts critical policy (commit-settings, branching, conventional commits) immediately after `CLAUDE.md` and `.claude/rules/*.md` are loaded — closes the gap where long sessions drift away from policy that lives only in the system prompt.*
 
-**Purpose**: Inject a policy-reinforcement block right after Claude finishes loading instruction files. The block restates AI-attribution prohibition, the active `CLAUDE_CONTENT_LANGUAGE` PR/issue rule (resolved from `commit-settings.md`), branching policy, and Conventional Commits format so they remain in active context even when the original instruction files scroll out.
+**Purpose**: Inject a short, fixed policy digest right after Claude finishes loading instruction files. The digest restates the AI-attribution prohibition, the `CLAUDE_CONTENT_LANGUAGE` policy pointer (full rules stay in `commit-settings.md`), protected-branch policy, and Conventional Commits format so they remain in active context even when the original instruction files scroll out. The full `commit-settings.md` text already reaches context via the `CLAUDE.md` @import chain, so the hook never re-injects it verbatim (issue #716); the payload is capped at ~10 lines / ~500 bytes.
 
 **Trigger**: `InstructionsLoaded` event — fires once per session, after `CLAUDE.md` / `.claude/rules/*.md` have been ingested.
 
 **Files**: `global/hooks/instructions-loaded-reinforcer.sh`, `global/hooks/instructions-loaded-reinforcer.ps1`
 
 **Logic**:
-1. Locate `commit-settings.md` in `~/.claude/commit-settings.md` (falls back to `${CLAUDE_HOME}/commit-settings.md`, then to an inline minimal policy if neither file exists).
-2. Compose a reinforcement block containing the located policy text plus branching and commit-format reminders.
-3. Emit JSON via `jq` if available; otherwise hand-escape and print the JSON literal.
+1. Compose a fixed four-item digest (attribution ban, content-language pointer, protected-branch rules, Conventional Commits format). No file is read into the payload.
+2. Emit JSON via `jq` if available; otherwise hand-escape and print the JSON literal.
 
 **Behavior**:
 - Returns JSON with `hookSpecificOutput.additionalContext` carrying the reinforcement text
@@ -509,7 +508,7 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 {
   "hookSpecificOutput": {
     "hookEventName": "InstructionsLoaded",
-    "additionalContext": "## Critical Policy Reinforcement (auto-injected after instruction load)\n\n# Commit, Issue, and PR Settings\n\nNo AI/Claude attribution in commits, issues, or PRs.\nAll GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy (values: english | korean_plus_english | exclusive_bilingual | any; default: english). See commit-settings.md for the per-policy artifact rule.\n\n## Branching\n\n- Default working branch: `develop`. Never push directly to `main` or `develop`.\n..."
+    "additionalContext": "## Critical Policy Reinforcement (digest)\n\n- No AI/Claude attribution in commits, issues, or PRs.\n- Issue/PR/commit prose: follow the CLAUDE_CONTENT_LANGUAGE policy (see commit-settings.md).\n- Branches: work branches from develop; never push directly to main or develop; squash merge only.\n- Commits: Conventional Commits `type(scope): description`; lowercase first char, no trailing period."
   }
 }
 ```

--- a/global/hooks/instructions-loaded-reinforcer.ps1
+++ b/global/hooks/instructions-loaded-reinforcer.ps1
@@ -9,50 +9,21 @@ Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -Warni
 # Hook Type: InstructionsLoaded (sync)
 # Exit codes: 0 (always - context is delivered via JSON)
 
-$policyText = $null
-$candidates = @(
-    (Join-Path $HOME '.claude' 'commit-settings.md')
-)
-if ($env:CLAUDE_HOME) {
-    $candidates += (Join-Path $env:CLAUDE_HOME 'commit-settings.md')
-}
-foreach ($candidate in $candidates) {
-    if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
-        $policyText = (([System.IO.File]::ReadAllText($candidate, [System.Text.Encoding]::UTF8)) -replace "`r`n", "`n").TrimEnd("`n")
-        break
-    }
-}
+# Fixed short digest (issue #716): the full commit-settings.md text already
+# reaches context via the CLAUDE.md @import chain, so re-injecting it verbatim
+# on every InstructionsLoaded event is pure duplication. Keep the payload to
+# ~10 lines / ~500 bytes and never read policy file contents into it.
+# Must stay byte-equivalent to the digest in instructions-loaded-reinforcer.sh.
+$reinforcement = @'
+## Critical Policy Reinforcement (digest)
 
-if (-not $policyText) {
-    $policyText = @'
-# Commit, Issue, and PR Settings
-
-No AI/Claude attribution in commits, issues, or PRs.
-All GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy
-(values: english | korean_plus_english | exclusive_bilingual | any; default: english).
-See commit-settings.md for the per-policy artifact rule.
+- No AI/Claude attribution in commits, issues, or PRs.
+- Issue/PR/commit prose: follow the CLAUDE_CONTENT_LANGUAGE policy (see commit-settings.md).
+- Branches: work branches from develop; never push directly to main or develop; squash merge only.
+- Commits: Conventional Commits `type(scope): description`; lowercase first char, no trailing period.
 '@
-}
 
-$reinforcement = @"
-## Critical Policy Reinforcement (auto-injected after instruction load)
-
-$policyText
-
-## Branching
-
-- Default working branch: ``develop``. Never push directly to ``main`` or ``develop``.
-- Feature/fix PRs target ``develop``; release PRs target ``main``.
-- Squash merge required.
-
-## Commit Format
-
-Conventional Commits: ``type(scope): description`` or ``type: description``.
-Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security.
-Description: first char is lowercase ASCII (default) or Hangul (when CLAUDE_CONTENT_LANGUAGE permits Korean). No trailing period, no emojis, no AI attribution.
-"@
-
-$reinforcement = ($reinforcement -replace "`r`n", "`n").TrimEnd("`n") + "`n"
+$reinforcement = ($reinforcement -replace "`r`n", "`n").TrimEnd("`n")
 
 $response = @{
     hookSpecificOutput = @{

--- a/global/hooks/instructions-loaded-reinforcer.sh
+++ b/global/hooks/instructions-loaded-reinforcer.sh
@@ -7,45 +7,17 @@
 
 set -euo pipefail
 
-# --- Locate commit-settings.md (try canonical user path, fall back to inline) ---
-POLICY_TEXT=""
-for candidate in \
-    "${HOME}/.claude/commit-settings.md" \
-    "${CLAUDE_HOME:-${HOME}/.claude}/commit-settings.md"; do
-    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
-        POLICY_TEXT="$(cat "$candidate")"
-        break
-    fi
-done
+# Fixed short digest (issue #716): the full commit-settings.md text already
+# reaches context via the CLAUDE.md @import chain, so re-injecting it verbatim
+# on every InstructionsLoaded event is pure duplication. Keep the payload to
+# ~10 lines / ~500 bytes and never read policy file contents into it.
+REINFORCEMENT=$(cat <<'EOF'
+## Critical Policy Reinforcement (digest)
 
-if [ -z "$POLICY_TEXT" ]; then
-    POLICY_TEXT=$(cat <<'EOF'
-# Commit, Issue, and PR Settings
-
-No AI/Claude attribution in commits, issues, or PRs.
-All GitHub Issues and Pull Requests follow the active CLAUDE_CONTENT_LANGUAGE policy
-(values: english | korean_plus_english | exclusive_bilingual | any; default: english).
-See commit-settings.md for the per-policy artifact rule.
-EOF
-)
-fi
-
-REINFORCEMENT=$(cat <<EOF
-## Critical Policy Reinforcement (auto-injected after instruction load)
-
-${POLICY_TEXT}
-
-## Branching
-
-- Default working branch: \`develop\`. Never push directly to \`main\` or \`develop\`.
-- Feature/fix PRs target \`develop\`; release PRs target \`main\`.
-- Squash merge required.
-
-## Commit Format
-
-Conventional Commits: \`type(scope): description\` or \`type: description\`.
-Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, security.
-Description: first char is lowercase ASCII (default) or Hangul (when CLAUDE_CONTENT_LANGUAGE permits Korean). No trailing period, no emojis, no AI attribution.
+- No AI/Claude attribution in commits, issues, or PRs.
+- Issue/PR/commit prose: follow the CLAUDE_CONTENT_LANGUAGE policy (see commit-settings.md).
+- Branches: work branches from develop; never push directly to main or develop; squash merge only.
+- Commits: Conventional Commits `type(scope): description`; lowercase first char, no trailing period.
 EOF
 )
 

--- a/tests/hooks/test-instructions-loaded-reinforcer.ps1
+++ b/tests/hooks/test-instructions-loaded-reinforcer.ps1
@@ -1,0 +1,73 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# Test suite for instructions-loaded-reinforcer.ps1
+# Run: pwsh tests/hooks/test-instructions-loaded-reinforcer.ps1
+#
+# Asserts the InstructionsLoaded digest contract (issue #716):
+# valid JSON envelope, payload size cap (~10 lines / ~500 bytes),
+# the four required policy items, and no verbatim commit-settings.md copy.
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'instructions-loaded-reinforcer.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Assert-True {
+    param([bool]$Condition, [string]$Label)
+    if ($Condition) {
+        $script:Passed++
+        Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++
+        $script:Errors.Add("FAIL: $Label")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host '=== instructions-loaded-reinforcer.ps1 tests ==='
+Write-Host ''
+
+Write-Host '[output structure]'
+$raw = '{}' | pwsh -NoProfile -File $script:HookPath 2>$null | Out-String
+$raw = $raw.Trim()
+$exitCode = $LASTEXITCODE
+Assert-True ($exitCode -eq 0) 'exit code is 0'
+
+$parsed = $null
+try { $parsed = $raw | ConvertFrom-Json } catch {}
+Assert-True ($null -ne $parsed) 'produces valid JSON'
+Assert-True ($parsed.hookSpecificOutput.hookEventName -eq 'InstructionsLoaded') 'event name is InstructionsLoaded'
+
+$ctx = $parsed.hookSpecificOutput.additionalContext
+Assert-True (-not [string]::IsNullOrEmpty($ctx)) 'includes additionalContext payload'
+
+Write-Host ''
+Write-Host '[digest constraints (issue #716)]'
+$ctxBytes = [System.Text.Encoding]::UTF8.GetByteCount($ctx)
+Assert-True ($ctxBytes -le 500) "payload is at most 500 bytes (got $ctxBytes)"
+$ctxLines = ($ctx -split "`n").Count
+Assert-True ($ctxLines -le 10) "payload is at most 10 lines (got $ctxLines)"
+
+# No verbatim copy of commit-settings.md: these markers exist only in the
+# full policy file (and the old inline fallback), never in the digest.
+Assert-True ($ctx -notmatch 'korean_plus_english') 'no verbatim copy marker: korean_plus_english'
+Assert-True ($ctx -notmatch 'commit-message-guard') 'no verbatim copy marker: commit-message-guard'
+Assert-True ($ctx -notmatch 'Enforced by') 'no verbatim copy marker: Enforced by'
+
+# Four required digest items (issue #716 AC2).
+Assert-True ($ctx -match 'No AI/Claude attribution') 'item 1: attribution ban'
+Assert-True ($ctx -match 'CLAUDE_CONTENT_LANGUAGE' -and $ctx -match 'commit-settings\.md') 'item 2: content-language policy pointer'
+Assert-True ($ctx -match 'develop' -and $ctx -match 'main' -and $ctx -match 'squash') 'item 3: protected branch rules'
+Assert-True ($ctx -match [regex]::Escape('type(scope): description') -and $ctx -match 'lowercase first char' -and $ctx -match 'no trailing period') 'item 4: Conventional Commits format'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-instructions-loaded-reinforcer.sh
+++ b/tests/hooks/test-instructions-loaded-reinforcer.sh
@@ -58,6 +58,83 @@ assert_contains 'Conventional Commits' "mentions Conventional Commits"
 assert_contains 'AI/Claude attribution\|attribution' "mentions attribution policy"
 assert_contains 'develop' "mentions develop branch policy"
 
+check() {
+    local rc="$1" label="$2"
+    if [ "$rc" -eq 0 ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("FAIL: $label")
+        echo "  FAIL: $label"
+    fi
+}
+
+# Extract additionalContext (raw string, no trailing-newline mangling) from
+# stdin JSON into a file. Prefers jq, falls back to python.
+extract_ctx() {
+    local outfile="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -j '.hookSpecificOutput.additionalContext' > "$outfile"
+        return
+    fi
+    local pybin=""
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1; then pybin="$c"; break; fi
+    done
+    if [ -n "$pybin" ]; then
+        "$pybin" -c 'import json,sys; sys.stdout.write(json.load(sys.stdin)["hookSpecificOutput"]["additionalContext"])' > "$outfile"
+    else
+        : > "$outfile"
+    fi
+}
+
+echo ""
+echo "[digest constraints (issue #716)]"
+CTX_FILE=$(mktemp)
+echo '{}' | bash "$HOOK" 2>/dev/null | extract_ctx "$CTX_FILE"
+
+if [ -s "$CTX_FILE" ]; then
+    check 0 "additionalContext extracted"
+
+    CTX_BYTES=$(wc -c < "$CTX_FILE")
+    [ "$CTX_BYTES" -le 500 ]; check $? "payload is at most 500 bytes (got $CTX_BYTES)"
+
+    CTX_LINES=$(awk 'END{print NR}' "$CTX_FILE")
+    [ "$CTX_LINES" -le 10 ]; check $? "payload is at most 10 lines (got $CTX_LINES)"
+
+    # No verbatim copy of commit-settings.md: these markers exist only in the
+    # full policy file (and the old inline fallback), never in the digest.
+    ! grep -q 'korean_plus_english' "$CTX_FILE"; check $? "no verbatim copy marker: korean_plus_english"
+    ! grep -q 'commit-message-guard' "$CTX_FILE"; check $? "no verbatim copy marker: commit-message-guard"
+    ! grep -q 'Enforced by' "$CTX_FILE"; check $? "no verbatim copy marker: Enforced by"
+
+    # Four required digest items (issue #716 AC2).
+    grep -qi 'No AI/Claude attribution' "$CTX_FILE"; check $? "item 1: attribution ban"
+    grep -q 'CLAUDE_CONTENT_LANGUAGE' "$CTX_FILE" && grep -q 'commit-settings.md' "$CTX_FILE"
+    check $? "item 2: content-language policy pointer"
+    grep -q 'develop' "$CTX_FILE" && grep -q 'main' "$CTX_FILE" && grep -qi 'squash' "$CTX_FILE"
+    check $? "item 3: protected branch rules"
+    grep -q 'type(scope): description' "$CTX_FILE" && grep -q 'lowercase first char' "$CTX_FILE" && grep -q 'no trailing period' "$CTX_FILE"
+    check $? "item 4: Conventional Commits format"
+else
+    check 1 "additionalContext extracted (jq/python unavailable or empty payload)"
+fi
+
+echo ""
+echo "[sh/ps1 parity]"
+PS1_HOOK="global/hooks/instructions-loaded-reinforcer.ps1"
+if command -v pwsh >/dev/null 2>&1; then
+    PS_CTX_FILE=$(mktemp)
+    echo '{}' | pwsh -NoProfile -File "$PS1_HOOK" 2>/dev/null | extract_ctx "$PS_CTX_FILE"
+    cmp -s "$CTX_FILE" "$PS_CTX_FILE"
+    check $? "additionalContext is byte-equivalent between .sh and .ps1"
+    rm -f "$PS_CTX_FILE"
+else
+    echo "  SKIP: pwsh not available"
+fi
+rm -f "$CTX_FILE"
+
 echo ""
 echo "[exit code]"
 echo '{}' | bash "$HOOK" >/dev/null 2>&1


### PR DESCRIPTION
Closes #716

## What

Replaces the full-text re-injection of `commit-settings.md` (~2.3 KB) in `instructions-loaded-reinforcer.{sh,ps1}` with a fixed 6-line / 391-byte digest. The digest covers the four rules the reinforcer exists to anchor: attribution ban, `CLAUDE_CONTENT_LANGUAGE` policy pointer, protected-branch rule, and Conventional Commits format. The hook JSON contract (`hookSpecificOutput.{hookEventName, additionalContext}`) is unchanged.

## Why

The full policy text already reaches context via the CLAUDE.md `@import` chain, so every `InstructionsLoaded` event (including each subagent session) paid ~700+ tokens of pure duplication. Across a 30-60 agent orchestration run this is tens of thousands of redundant tokens. The digest keeps the recency-anchoring effect at under a tenth of the cost.

## Where

- `global/hooks/instructions-loaded-reinforcer.sh` -- cat block and `$HOME`/`$CLAUDE_HOME` candidate scan removed; fixed digest emitted
- `global/hooks/instructions-loaded-reinforcer.ps1` -- mirrored; trailing-newline asymmetry removed so payloads are byte-equivalent
- `HOOKS.md` -- catalog entry updated (Purpose/Logic/Sample output were stale)
- `tests/hooks/test-instructions-loaded-reinforcer.sh` -- regression tests for size cap, verbatim-copy markers absent, four required items, sh/ps1 parity
- `tests/hooks/test-instructions-loaded-reinforcer.ps1` -- new mirror suite for the Windows runner

## How

### Acceptance criteria verification

- [x] Payload is at most ~10 lines / ~500 bytes with no verbatim copy of `commit-settings.md` (measured 391 bytes / 6 lines; absence of verbatim markers asserted in tests)
- [x] Digest states attribution ban, content-language policy pointer, protected-branch rule, Conventional Commits format (each asserted individually)
- [x] .sh and .ps1 outputs are equivalent (cmp byte-equivalent; parity asserted in both suites)
- [x] Hook tests updated and green (bash suite 19/19, pwsh suite 13/13; `scripts/gen-hooks-md.sh --check` exit 0)

### Test plan

1. `echo '{}' | bash global/hooks/instructions-loaded-reinforcer.sh` -- valid JSON, digest-only payload
2. `pwsh -NoProfile -File global/hooks/instructions-loaded-reinforcer.ps1` with `{}` on stdin -- identical `additionalContext`
3. `bash tests/hooks/test-instructions-loaded-reinforcer.sh` and `pwsh -NoProfile -File tests/hooks/test-instructions-loaded-reinforcer.ps1`

## Notes

- The sh jq-absent fallback keeps its pre-existing trailing-newline behavior (awk ORS); jq path is the default and is byte-equivalent with ps1.
- Deployed copies under `~/.claude/hooks/` are not touched by this PR; redeploy via the install script to pick up the change.
