### PR TITLE
docs(agents): add escalation-boundary guidance for sonnet-ceiling agents

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -116,6 +116,10 @@ If language-specific rules exist in the project's rules directory, read them bef
 
 Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
 
+## Escalation
+
+For Critical security findings (for example multi-step injection chains or authentication bypass), treat this review as a first-pass screening and escalate to the `security-audit` skill rather than relying on this agent as the final security authority. For large monorepos or audit-grade reviews that need deeper reasoning, the caller may override `model: opus`.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/codebase-analyzer.md
+++ b/plugin/agents/codebase-analyzer.md
@@ -115,6 +115,10 @@ Detect the primary language and apply matching analysis:
 
 If language-specific rules exist in the project's rules directory, read them before starting.
 
+## Escalation
+
+For large monorepos or deep structural reasoning — for example cyclic-dependency tracing across many modules — the caller may override `model: opus` if the default tier misses subtle relationships. Always report findings with confidence scores so the caller can decide whether to escalate.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/plugin/agents/test-strategist.md
+++ b/plugin/agents/test-strategist.md
@@ -118,6 +118,10 @@ One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major p
 
 Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
 
+## Escalation
+
+For large test suites or audit-grade coverage analysis, the caller may override `model: opus` if the default tier under-covers complex branch trees or cross-module coverage. Report gaps with enough context for the caller to decide whether to escalate.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/code-reviewer.md
+++ b/project/.claude/agents/code-reviewer.md
@@ -117,6 +117,10 @@ If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in t
 
 Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
 
+## Escalation
+
+For Critical security findings (for example multi-step injection chains or authentication bypass), treat this review as a first-pass screening and escalate to the `security-audit` skill rather than relying on this agent as the final security authority. For large monorepos or audit-grade reviews that need deeper reasoning, the caller may override `model: opus`.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/codebase-analyzer.md
+++ b/project/.claude/agents/codebase-analyzer.md
@@ -116,6 +116,10 @@ Detect the primary language and apply matching analysis:
 
 If `rules/coding/cpp-specifics.md` or similar language-specific rules exist in the project, read them before starting.
 
+## Escalation
+
+For large monorepos or deep structural reasoning — for example cyclic-dependency tracing across many modules — the caller may override `model: opus` if the default tier misses subtle relationships. Always report findings with confidence scores so the caller can decide whether to escalate.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.

--- a/project/.claude/agents/test-strategist.md
+++ b/project/.claude/agents/test-strategist.md
@@ -119,6 +119,10 @@ One of: `ADEQUATE` | `NEEDS_IMPROVEMENT` (gaps identified) | `CRITICAL` (major p
 
 Bash is restricted to read-only diagnostic commands — for example `git diff`, `git log`, repository linters, and type checks such as `tsc --noEmit`. Do not use Bash to write or modify files, install packages, or make network calls. This agent reports findings and never mutates the working tree.
 
+## Escalation
+
+For large test suites or audit-grade coverage analysis, the caller may override `model: opus` if the default tier under-covers complex branch trees or cross-module coverage. Report gaps with enough context for the caller to decide whether to escalate.
+
 ## Reporting
 
 Return your findings to the calling session as your final message. This agent runs as a single-return node; the calling session decides any follow-up. A multi-agent `team-lead` handoff topology is not wired in this configuration.


### PR DESCRIPTION
## 변경 내용

sonnet 모델 천장에 닿을 수 있는 3개 에이전트(`code-reviewer`, `codebase-analyzer`, `test-strategist`) 본문에 `## Escalation` 섹션을 추가했다(`plugin/` + `project/` 두 레이어, 총 6개 파일). `model` 필드는 변경하지 않았다.

## 배경

감사 결과 이 3개 에이전트는 깊은 보안(다단계 인젝션 체인 등)·순환 의존성 추적·audit-grade 커버리지 종합에서 sonnet 추론 천장에 닿을 수 있다. 그러나 `model`을 opus로 상향하는 것은 비용 대비 이득이 불명확하다. 따라서 모델 값을 바꾸는 대신 에스컬레이션 경계를 본문에 명문화하는 보수적 방식을 택했다.

## 구현

- `code-reviewer`: 심각도 높은 보안 발견은 1차 스크리닝으로 보고 `security-audit` 스킬로 에스컬레이션하도록 명시(이 에이전트를 보안 게이트의 최종 권위로 쓰지 않음) + 대규모/audit-grade 시 호출 측 `model: opus` override 안내.
- `codebase-analyzer`: 대규모 모노레포·순환 의존성 추적 시 호출 측 `model: opus` override 안내 + confidence 점수 보고로 에스컬레이션 판단 지원.
- `test-strategist`: 대형 테스트 스위트·audit-grade 커버리지 분석 시 호출 측 `model: opus` override 안내.
- 각 에이전트의 `## Reporting` 섹션 바로 앞에 삽입, plugin/project 동일 텍스트로 parity 유지.

## 검증

- `grep "## Escalation"` → 대상 6개 파일만 매칭(나머지 10개 미변경)
- `grep "^model:"` → 6개 파일 모두 `model: sonnet` 그대로(필드 불변)
- `scripts/check_agents.sh` → `OK (8 agent pairs: bodies + behavioral frontmatter in sync)` (#738에서 추가된 frontmatter parity 게이트 포함 통과)

## 비고

적대적 검토 반영: 모델 상향이 아닌 운영 가이드 추가(런타임 동작 불변)로, evidence 없는 비용 증가를 회피했다.

Closes #739
Part of #726
