### PR TITLE
fix(install): restore independent non-interactive language override contract

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -24,6 +24,7 @@ on:
       - 'tests/scripts/test-install-permissions-policy.sh'
       - 'tests/scripts/test-language-policy-drift.sh'
       - 'tests/scripts/test-installer-prompt-drift.sh'
+      - 'tests/scripts/test-language-override-contract.sh'
       - 'scripts/lib/**'
       - 'global/settings.json'
       - 'global/settings.windows.json'
@@ -117,6 +118,13 @@ jobs:
         # scripts/lib/InstallPrompts.psm1 (PowerShell) - the single source
         # of truth for installer prompts and the policy phrase table.
         run: bash tests/scripts/test-installer-prompt-drift.sh
+
+      - name: Run language override contract test
+        # Locks the independent non-interactive env-override contract
+        # (issue #762): presetting only AGENT_LANGUAGE or only
+        # CONTENT_LANGUAGE must be honored, not clobbered to the Hybrid
+        # default. Guards against the AND-gate regression from #757.
+        run: bash tests/scripts/test-language-override-contract.sh
 
       - name: Run installer robustness test
         # Guards the per-platform settings-source parity (PowerShell

--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -30,49 +30,71 @@ function Script:Write-PromptWarn {
 }
 
 function Show-LanguageProfilePrompt {
+    # Non-interactive override mirrors the bash prompt_language_profile contract
+    # (issue #762): AGENT_LANGUAGE / CONTENT_LANGUAGE are honored INDEPENDENTLY.
+    # The -AgentLanguage / -ContentLanguage params default to the ambient env
+    # vars (bash reads $AGENT_LANGUAGE / $CONTENT_LANGUAGE; the PowerShell twin
+    # reads $env:AGENT_LANGUAGE / $env:CONTENT_LANGUAGE). The interactive block
+    # runs only when BOTH are unset; presets are then re-applied over whatever
+    # the prompt set, and the still-unset half falls back to the Hybrid default
+    # (AGENT=korean / CONTENT=english) rather than being clobbered.
     [CmdletBinding()]
-    param()
+    param(
+        [string]$AgentLanguage = $env:AGENT_LANGUAGE,
+        [string]$ContentLanguage = $env:CONTENT_LANGUAGE
+    )
 
-    Write-Host ""
-    Script:Write-PromptInfo "Select Language Profile Preset:"
-    Write-Host "  1) English Unified (Dialogue & Documents both in English)"
-    Write-Host "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
-    Write-Host "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
-    Write-Host ""
+    # Capture which values the caller preset before the prompt may overwrite.
+    $agentPreset = if ([string]::IsNullOrEmpty($AgentLanguage)) { $null } else { $AgentLanguage }
+    $contentPreset = if ([string]::IsNullOrEmpty($ContentLanguage)) { $null } else { $ContentLanguage }
 
-    $sel = Read-Host "Selection (1-3) [default: 3]"
-    if ([string]::IsNullOrEmpty($sel)) { $sel = '3' }
+    $resolvedAgent = $null
+    $resolvedContent = $null
 
-    switch ($sel) {
-        '1' {
-            return [pscustomobject]@{
-                AgentLanguage = 'english'
-                AgentDisplay = 'English'
-                ContentLanguage = 'english'
+    # Run the interactive block only when BOTH are unset.
+    if ($null -eq $agentPreset -and $null -eq $contentPreset) {
+        Write-Host ""
+        Script:Write-PromptInfo "Select Language Profile Preset:"
+        Write-Host "  1) English Unified (Dialogue & Documents both in English)"
+        Write-Host "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
+        Write-Host "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
+        Write-Host ""
+
+        $sel = Read-Host "Selection (1-3) [default: 3]"
+        if ([string]::IsNullOrEmpty($sel)) { $sel = '3' }
+
+        switch ($sel) {
+            '1' { $resolvedAgent = 'english'; $resolvedContent = 'english' }
+            '2' { $resolvedAgent = 'korean';  $resolvedContent = 'exclusive_bilingual' }
+            '3' { $resolvedAgent = 'korean';  $resolvedContent = 'english' }
+            default {
+                Script:Write-PromptWarn "Unknown selection: $sel. Falling back to Hybrid Mode."
+                $resolvedAgent = 'korean'; $resolvedContent = 'english'
             }
         }
-        '2' {
-            return [pscustomobject]@{
-                AgentLanguage = 'korean'
-                AgentDisplay = 'Korean'
-                ContentLanguage = 'exclusive_bilingual'
-            }
-        }
-        '3' {
-            return [pscustomobject]@{
-                AgentLanguage = 'korean'
-                AgentDisplay = 'Korean'
-                ContentLanguage = 'english'
-            }
-        }
-        default {
-            Script:Write-PromptWarn "Unknown selection: $sel. Falling back to Hybrid Mode."
-            return [pscustomobject]@{
-                AgentLanguage = 'korean'
-                AgentDisplay = 'Korean'
-                ContentLanguage = 'english'
-            }
-        }
+    }
+
+    # Re-apply presets over whatever the prompt set, then fill the still-unset
+    # half from the Hybrid default. Each var is honored independently.
+    if ($null -ne $agentPreset)   { $resolvedAgent = $agentPreset }
+    if ($null -ne $contentPreset) { $resolvedContent = $contentPreset }
+    if ([string]::IsNullOrEmpty($resolvedAgent))   { $resolvedAgent = 'korean' }
+    if ([string]::IsNullOrEmpty($resolvedContent)) { $resolvedContent = 'english' }
+
+    # Derive Display from the final AGENT_LANGUAGE. An if/elseif (not a switch
+    # with quoted-literal arms) is used deliberately so this block does not
+    # collide with the installer-prompt-drift test's static phrase extractor,
+    # which scans for `'<policy>' { return '<phrase>' }` lines in this module.
+    if ($resolvedAgent -eq 'english') {
+        $agentDisplay = 'English'
+    } else {
+        $agentDisplay = 'Korean'
+    }
+
+    return [pscustomobject]@{
+        AgentLanguage = $resolvedAgent
+        AgentDisplay = $agentDisplay
+        ContentLanguage = $resolvedContent
     }
 }
 

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -60,49 +60,51 @@ _prompts_warn() {
 #   AGENT_DISPLAY_LANG  English | Korean
 #   CONTENT_LANGUAGE    english | exclusive_bilingual
 #
-# Non-interactive override: set AGENT_LANGUAGE and CONTENT_LANGUAGE before calling
-# to skip the prompt entirely.
+# Non-interactive override: set AGENT_LANGUAGE and/or CONTENT_LANGUAGE before
+# calling to skip or partially skip the prompt. Each var is honored
+# INDEPENDENTLY (issue #762): presetting only one still suppresses the prompt
+# only when both are set; the still-unset half falls back to the Hybrid default
+# (AGENT_LANGUAGE=korean / CONTENT_LANGUAGE=english) rather than being clobbered.
 prompt_language_profile() {
-    # If both are already set (e.g. non-interactive), derive Display and return
-    if [ -n "${AGENT_LANGUAGE:-}" ] && [ -n "${CONTENT_LANGUAGE:-}" ]; then
-        case "$AGENT_LANGUAGE" in
-            english) AGENT_DISPLAY_LANG="English" ;;
-            korean)  AGENT_DISPLAY_LANG="Korean"  ;;
-            *)       AGENT_DISPLAY_LANG="Korean"  ;;
-        esac
-        return 0
-    fi
-    echo ""
-    _prompts_info "Select Language Profile Preset:"
-    echo "  1) English Unified (Dialogue & Documents both in English)"
-    echo "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
-    echo "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
-    echo ""
-    read -r -p "Selection (1-3) [default: 3]: " _profile_type
-    _profile_type=${_profile_type:-3}
+    # Capture which vars the caller preset BEFORE the prompt may overwrite them.
+    local _agent_preset="" _content_preset=""
+    [ -n "${AGENT_LANGUAGE:-}" ]   && _agent_preset="$AGENT_LANGUAGE"
+    [ -n "${CONTENT_LANGUAGE:-}" ] && _content_preset="$CONTENT_LANGUAGE"
 
-    case "$_profile_type" in
-        1)
-            AGENT_LANGUAGE="english"
-            AGENT_DISPLAY_LANG="English"
-            CONTENT_LANGUAGE="english"
-            ;;
-        2)
-            AGENT_LANGUAGE="korean"
-            AGENT_DISPLAY_LANG="Korean"
-            CONTENT_LANGUAGE="exclusive_bilingual"
-            ;;
-        3)
-            AGENT_LANGUAGE="korean"
-            AGENT_DISPLAY_LANG="Korean"
-            CONTENT_LANGUAGE="english"
-            ;;
-        *)
-            _prompts_warn "Unknown selection: $_profile_type. Falling back to Hybrid Mode."
-            AGENT_LANGUAGE="korean"
-            AGENT_DISPLAY_LANG="Korean"
-            CONTENT_LANGUAGE="english"
-            ;;
+    # Run the interactive block only when BOTH are unset.
+    if [ -z "$_agent_preset" ] && [ -z "$_content_preset" ]; then
+        echo ""
+        _prompts_info "Select Language Profile Preset:"
+        echo "  1) English Unified (Dialogue & Documents both in English)"
+        echo "  2) Korean Unified  (Dialogue & Documents both in Korean - exclusive)"
+        echo "  3) Hybrid Mode     (Dialogue in Korean, Documents in English - default)"
+        echo ""
+        read -r -p "Selection (1-3) [default: 3]: " _profile_type
+        _profile_type=${_profile_type:-3}
+
+        case "$_profile_type" in
+            1) AGENT_LANGUAGE="english"; CONTENT_LANGUAGE="english" ;;
+            2) AGENT_LANGUAGE="korean";  CONTENT_LANGUAGE="exclusive_bilingual" ;;
+            3) AGENT_LANGUAGE="korean";  CONTENT_LANGUAGE="english" ;;
+            *)
+                _prompts_warn "Unknown selection: $_profile_type. Falling back to Hybrid Mode."
+                AGENT_LANGUAGE="korean"; CONTENT_LANGUAGE="english"
+                ;;
+        esac
+    fi
+
+    # Re-apply presets over whatever the prompt set, then fill the still-unset
+    # half from the Hybrid default. Each var is honored independently.
+    [ -n "$_agent_preset" ]   && AGENT_LANGUAGE="$_agent_preset"
+    [ -n "$_content_preset" ] && CONTENT_LANGUAGE="$_content_preset"
+    AGENT_LANGUAGE="${AGENT_LANGUAGE:-korean}"
+    CONTENT_LANGUAGE="${CONTENT_LANGUAGE:-english}"
+
+    # Derive Display from the final AGENT_LANGUAGE via the single existing case.
+    case "$AGENT_LANGUAGE" in
+        english) AGENT_DISPLAY_LANG="English" ;;
+        korean)  AGENT_DISPLAY_LANG="Korean"  ;;
+        *)       AGENT_DISPLAY_LANG="Korean"  ;;
     esac
 }
 

--- a/tests/scripts/test-language-override-contract.sh
+++ b/tests/scripts/test-language-override-contract.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# test-language-override-contract.sh
+# Contract regression for issue #762.
+#
+# prompt_language_profile() documents that the non-interactive env overrides
+# AGENT_LANGUAGE and CONTENT_LANGUAGE are honored INDEPENDENTLY. The prompt
+# unification (#757) silently broke this: it skipped the interactive prompt
+# only when BOTH were set (AND-gate), so presetting just one was clobbered to
+# the Hybrid default. This test locks the restored independent-override
+# contract across the full 2x2 matrix of (AGENT set?, CONTENT set?).
+#
+# Each case runs in a clean subshell via `env -u AGENT_LANGUAGE -u
+# CONTENT_LANGUAGE bash -c ...` so no ambient value leaks in. The real lib is
+# sourced inside that subshell, the env under test is exported, and the
+# resolved (AGENT_LANGUAGE, CONTENT_LANGUAGE, AGENT_DISPLAY_LANG) triple is
+# emitted as a single comma-joined line for comparison.
+#
+# Run: bash tests/scripts/test-language-override-contract.sh
+# Exit: 0 on all-pass, 1 otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BASH_LIB="$REPO_ROOT/scripts/lib/install-prompts.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $name"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+    fi
+}
+
+# emit_triple <stdin-feed> <env-assignments...>
+# Runs prompt_language_profile in a pristine subshell (AGENT_LANGUAGE and
+# CONTENT_LANGUAGE unset by env -u), applies the requested presets, feeds the
+# given string on stdin (for the interactive case), and echoes the resolved
+# triple "AGENT,CONTENT,DISPLAY".
+emit_triple() {
+    local feed="$1"
+    shift
+    # %b so "\n" in the feed is rendered as a real newline for `read`.
+    printf '%b' "$feed" | env -u AGENT_LANGUAGE -u CONTENT_LANGUAGE "$@" \
+        bash -c '
+            source "$0" >/dev/null 2>&1
+            prompt_language_profile >/dev/null 2>&1
+            printf "%s,%s,%s" "$AGENT_LANGUAGE" "$CONTENT_LANGUAGE" "$AGENT_DISPLAY_LANG"
+        ' "$BASH_LIB"
+}
+
+echo "=== Language override contract test (#762) ==="
+echo ""
+
+echo "[1] only AGENT_LANGUAGE set -> honored; CONTENT defaults to english (the #757 bug)"
+actual="$(emit_triple "" AGENT_LANGUAGE=english)"
+check "AGENT=english, CONTENT unset" "english,english,English" "$actual"
+
+actual="$(emit_triple "" AGENT_LANGUAGE=korean)"
+check "AGENT=korean, CONTENT unset" "korean,english,Korean" "$actual"
+
+echo ""
+echo "[2] only CONTENT_LANGUAGE set -> honored; AGENT defaults to korean"
+actual="$(emit_triple "" CONTENT_LANGUAGE=exclusive_bilingual)"
+check "CONTENT=exclusive_bilingual, AGENT unset" "korean,exclusive_bilingual,Korean" "$actual"
+
+actual="$(emit_triple "" CONTENT_LANGUAGE=english)"
+check "CONTENT=english, AGENT unset" "korean,english,Korean" "$actual"
+
+echo ""
+echo "[3] both set -> both honored (no prompt)"
+actual="$(emit_triple "" AGENT_LANGUAGE=english CONTENT_LANGUAGE=exclusive_bilingual)"
+check "AGENT=english, CONTENT=exclusive_bilingual" "english,exclusive_bilingual,English" "$actual"
+
+echo ""
+echo "[4] neither set -> interactive prompt (selection fed on stdin)"
+# Selection 1 = English Unified.
+actual="$(emit_triple "1\n")"
+check "neither set, selection 1" "english,english,English" "$actual"
+
+# Selection 2 = Korean Unified (exclusive).
+actual="$(emit_triple "2\n")"
+check "neither set, selection 2" "korean,exclusive_bilingual,Korean" "$actual"
+
+# Empty selection = default 3 = Hybrid.
+actual="$(emit_triple "\n")"
+check "neither set, default (Hybrid)" "korean,english,Korean" "$actual"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #762. Part of #758.

## Summary
Restore the independent non-interactive env-override contract that #757's prompt unification broke. `prompt_language_profile` skipped the prompt only when BOTH `AGENT_LANGUAGE` and `CONTENT_LANGUAGE` were set, silently clobbering a single-var override to the Hybrid default.

## Changes
- `scripts/lib/install-prompts.sh` `prompt_language_profile`: capture `_agent_preset`/`_content_preset` before the prompt; interactive only when BOTH unset; re-apply presets then fill the unset half from the Hybrid default (`korean`/`english`); derive `AGENT_DISPLAY_LANG` once. Inline (~12 lines), no helper.
- `scripts/lib/InstallPrompts.psm1` `Show-LanguageProfilePrompt`: mirror via optional `-AgentLanguage`/`-ContentLanguage` params defaulting to env; same partial-override logic; unchanged return shape, so zero-arg call sites in `install.ps1`/`bootstrap.ps1` are unaffected.
- New `tests/scripts/test-language-override-contract.sh`: 2x2 matrix via `env -u ... bash -c` asserting the `(AGENT_LANGUAGE, CONTENT_LANGUAGE, AGENT_DISPLAY_LANG)` triple, including the only-`AGENT_LANGUAGE` and only-`CONTENT_LANGUAGE` cases.
- Wire the test into `.github/workflows/validate-hooks.yml` (run step + `paths:`).

## Behaviors locked
- only `AGENT_LANGUAGE` -> honored, `CONTENT_LANGUAGE` defaults english (this was the bug)
- only `CONTENT_LANGUAGE` -> honored
- both / neither -> unchanged

## Verification
- `test-language-override-contract.sh`: **8 passed, 0 failed** (incl. the only-`AGENT_LANGUAGE` bug case).
- `test-installer-prompt-drift.sh`: **9 passed, 0 failed**.
- `bash -n` + shellcheck `--severity=error` clean; PowerShell module parses clean.

## Note
The PowerShell display derivation uses `if/elseif` (not a `switch` with quoted-literal arms) to avoid colliding with the installer-prompt-drift static phrase extractor.
