### PR TITLE
docs(agents): document advisory frontmatter fields and remove stale temperature

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -637,7 +637,6 @@ name: agent-name
 description: 에이전트의 역할
 model: sonnet
 tools: Read, Edit
-temperature: 0.3
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -663,7 +663,6 @@ name: agent-name
 description: What the agent does
 model: sonnet
 tools: Read, Edit
-temperature: 0.3
 ---
 ```
 

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -214,6 +214,10 @@ The eight agent definitions exist in two layers — `project/.claude/agents/` an
 
 **CI enforcement**: `.github/workflows/validate-skills.yml` runs `scripts/check_agents.sh` (PowerShell twin: `scripts/check_agents.ps1`). It strips frontmatter and normalizes that single sentence, then fails (exit 2) if the agent **bodies** otherwise diverge — so a behavioral instruction edited in one layer but not the other cannot ship silently.
 
+**Advisory frontmatter (`applies_to`, `keywords`)**: every agent declares `applies_to` (a glob list) and `keywords`. These are **not** official Claude Code runtime path-triggers — the runtime delegates to a sub-agent only by its `description`. They are advisory inputs consumed by the `fleet-orchestrator` skill's Top-K routing score (`score = 2 * matched_applies_to_globs + 1 * matched_keywords`, see `global/skills/_internal/fleet-orchestrator/SKILL.md`). Opening a file that matches an `applies_to` glob does **not** auto-invoke the agent; keep delegation intent in `description`.
+
+**`structure-explorer` memory scope**: `structure-explorer` is intentionally the only agent with `memory: local` and no `initialPrompt` — it performs stateless, 1-shot, breadth-first exploration with no cross-call state to persist, so the project-memory bootstrap pattern used by the other seven agents does not apply.
+
 **Skill reference files are intentionally NOT guarded this way.** Beyond the four workflow references above, the `plugin/skills/*/reference/` tree is a curated *re-structuring* of `project/.claude/rules/` — content is split and recombined across files (e.g. `rules/api/observability.md` becomes `observability.md` + `logging.md`; `rules/coding/` standards fan out into `general.md`/`quality.md`/`concurrency.md`/`memory.md`). A per-file 1:1 drift check would false-positive on that reorganization, so the plugin reference bundle is maintained as an independent curated distribution.
 
 ### Version Declarations (VERSION_MAP SSOT)


### PR DESCRIPTION
## 변경 내용

에이전트 fleet의 문서 정합을 위한 P2/P3 문서 항목 3가지를 처리했다.

1. `docs/CUSTOM_EXTENSIONS.md`에 `applies_to` / `keywords`가 공식 런타임 path-trigger가 아니라 `fleet-orchestrator`의 Top-K routing 입력임을 명문화.
2. `docs/CUSTOM_EXTENSIONS.md`에 `structure-explorer`의 `memory: local` + `initialPrompt` 미선언이 의도된 설계임을 명문화.
3. `README.md` / `README.ko.md`의 Agent Configuration 예시 YAML에서 stale `temperature: 0.3` 제거.

## 배경

- `applies_to` / `keywords`는 path-trigger처럼 보이지만 공식 런타임은 오직 `description`으로만 위임한다. 이 두 필드는 `fleet-orchestrator` 스킬의 Top-K routing 점수식(`score = 2 * matched_applies_to_globs + 1 * matched_keywords`, `global/skills/_internal/fleet-orchestrator/SKILL.md`)이 소비하는 advisory 입력이다. 문서가 없으면 유지보수자가 "특정 파일을 열면 에이전트가 자동 호출된다"고 오해할 수 있다. → 제거가 아니라 용도 문서화가 정답.
- `structure-explorer`는 8개 중 유일하게 `memory: project` + 부트스트랩 `initialPrompt` 패턴에서 벗어난다. stateless 1-shot 탐색 성격상 의도된 것이나, 문서가 없으면 "실수로 빠진 것"으로 오인된다.
- README 예시 YAML이 이미 모든 에이전트에서 제거(#662)된 비표준·무시 필드 `temperature: 0.3`을 여전히 노출해, 신규 작성자가 복제할 위험이 있었다.

## 검증

- `grep temperature README.md README.ko.md` → 각 0건
- `docs/CUSTOM_EXTENSIONS.md`에 advisory 필드·structure-explorer 노트 삽입 확인(CI enforcement 단락 뒤, Skill reference 단락 앞)
- 에이전트 정의 파일은 변경하지 않음

Closes #737
Part of #726
