### PR TITLE
fix(hooks): rewire post-compact restore to sessionstart compact matcher

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -31,14 +31,13 @@ Each hook event type requires a Claude Code version that supports it. If your Cl
 | `PreToolUse` | sensitive-file-guard, dangerous-command-guard, github-api-preflight, markdown-anchor-validator, prompt-validator (LLM), team-limit-guard | Block or allow tool calls before execution |
 | `PostToolUse` | post-task-checkpoint, pre-edit-read-guard, memory-access-logger | Run after a tool call completes (checkpointing, read-tracking, memory-access logging) |
 | `PostToolUseFailure` | tool-failure-logger | Log failed tool executions |
-| `SessionStart` | session-logger, version-check | Session lifecycle logging, version warnings |
+| `SessionStart` | session-logger, version-check, post-compact-restore (matcher: `compact`) | Session lifecycle logging, version warnings, post-compaction principles restore |
 | `SessionEnd` | session-logger, cleanup | Session logging, temp file cleanup |
 | `Stop` | session-logger | Log when Claude stops generating |
 | `UserPromptSubmit` | prompt-validator | Validate user prompts before processing |
 | `SubagentStart` | subagent-logger | Track subagent lifecycle |
 | `SubagentStop` | subagent-logger | Track subagent lifecycle |
 | `PreCompact` | pre-compact-snapshot | Snapshot context before auto-compaction |
-| `PostCompact` | post-compact-restore | Re-assert core principles after context compaction |
 | `WorktreeCreate` | worktree-create | Custom worktree initialization |
 | `WorktreeRemove` | worktree-remove | Custom worktree cleanup |
 | `TaskCreated` | task-created-validator | Validate newly created tasks (Agent Teams) |

--- a/ENFORCEMENT.md
+++ b/ENFORCEMENT.md
@@ -22,7 +22,7 @@ What gets blocked, by which layer, and how to unblock it. Read in five minutes. 
 | `TeamCreate` when `~/.claude/teams/` already has `MAX_TEAMS` (default 3) | `team-limit-guard` (PreToolUse) | Team creation blocked | Shut down an idle team first |
 | `rm -rf /`, `chmod 777`, `curl … \| sh` | `dangerous-command-guard` (PreToolUse) | Catastrophic command blocked | Use a smaller, scoped command |
 | Edit/Write/Read on `.env`, `.pem`, `.key`, `secrets/`, `credentials/` | `sensitive-file-guard` (PreToolUse) + `permissions.deny` | Tool call blocked | Do not exfiltrate secrets; reference variable names instead |
-| Auto-compaction discards core principles | `pre-compact-snapshot` + `post-compact-restore` (PreCompact / PostCompact) | Not blocking — re-injects principles into post-compact context | No action |
+| Auto-compaction discards core principles | `pre-compact-snapshot` + `post-compact-restore` (PreCompact / SessionStart matcher `compact`) | Not blocking — re-injects principles into post-compact context | No action |
 | Instruction load (CLAUDE.md ingest) | `instructions-loaded-reinforcer` (InstructionsLoaded) | Not blocking — re-asserts commit / branching / language policy | No action |
 | Task or Agent tool returns dirty working tree | `post-task-checkpoint` (PostToolUse, async) | Not blocking — auto-commits `wip(agent): ...` checkpoint | No action; squash at PR merge |
 

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -26,7 +26,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 | Block gh pr merge when any check is non-passing | [Merge Gate Guard](#14-merge-gate-guard-pretooluse) |
 | Block AI/Claude attribution in gh PR/issue commands | [Attribution Guard](#15-attribution-guard-pretooluse) |
 | Re-inject critical policy after instruction load | [Instructions Loaded Reinforcer](#16-instructions-loaded-reinforcer-instructionsloaded) |
-| Restore core principles after context compaction | [Post-Compact Restore](#17-post-compact-restore-postcompact) |
+| Restore core principles after context compaction | [Post-Compact Restore](#17-post-compact-restore-sessionstart) |
 | Validate task descriptions at creation time | [Task Created Validator](#18-task-created-validator-taskcreated) |
 | Auto-commit working tree after Task/Agent runs | [Post Task/Agent Checkpoint](#19-post-taskagent-checkpoint-posttooluse) |
 | Block Edit/Write on files that weren't Read first | [Pre-edit Read Guard](#20-pre-edit-read-guard-pretooluseposttooluse) |
@@ -513,34 +513,39 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 }
 ```
 
-### 17. Post-Compact Restore (PostCompact)
+### 17. Post-Compact Restore (SessionStart)
 
-*Re-injects `core/principles.md` immediately after Claude Code automatically compacts the conversation — pairs with `pre-compact-snapshot` to keep the four core principles in context across long sessions.*
+*Re-asserts the four core principles immediately after Claude Code automatically compacts the conversation - pairs with `pre-compact-snapshot` to keep the principles in context across long sessions.*
 
-**Purpose**: When automatic context compaction discards the original `CLAUDE.md` and rule files, this hook re-asserts the four core principles (Think, Minimize, Surgical, Verify) plus behavioral guardrails so the model does not regress to pre-policy defaults after compaction.
+**Purpose**: When automatic context compaction discards the original `CLAUDE.md` and rule files, this hook re-asserts the four core principles (Think, Minimize, Surgical, Verify) plus the senior-engineer self-check so the model does not regress to pre-policy defaults after compaction.
 
-**Trigger**: `PostCompact` event — fires once whenever the harness completes an automatic compaction cycle. Pairs with the existing `pre-compact-snapshot` hook (PreCompact event) which captures pre-compact state.
+**Trigger**: `SessionStart` event with matcher `compact` - fires once when the harness starts the fresh post-compaction context. The `PostCompact` event does NOT support `hookSpecificOutput` (Claude Code rejects such output with "Hook JSON output validation failed"); `SessionStart` with `source == "compact"` is the official channel for injecting context after compaction (issue #720). Pairs with the existing `pre-compact-snapshot` hook (PreCompact event) which captures pre-compact state.
 
 **Files**: `global/hooks/post-compact-restore.sh`, `global/hooks/post-compact-restore.ps1`
 
 **Logic**:
-1. Append a restore record (timestamp, session id, working directory) to `~/.claude/logs/compact-snapshots.log` — the same log written by `pre-compact-snapshot.sh` so PreCompact / PostCompact pairs can be correlated.
-2. Locate `core/principles.md` from one of: `${CLAUDE_PROJECT_DIR}/.claude/rules/core/principles.md`, `~/.claude/rules/core/principles.md`, or the current working directory tree (falls back to an inline minimal principles block if no file is found).
-3. Wrap the located text in a "Post-Compaction Restore" section explaining why it is being re-asserted.
-4. Emit JSON via `jq` if available; otherwise hand-escape and print the JSON literal.
+1. Parse stdin JSON and exit 0 silently (no output) unless `source` is `"compact"` - defense in depth in case the hook is ever wired without a matcher, so startup/resume/clear sessions are never spammed.
+2. Append a restore record (timestamp, session id, working directory) to `~/.claude/logs/compact-snapshots.log` - the same log written by `pre-compact-snapshot.sh` so snapshot / restore pairs can be correlated.
+3. Emit a fixed short digest (~500 bytes) of the four core principles plus the self-check line. The hook never reads rule files into the payload; `.sh` and `.ps1` emit byte-equivalent `additionalContext`.
 
 **Behavior**:
-- Returns JSON with `hookSpecificOutput.additionalContext` carrying the principles re-assertion
-- Always exits 0 — the hook never blocks compaction; it only augments the post-compact context
+- Returns JSON with `hookSpecificOutput.{hookEventName: "SessionStart", additionalContext}` carrying the principles digest
+- Always exits 0 - the hook never blocks session start; it only augments the post-compact context
+- Silent no-op (no output) for any `source` other than `"compact"`, for empty stdin, and when no JSON parser is available
 - Writes to `~/.claude/logs/compact-snapshots.log` (created on demand)
 - Cross-platform: `post-compact-restore.sh` and `post-compact-restore.ps1`
 
 **Configuration**:
 ```json
 {
-  "type": "command",
-  "command": "~/.claude/hooks/post-compact-restore.sh",
-  "timeout": 5
+  "matcher": "compact",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "~/.claude/hooks/post-compact-restore.sh",
+      "timeout": 5
+    }
+  ]
 }
 ```
 
@@ -548,7 +553,8 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 ```json
 {
   "session_id": "abc123",
-  "hook_event_name": "PostCompact",
+  "hook_event_name": "SessionStart",
+  "source": "compact",
   "cwd": "/path/to/project"
 }
 ```
@@ -557,8 +563,8 @@ Issue #480 extended scope from `gh (pr|issue) (create|edit|comment)` to include 
 ```json
 {
   "hookSpecificOutput": {
-    "hookEventName": "PostCompact",
-    "additionalContext": "## Post-Compaction Restore (auto-injected)\n\nContext was just compacted. Re-asserting core principles to prevent drift:\n\n# Core Principles\n\n1. **Think Before Acting** — State assumptions explicitly. If uncertain, ask.\n..."
+    "hookEventName": "SessionStart",
+    "additionalContext": "## Post-Compaction Restore (digest)\n\nContext was just compacted. Re-asserting the four core principles:\n\n1. Think Before Acting - state assumptions explicitly; if uncertain, ask.\n..."
   }
 }
 ```
@@ -1025,7 +1031,7 @@ this catalog for the canonical hook inventory.
 | [`memory-write-guard.sh`](#memory-write-guard) | PreToolUse (Edit|Write) | yes |
 | [`merge-gate-guard.sh`](#merge-gate-guard) | PreToolUse (Bash) | yes |
 | [`permission-denial-logger.sh`](#permission-denial-logger) | PermissionDenied | yes |
-| [`post-compact-restore.sh`](#post-compact-restore) | PostCompact (sync) | yes |
+| [`post-compact-restore.sh`](#post-compact-restore) | SessionStart (matcher: compact, sync) | yes |
 | [`post-task-checkpoint.sh`](#post-task-checkpoint) | PostToolUse | yes |
 | [`pr-language-guard.sh`](#pr-language-guard) | PreToolUse (Bash) | yes |
 | [`pr-target-guard.sh`](#pr-target-guard) | PreToolUse (Bash) | yes |
@@ -1362,14 +1368,15 @@ _File:_ `post-compact-restore.sh`
 
 _Anchor:_ `#post-compact-restore`
 
-Re-injects core/principles.md after automatic context compaction. Pairs with pre-compact-snapshot.sh (PreCompact event).
+Re-asserts the four core principles after automatic context compaction. Pairs with pre-compact-snapshot.sh (PreCompact event).
 
 | Field | Value |
 |---|---|
-| Hook Type | PostCompact (sync) |
-| Trigger / Matcher | sync |
-| Exit codes | 0 (always — context delivered via JSON) |
+| Hook Type | SessionStart (matcher: compact, sync) |
+| Trigger / Matcher | matcher: compact, sync |
+| Exit codes | 0 (always - silent no-op unless stdin source is "compact") |
 | Response format | hookSpecificOutput.additionalContext |
+| Fail policy | fails quiet - no JSON parser or non-compact source means no output |
 | PowerShell counterpart | present (`post-compact-restore.ps1`) |
 | Source | `global/hooks/post-compact-restore.sh` |
 

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -124,7 +124,7 @@ The table below shows which hook needs which tool, so an operator can decide whe
 | `task-created-validator.sh` | `jq` or `python3` | Hook fails open |
 | `pre-edit-read-guard.sh` | `jq` | Hook fails open |
 | `instructions-loaded-reinforcer.sh` | `jq` (preferred), falls back to hand-escape | Hook still emits JSON, with reduced robustness |
-| `post-compact-restore.sh` | `jq` (preferred) | Same as above |
+| `post-compact-restore.sh` | `jq` (preferred) or `python3` | No parser: silent no-op; no `jq`: hand-escaped JSON |
 
 ## Verifying After Install
 

--- a/docs/hooks-ownership.md
+++ b/docs/hooks-ownership.md
@@ -30,7 +30,7 @@ that could be registered from multiple surfaces.
 | `PostToolUseFailure` | `.*` | `tool-failure-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `SubagentStart`/`SubagentStop` | `.*` | `subagent-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `PreCompact` | — | `pre-compact-snapshot.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `PostCompact` | — | `post-compact-restore.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionStart` | `compact` | `post-compact-restore.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `InstructionsLoaded` | — | `instructions-loaded-reinforcer.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `TaskCreated` | — | `task-created-validator.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `WorktreeCreate`/`WorktreeRemove` | — | `worktree-create.{sh,ps1}` / `worktree-remove.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |

--- a/global/hooks/post-compact-restore.ps1
+++ b/global/hooks/post-compact-restore.ps1
@@ -5,11 +5,22 @@ $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
 
 # post-compact-restore.ps1
-# Re-injects core/principles.md after automatic context compaction.
+# Re-asserts the four core principles after automatic context compaction.
 # Pairs with pre-compact-snapshot.ps1 (PreCompact event).
-# Hook Type: PostCompact (sync)
-# Exit codes: 0 (always - context delivered via JSON)
+# Hook Type: SessionStart (matcher: compact, sync)
+# Exit codes: 0 (always - silent no-op unless stdin source is "compact")
 
+# Defense in depth (issue #720): the settings matcher ("compact") already
+# filters SessionStart invocations, but stay silent if the hook is ever
+# wired without a matcher so startup/resume/clear sessions are not spammed.
+$json = Read-HookInput
+$source = ''
+if ($null -ne $json) {
+    try { $source = [string]$json.source } catch { $source = '' }
+}
+if ($source -ne 'compact') { exit 0 }
+
+# --- Logging (mirrors pre-compact-snapshot.ps1 contract) ---
 $logDir = Join-Path $HOME '.claude' 'logs'
 $logFile = Join-Path $logDir 'compact-snapshots.log'
 Ensure-Directory $logDir | Out-Null
@@ -19,7 +30,7 @@ $sessionId = if ($env:CLAUDE_SESSION_ID) { $env:CLAUDE_SESSION_ID } else { 'unkn
 $workingDir = try { $PWD.Path } catch { 'unknown' }
 
 $entry = @"
-=== PostCompact Restore ===
+=== Post-Compact Restore ===
 Time: $timestamp
 Session: $sessionId
 Working Dir: $workingDir
@@ -27,53 +38,30 @@ Working Dir: $workingDir
 "@
 Add-Content -Path $logFile -Value $entry
 
-$principlesText = $null
-$candidates = @()
-if ($env:CLAUDE_PROJECT_DIR) {
-    $candidates += (Join-Path $env:CLAUDE_PROJECT_DIR '.claude' 'rules' 'core' 'principles.md')
-}
-$candidates += (Join-Path $HOME '.claude' 'rules' 'core' 'principles.md')
-$candidates += (Join-Path $PWD.Path '.claude' 'rules' 'core' 'principles.md')
-$candidates += (Join-Path (Split-Path -Parent $PWD.Path) '.claude' 'rules' 'core' 'principles.md')
+# Fixed short digest (issue #720): the PostCompact event does not support
+# hookSpecificOutput, so this hook listens on SessionStart (source ==
+# "compact") - the official channel for injecting context after compaction.
+# Keep the payload to a few lines and never read rule files into it.
+# Must stay byte-equivalent to the digest in post-compact-restore.sh.
+$digest = @'
+## Post-Compaction Restore (digest)
 
-foreach ($candidate in $candidates) {
-    if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
-        $principlesText = (([System.IO.File]::ReadAllText($candidate, [System.Text.Encoding]::UTF8)) -replace "`r`n", "`n").TrimEnd("`n")
-        break
-    }
-}
+Context was just compacted. Re-asserting the four core principles:
 
-if (-not $principlesText) {
-    $principlesText = @'
-# Core Principles
+1. Think Before Acting - state assumptions explicitly; if uncertain, ask.
+2. Minimize & Focus - minimum code that solves the problem; nothing speculative.
+3. Surgical Precision - touch only what you must; clean up only your own mess.
+4. Verify & Iterate - define success criteria; loop until verified.
 
-1. **Think Before Acting** — State assumptions explicitly. If uncertain, ask.
-2. **Minimize & Focus** — Minimum code that solves the problem. Nothing speculative.
-3. **Surgical Precision** — Touch only what you must. Clean up only your own mess.
-4. **Verify & Iterate** — Define success criteria. Loop until verified.
-
-## Behavioral Guardrails
-
-- Stay focused on the user's original request. Note unrelated issues at the end without acting on them.
-- If the same approach fails 3 times, stop and propose alternatives rather than retrying blindly.
-- Bias toward execution — start making changes immediately when asked to update or edit documents.
+Self-check: "Would a senior engineer say this diff is focused, minimal, and well-verified?"
 '@
-}
 
-$context = @"
-## Post-Compaction Restore (auto-injected)
-
-Context was just compacted. Re-asserting core principles to prevent drift:
-
-$principlesText
-"@
-
-$context = ($context -replace "`r`n", "`n").TrimEnd("`n") + "`n"
+$digest = ($digest -replace "`r`n", "`n").TrimEnd("`n")
 
 $response = @{
     hookSpecificOutput = @{
-        hookEventName     = 'PostCompact'
-        additionalContext = $context
+        hookEventName     = 'SessionStart'
+        additionalContext = $digest
     }
 }
 Write-Output ($response | ConvertTo-Json -Depth 3 -Compress)

--- a/global/hooks/post-compact-restore.sh
+++ b/global/hooks/post-compact-restore.sh
@@ -1,73 +1,81 @@
 #!/usr/bin/env bash
 # post-compact-restore.sh
-# Re-injects core/principles.md after automatic context compaction.
+# Re-asserts the four core principles after automatic context compaction.
 # Pairs with pre-compact-snapshot.sh (PreCompact event).
-# Hook Type: PostCompact (sync)
-# Exit codes: 0 (always — context delivered via JSON)
+# Hook Type: SessionStart (matcher: compact, sync)
+# Exit codes: 0 (always - silent no-op unless stdin source is "compact")
 # Response format: hookSpecificOutput.additionalContext
+# Fail policy: fails quiet - no JSON parser or non-compact source means no output
 
 set -euo pipefail
+
+INPUT=$(cat || true)
+
+# Defense in depth (issue #720): the settings matcher ("compact") already
+# filters SessionStart invocations, but stay silent if the hook is ever
+# wired without a matcher so startup/resume/clear sessions are not spammed.
+SOURCE=""
+if [ -n "$INPUT" ]; then
+    if command -v jq >/dev/null 2>&1; then
+        SOURCE=$(printf '%s' "$INPUT" | jq -r '.source? // empty' 2>/dev/null) || SOURCE=""
+    elif command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+        PY=$(command -v python3 || command -v python)
+        SOURCE=$(printf '%s' "$INPUT" | "$PY" -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+v = d.get("source") if isinstance(d, dict) else None
+if isinstance(v, str):
+    sys.stdout.write(v)
+' 2>/dev/null) || SOURCE=""
+    fi
+fi
+
+if [ "$SOURCE" != "compact" ]; then
+    exit 0
+fi
 
 # --- Logging (mirrors pre-compact-snapshot.sh contract) ---
 LOG_DIR="${HOME}/.claude/logs"
 LOG_FILE="${LOG_DIR}/compact-snapshots.log"
 mkdir -p "$LOG_DIR"
 {
-    echo "=== PostCompact Restore ==="
+    echo "=== Post-Compact Restore ==="
     echo "Time: $(date '+%Y-%m-%d %H:%M:%S %Z')"
     echo "Session: ${CLAUDE_SESSION_ID:-unknown}"
     echo "Working Dir: $(pwd 2>/dev/null || echo 'unknown')"
     echo "==========================="
 } >> "$LOG_FILE"
 
-# --- Locate core/principles.md (try common installation paths) ---
-PRINCIPLES_TEXT=""
-for candidate in \
-    "${CLAUDE_PROJECT_DIR:-}/.claude/rules/core/principles.md" \
-    "${HOME}/.claude/rules/core/principles.md" \
-    "$(pwd)/.claude/rules/core/principles.md" \
-    "$(pwd)/../.claude/rules/core/principles.md"; do
-    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
-        PRINCIPLES_TEXT="$(cat "$candidate")"
-        break
-    fi
-done
+# Fixed short digest (issue #720): the PostCompact event does not support
+# hookSpecificOutput, so this hook listens on SessionStart (source ==
+# "compact") - the official channel for injecting context after compaction.
+# Keep the payload to a few lines and never read rule files into it.
+# Must stay byte-equivalent to the digest in post-compact-restore.ps1.
+DIGEST=$(cat <<'EOF'
+## Post-Compaction Restore (digest)
 
-if [ -z "$PRINCIPLES_TEXT" ]; then
-    # Use read -d '' to avoid a bash 3.2 parsing bug where $(cat <<'EOF' ...)
-    # mishandles apostrophes inside the heredoc body. `|| true` absorbs the
-    # non-zero status that `read` returns when it reaches EOF.
-    read -r -d '' PRINCIPLES_TEXT <<'EOF' || true
-# Core Principles
+Context was just compacted. Re-asserting the four core principles:
 
-1. **Think Before Acting** — State assumptions explicitly. If uncertain, ask.
-2. **Minimize & Focus** — Minimum code that solves the problem. Nothing speculative.
-3. **Surgical Precision** — Touch only what you must. Clean up only your own mess.
-4. **Verify & Iterate** — Define success criteria. Loop until verified.
+1. Think Before Acting - state assumptions explicitly; if uncertain, ask.
+2. Minimize & Focus - minimum code that solves the problem; nothing speculative.
+3. Surgical Precision - touch only what you must; clean up only your own mess.
+4. Verify & Iterate - define success criteria; loop until verified.
 
-## Behavioral Guardrails
-
-- Stay focused on the user's original request. Note unrelated issues at the end without acting on them.
-- If the same approach fails 3 times, stop and propose alternatives rather than retrying blindly.
-- Bias toward execution — start making changes immediately when asked to update or edit documents.
+Self-check: "Would a senior engineer say this diff is focused, minimal, and well-verified?"
 EOF
-fi
+)
 
-read -r -d '' CONTEXT <<EOF || true
-## Post-Compaction Restore (auto-injected)
-
-Context was just compacted. Re-asserting core principles to prevent drift:
-
-${PRINCIPLES_TEXT}
-EOF
-
+# Emit JSON via jq if available (safe escaping); fall back to manual escaping.
 if command -v jq >/dev/null 2>&1; then
-    jq -nc --arg ctx "$CONTEXT" '{hookSpecificOutput: {hookEventName: "PostCompact", additionalContext: $ctx}}'
+    jq -nc --arg ctx "$DIGEST" '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
 else
-    ESCAPED=$(printf '%s' "$CONTEXT" \
+    ESCAPED=$(printf '%s' "$DIGEST" \
         | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
         | awk 'BEGIN{ORS="\\n"} {print}')
-    printf '{"hookSpecificOutput":{"hookEventName":"PostCompact","additionalContext":"%s"}}\n' "$ESCAPED"
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$ESCAPED"
 fi
 
 exit 0

--- a/global/settings.json
+++ b/global/settings.json
@@ -235,6 +235,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/post-compact-restore.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -347,17 +357,6 @@
             "command": "~/.claude/hooks/pre-compact-snapshot.sh",
             "timeout": 10,
             "async": true
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/post-compact-restore.sh",
-            "timeout": 5
           }
         ]
       }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -188,6 +188,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/post-compact-restore.ps1",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -300,17 +310,6 @@
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pre-compact-snapshot.ps1",
             "timeout": 10,
             "async": true
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pwsh -NoProfile -File ~/.claude/hooks/post-compact-restore.ps1",
-            "timeout": 5
           }
         ]
       }

--- a/tests/hooks/test-post-compact-restore.ps1
+++ b/tests/hooks/test-post-compact-restore.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# Test suite for post-compact-restore.ps1
+# Run: pwsh tests/hooks/test-post-compact-restore.ps1
+#
+# Asserts the SessionStart(compact) restore contract (issue #720):
+# the PostCompact event does not support hookSpecificOutput, so the hook
+# must emit a SessionStart envelope with exactly the schema keys
+# {hookSpecificOutput: {hookEventName, additionalContext}}, keep the
+# digest small, and stay silent for non-compact sources.
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'post-compact-restore.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Assert-True {
+    param([bool]$Condition, [string]$Label)
+    if ($Condition) {
+        $script:Passed++
+        Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++
+        $script:Errors.Add("FAIL: $Label")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+$compactInput = '{"session_id":"test","hook_event_name":"SessionStart","source":"compact"}'
+$startupInput = '{"session_id":"test","hook_event_name":"SessionStart","source":"startup"}'
+
+Write-Host '=== post-compact-restore.ps1 tests ==='
+Write-Host ''
+
+Write-Host '[output structure (source == compact)]'
+$raw = $compactInput | pwsh -NoProfile -File $script:HookPath 2>$null | Out-String
+$raw = $raw.Trim()
+$exitCode = $LASTEXITCODE
+Assert-True ($exitCode -eq 0) 'exit code is 0'
+
+$parsed = $null
+try { $parsed = $raw | ConvertFrom-Json } catch {}
+Assert-True ($null -ne $parsed) 'produces valid JSON'
+Assert-True ($parsed.hookSpecificOutput.hookEventName -eq 'SessionStart') 'event name is SessionStart'
+Assert-True ($raw -notmatch 'PostCompact') 'no PostCompact string in output (unsupported event)'
+
+$ctx = $parsed.hookSpecificOutput.additionalContext
+Assert-True (-not [string]::IsNullOrEmpty($ctx)) 'includes additionalContext payload'
+
+Write-Host ''
+Write-Host '[schema exactness (issue #720 AC4)]'
+$topKeys = @($parsed.PSObject.Properties.Name)
+Assert-True (($topKeys.Count -eq 1) -and ($topKeys[0] -eq 'hookSpecificOutput')) 'top-level keys are exactly {hookSpecificOutput}'
+$innerKeys = @($parsed.hookSpecificOutput.PSObject.Properties.Name | Sort-Object)
+Assert-True (($innerKeys.Count -eq 2) -and ($innerKeys[0] -eq 'additionalContext') -and ($innerKeys[1] -eq 'hookEventName')) 'hookSpecificOutput keys are exactly {hookEventName, additionalContext}'
+
+Write-Host ''
+Write-Host '[digest constraints (issue #720)]'
+$ctxBytes = [System.Text.Encoding]::UTF8.GetByteCount($ctx)
+Assert-True ($ctxBytes -le 1000) "payload is at most 1000 bytes (got $ctxBytes)"
+$ctxLines = ($ctx -split "`n").Count
+Assert-True ($ctxLines -le 12) "payload is at most 12 lines (got $ctxLines)"
+
+# No full-document re-injection: these markers exist only in the full
+# core/principles.md file (frontmatter, guardrail section), never in
+# the digest.
+Assert-True ($ctx -notmatch 'alwaysApply') 'no full-document marker: alwaysApply'
+Assert-True ($ctx -notmatch 'Behavioral Guardrails') 'no full-document marker: Behavioral Guardrails'
+
+# Digest items: the four core principles plus the self-check line.
+Assert-True ($ctx -match 'Think Before Acting') 'principle 1: Think Before Acting'
+Assert-True ($ctx -match 'Minimize & Focus') 'principle 2: Minimize & Focus'
+Assert-True ($ctx -match 'Surgical Precision') 'principle 3: Surgical Precision'
+Assert-True ($ctx -match 'Verify & Iterate') 'principle 4: Verify & Iterate'
+Assert-True ($ctx -match 'senior engineer') 'self-check line present'
+
+Write-Host ''
+Write-Host '[source gating (defense in depth)]'
+$startupOut = ($startupInput | pwsh -NoProfile -File $script:HookPath 2>$null | Out-String).Trim()
+Assert-True ($LASTEXITCODE -eq 0) 'source startup: exit code is 0'
+Assert-True ([string]::IsNullOrEmpty($startupOut)) 'source startup: stdout is empty'
+
+$noSrcOut = ('{}' | pwsh -NoProfile -File $script:HookPath 2>$null | Out-String).Trim()
+Assert-True (($LASTEXITCODE -eq 0) -and [string]::IsNullOrEmpty($noSrcOut)) 'missing source field: silent exit 0'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-post-compact-restore.sh
+++ b/tests/hooks/test-post-compact-restore.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Test suite for post-compact-restore.sh
 # Run: bash tests/hooks/test-post-compact-restore.sh
+#
+# Asserts the SessionStart(compact) restore contract (issue #720):
+# the PostCompact event does not support hookSpecificOutput, so the hook
+# must emit a SessionStart envelope with exactly the schema keys
+# {hookSpecificOutput: {hookEventName, additionalContext}}, keep the
+# digest small, stay silent for non-compact sources, and keep .sh/.ps1
+# additionalContext byte-equivalent.
 
 HOOK="global/hooks/post-compact-restore.sh"
 PASS=0
@@ -9,79 +16,163 @@ ERRORS=()
 
 cd "$(dirname "$0")/../.." || exit 1
 
-assert_contains() {
-    local needle="$1" label="$2"
-    local result
-    result=$(echo '{}' | bash "$HOOK" 2>/dev/null)
-    if echo "$result" | grep -q "$needle"; then
+COMPACT_INPUT='{"session_id":"test","hook_event_name":"SessionStart","source":"compact"}'
+STARTUP_INPUT='{"session_id":"test","hook_event_name":"SessionStart","source":"startup"}'
+
+check() {
+    local rc="$1" label="$2"
+    if [ "$rc" -eq 0 ]; then
         PASS=$((PASS + 1))
         echo "  PASS: $label"
     else
         FAIL=$((FAIL + 1))
-        ERRORS+=("FAIL: $label — needle '$needle' not found")
+        ERRORS+=("FAIL: $label")
         echo "  FAIL: $label"
     fi
 }
 
-assert_valid_json() {
-    local label="$1"
-    local result
-    result=$(echo '{}' | bash "$HOOK" 2>/dev/null)
-    if echo "$result" | jq empty >/dev/null 2>&1; then
-        PASS=$((PASS + 1))
-        echo "  PASS: $label"
-    elif echo "$result" | python3 -m json.tool >/dev/null 2>&1; then
-        PASS=$((PASS + 1))
-        echo "  PASS: $label"
-    elif echo "$result" | python -m json.tool >/dev/null 2>&1; then
-        PASS=$((PASS + 1))
-        echo "  PASS: $label"
+# Extract additionalContext (raw string, no trailing-newline mangling) from
+# stdin JSON into a file. Prefers jq, falls back to python.
+extract_ctx() {
+    local outfile="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -j '.hookSpecificOutput.additionalContext' > "$outfile"
+        return
+    fi
+    local pybin=""
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1; then pybin="$c"; break; fi
+    done
+    if [ -n "$pybin" ]; then
+        "$pybin" -c 'import json,sys; sys.stdout.write(json.load(sys.stdin)["hookSpecificOutput"]["additionalContext"])' > "$outfile"
     else
-        FAIL=$((FAIL + 1))
-        ERRORS+=("FAIL: $label — invalid JSON: $result")
-        echo "  FAIL: $label"
+        : > "$outfile"
     fi
 }
 
 echo "=== post-compact-restore.sh tests ==="
 echo ""
 
-echo "[output structure]"
-assert_valid_json "produces valid JSON"
-assert_contains '"hookEventName"' "includes hookEventName field"
-assert_contains '"PostCompact"' "event name is PostCompact"
-assert_contains '"additionalContext"' "includes additionalContext field"
-
-echo ""
-echo "[principles content]"
-assert_contains 'Think Before Acting\|Core Principles' "includes core principles"
-assert_contains 'Minimize\|Surgical\|Verify' "includes principle keywords"
-
-echo ""
-echo "[token budget — context under 5K]"
-result=$(echo '{}' | bash "$HOOK" 2>/dev/null)
-size=${#result}
-if [ "$size" -lt 5120 ]; then
-    PASS=$((PASS + 1))
-    echo "  PASS: response size ${size} bytes is under 5KB budget"
-else
-    FAIL=$((FAIL + 1))
-    ERRORS+=("FAIL: response size ${size} bytes exceeds 5KB budget")
-    echo "  FAIL: response size"
-fi
-
-echo ""
-echo "[exit code]"
-echo '{}' | bash "$HOOK" >/dev/null 2>&1
+echo "[output structure (source == compact)]"
+RESULT=$(printf '%s' "$COMPACT_INPUT" | bash "$HOOK" 2>/dev/null)
 RC=$?
-if [ "$RC" -eq 0 ]; then
-    PASS=$((PASS + 1))
-    echo "  PASS: exit code is 0"
+check $RC "exit code is 0"
+
+if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$RESULT" | jq empty >/dev/null 2>&1
+elif command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$RESULT" | python3 -m json.tool >/dev/null 2>&1
 else
-    FAIL=$((FAIL + 1))
-    ERRORS+=("FAIL: exit code expected 0, got $RC")
-    echo "  FAIL: exit code"
+    printf '%s' "$RESULT" | python -m json.tool >/dev/null 2>&1
 fi
+check $? "produces valid JSON"
+
+printf '%s' "$RESULT" | grep -q '"hookEventName"'
+check $? "includes hookEventName field"
+
+printf '%s' "$RESULT" | grep -q '"SessionStart"'
+check $? "event name is SessionStart"
+
+! printf '%s' "$RESULT" | grep -q 'PostCompact'
+check $? "no PostCompact string in output (unsupported event)"
+
+printf '%s' "$RESULT" | grep -q '"additionalContext"'
+check $? "includes additionalContext field"
+
+echo ""
+echo "[schema exactness (issue #720 AC4)]"
+SCHEMA_RC=1
+if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$RESULT" | jq -e '
+        (keys == ["hookSpecificOutput"]) and
+        (.hookSpecificOutput | keys == ["additionalContext", "hookEventName"]) and
+        (.hookSpecificOutput.hookEventName == "SessionStart") and
+        (.hookSpecificOutput.additionalContext | type == "string" and length > 0)
+    ' >/dev/null 2>&1
+    SCHEMA_RC=$?
+else
+    PYBIN=""
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1; then PYBIN="$c"; break; fi
+    done
+    if [ -n "$PYBIN" ]; then
+        printf '%s' "$RESULT" | "$PYBIN" -c '
+import json, sys
+d = json.load(sys.stdin)
+assert sorted(d.keys()) == ["hookSpecificOutput"]
+inner = d["hookSpecificOutput"]
+assert sorted(inner.keys()) == ["additionalContext", "hookEventName"]
+assert inner["hookEventName"] == "SessionStart"
+assert isinstance(inner["additionalContext"], str) and inner["additionalContext"]
+' >/dev/null 2>&1
+        SCHEMA_RC=$?
+    fi
+fi
+check $SCHEMA_RC "top-level keys are exactly {hookSpecificOutput} with exactly {hookEventName, additionalContext}"
+
+echo ""
+echo "[digest constraints (issue #720)]"
+CTX_FILE=$(mktemp)
+printf '%s' "$RESULT" | extract_ctx "$CTX_FILE"
+
+if [ -s "$CTX_FILE" ]; then
+    check 0 "additionalContext extracted"
+
+    CTX_BYTES=$(wc -c < "$CTX_FILE")
+    [ "$CTX_BYTES" -le 1000 ]; check $? "payload is at most 1000 bytes (got $CTX_BYTES)"
+
+    CTX_LINES=$(awk 'END{print NR}' "$CTX_FILE")
+    [ "$CTX_LINES" -le 12 ]; check $? "payload is at most 12 lines (got $CTX_LINES)"
+
+    # No full-document re-injection: these markers exist only in the full
+    # core/principles.md file (frontmatter, guardrail section), never in
+    # the digest.
+    ! grep -q 'alwaysApply' "$CTX_FILE"; check $? "no full-document marker: alwaysApply"
+    ! grep -q 'Behavioral Guardrails' "$CTX_FILE"; check $? "no full-document marker: Behavioral Guardrails"
+
+    # Digest items: the four core principles plus the self-check line.
+    grep -q 'Think Before Acting' "$CTX_FILE"; check $? "principle 1: Think Before Acting"
+    grep -q 'Minimize & Focus' "$CTX_FILE"; check $? "principle 2: Minimize & Focus"
+    grep -q 'Surgical Precision' "$CTX_FILE"; check $? "principle 3: Surgical Precision"
+    grep -q 'Verify & Iterate' "$CTX_FILE"; check $? "principle 4: Verify & Iterate"
+    grep -q 'senior engineer' "$CTX_FILE"; check $? "self-check line present"
+else
+    check 1 "additionalContext extracted (jq/python unavailable or empty payload)"
+fi
+
+echo ""
+echo "[source gating (defense in depth)]"
+STARTUP_OUT=$(printf '%s' "$STARTUP_INPUT" | bash "$HOOK" 2>/dev/null)
+STARTUP_RC=$?
+[ "$STARTUP_RC" -eq 0 ]; check $? "source startup: exit code is 0"
+[ -z "$STARTUP_OUT" ]; check $? "source startup: stdout is empty"
+
+EMPTY_OUT=$(printf '' | bash "$HOOK" 2>/dev/null)
+EMPTY_RC=$?
+[ "$EMPTY_RC" -eq 0 ]; check $? "empty stdin: exit code is 0"
+[ -z "$EMPTY_OUT" ]; check $? "empty stdin: stdout is empty"
+
+NOSRC_OUT=$(printf '%s' '{}' | bash "$HOOK" 2>/dev/null)
+NOSRC_RC=$?
+[ "$NOSRC_RC" -eq 0 ] && [ -z "$NOSRC_OUT" ]
+check $? "missing source field: silent exit 0"
+
+echo ""
+echo "[sh/ps1 parity]"
+PS1_HOOK="global/hooks/post-compact-restore.ps1"
+if command -v pwsh >/dev/null 2>&1; then
+    PS_CTX_FILE=$(mktemp)
+    printf '%s' "$COMPACT_INPUT" | pwsh -NoProfile -File "$PS1_HOOK" 2>/dev/null | extract_ctx "$PS_CTX_FILE"
+    cmp -s "$CTX_FILE" "$PS_CTX_FILE"
+    check $? "additionalContext is byte-equivalent between .sh and .ps1"
+
+    PS_STARTUP_OUT=$(printf '%s' "$STARTUP_INPUT" | pwsh -NoProfile -File "$PS1_HOOK" 2>/dev/null)
+    [ -z "$PS_STARTUP_OUT" ]; check $? "ps1 source startup: stdout is empty"
+    rm -f "$PS_CTX_FILE"
+else
+    echo "  SKIP: pwsh not available"
+fi
+rm -f "$CTX_FILE"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Closes #720

## What

Rewires the post-compaction restore hook from the `PostCompact` event (which does not support `hookSpecificOutput`) to the officially supported channel: `SessionStart` with matcher `"compact"`. The hook now emits `hookSpecificOutput.{hookEventName: "SessionStart", additionalContext}` and the payload is slimmed to a fixed 499-byte / 10-line digest of the four core principles (same digest style as #716).

## Why

PostCompact rejects `hookSpecificOutput` on every `/compact` ("Hook JSON output validation failed -- (root): Invalid input"), so the restore hook has been a silent no-op while appearing wired. Per the official hooks reference, `SessionStart` fires with `source == "compact"` after compaction and its `additionalContext` is injected into model context.

## How

- `global/hooks/post-compact-restore.{sh,ps1}`: parse stdin, exit 0 silently unless `source == "compact"` (defense-in-depth behind the matcher), emit the SessionStart schema with a fixed inline digest; sh/ps1 `additionalContext` is byte-equivalent (cmp-proven, 499 bytes UTF-8 in-memory on both sides)
- `global/settings.json` / `global/settings.windows.json`: remove the `PostCompact` key, add a `{"matcher": "compact"}` group to the pre-existing `SessionStart` array
- `HOOKS.md` section rewritten and catalog regenerated (`scripts/gen-hooks-md.sh --check` exits 0); stale PostCompact references updated in `COMPATIBILITY.md`, `ENFORCEMENT.md`, `PREREQUISITES.md`, `docs/hooks-ownership.md`
- Tests: `test-post-compact-restore.sh` rewritten (24/24) and new pwsh mirror `test-post-compact-restore.ps1` (19/19) asserting schema-key exactness, digest caps (1000 B / 12 lines), full-document marker absence, source gating, and sh/ps1 byte parity

## Verification

- Channel proof: a scratch project wired the script (marker variant) on SessionStart; headless `claude -p` returned the embedded marker string exactly, demonstrating `additionalContext` delivery into model context
- Gating proof: real scripts produce empty output / rc 0 for `{"source":"startup"}`, `{}`, and empty stdin; full JSON only for `{"source":"compact"}`
- Full suites: bash runner 674 passed / 7 failed (all 7 pre-existing on a pristine develop worktree: gh-write-verb-guard 2, memory-write-guard 3, merge-gate-guard-timeout 2 -- reproduced identically without this change); pwsh runner 235 passed / 0 failed
- Independent orchestrator spot-check re-ran both scripts and re-validated settings wiring and schema keys

## Notes

- Historical documents (`VERSION_HISTORY.md` #333 entry, dated audit reports) intentionally keep their PostCompact mentions as historical record
- Deployed copies under `~/.claude/hooks` still need redeployment via the install script (also pending from #715/#716)
