### PR TITLE
refactor(install): single-source the policy-template renderer and close the bootstrap render gap

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -228,10 +228,14 @@ function Install-GlobalSettings {
     }
 
     # Language policy selection (Unified Language Profile)
+    # Stored at script scope so the project-install path (Install-ProjectSettings)
+    # can reuse the resolved values for rule-template rendering (issue #760).
     $profileChoice = Show-LanguageProfilePrompt
     $script:agentLanguage = $profileChoice.AgentLanguage
-    $displayLang = $profileChoice.AgentDisplay
-    $contentLanguage = $profileChoice.ContentLanguage
+    $script:displayLang = $profileChoice.AgentDisplay
+    $script:contentLanguage = $profileChoice.ContentLanguage
+    $displayLang = $script:displayLang
+    $contentLanguage = $script:contentLanguage
 
     # conversation-language.md 템플릿 처리
     $tmplPath = Join-Path $InstallDir 'global' 'conversation-language.md.tmpl'
@@ -420,6 +424,27 @@ function Install-ProjectSettings {
 
     Write-Info "프로젝트 설정 설치 중: $projDir"
 
+    # Policy-template render prerequisites (issue #760).
+    # InstallPrompts.psm1 provides Invoke-PolicyTemplatesInDir and the language
+    # profile prompt. On the project-only path (install type 2) Install-GlobalSettings
+    # is not called, so the module import and language resolution must happen here.
+    # Both are idempotent / guarded:
+    #   - Import-Module -Force is safe to repeat.
+    #   - Resolve the profile only when the script-scoped values are not already
+    #     set (type 3 resolved them in Install-GlobalSettings), to avoid a second prompt.
+    $promptsModule = Join-Path $InstallDir 'scripts' 'lib' 'InstallPrompts.psm1'
+    if (Test-Path -LiteralPath $promptsModule) {
+        Import-Module $promptsModule -Force -DisableNameChecking
+    }
+    if (-not $script:contentLanguage -or -not $script:agentLanguage) {
+        if (Get-Command Show-LanguageProfilePrompt -ErrorAction SilentlyContinue) {
+            $profileChoice = Show-LanguageProfilePrompt
+            $script:agentLanguage = $profileChoice.AgentLanguage
+            $script:displayLang = $profileChoice.AgentDisplay
+            $script:contentLanguage = $profileChoice.ContentLanguage
+        }
+    }
+
     # Copy files
     Copy-Item -Path (Join-Path $InstallDir 'project' 'CLAUDE.md') -Destination $projDir -Force
 
@@ -432,6 +457,13 @@ function Install-ProjectSettings {
     $rulesDir = Join-Path $InstallDir 'project' '.claude' 'rules'
     if (Test-Path $rulesDir) {
         Copy-Item -Path $rulesDir -Destination $projClaudeDir -Recurse -Force
+        # issue #760: render any .md.tmpl under the copied rules/ via the same
+        # single-source function install.ps1 uses. Unset language values fall
+        # back to safe defaults inside Invoke-PolicyTemplate.
+        if (Get-Command Invoke-PolicyTemplatesInDir -ErrorAction SilentlyContinue) {
+            Invoke-PolicyTemplatesInDir -Path (Join-Path $projClaudeDir 'rules') `
+                -ContentLanguage $script:contentLanguage -AgentDisplay $script:displayLang -AgentLanguage $script:agentLanguage
+        }
     }
 
     $skillsDir = Join-Path $InstallDir 'project' '.claude' 'skills'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -386,12 +386,30 @@ install_project() {
 
     info "프로젝트 설정 설치 중: $PROJECT_DIR"
 
+    # 정책 템플릿 렌더링 준비 (issue #760)
+    # install-prompts.sh는 render_policy_tmpls_in_dir와 언어 프로파일 프롬프트를
+    # 제공한다. 프로젝트-단독 설치(타입 2)에서는 install_global이 호출되지 않으므로
+    # 이 시점에 lib 소싱과 언어 프로파일 해소가 모두 필요하다. 둘 다 멱등:
+    #   - lib는 INSTALL_PROMPTS_SH_LOADED 가드로 재소싱이 no-op
+    #   - 언어 변수가 이미 설정된 경우(타입 3에서 install_global이 프롬프트함)
+    #     재프롬프트하지 않도록 미설정일 때만 prompt_language_profile 호출
+    # shellcheck disable=SC1091
+    source "$INSTALL_DIR/scripts/lib/install-prompts.sh"
+    if [ -z "${AGENT_LANGUAGE:-}" ] || [ -z "${CONTENT_LANGUAGE:-}" ]; then
+        prompt_language_profile
+    fi
+
     # 파일 복사
     cp "$INSTALL_DIR/project/CLAUDE.md" "$PROJECT_DIR/"
 
     # .claude 디렉토리 설치
     mkdir -p "$PROJECT_DIR/.claude"
-    [ -d "$INSTALL_DIR/project/.claude/rules" ] && cp -r "$INSTALL_DIR/project/.claude/rules" "$PROJECT_DIR/.claude/"
+    if [ -d "$INSTALL_DIR/project/.claude/rules" ]; then
+        cp -r "$INSTALL_DIR/project/.claude/rules" "$PROJECT_DIR/.claude/"
+        # issue #760: 복사된 rules/ 안의 .md.tmpl을 정책 phrase로 치환
+        # (install.sh와 동일한 single-source 렌더 함수)
+        render_policy_tmpls_in_dir "$PROJECT_DIR/.claude/rules"
+    fi
     [ -d "$INSTALL_DIR/project/.claude/skills" ] && cp -r "$INSTALL_DIR/project/.claude/skills" "$PROJECT_DIR/.claude/"
     [ -d "$INSTALL_DIR/project/.claude/commands" ] && cp -r "$INSTALL_DIR/project/.claude/commands" "$PROJECT_DIR/.claude/"
     [ -d "$INSTALL_DIR/project/.claude/agents" ] && cp -r "$INSTALL_DIR/project/.claude/agents" "$PROJECT_DIR/.claude/"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -82,40 +82,14 @@ function New-LocalClaude {
     }
 }
 
-# Note: Get-PolicyPhrase is provided by scripts/lib/InstallPrompts.psm1
-# which is imported in the language-prompt section below. The local
-# definition was removed to keep the bash, PowerShell, and drift-test
-# tables in lockstep.
-
-function Invoke-PolicyTemplate {
-    # Renders a .md.tmpl file by replacing {{CONTENT_LANGUAGE_POLICY}},
-    # {{AGENT_LANGUAGE_POLICY}}, and {{AGENT_LANGUAGE}} with their resolved values
-    # and writes the result to $Destination as UTF-8.
-    param(
-        [Parameter(Mandatory)][string]$Source,
-        [Parameter(Mandatory)][string]$Destination
-    )
-    $phrase = Get-PolicyPhrase -Policy $script:contentLanguage
-
-    $content = [System.IO.File]::ReadAllText($Source)
-    $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
-    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $script:agentDisplayLang
-    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE\}\}', $script:agentLanguage
-    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::WriteAllText($Destination, $rendered, $utf8NoBom)
-}
-
-function Invoke-PolicyTemplatesInDir {
-    # Walks a directory, renders every *.md.tmpl to its *.md sibling,
-    # then deletes the .tmpl source. Used after bulk copy of rules/.
-    param([Parameter(Mandatory)][string]$Path)
-    if (-not (Test-Path -LiteralPath $Path)) { return }
-    Get-ChildItem -Path $Path -Filter '*.md.tmpl' -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
-        $dest = $_.FullName.Substring(0, $_.FullName.Length - '.tmpl'.Length)
-        Invoke-PolicyTemplate -Source $_.FullName -Destination $dest
-        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
-    }
-}
+# Note: Get-PolicyPhrase, Invoke-PolicyTemplate, and Invoke-PolicyTemplatesInDir
+# are provided by scripts/lib/InstallPrompts.psm1, imported in the language-prompt
+# section below. The render helpers were moved into the module (issue #760) so
+# the bootstrap install path can render the copied rules too; both install.ps1
+# and bootstrap.ps1 now call the same single source. Because PowerShell modules
+# have their own $script: scope, callers pass the three language values
+# explicitly (-ContentLanguage/-AgentDisplay/-AgentLanguage). The bash,
+# PowerShell, and drift-test tables stay in lockstep.
 
 function Get-EnterpriseDir {
     if ($IsWindows -or ($env:OS -eq 'Windows_NT')) {
@@ -401,7 +375,8 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         if (Test-Path $srcTmpl) {
             # Render to a temporary file using the existing policy substitution
             $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "policy_$([guid]::NewGuid()).md"
-            Invoke-PolicyTemplate -Source $srcTmpl -Destination $tmpFile
+            Invoke-PolicyTemplate -Source $srcTmpl -Destination $tmpFile `
+                -ContentLanguage $script:contentLanguage -AgentDisplay $script:agentDisplayLang -AgentLanguage $script:agentLanguage
             if (Invoke-GuardedCopy -Src $tmpFile -Dest (Join-Path $claudeDir $gf) -Key $gf) {
                 Write-Success "$gf installed (policy phrase: $(Get-PolicyPhrase -Policy $script:contentLanguage))"
             } else {
@@ -729,7 +704,8 @@ if ($installType -eq '2' -or $installType -eq '3' -or $installType -eq '5') {
     if (Test-Path $sourceRules) {
         Copy-Item -Path $sourceRules -Destination $projectClaudeDir -Recurse -Force
         # Issue #411: render any .md.tmpl found under rules/ with the chosen policy phrase.
-        Invoke-PolicyTemplatesInDir -Path (Join-Path $projectClaudeDir 'rules')
+        Invoke-PolicyTemplatesInDir -Path (Join-Path $projectClaudeDir 'rules') `
+            -ContentLanguage $script:contentLanguage -AgentDisplay $script:agentDisplayLang -AgentLanguage $script:agentLanguage
         Write-Success "Rules directory installed! (policy phrase: $(Get-PolicyPhrase -Policy $script:contentLanguage))"
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -242,36 +242,12 @@ create_local_claude() {
     fi
 }
 
-# Note: get_policy_phrase is provided by scripts/lib/install-prompts.sh,
-# which is sourced before any callers (the prompt section sources it
-# explicitly; render_policy_tmpl below depends on it). Kept centralized
-# in the lib so the bash, PowerShell, and drift-test definitions stay
-# in lockstep.
-
-# 함수: .tmpl 파일을 읽어 {{CONTENT_LANGUAGE_POLICY}}를 phrase로 치환한 뒤 대상에 기록
-# 사용법: render_policy_tmpl <src.tmpl> <dest.md>
-render_policy_tmpl() {
-    local src="$1"
-    local dest="$2"
-    local phrase
-    phrase="$(get_policy_phrase)"
-    # sed 구분자를 |로 사용해 경로/phrase 충돌 회피
-    sed -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
-        -e "s|{{AGENT_LANGUAGE_POLICY}}|${AGENT_DISPLAY_LANG:-Korean}|g" \
-        -e "s|{{AGENT_LANGUAGE}}|${AGENT_LANGUAGE:-korean}|g" "$src" > "$dest"
-}
-
-# 함수: 지정 디렉토리 내의 .md.tmpl 파일을 모두 찾아 .md로 렌더링 (원본 .tmpl 삭제)
-# 사용법: render_policy_tmpls_in_dir <dir>
-render_policy_tmpls_in_dir() {
-    local dir="$1"
-    local tmpl md
-    while IFS= read -r tmpl; do
-        md="${tmpl%.tmpl}"
-        render_policy_tmpl "$tmpl" "$md"
-        rm -f "$tmpl"
-    done < <(find "$dir" -type f -name '*.md.tmpl' 2>/dev/null)
-}
+# Note: get_policy_phrase, render_policy_tmpl, and render_policy_tmpls_in_dir
+# are provided by scripts/lib/install-prompts.sh, which is sourced before any
+# callers (the prompt section sources it explicitly). The render helpers were
+# moved into the lib (issue #760) so the bootstrap install path can render the
+# copied rules too; both install.sh and bootstrap.sh now call the same single
+# source. The bash, PowerShell, and drift-test definitions stay in lockstep.
 
 # 함수: Enterprise 경로 감지
 get_enterprise_dir() {

--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -95,6 +95,58 @@ function Get-PolicyPhrase {
     }
 }
 
+function Invoke-PolicyTemplate {
+    # Renders a .md.tmpl file by replacing {{CONTENT_LANGUAGE_POLICY}},
+    # {{AGENT_LANGUAGE_POLICY}}, and {{AGENT_LANGUAGE}} with their resolved
+    # values and writes the result to $Destination as UTF-8 (no BOM).
+    #
+    # The three language values are passed explicitly: PowerShell modules
+    # have their own $script: scope, so the importer's $script:contentLanguage
+    # etc. are not visible here (mirrors Get-PolicyPhrase's -Policy contract).
+    # Unset values fall back to safe defaults (issue #760), matching the bash
+    # render_policy_tmpl ambient-default behavior.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination,
+        [string]$ContentLanguage = 'english',
+        [string]$AgentDisplay = 'Korean',
+        [string]$AgentLanguage = 'korean'
+    )
+    if (-not $AgentDisplay)  { $AgentDisplay = 'Korean' }
+    if (-not $AgentLanguage) { $AgentLanguage = 'korean' }
+    $phrase = Get-PolicyPhrase -Policy $ContentLanguage
+
+    $content = [System.IO.File]::ReadAllText($Source)
+    $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
+    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $AgentDisplay
+    $rendered = $rendered -replace '\{\{AGENT_LANGUAGE\}\}', $AgentLanguage
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($Destination, $rendered, $utf8NoBom)
+}
+
+function Invoke-PolicyTemplatesInDir {
+    # Walks a directory, renders every *.md.tmpl to its *.md sibling,
+    # then deletes the .tmpl source. Used after bulk copy of rules/.
+    # Forwards the three language values to Invoke-PolicyTemplate so both
+    # install.ps1 and bootstrap.ps1 render through this single source
+    # (issue #760).
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [string]$ContentLanguage = 'english',
+        [string]$AgentDisplay = 'Korean',
+        [string]$AgentLanguage = 'korean'
+    )
+    if (-not (Test-Path -LiteralPath $Path)) { return }
+    Get-ChildItem -Path $Path -Filter '*.md.tmpl' -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $dest = $_.FullName.Substring(0, $_.FullName.Length - '.tmpl'.Length)
+        Invoke-PolicyTemplate -Source $_.FullName -Destination $dest `
+            -ContentLanguage $ContentLanguage -AgentDisplay $AgentDisplay -AgentLanguage $AgentLanguage
+        Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-AllPolicyValues {
     # Emits the four canonical CLAUDE_CONTENT_LANGUAGE values.
     # Used by the drift test to iterate without hard-coding the list.
@@ -155,4 +207,4 @@ function Show-LegacySettingsWarning {
     return $true
 }
 
-Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning
+Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Invoke-PolicyTemplate, Invoke-PolicyTemplatesInDir, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -123,6 +123,34 @@ get_policy_phrase() {
     esac
 }
 
+# 함수: .tmpl 파일을 읽어 {{CONTENT_LANGUAGE_POLICY}}를 phrase로 치환한 뒤 대상에 기록
+# 사용법: render_policy_tmpl <src.tmpl> <dest.md>
+# get_policy_phrase에 의존하며 ambient CONTENT_LANGUAGE/AGENT_DISPLAY_LANG/
+# AGENT_LANGUAGE를 읽는다(미설정 시 안전 기본값). install.sh와 bootstrap.sh
+# 양쪽이 동일하게 호출하도록 단일 출처(이 lib)에 둔다 (issue #760).
+render_policy_tmpl() {
+    local src="$1"
+    local dest="$2"
+    local phrase
+    phrase="$(get_policy_phrase)"
+    # sed 구분자를 |로 사용해 경로/phrase 충돌 회피
+    sed -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
+        -e "s|{{AGENT_LANGUAGE_POLICY}}|${AGENT_DISPLAY_LANG:-Korean}|g" \
+        -e "s|{{AGENT_LANGUAGE}}|${AGENT_LANGUAGE:-korean}|g" "$src" > "$dest"
+}
+
+# 함수: 지정 디렉토리 내의 .md.tmpl 파일을 모두 찾아 .md로 렌더링 (원본 .tmpl 삭제)
+# 사용법: render_policy_tmpls_in_dir <dir>
+render_policy_tmpls_in_dir() {
+    local dir="$1"
+    local tmpl md
+    while IFS= read -r tmpl; do
+        md="${tmpl%.tmpl}"
+        render_policy_tmpl "$tmpl" "$md"
+        rm -f "$tmpl"
+    done < <(find "$dir" -type f -name '*.md.tmpl' 2>/dev/null)
+}
+
 # all_policy_values
 # Emits the four canonical CLAUDE_CONTENT_LANGUAGE values, one per line.
 # Used by the drift test to iterate without hard-coding the list.


### PR DESCRIPTION
Closes #760. Part of #758.

## Summary
Make the policy-template render step single-source so the **bootstrap** install path renders `*.md.tmpl` too. Previously `install.{sh,ps1}` rendered templates but `bootstrap.{sh,ps1}` copied `project/.claude/rules` verbatim, leaking literal `{{TOKEN}}` (e.g. `{{AGENT_LANGUAGE}}`) into user projects.

## Changes
- **Bash**: move `render_policy_tmpl` + `render_policy_tmpls_in_dir` verbatim from `install.sh` into `scripts/lib/install-prompts.sh` (next to `get_policy_phrase`). `install.sh` call sites are unchanged (it already sources the lib). `bootstrap.sh` `install_project` now calls `render_policy_tmpls_in_dir` after copying the rules.
- **PowerShell**: move `Invoke-PolicyTemplate` + `Invoke-PolicyTemplatesInDir` into `scripts/lib/InstallPrompts.psm1` and export them. Because a module has its own `$script:` scope, the functions now take explicit `-ContentLanguage`/`-AgentDisplay`/`-AgentLanguage` params (same contract `Get-PolicyPhrase -Policy` already uses); `install.ps1` call sites forward the three values. `bootstrap.ps1` `Install-ProjectSettings` calls `Invoke-PolicyTemplatesInDir` after the copy.
- **Safety belt**: the project-only install path (type 2) never runs global-install, so it now sources the lib / imports the module and resolves the language profile **only when** the vars are unset (no double prompt on type 3). Render fns default unset vars, so no crash / no wrong-preset output.
- `communication.md` content is unchanged (it remains the canonical baseline).

## Verification
- Temp-render of `project/.claude/rules` (bash preset korean/Korean/english; PS preset exclusive_bilingual): **0 leftover `.tmpl`**, `grep -rE '\{\{[A-Z_]+\}\}'` -> **empty**.
- `install.sh`/`install.ps1` diffs are only the function move with call sites intact.
- `bash -n` clean; existing drift tests pass: `test-language-policy-drift.sh` 15/0, `test-installer-prompt-drift.sh` 9/0.

## Note
The leftover-token guard and 3-preset test that lock this in are in sibling issue #761 (depends on this PR's moved renderer).

### Out of scope
Not deleting `communication.md` (canonical baseline + drift-test pin).
