### PR TITLE
test(spec-lint): align PowerShell suite with bash

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -24,6 +24,8 @@ on:
       - 'scripts/spec_lint.ps1'
       - 'scripts/spec_lint.py'
       - 'scripts/schemas/**'
+      - 'tests/scripts/test-spec-lint.sh'
+      - 'tests/scripts/test-spec-lint.ps1'
       - 'scripts/fleet_orchestrator/**'
       - 'tests/fleet_orchestrator/**'
       - 'docs/design/**'
@@ -41,6 +43,7 @@ on:
       - 'global/settings.json'
       - 'global/settings.windows.json'
       - 'project/.claude/settings.json'
+      - '.github/workflows/validate-skills.yml'
       - 'README.md'
       - 'README.ko.md'
 
@@ -82,6 +85,9 @@ jobs:
 
       - name: Run spec linter test suite
         run: bash tests/scripts/test-spec-lint.sh
+
+      - name: Run spec linter test suite (PowerShell)
+        run: pwsh -NoProfile -File tests/scripts/test-spec-lint.ps1
 
       - name: Install pytest for fleet_orchestrator tests
         # pytest is already a transitive dep of jsonschema in some envs; pin

--- a/scripts/spec_lint.ps1
+++ b/scripts/spec_lint.ps1
@@ -114,8 +114,10 @@ function Invoke-LintGroup {
     )
     if (-not $Paths -or $Paths.Count -eq 0) { return 0 }
     Write-Host "[spec_lint] mode=$ModeName files=$($Paths.Count)"
-    & $python $SpecLintPy '--mode' $ModeName @script:commonArgs @Paths
-    return $LASTEXITCODE
+    $output = & $python $SpecLintPy '--mode' $ModeName @script:commonArgs @Paths 2>&1
+    $rc = $LASTEXITCODE
+    foreach ($line in $output) { Write-Host $line }
+    return $rc
 }
 
 # Make commonArgs visible to helper

--- a/tests/scripts/test-spec-lint.ps1
+++ b/tests/scripts/test-spec-lint.ps1
@@ -45,9 +45,21 @@ function Write-Fixture {
 }
 
 function Invoke-Lint {
-    param([string]$Mode, [string[]]$Files)
-    $output = & $python $Linter '--mode' $Mode '--quiet' @Files 2>&1 | Out-String
-    return @{ Exit = $LASTEXITCODE; Output = $output }
+    param(
+        [string]$Mode,
+        [string[]]$Files,
+        [switch]$StrictSchema
+    )
+    $oldStrict = $env:STRICT_SCHEMA
+    try {
+        if ($StrictSchema) { $env:STRICT_SCHEMA = '1' }
+        else { Remove-Item Env:STRICT_SCHEMA -ErrorAction SilentlyContinue }
+        $output = & $python $Linter '--mode' $Mode '--quiet' @Files 2>&1 | Out-String
+        return @{ Exit = $LASTEXITCODE; Output = $output }
+    } finally {
+        if ($null -eq $oldStrict) { Remove-Item Env:STRICT_SCHEMA -ErrorAction SilentlyContinue }
+        else { $env:STRICT_SCHEMA = $oldStrict }
+    }
 }
 
 function Assert-Exit {
@@ -69,7 +81,7 @@ function Assert-Contains {
         Write-Host "  PASS: $Label"
     } else {
         $script:FAIL++
-        $script:ERRORS += "FAIL: $Label -- output did not contain '$Needle'"
+        $script:ERRORS += "FAIL: $Label -- output did not contain '$Needle': $Output"
         Write-Host "  FAIL: $Label"
     }
 }
@@ -77,7 +89,7 @@ function Assert-Contains {
 Write-Host "=== spec_lint.py / spec_lint.ps1 tests ==="
 Write-Host ""
 
-# ── Fixture: valid SKILL.md ──────────────────────────────────
+# -- Fixture: valid SKILL.md -------------------------------------------------
 $GoodSkill = Join-Path $Work 'good-skill.md'
 Write-Fixture $GoodSkill @'
 ---
@@ -97,12 +109,12 @@ Write-Host "[case 1: valid SKILL.md passes]"
 $r = Invoke-Lint 'skill' @($GoodSkill)
 Assert-Exit 0 $r.Exit 'valid SKILL.md -> exit 0'
 
-# ── Fixture: underscore typo ─────────────────────────────────
+# -- Fixture: underscore typo (did-you-mean) ---------------------------------
 $TypoSkill = Join-Path $Work 'typo-skill.md'
 Write-Fixture $TypoSkill @'
 ---
 name: typo-skill
-description: SKILL with underscore typo on disable_model_invocation field for did-you-mean coverage.
+description: SKILL with underscore typo on disable_model_invocation field. Lenient accepts; strict + _internal/ catches with did-you-mean.
 disable_model_invocation: true
 ---
 
@@ -110,17 +122,34 @@ content
 '@
 
 Write-Host ""
-Write-Host "[case 2: underscore typo caught with did-you-mean]"
+Write-Host "[case 2: lenient accepts underscore typo silently]"
 $r = Invoke-Lint 'skill' @($TypoSkill)
-Assert-Exit 1 $r.Exit 'underscore typo -> exit 1'
+Assert-Exit 0 $r.Exit 'lenient accepts unknown field -> exit 0'
+
+$InternalTypoDir = Join-Path $Work 'repo/global/skills/_internal/typo'
+$InternalTypo = Join-Path $InternalTypoDir 'SKILL.md'
+Write-Fixture $InternalTypo @'
+---
+name: typo-strict
+description: Strict-mode underscore-typo fixture under _internal/ path. additionalProperties:false must reject.
+disable_model_invocation: true
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 2-strict: strict + _internal/ catches underscore typo with did-you-mean]"
+$r = Invoke-Lint 'skill' @($InternalTypo) -StrictSchema
+Assert-Exit 1 $r.Exit 'strict + _internal/ on typo -> exit 1'
 Assert-Contains "did you mean 'disable-model-invocation'" $r.Output 'did-you-mean suggestion present'
 
-# ── Fixture: unknown field ───────────────────────────────────
+# -- Fixture: unknown field accepted by lenient, rejected by strict ----------
 $UnkSkill = Join-Path $Work 'unknown-field-skill.md'
 Write-Fixture $UnkSkill @'
 ---
 name: unknown-field
-description: SKILL with a totally unknown field that must be rejected by the additionalProperties rule.
+description: SKILL with a totally unknown field. Lenient accepts (additionalProperties:true); strict + _internal/ rejects.
 memory: persistent
 ---
 
@@ -128,12 +157,29 @@ content
 '@
 
 Write-Host ""
-Write-Host "[case 3: unknown field rejected]"
+Write-Host "[case 3: lenient accepts unknown 'memory' field]"
 $r = Invoke-Lint 'skill' @($UnkSkill)
-Assert-Exit 1 $r.Exit "unknown 'memory' field -> exit 1"
+Assert-Exit 0 $r.Exit 'lenient accepts unknown -> exit 0'
+
+$InternalUnkDir = Join-Path $Work 'repo/global/skills/_internal/unk'
+$InternalUnk = Join-Path $InternalUnkDir 'SKILL.md'
+Write-Fixture $InternalUnk @'
+---
+name: unk-strict
+description: Strict-mode unknown-field fixture under _internal/. additionalProperties:false must reject.
+memory: persistent
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 3-strict: strict + _internal/ rejects unknown 'memory' field]"
+$r = Invoke-Lint 'skill' @($InternalUnk) -StrictSchema
+Assert-Exit 1 $r.Exit "strict + _internal/ on unknown field -> exit 1"
 Assert-Contains 'unknown field(s)' $r.Output 'unknown field message'
 
-# ── Fixture: invalid enum values ─────────────────────────────
+# -- Fixture: invalid enum values -------------------------------------------
 $EnumSkill = Join-Path $Work 'bad-enum-skill.md'
 Write-Fixture $EnumSkill @'
 ---
@@ -155,8 +201,8 @@ Assert-Contains "'turbo' is not one of" $r.Output 'effort enum error'
 Assert-Contains "'warp' is not one of"  $r.Output 'context enum error'
 Assert-Contains "'zsh' is not one of"   $r.Output 'shell enum error'
 
-# ── Fixture: description too long ────────────────────────────
-$LongDesc = 'x' * 1100
+# -- Fixture: description too long ------------------------------------------
+$LongDesc = 'x' * 1600
 $LongSkill = Join-Path $Work 'long-desc-skill.md'
 Write-Fixture $LongSkill @"
 ---
@@ -168,12 +214,12 @@ content
 "@
 
 Write-Host ""
-Write-Host "[case 5: description >1024 chars rejected]"
+Write-Host "[case 5: description >1536 chars rejected]"
 $r = Invoke-Lint 'skill' @($LongSkill)
-Assert-Exit 1 $r.Exit '1100-char description -> exit 1'
+Assert-Exit 1 $r.Exit '1600-char description -> exit 1'
 Assert-Contains 'is too long' $r.Output 'max length error'
 
-# ── Fixture: missing required name ───────────────────────────
+# -- Fixture: missing required name/description -----------------------------
 $NoName = Join-Path $Work 'no-name-skill.md'
 Write-Fixture $NoName @'
 ---
@@ -204,7 +250,7 @@ $r = Invoke-Lint 'skill' @($NoDesc)
 Assert-Exit 1 $r.Exit 'missing description -> exit 1'
 Assert-Contains "'description' is a required property" $r.Output 'missing description error'
 
-# ── Fixture: plugin.json bad semver ──────────────────────────
+# -- Fixture: plugin.json with unknown field --------------------------------
 $BadPlugin = Join-Path $Work 'bad-plugin.json'
 Write-Fixture $BadPlugin @'
 {
@@ -216,12 +262,12 @@ Write-Fixture $BadPlugin @'
 '@
 
 Write-Host ""
-Write-Host "[case 7: plugin.json with bad semver rejected]"
+Write-Host "[case 7: plugin.json with bad semver rejected, unknown top-level tolerated]"
 $r = Invoke-Lint 'plugin' @($BadPlugin)
 Assert-Exit 1 $r.Exit 'bad semver -> exit 1'
 Assert-Contains 'does not match' $r.Output 'semver pattern error'
 
-# ── Fixture: settings.json with bad enums ────────────────────
+# -- Fixture: settings.json with bad enums ----------------------------------
 $BadSettings = Join-Path $Work 'bad-settings.json'
 Write-Fixture $BadSettings @'
 {
@@ -241,7 +287,7 @@ Assert-Contains "'telepathic' is not one of" $r.Output 'teammateMode enum error'
 Assert-Contains "'ludicrous' is not one of"  $r.Output 'effortLevel enum error'
 Assert-Contains "'yolo' is not one of"       $r.Output 'permissions.defaultMode enum error'
 
-# ── Mode flags ───────────────────────────────────────────────
+# -- Mode flags --------------------------------------------------------------
 Write-Host ""
 Write-Host "[case 9: --warn-only exits 0 even on violations]"
 & $python $Linter '--mode' 'skill' '--warn-only' '--quiet' $EnumSkill *> $null
@@ -252,7 +298,182 @@ Write-Host "[case 10: --strict exits 2 on violations]"
 & $python $Linter '--mode' 'skill' '--strict' '--quiet' $EnumSkill *> $null
 Assert-Exit 2 $LASTEXITCODE '--strict on violations -> exit 2'
 
-# ── Wrapper invocation ───────────────────────────────────────
+# -- halt_conditions coverage (A1/P1, mirrors bash cases 10a-10j) -----------
+$HaltArraySkill = Join-Path $Work 'halt-array-skill.md'
+Write-Fixture $HaltArraySkill @'
+---
+name: halt-array-skill
+description: SKILL.md verifying that the new halt_conditions array form is accepted by the schema.
+max_iterations: 5
+halt_conditions:
+  - { type: success, expr: "All checks pass" }
+  - { type: limit, expr: "max_iterations reached" }
+loop_safe: true
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10a: halt_conditions array form accepted]"
+$r = Invoke-Lint 'skill' @($HaltArraySkill)
+Assert-Exit 0 $r.Exit 'halt_conditions array -> exit 0'
+
+$HaltStringSkill = Join-Path $Work 'halt-string-skill.md'
+Write-Fixture $HaltStringSkill @'
+---
+name: halt-string-skill
+description: SKILL.md verifying that the legacy halt_conditions single-string form is still accepted during the P1 grace period.
+halt_conditions: "All checks pass OR user aborts"
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10b: halt_conditions legacy string form accepted]"
+$r = Invoke-Lint 'skill' @($HaltStringSkill)
+Assert-Exit 0 $r.Exit 'halt_conditions string -> exit 0'
+
+$HaltEmptySkill = Join-Path $Work 'halt-empty-skill.md'
+Write-Fixture $HaltEmptySkill @'
+---
+name: halt-empty-skill
+description: SKILL.md verifying that an empty halt_conditions array is rejected by the schema.
+halt_conditions: []
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10c: halt_conditions empty array rejected]"
+$r = Invoke-Lint 'skill' @($HaltEmptySkill)
+Assert-Exit 1 $r.Exit 'halt_conditions [] -> exit 1'
+
+$HaltBadTypeSkill = Join-Path $Work 'halt-bad-type-skill.md'
+Write-Fixture $HaltBadTypeSkill @'
+---
+name: halt-bad-type-skill
+description: SKILL.md with an unknown halt_conditions entry type. Lenient accepts; strict + _internal/ rejects via enum.
+halt_conditions:
+  - { type: telepathy, expr: "psychic signal" }
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10d: lenient accepts halt_conditions with unknown entry type]"
+$r = Invoke-Lint 'skill' @($HaltBadTypeSkill)
+Assert-Exit 0 $r.Exit 'lenient -> exit 0'
+
+$InternalHaltBadDir = Join-Path $Work 'repo/global/skills/_internal/halt-bad'
+$InternalHaltBad = Join-Path $InternalHaltBadDir 'SKILL.md'
+Write-Fixture $InternalHaltBad @'
+---
+name: halt-bad-strict
+description: Strict-mode fixture for halt_conditions enum violation under _internal/ path.
+halt_conditions:
+  - { type: telepathy, expr: "psychic signal" }
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10d-strict: strict + _internal/ rejects unknown halt_conditions type]"
+$r = Invoke-Lint 'skill' @($InternalHaltBad) -StrictSchema
+Assert-Exit 1 $r.Exit 'strict + _internal/ on bad halt type -> exit 1'
+
+$IterNoHaltSkill = Join-Path $Work 'iter-no-halt-skill.md'
+Write-Fixture $IterNoHaltSkill @'
+---
+name: iter-no-halt-skill
+description: SKILL.md declaring max_iterations but missing halt_conditions. Lenient accepts; strict + _internal/ path rejects.
+max_iterations: 5
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10e: lenient (default) accepts max_iterations without halt_conditions]"
+$r = Invoke-Lint 'skill' @($IterNoHaltSkill)
+Assert-Exit 0 $r.Exit 'lenient mode -> exit 0'
+
+$LoopNoHaltSkill = Join-Path $Work 'loop-no-halt-skill.md'
+Write-Fixture $LoopNoHaltSkill @'
+---
+name: loop-no-halt-skill
+description: SKILL.md declaring loop_safe true but missing halt_conditions. Lenient accepts; strict + _internal/ path rejects.
+loop_safe: true
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10f: lenient (default) accepts loop_safe: true without halt_conditions]"
+$r = Invoke-Lint 'skill' @($LoopNoHaltSkill)
+Assert-Exit 0 $r.Exit 'lenient mode -> exit 0'
+
+$LoopFalseSkill = Join-Path $Work 'loop-false-skill.md'
+Write-Fixture $LoopFalseSkill @'
+---
+name: loop-false-skill
+description: SKILL.md with loop_safe false and no halt_conditions. Always accepted (rule never applies).
+loop_safe: false
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10g: loop_safe: false without halt_conditions accepted (lenient and strict)]"
+$r = Invoke-Lint 'skill' @($LoopFalseSkill)
+Assert-Exit 0 $r.Exit 'lenient mode -> exit 0'
+
+$InternalRoot = Join-Path $Work 'repo/global/skills/_internal'
+$InternalIter = Join-Path $InternalRoot 'iter-strict/SKILL.md'
+$InternalLoop = Join-Path $InternalRoot 'loop-strict/SKILL.md'
+Write-Fixture $InternalIter @'
+---
+name: iter-strict
+description: Strict-mode fixture (max_iterations declared, halt_conditions missing) under a simulated _internal/ path. P1-c must reject under STRICT_SCHEMA=1.
+max_iterations: 5
+---
+
+content
+'@
+Write-Fixture $InternalLoop @'
+---
+name: loop-strict
+description: Strict-mode fixture (loop_safe true, halt_conditions missing) under a simulated _internal/ path. P1-c must reject under STRICT_SCHEMA=1.
+loop_safe: true
+---
+
+content
+'@
+
+Write-Host ""
+Write-Host "[case 10h: strict + _internal/ rejects max_iterations without halt_conditions]"
+$r = Invoke-Lint 'skill' @($InternalIter) -StrictSchema
+Assert-Exit 1 $r.Exit 'strict + _internal/ on iter -> exit 1'
+Assert-Contains "'halt_conditions' is a required property" $r.Output 'P1-c rejection message'
+
+Write-Host ""
+Write-Host "[case 10i: strict + _internal/ rejects loop_safe true without halt_conditions]"
+$r = Invoke-Lint 'skill' @($InternalLoop) -StrictSchema
+Assert-Exit 1 $r.Exit 'strict + _internal/ on loop_safe -> exit 1'
+Assert-Contains "'halt_conditions' is a required property" $r.Output 'P1-c rejection message'
+
+Write-Host ""
+Write-Host "[case 10j: strict ON but path NOT in _internal/ -> dispatches to lenient]"
+$r = Invoke-Lint 'skill' @($IterNoHaltSkill) -StrictSchema
+Assert-Exit 0 $r.Exit 'strict ON outside _internal/ -> still lenient -> exit 0'
+
+# -- Wrapper invocation ------------------------------------------------------
 Write-Host ""
 Write-Host "[case 11: spec_lint.ps1 wrapper works in -Mode form]"
 & $Wrapper -Mode 'skill' $GoodSkill *> $null
@@ -264,24 +485,27 @@ Assert-Exit 1 $LASTEXITCODE 'wrapper -Mode skill on bad file -> exit 1'
 & $Wrapper -Mode 'skill' -WarnOnly $EnumSkill *> $null
 Assert-Exit 0 $LASTEXITCODE 'wrapper -WarnOnly -> exit 0 even on violations'
 
-# ── Repo discovery ───────────────────────────────────────────
+# -- Repo discovery ----------------------------------------------------------
 Write-Host ""
 Write-Host "[case 12: full repo lints clean (regression guard)]"
 & $Wrapper -Quiet *> $null
 Assert-Exit 0 $LASTEXITCODE 'all canonical SKILL.md/plugin.json/settings.json pass'
 
-# ── sync.ps1 integration: --lint fast-path is side-effect free ─
+Write-Host ""
+Write-Host "[case 12b: wrapper default output does not corrupt exit code]"
+& $Wrapper -Quiet
+Assert-Exit 0 $LASTEXITCODE 'wrapper -Quiet with visible output -> exit 0'
+
+# -- sync.ps1 integration: --lint fast-path is side-effect free --------------
 Write-Host ""
 Write-Host "[case 13: sync.ps1 --lint is a side-effect-free fast path]"
 $syncPs1 = Join-Path $RootDir 'scripts' 'sync.ps1'
 & pwsh -NoProfile -File $syncPs1 '--lint' '--quiet' *> $null
 Assert-Exit 0 $LASTEXITCODE 'sync.ps1 --lint returns linter exit code (no prompts)'
 
-# ── sync.ps1 integration: pre-flight aborts on lint failure ──
+# -- sync.ps1 integration: pre-flight aborts on lint failure -----------------
 Write-Host ""
 Write-Host "[case 14: sync.ps1 (no flag) aborts when spec_lint detects violations]"
-# Stage a sandbox copy of sync.ps1 next to a stub spec_lint.ps1 that always fails.
-# sync.ps1 imports CommonHelpers.psm1 from ../global/hooks/lib — stub it too.
 $Sandbox = Join-Path $Work 'sync-abort-sandbox'
 $SandboxScripts = Join-Path $Sandbox 'scripts'
 $SandboxLib     = Join-Path $Sandbox 'global' 'hooks' 'lib'
@@ -308,13 +532,10 @@ Assert-Exit 1 $LASTEXITCODE 'sync.ps1 aborts with exit 1 when linter fails'
 Assert-Contains 'spec_lint detected schema violations' $abortOut 'abort message present'
 Assert-Contains '--skip-lint' $abortOut 'bypass hint present'
 
-# ── sync.ps1 integration: --skip-lint bypasses pre-flight ────
+# -- sync.ps1 integration: --skip-lint bypasses pre-flight -------------------
 Write-Host ""
 Write-Host "[case 15: sync.ps1 --skip-lint bypasses pre-flight even when linter fails]"
-# Use pre-supplied stdin so any Read-Host call returns immediately.
 $bypassOut = '3' | & pwsh -NoProfile -File (Join-Path $SandboxScripts 'sync.ps1') '--skip-lint' 2>&1 | Out-String
-# We don't assert downstream exit code (sandbox lacks the real backup tree).
-# The contract: bypass is honored, abort message MUST NOT appear.
 if ($bypassOut -like '*spec_lint detected schema violations*') {
     $script:FAIL++
     $script:ERRORS += 'FAIL: --skip-lint should suppress abort message but did not'
@@ -325,7 +546,7 @@ if ($bypassOut -like '*spec_lint detected schema violations*') {
 }
 Assert-Contains 'Claude Configuration Sync Tool' $bypassOut 'banner displayed (pre-flight bypassed)'
 
-# ── Summary ──────────────────────────────────────────────────
+# -- Summary -----------------------------------------------------------------
 Write-Host ""
 Write-Host '=== Summary ==='
 Write-Host "  $($script:PASS) passed, $($script:FAIL) failed"


### PR DESCRIPTION
## What

- Update `tests/scripts/test-spec-lint.ps1` to match the current bash spec-lint regression suite.
- Add PowerShell coverage for lenient vs strict `_internal/` dispatch, `halt_conditions`, `max_iterations`, and `loop_safe` cases.
- Fix `scripts/spec_lint.ps1` default discovery mode so linter output does not contaminate the function return stream and force a false non-zero exit.
- Run the PowerShell spec-lint suite in `validate-skills.yml` and add the missing path filters for spec-lint tests/workflow changes.

## Why

The PowerShell regression suite was still asserting older schema behavior and failed against the current lenient/strict schema split. The wrapper also returned exit code 1 in default discovery mode when visible linter output was present.

## Scope

- `tests/scripts/test-spec-lint.ps1`
- `scripts/spec_lint.ps1`
- `.github/workflows/validate-skills.yml`

## Verification

- `bash scripts/spec_lint.sh --strict --quiet`
- `pwsh -NoProfile -File scripts\spec_lint.ps1 -Strict -Quiet`
- `bash tests/scripts/test-spec-lint.sh`
- `pwsh -NoProfile -File tests\scripts\test-spec-lint.ps1`
- `bash scripts/validate_skills.sh`
- `git diff --check`

## Risk

Low. The production linter implementation remains Python-backed; this change updates the PowerShell wrapper's output handling and expands regression coverage to match the bash suite.

Closes #724