### PR TITLE
docs(rules): avoid if/Test-Path file checks that prompt

### DIFF
--- a/project/.claude/rules/core/environment.md
+++ b/project/.claude/rules/core/environment.md
@@ -66,6 +66,7 @@ Prompt-free rewrites (generalized):
 | `Get-ChildItem X -Recurse \| Where-Object {...} \| Select-Object ...` | Glob tool, or `Get-ChildItem X -Recurse -Filter *.ts -Name` |
 | `Select-String -Path X -Pattern Y \| ... \| ForEach-Object {...}` | Grep tool, or `Select-String -Path X -Pattern Y` |
 | `(Get-Content X \| Measure-Object -Line).Lines` | Read tool, or `Get-Content X -TotalCount <n>` |
+| `if (Test-Path X) { Get-Content X } else {...}` | Read tool on X (a not-found error signals absence), or `Get-Content X -ErrorAction SilentlyContinue` |
 
 > **Sandbox note**: `autoAllowBashIfSandboxed` auto-approves the Bash tool only,
 > never PowerShell tool calls, and the sandbox does not run on Windows — so

--- a/project/.claude/rules/workflow/session-resume.md
+++ b/project/.claude/rules/workflow/session-resume.md
@@ -18,8 +18,14 @@ Write `.claude/resume.md` in the project directory when:
 
 ## How to Resume
 
-At session start, if `.claude/resume.md` exists:
-1. Read and present the saved state to the user
+At session start, use the **Read tool** on `.claude/resume.md` to check for and
+load saved state. A not-found error means there is no resume file — proceed
+normally. Do **not** wrap the check in an `if`/`Test-Path` compound shell command:
+it erodes the matchable command prefix and triggers a permission prompt (see
+`core/environment.md`, "Compound commands erode the matchable prefix").
+
+When the file is present:
+1. Present the saved state to the user
 2. If user confirms, proceed from the documented "Next Action"
 3. After completing the workflow, delete the resume file
 


### PR DESCRIPTION
## What

Steers `session-resume.md` and the `environment.md` cheatsheet away from
`if`/`Test-Path` compound file-existence checks toward the **Read tool**.

## Why

Closes #754.

Follow-up to #752. The #752 cheatsheet is prevention; it cannot stop prompts when
a rule itself *induces* a compound command. `session-resume.md` phrased the resume
check as "if resume.md exists", so the agent built an
`if (Test-Path) { Get-Content } else` command whose `if` first token erodes the
matchable prefix and triggers a permission prompt. This is the structure /
prefix-erosion axis, independent of the #750 length axis.

## How

- **session-resume.md** "How to Resume": use the Read tool on `.claude/resume.md`;
  a not-found error means no resume file; do not wrap the check in `if`/`Test-Path`.
- **environment.md** cheatsheet: add a row mapping
  `if (Test-Path X) { Get-Content X } else {...}` -> Read tool on X
  (or `Get-Content X -ErrorAction SilentlyContinue`).

## Where

- `project/.claude/rules/workflow/session-resume.md`
- `project/.claude/rules/core/environment.md`
- +9 / -2 lines, docs only.

## Test

Verified prompt-free: the Read tool and `Get-Content X -ErrorAction SilentlyContinue`
both run without a permission prompt (the original `if`/`else` form prompted). No
`settings.json` / `settings.windows.json` `permissions` entries touched, so
`tests/scripts/test-windows-powershell-permissions.sh` and the narrow Windows
PowerShell allow policy are unaffected.

Closes #754
