### PR TITLE
ci(validate): widen shellcheck scope to all tracked shell scripts

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -163,17 +163,27 @@ jobs:
             brew install shellcheck
           fi
 
-      - name: Run shellcheck on hook scripts
+      - name: Run shellcheck on shell scripts
         run: |
           failed=0
+          # Broad loop: every tracked .sh, gated at error severity. Self-tracking
+          # — new scripts are covered automatically with no workflow change.
+          mapfile -t scripts < <(git ls-files '*.sh')
+          for f in "${scripts[@]}"; do
+            echo "Checking (error) $f..."
+            if ! shellcheck --severity=error -e SC2086 "$f"; then
+              failed=1
+            fi
+          done
+          # Strict loop: hook + benchmark scripts held to the stricter warning bar.
           for script in global/hooks/*.sh tests/batch_drift_benchmark/*.sh; do
-            echo "Checking $script..."
+            echo "Checking (warning) $script..."
             if ! shellcheck -S warning -e SC2086 "$script"; then
               failed=1
             fi
           done
-          if [ $failed -eq 1 ]; then
-            echo "Shellcheck found issues in hook scripts"
+          if [ "$failed" -ne 0 ]; then
+            echo "Shellcheck found issues"
             exit 1
           fi
-          echo "All hook scripts passed shellcheck!"
+          echo "All shell scripts passed shellcheck!"

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -168,13 +168,15 @@ jobs:
           failed=0
           # Broad loop: every tracked .sh, gated at error severity. Self-tracking
           # — new scripts are covered automatically with no workflow change.
-          mapfile -t scripts < <(git ls-files '*.sh')
-          for f in "${scripts[@]}"; do
+          # while-read over process substitution (not `... | while`) keeps the
+          # failed flag in the current shell and stays bash 3.2 compatible
+          # (macOS runners lack the bash 4+ `mapfile`).
+          while IFS= read -r f; do
             echo "Checking (error) $f..."
             if ! shellcheck --severity=error -e SC2086 "$f"; then
               failed=1
             fi
-          done
+          done < <(git ls-files '*.sh')
           # Strict loop: hook + benchmark scripts held to the stricter warning bar.
           for script in global/hooks/*.sh tests/batch_drift_benchmark/*.sh; do
             echo "Checking (warning) $script..."

--- a/scripts/lib/safe-rm.sh
+++ b/scripts/lib/safe-rm.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # scripts/lib/safe-rm.sh
 # =====================================================================
 # Sourced library: no shebang, no `set -e`. The caller is responsible

--- a/scripts/memory-sync-issues/tooling/create-issues.sh
+++ b/scripts/memory-sync-issues/tooling/create-issues.sh
@@ -61,7 +61,7 @@ EOF
 done
 
 # Default to dry-run if no flag given (safety)
-if [[ "$RESUME" -eq 0 ]] && ! grep -qE -- '--execute|--dry-run' <<<"$@$0"; then
+if [[ "$RESUME" -eq 0 ]] && ! grep -qE -- '--execute|--dry-run' <<<"$* $0"; then
   : # already defaulted
 fi
 


### PR DESCRIPTION
Closes #764. Part of #758.

## Summary
- Replace the two-glob shellcheck loop in `validate-hooks.yml` with a self-tracking `mapfile -t scripts < <(git ls-files '*.sh')` loop at `--severity=error -e SC2086` (covers all 176 tracked `.sh`; new scripts are covered automatically).
- Keep the existing hook/benchmark globs (`global/hooks/*.sh`, `tests/batch_drift_benchmark/*.sh`) at the stricter `-S warning` bar as a separate loop, sharing the `failed` gate.
- Fix the 2 pre-existing **error-level** findings the wider scope surfaces (real fixes, not suppression):
  - `scripts/lib/safe-rm.sh`: `SC2148` -- add a `# shellcheck shell=bash` directive (it is a sourced library with no shebang).
  - `scripts/memory-sync-issues/tooling/create-issues.sh:64`: `SC2145` -- `<<<"$@$0"` -> `<<<"$* $0"` (the array/string mix is joined on IFS, semantically equivalent for the `grep` match).

## Note on scope
The issue body claimed "0 error-level findings"; local verification with shellcheck 0.11.0 surfaced **2**. They are fixed here so the widened error-severity loop actually lands green. Re-verified: **0 errors across all 176 tracked `.sh`**.

## Test Plan
- `git ls-files '*.sh'` + `shellcheck --severity=error -e SC2086` over each -> 0 findings.
- The hook/benchmark `-S warning` loop keeps its exact prior command and behavior.

### Out of scope
No `.shellcheckrc`. The follow-up warning-severity ratchet (e.g. SC2164/SC2155) is deferred per the issue.
