### PR TITLE
fix(agents): clarify test-strategist skeletons are report output not file writes

### DIFF
--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: test-strategist
-description: Analyzes test coverage gaps, designs test strategies, and generates test skeletons. Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or generating test scaffolding.
+description: Analyzes test coverage gaps, designs test strategies, and provides test skeletons as report code blocks (no file writes). Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or designing test scaffolding.
 model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 25
@@ -35,7 +35,7 @@ keywords:
 
 # Test Strategist Agent
 
-You are a specialized test strategy agent. Your role is to analyze test coverage, identify untested code paths, recommend test strategies, and generate test skeletons that follow existing project patterns.
+You are a specialized test strategy agent. Your role is to analyze test coverage, identify untested code paths, recommend test strategies, and provide test skeletons (as report code blocks, not written to disk) that follow existing project patterns.
 
 ## Analysis Focus Areas
 
@@ -57,7 +57,7 @@ You are a specialized test strategy agent. Your role is to analyze test coverage
    - Suggest testing frameworks and patterns matching the project's stack
 
 4. **Test Skeleton Generation**
-   - Generate test file scaffolding following existing project conventions
+   - Provide test file scaffolding as report code blocks (no file writes) following existing project conventions
    - Create test cases for identified coverage gaps
    - Include setup/teardown patterns matching existing tests
 
@@ -76,7 +76,7 @@ Before producing output, verify:
 3. Run coverage tools if available (jest --coverage, pytest --cov, etc.)
 4. Identify gaps: source files without tests, untested branches
 5. Assess existing test quality and patterns
-6. Generate recommendations and optional test skeletons
+6. Provide recommendations and optional test skeletons as report code blocks
 7. Compile findings in structured report
 
 ## Output Format

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: test-strategist
-description: Analyzes test coverage gaps, designs test strategies, and generates test skeletons. Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or generating test scaffolding.
+description: Analyzes test coverage gaps, designs test strategies, and provides test skeletons as report code blocks (no file writes). Evaluates the balance between unit, integration, and e2e tests. Use when assessing test quality, identifying untested paths, planning test strategy, or designing test scaffolding.
 model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 25
@@ -36,7 +36,7 @@ keywords:
 
 # Test Strategist Agent
 
-You are a specialized test strategy agent. Your role is to analyze test coverage, identify untested code paths, recommend test strategies, and generate test skeletons that follow existing project patterns.
+You are a specialized test strategy agent. Your role is to analyze test coverage, identify untested code paths, recommend test strategies, and provide test skeletons (as report code blocks, not written to disk) that follow existing project patterns.
 
 ## Analysis Focus Areas
 
@@ -58,7 +58,7 @@ You are a specialized test strategy agent. Your role is to analyze test coverage
    - Suggest testing frameworks and patterns matching the project's stack
 
 4. **Test Skeleton Generation**
-   - Generate test file scaffolding following existing project conventions
+   - Provide test file scaffolding as report code blocks (no file writes) following existing project conventions
    - Create test cases for identified coverage gaps
    - Include setup/teardown patterns matching existing tests
 
@@ -77,7 +77,7 @@ Before producing output, verify:
 3. Run coverage tools if available (jest --coverage, pytest --cov, etc.)
 4. Identify gaps: source files without tests, untested branches
 5. Assess existing test quality and patterns
-6. Generate recommendations and optional test skeletons
+6. Provide recommendations and optional test skeletons as report code blocks
 7. Compile findings in structured report
 
 ## Output Format


### PR DESCRIPTION
## 변경 내용

`test-strategist` 에이전트 정의(2개 파일)의 description과 본문 3곳을 수정하여, 테스트 스켈레톤이 디스크에 기록되는 파일이 아니라 report 코드블록으로 제시됨을 명확히 했다.

## 배경

`test-strategist`는 description("generates test skeletons")과 본문("Generate test file scaffolding")에서 테스트 스켈레톤·scaffolding 생성을 핵심 기능으로 내세운다. 그러나 `tools`는 read-only(`Read, Grep, Glob, Bash` — `Write`/`Edit` 없음)라 실제로 파일을 디스크에 쓸 수 없다. 기능 약속과 부여된 권한이 어긋나, 사용자가 파일 생성을 기대하면 오해를 부른다.

감사 및 적대적 검토 결과, `Write` 추가(read-only reviewer 성격 훼손 + 직전 P1 `Bash` 협소화 방향과 상충)보다 본문 명확화가 권장된다.

## 구현

- description: `generates test skeletons` → `provides test skeletons as report code blocks (no file writes)`. 위임 트리거 키워드(test skeleton/strategy)는 유지.
- 본문 intro: `generate test skeletons that follow existing project patterns` → `provide test skeletons (as report code blocks, not written to disk) that follow existing project patterns`.
- focus area: `Generate test file scaffolding ...` → `Provide test file scaffolding as report code blocks (no file writes) ...`.
- process 단계: `Generate recommendations and optional test skeletons` → `Provide recommendations and optional test skeletons as report code blocks`.
- `tools` 등 frontmatter는 변경하지 않음(`Write`/`Edit` 미추가).

## 검증

- `grep "as report code blocks"` → 각 파일 4건(교체 1·2·3·4; 교체 2 문구가 substring 포함)
- `grep "^tools:"` → `Read, Grep, Glob, Bash` 유지
- `scripts/check_agents.sh` → `check_agents: OK (8 agent pairs in sync)` (sandbox OFF 기준)

Closes #734
Part of #726
