### PR TITLE
feat(hooks): add shell-env-secret-guard to block secret env var exposure

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1084,6 +1084,7 @@ this catalog for the canonical hook inventory.
 | [`prompt-validator.sh`](#prompt-validator) | UserPromptSubmit | yes |
 | [`sensitive-file-guard.sh`](#sensitive-file-guard) | PreToolUse (Edit|Write|Read) | yes |
 | [`session-logger.sh`](#session-logger) | SessionStart, SessionEnd, Stop, TeammateIdle | yes |
+| [`shell-env-secret-guard.sh`](#shell-env-secret-guard) | PreToolUse (Bash) | yes |
 | [`subagent-logger.sh`](#subagent-logger) | SubagentStart, SubagentStop | yes |
 | [`task-completed-logger.sh`](#task-completed-logger) | TaskCompleted | yes |
 | [`task-created-validator.sh`](#task-created-validator) | TaskCreated (sync, blocking) | yes |
@@ -1094,7 +1095,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 36 bash hooks, 36 with PowerShell counterparts._
+_Total: 37 bash hooks, 37 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1559,6 +1560,23 @@ Logs session start/end events
 | Response format | none (lifecycle event, no JSON output needed) |
 | PowerShell counterpart | present (`session-logger.ps1`) |
 | Source | `global/hooks/session-logger.sh` |
+
+### shell-env-secret-guard
+
+_File:_ `shell-env-secret-guard.sh`
+
+_Anchor:_ `#shell-env-secret-guard`
+
+Blocks bash commands that would print or dump secret-bearing environment variables into the transcript.
+
+| Field | Value |
+|---|---|
+| Hook Type | PreToolUse (Bash) |
+| Trigger / Matcher | Bash |
+| Exit codes | 0 (always — decision is in JSON) |
+| Response format | hookSpecificOutput with hookEventName |
+| PowerShell counterpart | present (`shell-env-secret-guard.ps1`) |
+| Source | `global/hooks/shell-env-secret-guard.sh` |
 
 ### subagent-logger
 

--- a/global/hooks/shell-env-secret-guard.ps1
+++ b/global/hooks/shell-env-secret-guard.ps1
@@ -1,0 +1,89 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
+
+# shell-env-secret-guard.ps1
+# Blocks Bash commands that would print or dump secret-bearing environment
+# variables into the transcript.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+#
+# Rationale: Codex scrubs *KEY*/*SECRET*/*TOKEN*/AWS_* env vars from the child
+# process via config.toml [shell_environment_policy].exclude. A Claude hook
+# runs out-of-process and cannot mutate the Bash child's env, so the achievable
+# analog is to DENY commands that leak a named secret var (echo/printf/printenv
+# $SECRET) and WARN on bare env dumps. Deliberately narrow to avoid breaking
+# legitimate tooling (e.g. `gh api`, which uses GH_TOKEN internally, not via
+# $-expansion).
+#
+# Matching is CASE-SENSITIVE (-cmatch) and segment-aware: the secret keyword
+# must be an underscore-delimited segment / suffix of an UPPER_SNAKE var name,
+# so API_KEY / AWS_SECRET_ACCESS_KEY / GITHUB_TOKEN match, while TOKENIZER /
+# KEYBOARD / monkey do not.
+
+$logDir  = if ($env:CLAUDE_LOG_DIR) { $env:CLAUDE_LOG_DIR } else { Join-Path $HOME '.claude/logs' }
+$logFile = Join-Path $logDir 'shell-env-secret-guard.log'
+
+function Write-Decision {
+    param([string]$Decision, [string]$Reason, [string]$Command)
+    try {
+        if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+        $entry = [ordered]@{
+            ts       = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+            decision = $Decision
+            reason   = $Reason
+            command  = $Command
+        }
+        ($entry | ConvertTo-Json -Compress -Depth 3) | Out-File -FilePath $logFile -Append -Encoding utf8
+    } catch { }
+}
+
+$json = Read-HookInput
+if (-not $json) {
+    # Fail-open: dangerous-command-guard in the same chain is fail-closed on
+    # unparseable input, so this one stays quiet to avoid double-denial noise.
+    New-HookAllowResponse
+    exit 0
+}
+
+$CMD = $null
+try { $CMD = [string]$json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+if ([string]::IsNullOrWhiteSpace($CMD)) {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Secret keyword as an underscore-delimited segment/suffix of an UPPER_SNAKE
+# var name. The optional '([A-Z0-9_]*_)?' eats leading segments; the trailing
+# '([^A-Z0-9]|$)' is the right boundary so TOKEN in TOKENIZER does not match.
+$secretSeg = '([A-Z0-9_]*_)?(KEY|KEYS|SECRET|SECRETS|TOKEN|TOKENS|PASSWORD|PASSWD|PASSPHRASE|CREDENTIAL|CREDENTIALS)([^A-Z0-9]|$)'
+
+# DENY 1: echo/printf expanding a secret var ($SECRET or ${SECRET}).
+if ($CMD -cmatch ('(echo|printf)[^|;&]*[$]\{?' + $secretSeg)) {
+    $reason = 'shell-env-secret-guard: refusing to print a secret-bearing env var. Do not echo secret values into the transcript; use the secret directly in the consuming command, or let the user run it.'
+    Write-Decision -Decision 'deny' -Reason $reason -Command $CMD
+    New-HookDenyResponse -Reason $reason
+    exit 0
+}
+
+# DENY 2: printenv NAME where NAME is a secret var (no $ prefix for printenv).
+if ($CMD -cmatch ('printenv\s+\{?' + $secretSeg)) {
+    $reason = 'shell-env-secret-guard: refusing to printenv a secret-bearing env var into the transcript.'
+    Write-Decision -Decision 'deny' -Reason $reason -Command $CMD
+    New-HookDenyResponse -Reason $reason
+    exit 0
+}
+
+# WARN: bare env dump that exposes ALL env vars (secrets included). Allowed
+# (legitimate for debugging) but flagged so the model narrows it.
+if ($CMD -cmatch '(^|[;&|]\s*)(env|printenv|set|export\s+-p|declare\s+-p|compgen\s+-v)\s*($|[;&|])') {
+    $reason = 'shell-env-secret-guard: this dumps the full environment (secrets included) into the transcript. Narrow to the specific non-secret var you need.'
+    Write-Decision -Decision 'allow-warn' -Reason $reason -Command $CMD
+    New-HookAllowResponse -AdditionalContext $reason
+    exit 0
+}
+
+Write-Decision -Decision 'allow' -Reason 'no secret-exposure pattern matched' -Command $CMD
+New-HookAllowResponse
+exit 0

--- a/global/hooks/shell-env-secret-guard.sh
+++ b/global/hooks/shell-env-secret-guard.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# shell-env-secret-guard.sh
+# Blocks bash commands that would print or dump secret-bearing environment
+# variables into the transcript.
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+# Response format: hookSpecificOutput with hookEventName
+#
+# Rationale: Codex scrubs *KEY*/*SECRET*/*TOKEN*/AWS_* env vars from the child
+# process via config.toml [shell_environment_policy].exclude. A Claude hook runs
+# out-of-process and cannot mutate the bash child's env, so the achievable
+# analog is to DENY commands that leak a named secret var (echo/printf/printenv
+# $SECRET) and WARN on bare env dumps. Deliberately narrow to avoid breaking
+# legitimate tooling (e.g. `gh api`, which uses GH_TOKEN internally, not via
+# $-expansion).
+#
+# Matching is CASE-SENSITIVE and segment-aware: the secret keyword must be an
+# underscore-delimited segment/suffix of an UPPER_SNAKE var name, so API_KEY /
+# AWS_SECRET_ACCESS_KEY / GITHUB_TOKEN match while TOKENIZER / KEYBOARD / monkey
+# do not.
+
+set -euo pipefail
+
+LOG_DIR="${CLAUDE_LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/shell-env-secret-guard.log"
+
+log_decision() {
+    local decision="$1" reason="$2" cmd="$3"
+    mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg ts "$ts" --arg d "$decision" --arg r "$reason" --arg c "$cmd" \
+            '{ts:$ts, decision:$d, reason:$r, command:$c}' >>"$LOG_FILE" 2>/dev/null || true
+    else
+        local esc_cmd esc_reason
+        esc_cmd=${cmd//\\/\\\\}; esc_cmd=${esc_cmd//\"/\\\"}
+        esc_reason=${reason//\\/\\\\}; esc_reason=${esc_reason//\"/\\\"}
+        printf '{"ts":"%s","decision":"%s","reason":"%s","command":"%s"}\n' \
+            "$ts" "$decision" "$esc_reason" "$esc_cmd" >>"$LOG_FILE" 2>/dev/null || true
+    fi
+}
+
+deny_response() {
+    local reason="$1"
+    log_decision "deny" "$reason" "${CMD:-}"
+    jq -nc --arg reason "$reason" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+    exit 0
+}
+
+allow_response() {
+    local reason="${1:-shell-env-secret-guard: no secret-exposure pattern matched}"
+    log_decision "allow" "$reason" "${CMD:-}"
+    jq -nc '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
+    exit 0
+}
+
+allow_with_context() {
+    local reason="$1"
+    log_decision "allow-warn" "$reason" "${CMD:-}"
+    jq -nc --arg reason "$reason" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow", additionalContext: $reason}}'
+    exit 0
+}
+
+INPUT=$(cat)
+
+# Fail-open on unparseable/empty input: dangerous-command-guard in the same
+# chain is fail-closed, so this guard stays quiet to avoid double-denial noise.
+if [ -z "$INPUT" ]; then
+    CMD=""
+    allow_response
+fi
+
+JQ_RC=0
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || JQ_RC=$?
+if [ "$JQ_RC" -ne 0 ]; then
+    CMD=""
+    allow_response
+fi
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+if [ -z "$CMD" ]; then
+    allow_response
+fi
+
+# Secret keyword as an underscore-delimited segment/suffix of an UPPER_SNAKE
+# var name. Trailing '([^A-Z0-9]|$)' is the right boundary so TOKEN in
+# TOKENIZER does not match.
+SECRET_SEG='([A-Z0-9_]*_)?(KEY|KEYS|SECRET|SECRETS|TOKEN|TOKENS|PASSWORD|PASSWD|PASSPHRASE|CREDENTIAL|CREDENTIALS)([^A-Z0-9]|$)'
+
+# DENY 1: echo/printf expanding a secret var ($SECRET or ${SECRET}).
+if echo "$CMD" | grep -qE "(echo|printf)[^|;&]*[$][{]?$SECRET_SEG"; then
+    deny_response "shell-env-secret-guard: refusing to print a secret-bearing env var. Do not echo secret values into the transcript; use the secret directly in the consuming command, or let the user run it."
+fi
+
+# DENY 2: printenv NAME where NAME is a secret var (no \$ prefix for printenv).
+if echo "$CMD" | grep -qE "printenv[[:space:]]+[{]?$SECRET_SEG"; then
+    deny_response "shell-env-secret-guard: refusing to printenv a secret-bearing env var into the transcript."
+fi
+
+# WARN: bare env dump that exposes ALL env vars (secrets included).
+if echo "$CMD" | grep -qE '(^|[;&|][[:space:]]*)(env|printenv|set|export[[:space:]]+-p|declare[[:space:]]+-p|compgen[[:space:]]+-v)[[:space:]]*($|[;&|])'; then
+    allow_with_context "shell-env-secret-guard: this dumps the full environment (secrets included) into the transcript. Narrow to the specific non-secret var you need."
+fi
+
+allow_response

--- a/global/hooks/shell-env-secret-guard.sh
+++ b/global/hooks/shell-env-secret-guard.sh
@@ -70,20 +70,20 @@ INPUT=$(cat)
 # chain is fail-closed, so this guard stays quiet to avoid double-denial noise.
 if [ -z "$INPUT" ]; then
     CMD=""
-    allow_response
+    allow_response "fail-open: empty hook input"
 fi
 
 JQ_RC=0
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || JQ_RC=$?
 if [ "$JQ_RC" -ne 0 ]; then
     CMD=""
-    allow_response
+    allow_response "fail-open: unparseable hook input"
 fi
 if [ -z "$CMD" ]; then
     CMD="${CLAUDE_TOOL_INPUT:-}"
 fi
 if [ -z "$CMD" ]; then
-    allow_response
+    allow_response "no command to inspect"
 fi
 
 # Secret keyword as an underscore-delimited segment/suffix of an UPPER_SNAKE

--- a/global/settings.json
+++ b/global/settings.json
@@ -175,6 +175,11 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/shell-env-secret-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/bash-write-guard.sh",
             "timeout": 5
           },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security)",
+  "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security). NOTE: the sandbox block below (sandbox.network.allowedDomains, sandbox.excludedCommands) is inert on Windows - the sandbox does not run on this platform (see core/environment.md), so permissions.allow/deny matching is the only active command gate; the env-secret leak channel is covered by hooks/shell-env-secret-guard.ps1.",
   "version": "1.17.0",
 
   "respectGitignore": true,
@@ -98,6 +98,11 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/bash-sensitive-read-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/shell-env-secret-guard.ps1",
             "timeout": 5
           },
           {


### PR DESCRIPTION
## What

Add `shell-env-secret-guard`, a PreToolUse(Bash) hook that prevents secret-bearing
environment variables from leaking into the transcript, and wire it into the Bash
guard chain on both platforms.

- Change type: **Feature** (new security hook)
- Affected components:
  - `global/hooks/shell-env-secret-guard.ps1` / `.sh` (new, cross-platform pair)
  - `global/settings.json` (base, `.sh` invocation)
  - `global/settings.windows.json` (Windows, `pwsh .ps1` invocation + description note)

## Why

A cross-tool review of the Codex and Claude config ecosystems found that the Claude
side protects secret **files** (`permissions.deny` + `bash-sensitive-read-guard`) but
has **no protection for secret environment variables**: a command like
`echo $AWS_SECRET_ACCESS_KEY` would expose the value into the transcript/logs.

Codex covers this with `config.toml [shell_environment_policy].exclude`, which scrubs
`*KEY*/*SECRET*/*TOKEN*/AWS_*` vars from the child process env. A Claude hook runs
out-of-process and cannot mutate the Bash child's env, so this guard implements the
achievable analog: it **denies** commands that print a named secret var and **warns**
on bare full-env dumps.

No tracking issue (hardening derived from the config cross-analysis).

## Where

| File | Change |
|------|--------|
| `global/hooks/shell-env-secret-guard.ps1` | New guard (PowerShell) |
| `global/hooks/shell-env-secret-guard.sh` | New guard (bash, parity) |
| `global/settings.json` | Wire `.sh` after `bash-sensitive-read-guard` |
| `global/settings.windows.json` | Wire `pwsh .ps1` + note Windows sandbox dormancy |

## How

### Implementation
- **DENY**: `echo`/`printf`/`printenv` of an `UPPER_SNAKE` var whose name has a
  secret keyword segment/suffix (`*_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD`,
  `*_PASSPHRASE`, `*_CREDENTIAL`).
- **WARN** (allow + context): bare `env` / `printenv` / `set` / `export -p` /
  `declare -p` / `compgen -v` that dump the whole environment.
- Matching is **case-sensitive and segment-aware** to avoid false positives.
- Fail-open on unparseable input (the chain's `dangerous-command-guard` is the
  fail-closed gate), so no double-denial.

### Testing done
Cross-checked `.ps1` and `.sh` against 17 cases; decisions identical, 0 failures:
- DENY: `echo $AWS_SECRET_ACCESS_KEY`, `printf "${GITHUB_TOKEN}"`,
  `printenv OPENAI_API_KEY`, `echo $API_KEY`, `echo $DB_PASSWORD`,
  `echo $AWS_ACCESS_KEY_ID`, `echo ${SSH_PRIVATE_KEY}`
- WARN: bare `env`, bare `printenv`
- ALLOW (no false positives): `gh api ...`, `git status`, `echo "build done"`,
  `echo $PATH`, `echo $monkey`, `echo $TOKENIZER_PATH`, `echo $KEYBOARD`,
  `/usr/bin/env python3 x.py`

Both `settings.json` files revalidated as valid JSON; `.sh` confirmed LF per
`.gitattributes`.

### Breaking changes
None. Additive guard; fail-open; only narrows clearly-unsafe secret-printing
commands.
