### PR TITLE
feat(lang): introduce unified language profile preset and dynamic rules templates

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -227,13 +227,15 @@ function Install-GlobalSettings {
         }
     }
 
+    # Language policy selection (Unified Language Profile)
+    $profileChoice = Show-LanguageProfilePrompt
+    $script:agentLanguage = $profileChoice.AgentLanguage
+    $displayLang = $profileChoice.AgentDisplay
+    $contentLanguage = $profileChoice.ContentLanguage
+
     # conversation-language.md 템플릿 처리
     $tmplPath = Join-Path $InstallDir 'global' 'conversation-language.md.tmpl'
     if (Test-Path -LiteralPath $tmplPath) {
-        $agentChoice = Show-AgentLanguagePrompt
-        $script:agentLanguage = $agentChoice.Language
-        $displayLang = $agentChoice.Display
-
         $dest = Join-Path $ClaudeDir "conversation-language.md"
         if (Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest $dest -Key "conversation-language.md" -DisplayLang $displayLang) {
             Write-Ok "conversation-language.md 설치됨 (언어: $displayLang)"
@@ -241,7 +243,6 @@ function Install-GlobalSettings {
             Write-Info "conversation-language.md 로컬 변경 유지"
         }
     } else {
-        $script:agentLanguage = "korean"
         # Static-file fallback. The default repo ships only the .tmpl, so this
         # branch is unreachable in normal use. It exists to support fork users
         # who replace the .tmpl with a hand-edited static .md — preserving
@@ -256,9 +257,6 @@ function Install-GlobalSettings {
             }
         }
     }
-
-    # Content language policy selection (CLAUDE_CONTENT_LANGUAGE)
-    $contentLanguage = Show-ContentLanguagePrompt
 
     # Legacy settings.json migration warning (informational only).
     $null = Show-LegacySettingsWarning -SettingsPath (Join-Path $HOME '.claude/settings.json') -NewSelection $contentLanguage

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -250,17 +250,17 @@ install_global() {
         fi
     done
 
+    # Language policy selection (Unified Language Profile)
+    prompt_language_profile
+
     # conversation-language.md 템플릿 처리
     if [ -f "$INSTALL_DIR/global/conversation-language.md.tmpl" ]; then
-        prompt_agent_language
-
         if guarded_template_copy "$INSTALL_DIR/global/conversation-language.md.tmpl" "$CLAUDE_DIR/conversation-language.md" "conversation-language.md" "$AGENT_DISPLAY_LANG"; then
             success "conversation-language.md 설치됨 (언어: $AGENT_DISPLAY_LANG)"
         else
             info "conversation-language.md 로컬 변경 유지"
         fi
     else
-        AGENT_LANGUAGE="korean"
         # Static-file fallback. The default repo ships only the .tmpl, so this
         # branch is unreachable in normal use. It exists to support fork users
         # who replace the .tmpl with a hand-edited static .md — preserving
@@ -273,9 +273,6 @@ install_global() {
             fi
         fi
     fi
-
-    # Content language policy selection (CLAUDE_CONTENT_LANGUAGE)
-    prompt_content_language
 
     # Legacy settings.json migration warning (informational only).
     warn_legacy_settings_value "$HOME/.claude/settings.json" || true

--- a/project/.claude/rules/core/communication.md
+++ b/project/.claude/rules/core/communication.md
@@ -16,7 +16,7 @@ Code identifiers (variables, functions, classes, files) always use **English** d
 
 ## Relationship with Conversation Language
 
-Claude responds to users in Korean (via `settings.json` `language: "korean"`).
+Claude responds to users in English (via `settings.json` `language: "english"`).
 Prose content remains in English regardless of conversation language.
 
 ## Special Cases

--- a/project/.claude/rules/core/communication.md.tmpl
+++ b/project/.claude/rules/core/communication.md.tmpl
@@ -16,7 +16,7 @@ Code identifiers (variables, functions, classes, files) always use **English** d
 
 ## Relationship with Conversation Language
 
-Claude responds to users in Korean (via `settings.json` `language: "korean"`).
+Claude responds to users in {{AGENT_LANGUAGE_POLICY}} (via `settings.json` `language: "{{AGENT_LANGUAGE}}"`).
 Prose content remains in {{CONTENT_LANGUAGE_POLICY}} regardless of conversation language.
 
 ## Special Cases

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,18 +88,19 @@ function New-LocalClaude {
 # tables in lockstep.
 
 function Invoke-PolicyTemplate {
-    # Renders a .md.tmpl file by replacing {{CONTENT_LANGUAGE_POLICY}}
-    # with the resolved phrase and writes the result to $Destination as UTF-8.
+    # Renders a .md.tmpl file by replacing {{CONTENT_LANGUAGE_POLICY}},
+    # {{AGENT_LANGUAGE_POLICY}}, and {{AGENT_LANGUAGE}} with their resolved values
+    # and writes the result to $Destination as UTF-8.
     param(
         [Parameter(Mandatory)][string]$Source,
         [Parameter(Mandatory)][string]$Destination
     )
     $phrase = Get-PolicyPhrase -Policy $script:contentLanguage
 
-    # Note: Agent language substitution is handled by Invoke-GuardedTemplateCopy.
-
     $content = [System.IO.File]::ReadAllText($Source)
     $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
+    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $script:agentDisplayLang
+    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE\}\}', $script:agentLanguage
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($Destination, $rendered, $utf8NoBom)
 }
@@ -333,10 +334,10 @@ if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
 $promptsModule = Join-Path $ScriptDir 'lib' 'InstallPrompts.psm1'
 Import-Module $promptsModule -Force -DisableNameChecking
 
-$contentLanguage = Show-ContentLanguagePrompt
-$agentChoice = Show-AgentLanguagePrompt
-$agentLanguage = $agentChoice.Language
-$agentDisplayLang = $agentChoice.Display
+$profileChoice = Show-LanguageProfilePrompt
+$agentLanguage = $profileChoice.AgentLanguage
+$agentDisplayLang = $profileChoice.AgentDisplay
+$contentLanguage = $profileChoice.ContentLanguage
 
 # Legacy settings.json migration warning (informational only).
 $null = Show-LegacySettingsWarning -SettingsPath (Join-Path $HOME '.claude/settings.json') -NewSelection $contentLanguage

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -256,7 +256,9 @@ render_policy_tmpl() {
     local phrase
     phrase="$(get_policy_phrase)"
     # sed 구분자를 |로 사용해 경로/phrase 충돌 회피
-    sed "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" "$src" > "$dest"
+    sed -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
+        -e "s|{{AGENT_LANGUAGE_POLICY}}|${AGENT_DISPLAY_LANG:-Korean}|g" \
+        -e "s|{{AGENT_LANGUAGE}}|${AGENT_LANGUAGE:-korean}|g" "$src" > "$dest"
 }
 
 # 함수: 지정 디렉토리 내의 .md.tmpl 파일을 모두 찾아 .md로 렌더링 (원본 .tmpl 삭제)
@@ -587,8 +589,7 @@ fi
 # the dispatcher at its default and skips writing settings.json.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/install-prompts.sh"
-prompt_content_language
-prompt_agent_language
+prompt_language_profile
 
 # Legacy settings.json migration warning (informational only).
 # If the existing settings.json holds a CLAUDE_CONTENT_LANGUAGE value the

--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -29,49 +29,49 @@ function Script:Write-PromptWarn {
     Write-Host "  $Message" -ForegroundColor Yellow
 }
 
-function Show-AgentLanguagePrompt {
+function Show-LanguageProfilePrompt {
     [CmdletBinding()]
     param()
 
     Write-Host ""
-    Script:Write-PromptInfo "Select Agent Conversation Language:"
-    Write-Host "  1) English"
-    Write-Host "  2) Korean"
+    Script:Write-PromptInfo "Select Language Profile Preset:"
+    Write-Host "  1) English Unified (Dialogue & Documents both in English)"
+    Write-Host "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
+    Write-Host "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
     Write-Host ""
 
-    $sel = Read-Host "Selection (1-2) [default: 2]"
-    if ([string]::IsNullOrEmpty($sel)) { $sel = '2' }
+    $sel = Read-Host "Selection (1-3) [default: 3]"
+    if ([string]::IsNullOrEmpty($sel)) { $sel = '3' }
 
     switch ($sel) {
-        '1'     { return [pscustomobject]@{ Language = 'english'; Display = 'English' } }
-        '2'     { return [pscustomobject]@{ Language = 'korean';  Display = 'Korean'  } }
-        default {
-            Script:Write-PromptWarn "Unknown selection: $sel. Falling back to korean."
-            return [pscustomobject]@{ Language = 'korean'; Display = 'Korean' }
+        '1' {
+            return [pscustomobject]@{
+                AgentLanguage = 'english'
+                AgentDisplay = 'English'
+                ContentLanguage = 'english'
+            }
         }
-    }
-}
-
-function Show-ContentLanguagePrompt {
-    [CmdletBinding()]
-    param()
-
-    Write-Host ""
-    Script:Write-PromptInfo "Select Content Language (artifact validation scope):"
-    Script:Write-PromptInfo "  Locks the language of generated documents, commits, PRs, issues, and comments."
-    Write-Host "  1) English (ASCII only - no Hangul allowed in artifacts)"
-    Write-Host "  2) Korean  (per-artifact strict - Hangul or English document, no inline mixing)"
-    Write-Host ""
-
-    $sel = Read-Host "Selection (1-2) [default: 1]"
-    if ([string]::IsNullOrEmpty($sel)) { $sel = '1' }
-
-    switch ($sel) {
-        '1'     { return 'english' }
-        '2'     { return 'exclusive_bilingual' }
+        '2' {
+            return [pscustomobject]@{
+                AgentLanguage = 'korean'
+                AgentDisplay = 'Korean'
+                ContentLanguage = 'exclusive_bilingual'
+            }
+        }
+        '3' {
+            return [pscustomobject]@{
+                AgentLanguage = 'korean'
+                AgentDisplay = 'Korean'
+                ContentLanguage = 'english'
+            }
+        }
         default {
-            Script:Write-PromptWarn "Unknown selection: $sel. Falling back to english."
-            return 'english'
+            Script:Write-PromptWarn "Unknown selection: $sel. Falling back to Hybrid Mode."
+            return [pscustomobject]@{
+                AgentLanguage = 'korean'
+                AgentDisplay = 'Korean'
+                ContentLanguage = 'english'
+            }
         }
     }
 }
@@ -155,4 +155,4 @@ function Show-LegacySettingsWarning {
     return $true
 }
 
-Export-ModuleMember -Function Show-AgentLanguagePrompt, Show-ContentLanguagePrompt, Get-PolicyPhrase, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning
+Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -54,16 +54,17 @@ _prompts_warn() {
     fi
 }
 
-# prompt_agent_language
+# prompt_language_profile
 # Sets:
 #   AGENT_LANGUAGE      english | korean
 #   AGENT_DISPLAY_LANG  English | Korean
+#   CONTENT_LANGUAGE    english | exclusive_bilingual
 #
-# Non-interactive override: set AGENT_LANGUAGE before calling to skip the
-# prompt. AGENT_DISPLAY_LANG is derived automatically when AGENT_LANGUAGE
-# is already set, so callers can rely on both being populated afterwards.
-prompt_agent_language() {
-    if [ -n "${AGENT_LANGUAGE:-}" ]; then
+# Non-interactive override: set AGENT_LANGUAGE and CONTENT_LANGUAGE before calling
+# to skip the prompt entirely.
+prompt_language_profile() {
+    # If both are already set (e.g. non-interactive), derive Display and return
+    if [ -n "${AGENT_LANGUAGE:-}" ] && [ -n "${CONTENT_LANGUAGE:-}" ]; then
         case "$AGENT_LANGUAGE" in
             english) AGENT_DISPLAY_LANG="English" ;;
             korean)  AGENT_DISPLAY_LANG="Korean"  ;;
@@ -72,53 +73,34 @@ prompt_agent_language() {
         return 0
     fi
     echo ""
-    _prompts_info "Select Agent Conversation Language:"
-    echo "  1) English"
-    echo "  2) Korean"
+    _prompts_info "Select Language Profile Preset:"
+    echo "  1) English Unified (Dialogue & Documents both in English)"
+    echo "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
+    echo "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
     echo ""
-    read -r -p "Selection (1-2) [default: 2]: " _agent_lang_type
-    _agent_lang_type=${_agent_lang_type:-2}
+    read -r -p "Selection (1-3) [default: 3]: " _profile_type
+    _profile_type=${_profile_type:-3}
 
-    case "$_agent_lang_type" in
+    case "$_profile_type" in
         1)
             AGENT_LANGUAGE="english"
             AGENT_DISPLAY_LANG="English"
+            CONTENT_LANGUAGE="english"
             ;;
         2)
             AGENT_LANGUAGE="korean"
             AGENT_DISPLAY_LANG="Korean"
+            CONTENT_LANGUAGE="exclusive_bilingual"
             ;;
-        *)
-            _prompts_warn "Unknown selection: $_agent_lang_type. Falling back to korean."
+        3)
             AGENT_LANGUAGE="korean"
             AGENT_DISPLAY_LANG="Korean"
+            CONTENT_LANGUAGE="english"
             ;;
-    esac
-}
-
-# prompt_content_language
-# Sets:
-#   CONTENT_LANGUAGE  english | exclusive_bilingual
-#
-# Non-interactive override: set CONTENT_LANGUAGE before calling to skip the
-# prompt entirely.  All four canonical values are accepted; the simplified UI
-# surfaces only english and exclusive_bilingual.
-prompt_content_language() {
-    [ -n "${CONTENT_LANGUAGE:-}" ] && return 0
-    echo ""
-    _prompts_info "Select Content Language (artifact validation scope):"
-    _prompts_info "  Locks the language of generated documents, commits, PRs, issues, and comments."
-    echo "  1) English (ASCII only - no Hangul allowed in artifacts)"
-    echo "  2) Korean  (per-artifact strict - Hangul or English document, no inline mixing)"
-    echo ""
-    read -r -p "Selection (1-2) [default: 1]: " _content_lang_type
-    _content_lang_type=${_content_lang_type:-1}
-
-    case "$_content_lang_type" in
-        1) CONTENT_LANGUAGE="english" ;;
-        2) CONTENT_LANGUAGE="exclusive_bilingual" ;;
         *)
-            _prompts_warn "Unknown selection: $_content_lang_type. Falling back to english."
+            _prompts_warn "Unknown selection: $_profile_type. Falling back to Hybrid Mode."
+            AGENT_LANGUAGE="korean"
+            AGENT_DISPLAY_LANG="Korean"
             CONTENT_LANGUAGE="english"
             ;;
     esac

--- a/tests/scripts/test-installer-prompt-drift.sh
+++ b/tests/scripts/test-installer-prompt-drift.sh
@@ -110,26 +110,20 @@ check "surfaced policies (PowerShell)" "$expected_surfaced" "$ps_surfaced"
 echo ""
 echo "[4] Prompt-string parity (selection prompts)"
 
-# Both libs must use the same "Selection (1-2) [default: N]" defaults
-# for both prompts. Defaults: agent=2, content=1.
-# The agent prompt appears first in both files; the content prompt appears
-# second. Extract the digit inside the [default: N] suffix.
+# Both libs must use the same "Selection (1-3) [default: 3]" default.
+# Extract the digit inside the [default: N] suffix.
 extract_default() {
-    local file="$1" rank="$2"  # rank = "head" | "tail"
-    grep -E 'Selection \(1-2\) \[default: [0-9]\]' "$file" \
-        | "$rank" -1 \
+    local file="$1"
+    grep -E 'Selection \(1-3\) \[default: [0-9]\]' "$file" \
+        | head -1 \
         | sed -E 's/.*\[default: ([0-9])\].*/\1/'
 }
 
-bash_agent_default="$(extract_default "$BASH_LIB" head)"
-bash_content_default="$(extract_default "$BASH_LIB" tail)"
-ps_agent_default="$(extract_default "$PS_LIB" head)"
-ps_content_default="$(extract_default "$PS_LIB" tail)"
+bash_default="$(extract_default "$BASH_LIB")"
+ps_default="$(extract_default "$PS_LIB")"
 
-check "agent default"   "$bash_agent_default"   "$ps_agent_default"
-check "content default" "$bash_content_default" "$ps_content_default"
-check "agent default = 2" "2" "$bash_agent_default"
-check "content default = 1" "1" "$bash_content_default"
+check "unified default match" "$bash_default" "$ps_default"
+check "unified default is 3" "3" "$bash_default"
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/tests/scripts/test-language-policy-drift.sh
+++ b/tests/scripts/test-language-policy-drift.sh
@@ -47,7 +47,9 @@ FAIL=0
 
 render() {
     local tmpl="$1" phrase="$2"
-    sed "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" "$tmpl"
+    sed -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
+        -e "s|{{AGENT_LANGUAGE_POLICY}}|English|g" \
+        -e "s|{{AGENT_LANGUAGE}}|english|g" "$tmpl"
 }
 
 echo "=== Content-language policy drift test (#411) ==="


### PR DESCRIPTION
## What

### Summary
This PR implements unified language profile presets (English Unified, Korean Unified, Hybrid Mode) in the installer prompts, and decouples rules templates to dynamically substitute agent language policies instead of hardcoding Korean conversation.

### Change Type
- [x] Feature (new functionality)
- [ ] Bugfix (fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Test

### Affected Components
- **Installer Prompts**: `scripts/lib/install-prompts.sh`, `scripts/lib/InstallPrompts.psm1`
- **Installation entrypoints**: `bootstrap.sh`, `bootstrap.ps1`, `scripts/install.sh`, `scripts/install.ps1`
- **Configuration templates**: `project/.claude/rules/core/communication.md.tmpl`, `project/.claude/rules/core/communication.md`
- **Regression Tests**: `tests/scripts/test-installer-prompt-drift.sh`, `tests/scripts/test-language-policy-drift.sh`

---

## Why

### Problem Solved
Resolves #756.
Previously, conversational language and artifact validation language prompts were asked separately. Additionally, `communication.md.tmpl` hardcoded `korean` as the conversational response language, creating a discrepancy (drift) when developers chose English-only setups. This PR unifies configuration presets and dynamically templates rules.

### Related Issues
- Resolves #756

---

## Who
- Reviewer: @kcenon
- Stakeholders: Developers setting up new installations.

---

## When
- Urgency: Normal. Follow standard review process.

---

## Where
- **Files Changed:**
  - `scripts/lib/install-prompts.sh`
  - `scripts/lib/InstallPrompts.psm1`
  - `scripts/install.sh`
  - `scripts/install.ps1`
  - `bootstrap.sh`
  - `bootstrap.ps1`
  - `project/.claude/rules/core/communication.md.tmpl`
  - `project/.claude/rules/core/communication.md`
  - `tests/scripts/test-installer-prompt-drift.sh`
  - `tests/scripts/test-language-policy-drift.sh`

---

## How

### Implementation Details
1. **Deduplicated Prompts**: Merged individual dialogue and artifact language prompts into a single `prompt_language_profile` (and `Show-LanguageProfilePrompt` for PowerShell). 
2. **Template Variables Integration**: Added `{{AGENT_LANGUAGE}}` and `{{AGENT_LANGUAGE_POLICY}}` to `communication.md.tmpl`. Refactored `render_policy_tmpl` / `Invoke-PolicyTemplate` inside the installation scripts to substitute all three variables.
3. **Drift Tests Update**: Updated the static defaults check in `test-installer-prompt-drift.sh` to match `Selection (1-3) [default: 3]`. Extended the mock renderer in `test-language-policy-drift.sh` to handle new template variables.

### Testing Done
- Ran both regression tests locally:
  ```bash
  bash tests/scripts/test-installer-prompt-drift.sh
  # Result: === Results: 9 passed, 0 failed ===
  
  bash tests/scripts/test-language-policy-drift.sh
  # Result: === Results: 15 passed, 0 failed ===
  ```
- Verified interactive install workflow on all modes.
