### PR TITLE
fix(agents): align permissionMode acceptEdits across plugin and project layers

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -210,7 +210,7 @@ pwsh scripts/sync_references.ps1   # Windows
 
 **Type**: Repository-internal convention
 
-The eight agent definitions exist in two layers — `project/.claude/agents/` and the standalone `plugin/agents/` bundle. They are near-duplicates but **not** byte-identical by design: frontmatter differs per layer (the project copy carries `color:`; neither carries the non-canonical `temperature:` field), and the body genericizes exactly one repo-specific "language-specific rules" sentence in the plugin copy.
+The eight agent definitions exist in two layers — `project/.claude/agents/` and the standalone `plugin/agents/` bundle. They are near-duplicates but **not** byte-identical by design: frontmatter differs per layer (the project copy carries `color:`; neither carries the non-canonical `temperature:` field; `permissionMode: acceptEdits` is kept identical across both layers for the two write agents, documentation-writer and refactor-assistant), and the body genericizes exactly one repo-specific "language-specific rules" sentence in the plugin copy.
 
 **CI enforcement**: `.github/workflows/validate-skills.yml` runs `scripts/check_agents.sh` (PowerShell twin: `scripts/check_agents.ps1`). It strips frontmatter and normalizes that single sentence, then fails (exit 2) if the agent **bodies** otherwise diverge — so a behavioral instruction edited in one layer but not the other cannot ship silently.
 

--- a/plugin/agents/documentation-writer.md
+++ b/plugin/agents/documentation-writer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Write, Edit, Glob
 maxTurns: 30
 effort: high
+permissionMode: acceptEdits
 memory: project
 initialPrompt: "Check your memory for established documentation patterns and style conventions in this project."
 applies_to:

--- a/plugin/agents/refactor-assistant.md
+++ b/plugin/agents/refactor-assistant.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Edit, Glob, Grep
 maxTurns: 25
 effort: high
+permissionMode: acceptEdits
 memory: project
 initialPrompt: "Check your memory for past refactoring decisions and established patterns in this project."
 applies_to:


### PR DESCRIPTION
## 변경 내용

`plugin/agents/` 의 두 write 에이전트(`documentation-writer`, `refactor-assistant`) frontmatter에 `permissionMode: acceptEdits`를 추가하여 `project/.claude/agents/` 사본과 정렬하고, `docs/CUSTOM_EXTENSIONS.md`에 이 필드가 두 레이어에서 동일하게 유지됨을 명문화했다.

## 배경

`permissionMode`는 런타임이 honor하는 공식 frontmatter 필드다. 그러나 `permissionMode: acceptEdits`가 `project/.claude/agents/documentation-writer.md` 와 `refactor-assistant.md` 에만 선언되어 있고, 대응하는 `plugin/agents/` 사본에는 누락되어 있었다.

`docs/CUSTOM_EXTENSIONS.md`의 의도된 레이어 차이 목록은 `color`와 `temperature`만 명시하고 `permissionMode`는 언급하지 않으므로, 이 누락은 의도된 차이가 아니라 조용한 권한 드리프트(silent capability drift)였다. 그 결과 standalone plugin 배포본에서는 동일한 write 에이전트가 매 편집마다 권한 프롬프트를 받아 무인·배치 문서/리팩터링 작업 흐름이 끊겼다. 또한 `scripts/check_agents.sh`는 frontmatter를 제거하고 본문만 비교하므로 이 차이가 CI에서 잡히지 않고 출하되었다.

## 구현

- `plugin/agents/documentation-writer.md` frontmatter의 `effort: high` 다음에 `permissionMode: acceptEdits` 추가.
- `plugin/agents/refactor-assistant.md` frontmatter에 동일하게 추가.
- `docs/CUSTOM_EXTENSIONS.md`의 레이어-차이 설명 문장에 `permissionMode: acceptEdits`가 두 write 에이전트에 대해 양 레이어 동일하게 유지됨을 명문화.

## 검증

- `grep "permissionMode" plugin/agents/{documentation-writer,refactor-assistant}.md` → 각 1건(`effort: high` 다음 줄)
- `scripts/check_agents.sh` → `check_agents: OK (8 agent pairs in sync)` (본문 parity 영향 없음; frontmatter는 비교 대상 아님)

## 비고

`refactor-assistant`는 직전 PR(#731, 옵션 B)에서 `tools`를 변경하지 않고 본문만 재서술했으므로, 이 PR에서 `acceptEdits`를 추가해도 "미검증 자동편집 + 자동 셸 실행" 동시 개방 문제는 발생하지 않는다.

후속(epic #726의 P2): `scripts/check_agents.sh`에 `permissionMode`/`tools` 같은 동작 필드의 레이어 간 정합성 검사를 추가하여(의도된 차이인 `color`는 allowlist) 재발을 CI에서 차단하는 작업이 남아 있다.

Closes #729
Part of #726
