### PR TITLE
fix(agents): replace dangling team-lead protocol with single-return reporting

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -112,22 +112,6 @@ Detect the primary language and apply matching checks:
 
 If language-specific rules exist in the project's rules directory, read them before starting.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Review target (file paths, PR number, priority level)
-- **qa-reviewer**: Boundary mismatch findings requiring code-level verification
-
-### Sends To
-- **team-lead**: Review completion report (severity summary, verdict, blocker status)
-- **refactor-assistant**: Critical/Major issues suitable for automated refactoring
-- **qa-reviewer**: Boundary mismatches discovered during code review
-
-### Handoff Triggers
-- Finding a Critical security issue → notify team-lead immediately, do not wait for full review
-- Discovering duplicated code across 3+ files → delegate to refactor-assistant
-- Noticing API response shape differs from frontend consumer → notify qa-reviewer
-
-### Task Management
-- Create TaskCreate entry for each Critical finding (enables tracking)
-- Mark own review task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/codebase-analyzer.md
+++ b/plugin/agents/codebase-analyzer.md
@@ -115,25 +115,9 @@ Detect the primary language and apply matching analysis:
 
 If language-specific rules exist in the project's rules directory, read them before starting.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Analysis target (repository path, scope, specific questions)
-- **structure-explorer**: Project structure map and file classification
-
-### Sends To
-- **team-lead**: Architecture analysis report (patterns, conventions, quality indicators)
-- **documentation-writer**: Architecture findings for documentation updates
-- **code-reviewer**: Detected conventions and patterns for review context
-
-### Handoff Triggers
-- Identifying circular dependencies → notify team-lead with affected modules
-- Detecting undocumented architecture patterns → delegate to documentation-writer
-- Finding convention violations across multiple files → notify code-reviewer
-
-### Task Management
-- Create TaskCreate entry for each architectural concern found
-- Mark own analysis task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.
 
 ## Process
 

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -117,20 +117,6 @@ Before producing output, verify:
 ### Verdict
 One of: `PASS` | `WARN` (non-critical issues) | `FAIL` (critical vulnerabilities or license conflicts)
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Audit scope (full project, specific packages, or pre-merge check)
-
-### Sends To
-- **team-lead**: Audit completion report (vulnerability count, license status, verdict)
-- **code-reviewer**: Findings relevant to code changes under review
-
-### Handoff Triggers
-- Finding a Critical CVE → notify team-lead immediately
-- Detecting a copyleft license conflict → notify team-lead with affected packages
-- Discovering an abandoned dependency (no updates >24 months) → note for team-lead
-
-### Task Management
-- Create TaskCreate entry for each Critical or High vulnerability
-- Mark own audit task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/documentation-writer.md
+++ b/plugin/agents/documentation-writer.md
@@ -89,19 +89,6 @@ Before producing output, verify:
 - Provide table of contents for long documents
 - Match existing documentation style and structure
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Documentation update scope (affected files, feature description)
-- **codebase-analyzer**: Architecture findings and convention descriptions for documentation
-
-### Sends To
-- **team-lead**: Documentation update completion report (files updated, coverage status)
-
-### Handoff Triggers
-- Finding undocumented public APIs during doc review → create TaskCreate entry for team-lead
-- Discovering stale documentation that contradicts current code → notify team-lead
-
-### Task Management
-- Create TaskCreate entry for documentation gaps discovered during update
-- Mark own documentation task as completed only after all updates are committed
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/qa-reviewer.md
+++ b/plugin/agents/qa-reviewer.md
@@ -148,21 +148,6 @@ Provide findings in the following structure:
 
 Always provide specific file paths and line numbers for any issues found. Be precise about what mismatches exist and how they manifest at runtime.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Verification scope (module boundaries, integration points to check)
-- **code-reviewer**: Boundary mismatches discovered during code review
-
-### Sends To
-- **team-lead**: QA verification report (passed/failed/unverified counts, blocker status)
-- **code-reviewer**: Boundary mismatch findings requiring code-level verification
-
-### Handoff Triggers
-- Finding a Failed boundary with data loss risk → notify team-lead immediately
-- Discovering type casting bypass (`as any`) hiding shape mismatch → notify code-reviewer
-- Finding orphaned API endpoints or hooks → create TaskCreate entry for team-lead
-
-### Task Management
-- Create TaskCreate entry for each Failed boundary (enables tracking)
-- Mark own verification task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/refactor-assistant.md
+++ b/plugin/agents/refactor-assistant.md
@@ -141,21 +141,6 @@ If language-specific rules exist in the project's rules directory, read them bef
 4. Apply incrementally with test verification
 5. Report before/after comparison
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Refactoring target (files, scope, specific technique to apply)
-- **code-reviewer**: Critical/Major issues suitable for automated refactoring
-
-### Sends To
-- **team-lead**: Refactoring completion report (before/after summary, test verification results)
-- **code-reviewer**: Notification when refactoring changes public interfaces
-
-### Handoff Triggers
-- Discovering untested code in refactoring scope → notify team-lead (hard stop)
-- Refactoring reveals a deeper architectural issue → create TaskCreate for codebase-analyzer
-- Test failure during refactoring → revert and notify team-lead with failure details
-
-### Task Management
-- Create TaskCreate entry for each discovered issue outside refactoring scope
-- Mark own refactoring task as completed only after test verification passes
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/structure-explorer.md
+++ b/plugin/agents/structure-explorer.md
@@ -107,19 +107,6 @@ Report findings using this structure:
 4. Read key configuration files for project metadata
 5. Compile structure summary
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Exploration target (repository path, scope, depth preference)
-
-### Sends To
-- **team-lead**: Structure summary report (directory layout, file statistics, key files)
-- **codebase-analyzer**: Project structure map for architecture analysis
-
-### Handoff Triggers
-- Exploration complete → send structure map to codebase-analyzer for deeper analysis
-- Discovering unusually complex directory nesting (>5 levels) → note in report for team-lead
-
-### Task Management
-- Mark own exploration task as completed after structure summary is delivered
-- Do not create follow-up tasks (structure exploration is a one-shot operation)
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -114,21 +114,6 @@ Before producing output, verify:
 ### Verdict
 One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major paths untested)
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Test strategy scope (full project, specific module, or pre-merge check)
-- **code-reviewer**: Code changes that may need new tests
-
-### Sends To
-- **team-lead**: Test strategy report (coverage map, gaps, recommendations)
-- **refactor-assistant**: Test-related findings that affect refactoring safety
-
-### Handoff Triggers
-- Finding critical paths with zero test coverage → notify team-lead immediately
-- Discovering test infrastructure issues (broken CI, misconfigured coverage) → notify team-lead
-- Identifying code that needs refactoring before it can be tested → notify refactor-assistant
-
-### Task Management
-- Create TaskCreate entry for each high-priority coverage gap
-- Mark own strategy task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -113,22 +113,6 @@ Detect the primary language and apply matching checks:
 
 If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in the project, read them before starting.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Review target (file paths, PR number, priority level)
-- **qa-reviewer**: Boundary mismatch findings requiring code-level verification
-
-### Sends To
-- **team-lead**: Review completion report (severity summary, verdict, blocker status)
-- **refactor-assistant**: Critical/Major issues suitable for automated refactoring
-- **qa-reviewer**: Boundary mismatches discovered during code review
-
-### Handoff Triggers
-- Finding a Critical security issue → notify team-lead immediately, do not wait for full review
-- Discovering duplicated code across 3+ files → delegate to refactor-assistant
-- Noticing API response shape differs from frontend consumer → notify qa-reviewer
-
-### Task Management
-- Create TaskCreate entry for each Critical finding (enables tracking)
-- Mark own review task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/codebase-analyzer.md
+++ b/project/.claude/agents/codebase-analyzer.md
@@ -116,25 +116,9 @@ Detect the primary language and apply matching analysis:
 
 If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in the project, read them before starting.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Analysis target (repository path, scope, specific questions)
-- **structure-explorer**: Project structure map and file classification
-
-### Sends To
-- **team-lead**: Architecture analysis report (patterns, conventions, quality indicators)
-- **documentation-writer**: Architecture findings for documentation updates
-- **code-reviewer**: Detected conventions and patterns for review context
-
-### Handoff Triggers
-- Identifying circular dependencies → notify team-lead with affected modules
-- Detecting undocumented architecture patterns → delegate to documentation-writer
-- Finding convention violations across multiple files → notify code-reviewer
-
-### Task Management
-- Create TaskCreate entry for each architectural concern found
-- Mark own analysis task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.
 
 ## Process
 

--- a/project/.claude/agents/dependency-auditor.md
+++ b/project/.claude/agents/dependency-auditor.md
@@ -118,20 +118,6 @@ Before producing output, verify:
 ### Verdict
 One of: `PASS` | `WARN` (non-critical issues) | `FAIL` (critical vulnerabilities or license conflicts)
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Audit scope (full project, specific packages, or pre-merge check)
-
-### Sends To
-- **team-lead**: Audit completion report (vulnerability count, license status, verdict)
-- **code-reviewer**: Findings relevant to code changes under review
-
-### Handoff Triggers
-- Finding a Critical CVE → notify team-lead immediately
-- Detecting a copyleft license conflict → notify team-lead with affected packages
-- Discovering an abandoned dependency (no updates >24 months) → note for team-lead
-
-### Task Management
-- Create TaskCreate entry for each Critical or High vulnerability
-- Mark own audit task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/documentation-writer.md
+++ b/project/.claude/agents/documentation-writer.md
@@ -91,19 +91,6 @@ Before producing output, verify:
 - Provide table of contents for long documents
 - Match existing documentation style and structure
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Documentation update scope (affected files, feature description)
-- **codebase-analyzer**: Architecture findings and convention descriptions for documentation
-
-### Sends To
-- **team-lead**: Documentation update completion report (files updated, coverage status)
-
-### Handoff Triggers
-- Finding undocumented public APIs during doc review → create TaskCreate entry for team-lead
-- Discovering stale documentation that contradicts current code → notify team-lead
-
-### Task Management
-- Create TaskCreate entry for documentation gaps discovered during update
-- Mark own documentation task as completed only after all updates are committed
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/qa-reviewer.md
+++ b/project/.claude/agents/qa-reviewer.md
@@ -149,21 +149,6 @@ Provide findings in the following structure:
 
 Always provide specific file paths and line numbers for any issues found. Be precise about what mismatches exist and how they manifest at runtime.
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Verification scope (module boundaries, integration points to check)
-- **code-reviewer**: Boundary mismatches discovered during code review
-
-### Sends To
-- **team-lead**: QA verification report (passed/failed/unverified counts, blocker status)
-- **code-reviewer**: Boundary mismatch findings requiring code-level verification
-
-### Handoff Triggers
-- Finding a Failed boundary with data loss risk → notify team-lead immediately
-- Discovering type casting bypass (`as any`) hiding shape mismatch → notify code-reviewer
-- Finding orphaned API endpoints or hooks → create TaskCreate entry for team-lead
-
-### Task Management
-- Create TaskCreate entry for each Failed boundary (enables tracking)
-- Mark own verification task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/refactor-assistant.md
+++ b/project/.claude/agents/refactor-assistant.md
@@ -143,21 +143,6 @@ If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in t
 4. Apply incrementally with test verification
 5. Report before/after comparison
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Refactoring target (files, scope, specific technique to apply)
-- **code-reviewer**: Critical/Major issues suitable for automated refactoring
-
-### Sends To
-- **team-lead**: Refactoring completion report (before/after summary, test verification results)
-- **code-reviewer**: Notification when refactoring changes public interfaces
-
-### Handoff Triggers
-- Discovering untested code in refactoring scope → notify team-lead (hard stop)
-- Refactoring reveals a deeper architectural issue → create TaskCreate for codebase-analyzer
-- Test failure during refactoring → revert and notify team-lead with failure details
-
-### Task Management
-- Create TaskCreate entry for each discovered issue outside refactoring scope
-- Mark own refactoring task as completed only after test verification passes
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/structure-explorer.md
+++ b/project/.claude/agents/structure-explorer.md
@@ -108,19 +108,6 @@ Report findings using this structure:
 4. Read key configuration files for project metadata
 5. Compile structure summary
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Exploration target (repository path, scope, depth preference)
-
-### Sends To
-- **team-lead**: Structure summary report (directory layout, file statistics, key files)
-- **codebase-analyzer**: Project structure map for architecture analysis
-
-### Handoff Triggers
-- Exploration complete → send structure map to codebase-analyzer for deeper analysis
-- Discovering unusually complex directory nesting (>5 levels) → note in report for team-lead
-
-### Task Management
-- Mark own exploration task as completed after structure summary is delivered
-- Do not create follow-up tasks (structure exploration is a one-shot operation)
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -115,21 +115,6 @@ Before producing output, verify:
 ### Verdict
 One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major paths untested)
 
-## Team Communication Protocol
+## Reporting
 
-### Receives From
-- **team-lead**: Test strategy scope (full project, specific module, or pre-merge check)
-- **code-reviewer**: Code changes that may need new tests
-
-### Sends To
-- **team-lead**: Test strategy report (coverage map, gaps, recommendations)
-- **refactor-assistant**: Test-related findings that affect refactoring safety
-
-### Handoff Triggers
-- Finding critical paths with zero test coverage → notify team-lead immediately
-- Discovering test infrastructure issues (broken CI, misconfigured coverage) → notify team-lead
-- Identifying code that needs refactoring before it can be tested → notify refactor-assistant
-
-### Task Management
-- Create TaskCreate entry for each high-priority coverage gap
-- Mark own strategy task as completed only after full report is delivered
+Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.


### PR DESCRIPTION
## 변경 내용

8개 서브 에이전트 정의(`plugin/agents/` + `project/.claude/agents/`, 총 16개 파일)에서 `## Team Communication Protocol` 섹션을 제거하고 `## Reporting` 섹션으로 대체했다.

## 배경

이 섹션은 정의되지 않은 `team-lead` 오케스트레이터로의 핸드오프와, 모든 에이전트의 `tools` 화이트리스트에 존재하지 않는 `SendMessage` / `TaskCreate` / `TaskUpdate` 도구를 전제로 작성되어 있었다. 그 결과 팀 모드에서 "심각도 높은 발견 시 `team-lead`에 즉시 통지", "발견마다 `TaskCreate` 항목 생성", "자기 작업 완료 표시" 같은 지시는 런타임에서 실행할 수 없는 죽은 지시(dead instruction)였다. `team-lead`는 저장소 어디에도 `name: team-lead`로 정의되어 있지 않다.

## 구현

- 16개 파일에서 `## Team Communication Protocol` 섹션(하위 `### Receives From` / `### Sends To` / `### Handoff Triggers` / `### Task Management` 포함)을 제거했다.
- 그 자리에 모든 파일에 동일한 `## Reporting` 섹션을 삽입하여 실제 단일 반환(single-return) 실행 모델을 명문화했다. 즉 각 에이전트는 결과를 호출 세션에 반환하고, 후속 위임 여부는 호출 세션이 결정한다.
- `codebase-analyzer.md`는 해당 섹션 뒤에 이어지는 `## Process` 섹션을 그대로 보존했다.
- `plugin`과 `project` 두 레이어의 본문 정합성을 유지했다.

## 검증

- `scripts/check_agents.sh` → `check_agents: OK (8 agent pairs in sync)`
- `grep "Team Communication Protocol"` → 16개 파일 모두 0건
- `grep "## Reporting"` → 16개 파일 모두 1건

## 비고

이번 변경은 옵션 (B) 단일 반환 설계를 택했다. 향후 실제 멀티에이전트 팀 운용을 도입할 경우 `team-lead` 정의와 협업 도구 부여(옵션 A)로 재작성할 수 있다.

Closes #727
Part of #726
