### PR TITLE
docs(rules): prefix-erosion PowerShell cheatsheet

### DIFF
--- a/project/.claude/rules/core/environment.md
+++ b/project/.claude/rules/core/environment.md
@@ -35,5 +35,41 @@ prompt, even when every cmdlet it uses is individually allowlisted.
     `Write-Output` lines) — these also fail to match single-cmdlet allow rules
     such as `PowerShell(Get-ChildItem:*)`, so they prompt regardless of length.
 
+### Compound commands erode the matchable prefix
+
+Length is not the only trigger. A *compound* PowerShell command — even a short
+one — often cannot be reduced to a matchable prefix, so the permission engine
+stores the **entire command string** as a one-off literal. The next call with
+any argument changed no longer matches, so "Yes, and don't ask again" never
+accumulates reusable coverage. The fix is to make the **first token a plain
+cmdlet** and keep each call to a single subcommand.
+
+Three rules of thumb:
+
+1. **First token must be a cmdlet.** A leading variable assignment
+   (`$env:X='y'; ...`, `$work = ...`) or a `cd <path>; ...` chain makes the
+   whole line the prefix. Pass paths/values inline instead
+   (`gh ... --repo <owner/repo>`, `git -C <path> ...`, `python -X utf8 ...`).
+2. **Break the chain.** `A; B; foreach {...}` and deep `A | B | C | D` require
+   every subcommand to be allow-listed; split into focused calls.
+3. **Prefer the dedicated tool.** File discovery -> Glob; content search ->
+   Grep; file read -> Read. These bypass shell permission matching entirely.
+
+Prompt-free rewrites (generalized):
+
+| Instead of | Use |
+|------------|-----|
+| `cd <repo>; gh issue view <n> ... \| ConvertFrom-Json \| ...` | `gh issue view <n> --repo <owner/repo> --json number,title,state,body` |
+| `cd <repo>; foreach ($n in <a>,<b>) { gh issue view $n ... }` | one `gh issue view <n>` per number, or `gh issue list --search "<a> <b>"` |
+| `$env:PYTHONIOENCODING='utf-8'; python -m <mod>` | `python -X utf8 -m <mod>` |
+| `$work = ...; if (...) {...}; git -C $work ...` | `git -C <literal-path> ...` |
+| `Get-ChildItem X -Recurse \| Where-Object {...} \| Select-Object ...` | Glob tool, or `Get-ChildItem X -Recurse -Filter *.ts -Name` |
+| `Select-String -Path X -Pattern Y \| ... \| ForEach-Object {...}` | Grep tool, or `Select-String -Path X -Pattern Y` |
+| `(Get-Content X \| Measure-Object -Line).Lines` | Read tool, or `Get-Content X -TotalCount <n>` |
+
+> **Sandbox note**: `autoAllowBashIfSandboxed` auto-approves the Bash tool only,
+> never PowerShell tool calls, and the sandbox does not run on Windows — so
+> PowerShell prompts are governed by `permissions.allow` matching alone.
+
 See `HOOKS.md` (Windows permission profile) for why the allow-list is not
 widened to auto-approve arbitrary `pwsh -File` invocations.


### PR DESCRIPTION
## What

Adds a PowerShell command-construction cheatsheet to the always-loaded
`core/environment.md` rule, covering the **prefix-erosion** case: compound
commands that cannot be reduced to a matchable prefix and are therefore stored
as one-off literals in `settings.local.json`.

## Why

Closes #752.

#750 addressed the harness parser **over-length** (~965 byte) axis. This PR
adds the complementary **structure** axis, which is independent of length: a
short command like `$env:X='y'; cmd` still erodes the prefix because its first
token is not a cmdlet, so "don't ask again" never accumulates reusable coverage
and the command re-prompts on every argument change.

## How

- New subsection "Compound commands erode the matchable prefix".
- Three rules of thumb: first token must be a cmdlet; break the chain; prefer
  the dedicated tool (Glob / Grep / Read).
- A before/after rewrite table for the most common patterns (gh lookups, python
  with env-var prefix, temp clone, file discovery, content search, line count).
- A sandbox note clarifying that `autoAllowBashIfSandboxed` covers the Bash tool
  only (never PowerShell) and does not run on Windows.

## Where

- `project/.claude/rules/core/environment.md` (+36 lines, docs only).

## Test

Docs-only change. No `settings.json` / `settings.windows.json` `permissions`
entries are touched, so `tests/scripts/test-windows-powershell-permissions.sh`
and the narrow Windows PowerShell allow policy are unaffected.

Closes #752
