### PR TITLE
fix(install): also strip tmpl-contract in the guarded-template render path

### DIFF
--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -150,6 +150,8 @@ function Invoke-GuardedTemplateCopy {
     $tmpLang = Join-Path ([System.IO.Path]::GetTempPath()) "conversation-language_$([guid]::NewGuid()).md"
     $tmplContent = [System.IO.File]::ReadAllText($SrcTmpl)
     $rendered = $tmplContent -replace '\{\{AGENT_LANGUAGE_POLICY\}\}', $DisplayLang
+    # Strip the developer-only tmpl-contract comment line so it does not leak into the rendered .md (issue #773, parity with #771).
+    $rendered = (($rendered -split "`n") | Where-Object { $_ -notmatch 'tmpl-contract' }) -join "`n"
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($tmpLang, $rendered, $utf8NoBom)
     

--- a/scripts/install-manifest.sh
+++ b/scripts/install-manifest.sh
@@ -157,7 +157,9 @@ guarded_template_copy() {
 
     local tmp_lang
     tmp_lang=$(mktemp)
-    sed "s/{{AGENT_LANGUAGE_POLICY}}/$display_lang/g" "$src_tmpl" > "$tmp_lang"
+    # Strip the developer-only tmpl-contract comment line so it does not leak
+    # into the rendered .md (issue #773, parity with the #771 render_policy_tmpl fix).
+    sed -e "/tmpl-contract/d" -e "s/{{AGENT_LANGUAGE_POLICY}}/$display_lang/g" "$src_tmpl" > "$tmp_lang"
     
     local result
     if guarded_copy "$tmp_lang" "$dest" "$key"; then


### PR DESCRIPTION
Closes #773.

## Summary
Follow-up to #771. `conversation-language.md` still leaked the `tmpl-contract` comment because it renders through the **guarded-template** path (`guarded_template_copy` / `Invoke-GuardedTemplateCopy`), which #771 did not touch — #771 only fixed `render_policy_tmpl` / `Invoke-PolicyTemplate`.

## Changes
- `scripts/install-manifest.sh` `guarded_template_copy`: add `sed -e '/tmpl-contract/d'` before the `{{AGENT_LANGUAGE_POLICY}}` substitution.
- `scripts/install-manifest.ps1` `Invoke-GuardedTemplateCopy`: filter out `tmpl-contract` lines after substitution (parity with bash).

## Verification
- Rendered `conversation-language.md.tmpl`: `grep -c tmpl-contract` → **0**, no leftover `{{ }}`.
- `bash -n` + `shellcheck --severity=error` clean.
- Confirmed against a real clean install: this was the one remaining leak after #771.

## Origin
Found during clean-install re-verification after #771; that fix was incomplete for the 4th template's render path.
