### PR TITLE
ci(validate): trigger code-validation workflows on develop-targeted PRs

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -2,7 +2,7 @@ name: Validate Hooks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'global/hooks/**'
       - 'hooks/**'
@@ -34,6 +34,12 @@ on:
       - 'scripts/backup.sh'
       - 'scripts/backup.ps1'
       - 'tests/scripts/test-installer-robustness.sh'
+
+# Cancel in-progress runs of the same PR / schedule so a fast follow-up commit
+# does not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,7 +2,7 @@ name: Validate Skills
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'project/.claude/skills/**'
       - 'project/.claude/rules/workflow/**'
@@ -46,6 +46,12 @@ on:
       - '.github/workflows/validate-skills.yml'
       - 'README.md'
       - 'README.ko.md'
+
+# Cancel in-progress runs of the same PR / schedule so a fast follow-up commit
+# does not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
Closes #759. Part of #758.

## Summary
- Add `develop` to the `pull_request` `branches` filter of `validate-hooks.yml` and `validate-skills.yml`, so `feature -> develop` PRs run code validation (previously gated on `main` only).
- Add a `concurrency` block (mirroring `validate-memory.yml`) to cancel superseded runs.
- `validate-pr-target.yml` is unchanged (`main`-only) -- it enforces the develop->main rule.

## Why
This is the **prerequisite** of epic #758. The guards/tests added by sibling issues (#761, #762) only execute on develop-targeted PRs once these workflows trigger on `develop`. Without this, those guards are decorative on the path where regressions land.

## Test Plan
- This PR targets `develop`; confirm `validate-hooks` and `validate-skills` now run on it (they would not before this change).
- Confirm `validate-pr-target` does not run (base is `develop`, not `main`).

### Scope
Minimal CI-trigger change only: no OS matrix, no shellcheck-glob widening (that is #764).
