### PR TITLE
fix(agents): delegate refactor-assistant test execution to the caller

### DIFF
--- a/plugin/agents/refactor-assistant.md
+++ b/plugin/agents/refactor-assistant.md
@@ -72,25 +72,29 @@ Before producing output, verify:
 
 ## Safety Verification Protocol
 
+This agent applies edits but does not run tests, commits, or reverts itself — its
+tool set is read-and-edit only by design. Test execution, commits, and rollback are
+the calling session's responsibility. Preserve behavior as follows:
+
 ### Before Refactoring
-1. Run existing test suite — record baseline pass count and test names
+1. Confirm the test baseline with the calling session (pass count and test names), or record the exact test command to run — do not assume tests pass
 2. Identify all callers of the code being refactored (grep for usages)
-3. Confirm no untested code will be refactored (hard stop if tests are missing)
+3. Confirm no untested code will be refactored — if coverage is unknown, raise it as a hard stop for the caller
 
 ### During Refactoring
-1. One refactoring at a time — commit each independently
-2. Re-run tests after each change — revert immediately on any failure
+1. One refactoring at a time — keep each change a self-contained logical unit the caller can review and verify independently
+2. After each change, report the exact test command for the caller to run; if the caller reports a failure, revert that change before proceeding
 3. Never change public API signatures without updating all callers first
 
 ### After Refactoring
-1. Run full test suite — compare pass count against baseline
-2. Verify no new warnings or deprecation notices
-3. Confirm all callers still compile and pass tests
+1. Report the full test command and the expected pass count against baseline for the caller to verify
+2. Verify by inspection that no new warnings or deprecation notices are introduced
+3. List every caller that the calling session must re-compile and re-test
 
 ### Hard Stops
-- **No refactoring of untested code** — add tests first, then refactor
+- **No refactoring of untested code** — request tests from the caller first, then refactor
 - **No public API changes without caller updates** — find all consumers before changing signatures
-- **Revert on any test failure** — do not attempt to fix tests to match refactored code
+- **Recommend revert on any reported test failure** — never edit tests to match refactored code
 
 ## Refactoring Techniques
 
@@ -135,7 +139,7 @@ If language-specific rules exist in the project's rules directory, read them bef
 
 ## Process
 
-1. Understand current code and run baseline tests
+1. Understand current code and confirm the test baseline with the calling session
 2. Identify refactoring opportunities
 3. Plan the change (one technique at a time)
 4. Apply incrementally with test verification

--- a/project/.claude/agents/refactor-assistant.md
+++ b/project/.claude/agents/refactor-assistant.md
@@ -74,25 +74,29 @@ Before producing output, verify:
 
 ## Safety Verification Protocol
 
+This agent applies edits but does not run tests, commits, or reverts itself — its
+tool set is read-and-edit only by design. Test execution, commits, and rollback are
+the calling session's responsibility. Preserve behavior as follows:
+
 ### Before Refactoring
-1. Run existing test suite — record baseline pass count and test names
+1. Confirm the test baseline with the calling session (pass count and test names), or record the exact test command to run — do not assume tests pass
 2. Identify all callers of the code being refactored (grep for usages)
-3. Confirm no untested code will be refactored (hard stop if tests are missing)
+3. Confirm no untested code will be refactored — if coverage is unknown, raise it as a hard stop for the caller
 
 ### During Refactoring
-1. One refactoring at a time — commit each independently
-2. Re-run tests after each change — revert immediately on any failure
+1. One refactoring at a time — keep each change a self-contained logical unit the caller can review and verify independently
+2. After each change, report the exact test command for the caller to run; if the caller reports a failure, revert that change before proceeding
 3. Never change public API signatures without updating all callers first
 
 ### After Refactoring
-1. Run full test suite — compare pass count against baseline
-2. Verify no new warnings or deprecation notices
-3. Confirm all callers still compile and pass tests
+1. Report the full test command and the expected pass count against baseline for the caller to verify
+2. Verify by inspection that no new warnings or deprecation notices are introduced
+3. List every caller that the calling session must re-compile and re-test
 
 ### Hard Stops
-- **No refactoring of untested code** — add tests first, then refactor
+- **No refactoring of untested code** — request tests from the caller first, then refactor
 - **No public API changes without caller updates** — find all consumers before changing signatures
-- **Revert on any test failure** — do not attempt to fix tests to match refactored code
+- **Recommend revert on any reported test failure** — never edit tests to match refactored code
 
 ## Refactoring Techniques
 
@@ -137,7 +141,7 @@ If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in t
 
 ## Process
 
-1. Understand current code and run baseline tests
+1. Understand current code and confirm the test baseline with the calling session
 2. Identify refactoring opportunities
 3. Plan the change (one technique at a time)
 4. Apply incrementally with test verification


### PR DESCRIPTION
## 변경 내용

`refactor-assistant` 에이전트 정의(`plugin/agents/` + `project/.claude/agents/`, 2개 파일)의 `## Safety Verification Protocol` 섹션을 재서술하여, 테스트 실행·커밋·revert 책임을 호출 세션(calling session)에 위임하도록 정직하게 표현했다.

## 배경

이 에이전트의 `tools`는 `Read, Edit, Glob, Grep`로 `Bash`가 없다. 그런데 기존 `## Safety Verification Protocol`은 다음을 hard requirement로 명시하고 있었다.

- "Run existing test suite — record baseline"
- "Re-run tests after each change — revert immediately on any failure"
- "Run full test suite — compare pass count against baseline"
- Hard Stop: "Revert on any test failure"
- "commit each independently"

`Bash`가 없으므로 테스트 실행·커밋·`git revert` 중 어느 것도 수행할 수 없다. 즉 동작 보존(behavior-preserving) 안전 계약 전체가 실행 도구 없이 약속되어 있어, 검증 없는 "테스트 통과" 보고로 이어질 수 있는 자기모순이었다. 또한 `project` 레이어의 `permissionMode: acceptEdits`와 결합되면 검증되지 않은 편집이 자동 수락된다.

## 구현

- `## Safety Verification Protocol` 섹션을 재서술하여, 이 에이전트는 편집만 적용하고 테스트 실행·커밋·rollback은 호출 세션이 담당함을 명문화했다.
- `Before / During / After / Hard Stops` 하위 항목을 "호출 세션에 테스트 baseline 확인 요청", "각 변경마다 호출 세션이 실행할 테스트 명령을 보고", "실패 보고 시 해당 변경 revert 권고" 형태로 조정했다.
- `## Process`의 `run baseline tests` 문구를 `confirm the test baseline with the calling session`으로 수정했다.
- `tools`, `permissionMode` 등 frontmatter는 변경하지 않았다(옵션 B). 따라서 후속 `permissionMode` 정렬 작업과 충돌하지 않는다.

## 검증

- `scripts/check_agents.sh` → `check_agents: OK (8 agent pairs in sync)` (sandbox OFF 기준 — CI 게이트와 일치)
- `grep "Run existing test suite\|Re-run tests after each change\|Run full test suite"` → 2개 파일 모두 0건
- 두 레이어의 본문 정합성 유지

## 비고

옵션 (B) 단일 반환·호출자 위임 설계를 택했다. 별도의 테스트 실행 전담 노드(`test-runner`) 신설은 epic #726의 P1 항목으로 분리되어 있다.

Closes #728
Part of #726
