### PR TITLE
docs(rules): guide agents away from over-length unparseable shell commands

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -838,6 +838,29 @@ The Windows profile intentionally keeps these guardrails:
 launch warning. It does not widen `permissions.allow`, and it does not override
 the installed profile's bypass/auto-mode disable settings.
 
+### Over-length commands and the parse limit
+
+A single Bash/PowerShell command that exceeds the harness command-parser limit
+(observed at ~965 bytes; harness-internal and not configurable here) cannot be
+parsed, so it cannot match any `permissions.allow` rule and falls back to a
+manual prompt. This is distinct from the hooks' own 16384-byte tokenizer budget
+(`DCG_TOKENIZER_MAX_BYTES`), which is a downstream performance guard, not the
+cause of the prompt.
+
+Decisions for this repo:
+
+- **Do not widen the allow-list to escape the prompt.** A rule like
+  `Bash(pwsh -File:*)` would auto-approve execution of *any* script file — the
+  allow-list grammar cannot scope by path
+  (`scripts/schemas/settings-json.schema.json`) — which would defeat the narrow
+  Windows profile above. Accept a one-time prompt for the wrapper invocation
+  instead.
+- **No hook mitigation.** The parse limit is upstream of the hook layer; a hook
+  cannot pre-empt or override the harness fallback, so this is out of scope.
+- **Prevention is the lever.** Keep single commands short and extract long logic
+  to a script — see `project/.claude/rules/core/environment.md`
+  (Command Construction).
+
 ## Windows Support (PowerShell)
 
 ### Overview

--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -14,6 +14,7 @@ Global settings applied every session. Routing index only — procedural detail 
 - Protected branches: never direct-push to `main` or `develop`; PR + squash merge only
 - Read-before-Edit: Read any file before Edit/Write
 - Conflicts: never auto-resolve source code; `git merge --abort` if intractable
+- Command length: keep each Bash/PowerShell call short enough to parse (target <~900 bytes); extract longer logic to a `.ps1`/`.sh` file and invoke by path
 
 ## Routing
 

--- a/project/.claude/rules/core/environment.md
+++ b/project/.claude/rules/core/environment.md
@@ -12,3 +12,28 @@ alwaysApply: true
 
 - PowerShell scripts with non-ASCII characters (Korean, CJK): use UTF-8 with BOM encoding.
 - When converting between document formats, prefer Mermaid for diagram representation over ASCII art or SVG generation.
+
+## Command Construction (Bash / PowerShell)
+
+Keep each Bash or PowerShell tool call small so the harness can parse it and
+match it against `permissions.allow`. A command that is too long to parse
+cannot match any allow rule and always falls back to a manual permission
+prompt, even when every cmdlet it uses is individually allowlisted.
+
+- **Length budget**: target under ~900 bytes per single tool call. The harness
+  rejects parsing well below ~1 KB; the exact limit is harness-internal and not
+  configurable from this repo, so this is prevention, not a guarantee.
+- **Extract long logic to a script**: when logic needs loops, conditionals, or
+  several pipes, write it to a `.ps1`/`.sh` file (the Write tool has no length
+  limit) and invoke it by path, or split it into several smaller sequential
+  calls. Prefer many focused commands over one mega-pipeline.
+- **PowerShell pitfalls** that inflate a single call:
+  - Verbose formatting on inspection commands
+    (`| Format-Table -AutoSize | Out-String -Width 200`) — drop it when you only
+    need the data.
+  - Multi-statement / control-flow scripts (`foreach`, `if`, `switch`, multiple
+    `Write-Output` lines) — these also fail to match single-cmdlet allow rules
+    such as `PowerShell(Get-ChildItem:*)`, so they prompt regardless of length.
+
+See `HOOKS.md` (Windows permission profile) for why the allow-list is not
+widened to auto-approve arbitrary `pwsh -File` invocations.


### PR DESCRIPTION
## What

Adds always-loaded guidance so the agent avoids generating Bash/PowerShell
commands that are too long for the harness to parse. Documentation only — no
hook, settings, or permission changes.

Change type: docs / enhancement.

## Why

A single command that exceeds the harness command-parser limit (~965 bytes)
cannot be matched against `permissions.allow`, so it falls back to a manual
permission prompt even when every cmdlet it uses is individually allowlisted.
The minimize-user-input epic (#743) reduced asks at the allow-list, hook, and
skill layers but does not reach this harness-parser layer. Prevention (keep
commands short / extract long logic to a script) is the only lever inside this
repo's domain.

## Where

| File | Change |
|------|--------|
| `project/.claude/rules/core/environment.md` | New "Command Construction" section (alwaysApply rule) |
| `global/CLAUDE.md` | One "Always-on Invariants" bullet for command length |
| `HOOKS.md` | Record the allow-list decision + hook out-of-scope rationale (outside the auto-generated region) |

## How

- **Length budget + extraction**: target under ~900 bytes per call; extract loops/conditionals/multi-pipe logic to a `.ps1`/`.sh` file and invoke by path, or split into smaller calls.
- **PowerShell pitfalls** named explicitly: verbose `| Format-Table | Out-String` formatting, and multi-statement / control-flow scripts that also miss single-cmdlet allow rules.
- **Allow-list decision recorded** in HOOKS.md: do **not** blanket-allow `pwsh -File` — the allow-list grammar cannot scope by path (`scripts/schemas/settings-json.schema.json`), so it would defeat the narrow Windows profile. Accept a one-time prompt instead.
- **Hook mitigation marked out of scope**: the parse limit is upstream of the hook layer, distinct from the 16384-byte tokenizer budget (`DCG_TOKENIZER_MAX_BYTES`).

### Testing done

- `bash scripts/gen-hooks-md.sh --check` — PASS (HOOKS.md insertion is outside the auto-generated markers, lines 1040-1716; drift check green).
- `bash scripts/validate_skills.sh` — 360/360 pass (global/CLAUDE.md edit clean).
- `bash tests/scripts/test-windows-powershell-permissions.sh` — PASS (narrow PowerShell allow policy and guardrails unchanged).

### Breaking changes

None. Documentation/guidance only; no deny-list or allow-list change.

## Related

Part of #743 (minimize user input requests across the harness).

Closes #750
