### PR TITLE
security(agents): restrict read-only auditors to read-only Bash usage

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -112,6 +112,10 @@ Detect the primary language and apply matching checks:
 
 If language-specific rules exist in the project's rules directory, read them before starting.
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -117,6 +117,10 @@ Before producing output, verify:
 ### Verdict
 One of: `PASS` | `WARN` (non-critical issues) | `FAIL` (critical vulnerabilities or license conflicts)
 
+## Tool Constraints
+
+Bash is restricted to read-only audit and diagnostic commands. Prefer side-effect-free flags: `npm audit --package-lock-only`, `pip-audit` without installs, `cargo audit` (read-only), plus `git diff` / `git log`. Do not install packages, modify lockfiles, write files, or make network calls beyond read-only vulnerability-database lookups. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/qa-reviewer.md
+++ b/plugin/agents/qa-reviewer.md
@@ -148,6 +148,10 @@ Provide findings in the following structure:
 
 Always provide specific file paths and line numbers for any issues found. Be precise about what mismatches exist and how they manifest at runtime.
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -114,6 +114,10 @@ Before producing output, verify:
 ### Verdict
 One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major paths untested)
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -113,6 +113,10 @@ Detect the primary language and apply matching checks:
 
 If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in the project, read them before starting.
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/dependency-auditor.md
+++ b/project/.claude/agents/dependency-auditor.md
@@ -118,6 +118,10 @@ Before producing output, verify:
 ### Verdict
 One of: `PASS` | `WARN` (non-critical issues) | `FAIL` (critical vulnerabilities or license conflicts)
 
+## Tool Constraints
+
+Bash is restricted to read-only audit and diagnostic commands. Prefer side-effect-free flags: `npm audit --package-lock-only`, `pip-audit` without installs, `cargo audit` (read-only), plus `git diff` / `git log`. Do not install packages, modify lockfiles, write files, or make network calls beyond read-only vulnerability-database lookups. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/qa-reviewer.md
+++ b/project/.claude/agents/qa-reviewer.md
@@ -149,6 +149,10 @@ Provide findings in the following structure:
 
 Always provide specific file paths and line numbers for any issues found. Be precise about what mismatches exist and how they manifest at runtime.
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -115,6 +115,10 @@ Before producing output, verify:
 ### Verdict
 One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major paths untested)
 
+## Tool Constraints
+
+Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.


### PR DESCRIPTION
## 변경 내용

read-only 감사 에이전트 4개(`code-reviewer`, `dependency-auditor`, `qa-reviewer`, `test-strategist`)의 본문에 `## Tool Constraints` 섹션을 추가하여, `Bash`를 읽기 전용 진단 명령으로 제한함을 명문화했다(`plugin/` + `project/` 두 레이어, 총 8개 파일).

## 배경

이 4개 에이전트는 description·본문상 "reports findings" 순수 read-only 역할인데 `tools`에 무제한 `Bash`를 보유한다. 무제한 `Bash`는 파일 쓰기(`>`, `sed -i`), 네트워크 호출(`curl`), 패키지 설치까지 허용하므로 read-only 계약과 모순되고 최소 권한(least-privilege) 원칙을 위반한다. 특히 `dependency-auditor`의 `npm audit` / `pip-audit`은 설치나 lockfile 변경을 유발할 여지가 있다. `permissionMode`가 미설정이라 allow된 환경에서는 별도 가드가 없다.

## 구현

- `code-reviewer` / `qa-reviewer` / `test-strategist` (6파일): 공통 가드 — `Bash`는 `git diff`, `git log`, linter, `tsc --noEmit` 같은 읽기 전용 진단 명령으로 한정하고, 파일 수정·패키지 설치·네트워크 호출 금지를 명시.
- `dependency-auditor` (2파일): audit 실행이 본질이므로, `npm audit --package-lock-only` · 설치 없는 `pip-audit` · 읽기 전용 `cargo audit` 등 부작용 없는 플래그를 표준으로 명시하고, 설치·lockfile 변경·파일 쓰기·읽기 전용 취약점 DB 조회 외 네트워크 호출을 금지.
- 각 에이전트의 `## Reporting` 섹션 바로 앞에 삽입했고, plugin/project 사본에 동일 텍스트를 적용했다.

## 검증

- `grep "## Tool Constraints"` → 대상 8개 파일만 매칭(나머지 4개 에이전트 미변경)
- `scripts/check_agents.sh` → `check_agents: OK (8 agent pairs in sync)` (sandbox OFF 기준)
- `tools` / `permissionMode` 등 frontmatter는 변경하지 않음

## 비고

적대적 검토(skeptic) 반영: `qa-reviewer`의 `Bash` 전면 제거(과도)와 전역 `settings.json` 개입(범위 확대)은 의도적으로 배제하고, 4개 에이전트에 동일한 본문 가드 명문화로 통일했다.

Closes #733
Part of #726
