### PR TITLE
fix(install): strip tmpl-contract comments during render so they do not leak into installed .md

### DIFF
--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -143,6 +143,12 @@ function Invoke-PolicyTemplate {
     $rendered = $content -replace '\{\{CONTENT_LANGUAGE_POLICY\}\}', $phrase
     $rendered = $rendered -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $AgentDisplay
     $rendered = $rendered -replace '\{\{AGENT_LANGUAGE\}\}', $AgentLanguage
+    # Strip the developer-only tmpl-contract comment line so it never leaks
+    # into the rendered .md, with parity to bash render_policy_tmpl's
+    # `sed -e '/tmpl-contract/d'` (issue #771). The comment stays in the .tmpl.
+    # `-notmatch` drops every line containing the marker; -join keeps LF endings
+    # to match the bash renderer's line-oriented output.
+    $rendered = (($rendered -split "`n") | Where-Object { $_ -notmatch 'tmpl-contract' }) -join "`n"
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($Destination, $rendered, $utf8NoBom)
 }

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -135,8 +135,11 @@ render_policy_tmpl() {
     local dest="$2"
     local phrase
     phrase="$(get_policy_phrase)"
-    # sed 구분자를 |로 사용해 경로/phrase 충돌 회피
-    sed -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
+    # sed 구분자를 |로 사용해 경로/phrase 충돌 회피.
+    # tmpl-contract 주석 줄은 개발자 전용 가이드이므로 .tmpl에는 남기되
+    # 렌더된 .md로는 새어 나가지 않도록 삭제한다 (issue #771).
+    sed -e "/tmpl-contract/d" \
+        -e "s|{{CONTENT_LANGUAGE_POLICY}}|${phrase}|g" \
         -e "s|{{AGENT_LANGUAGE_POLICY}}|${AGENT_DISPLAY_LANG:-Korean}|g" \
         -e "s|{{AGENT_LANGUAGE}}|${AGENT_LANGUAGE:-korean}|g" "$src" > "$dest"
 }

--- a/tests/scripts/test-language-policy-drift.sh
+++ b/tests/scripts/test-language-policy-drift.sh
@@ -20,8 +20,14 @@
 #      the english-preset render must equal that canonical .md. Editing the
 #      .md without the .tmpl (or vice versa) would let the installer overwrite
 #      the doc with a stale phrase on a non-english policy; this catches it.
-#      The template-only canonical-contract comment line is stripped before
-#      comparison (it ships in the .tmpl, never in the rendered .md).
+#      The renderer now strips the template-only tmpl-contract comment line
+#      during render (issue #771), so the rendered output already equals the
+#      committed .md with no test-side workaround — only CRLF is normalized.
+#
+#   2b. No-marker gate — for every template and preset, the rendered output
+#      must contain ZERO tmpl-contract markers. This is the regression guard
+#      for #771: the renderer, not the test, is responsible for stripping the
+#      developer-only comment so it never leaks into the installed .md.
 #
 #   3. Directory render — copy project/.claude/rules to a tempdir, run
 #      render_policy_tmpls_in_dir over it, and assert no {{...}} residue and
@@ -48,10 +54,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/install-prompts.sh"
 
-# Marker prefix for the template-only canonical-contract comment. Stripped
-# before the canonical .md == rendered .tmpl comparison so the comment can
-# live in the .tmpl without being mirrored into the committed .md.
-CONTRACT_MARKER='tmpl-contract:'
+# Marker substring for the template-only canonical-contract comment. The
+# renderer strips any line containing it (issue #771); the test asserts the
+# rendered output carries none, rather than stripping it before comparison.
+CONTRACT_MARKER='tmpl-contract'
 
 # All shipped templates. The .md column is the committed canonical twin, or
 # "-" for bootstrap-only templates that render straight into ~/.claude with no
@@ -77,10 +83,11 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
-# strip_contract <file>  — emit file with the contract-comment line removed
-# and CR stripped (repo carries mixed CRLF/LF on Windows clones).
-strip_contract() {
-    grep -v "$CONTRACT_MARKER" "$1" | tr -d '\r'
+# normalize_lf <file>  — emit file with CR stripped (the repo carries mixed
+# CRLF/LF on Windows clones). The contract comment is no longer stripped here:
+# the renderer removes it, so the rendered output must already match the .md.
+normalize_lf() {
+    tr -d '\r' < "$1"
 }
 
 echo "=== Content-language policy drift test (#411, #761) ==="
@@ -154,21 +161,31 @@ for entry in "${TEMPLATES[@]}"; do
             pass "${pname}: no leftover {{...}} placeholders"
         fi
 
+        # 2b: no-marker gate (#771) — the tmpl-contract comment must never
+        # leak into the rendered output for any preset.
+        if grep -qF "$CONTRACT_MARKER" "$rendered"; then
+            fail "${pname}: tmpl-contract marker leaked into render"
+        else
+            pass "${pname}: no tmpl-contract marker in render"
+        fi
+
         # 2: canonical drift — english preset must equal the committed .md.
+        # The renderer strips the contract comment, so the rendered output
+        # must match the .md verbatim (only CRLF normalized).
         if [ "$pname" = "english" ] && [ "$md_rel" != "-" ]; then
             md="$REPO_ROOT/$md_rel"
             if [ ! -f "$md" ]; then
                 fail "canonical .md missing: $md_rel"
             elif diff -q \
-                <(strip_contract "$rendered") \
-                <(strip_contract "$md") >/dev/null 2>&1; then
+                <(normalize_lf "$rendered") \
+                <(normalize_lf "$md") >/dev/null 2>&1; then
                 pass "canonical .md matches english render"
             else
                 fail "canonical .md drifted from english render"
-                echo "  --- diff (rendered vs canonical, contract-stripped, LF-normalized) ---"
-                diff <(strip_contract "$rendered") <(strip_contract "$md") \
+                echo "  --- diff (rendered vs canonical, LF-normalized) ---"
+                diff <(normalize_lf "$rendered") <(normalize_lf "$md") \
                     | head -20 | sed 's/^/      /'
-                echo "  ---------------------------------------------------------------------"
+                echo "  ---------------------------------------------------"
             fi
         fi
 
@@ -220,6 +237,14 @@ else
             grep -rnE '\{\{[A-Z_]+\}\}' "$work/rules" | head -10 | sed 's/^/      /'
         else
             pass "no leftover {{...}} placeholders in rendered rules tree"
+        fi
+
+        # No tmpl-contract marker may survive in any rendered .md (#771).
+        if grep -rqF "$CONTRACT_MARKER" "$work/rules"; then
+            fail "tmpl-contract marker survives in rendered rules tree"
+            grep -rnF "$CONTRACT_MARKER" "$work/rules" | head -10 | sed 's/^/      /'
+        else
+            pass "no tmpl-contract marker in rendered rules tree"
         fi
     fi
 


### PR DESCRIPTION
Closes #771.

## Summary
The `tmpl-contract` comments added in #761/#763 leaked into the rendered `.md` because the renderer only substituted `{{...}}` tokens. Strip them at render time (bash + PowerShell), and replace the drift test's strip-before-compare workaround with positive no-leak assertions so this cannot regress.

## Changes
- `render_policy_tmpl` (`scripts/lib/install-prompts.sh`): add `sed -e '/tmpl-contract/d'` so the rendered `.md` drops the comment line. The `.tmpl` keeps the comment (developer-only guidance).
- `Invoke-PolicyTemplate` (`scripts/lib/InstallPrompts.psm1`): filter out `tmpl-contract` lines after substitution (parity with bash).
- `tests/scripts/test-language-policy-drift.sh`: remove the strip-before-compare workaround (the renderer now strips, so rendered output equals the canonical `.md` verbatim, LF-normalized). Add per-preset "no `tmpl-contract` marker" assertions for every template and for the rendered rules tree. CRLF normalization is kept separately (a real Windows robustness concern, not the leak workaround).

## Verification
- Tempdir render, all presets (`english` / `exclusive_bilingual` / `any` / `korean_plus_english`): `grep -rl tmpl-contract` → **NONE**.
- `test-language-policy-drift.sh`: **49 passed, 0 failed**.
- `test-installer-prompt-drift.sh`: **9 passed, 0 failed**.
- `bash -n` + `shellcheck --severity=error` clean; PowerShell `ParseFile` OK; bash/PowerShell render parity confirmed (`render_equals_canonical=True`).

## Origin
Found during a real clean-install verification of the #758 epic (PR #757 follow-up); regression introduced by #761/#763. Only the rendered output is cleaned — the `.tmpl` files retain their developer comments.
