### PR TITLE
fix(install): add git-identity/token templates and shared auto-seed

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -227,6 +227,17 @@ function Install-GlobalSettings {
         }
     }
 
+    # Auto-seed git identity from `git config --global` (issue #777). Shared
+    # with scripts/install.ps1 via Set-GitIdentitySeed in InstallPrompts.psm1,
+    # so the later Invoke-PersonalizeGitIdentity step becomes confirm-only when
+    # the user already has a global git identity configured.
+    if (Get-Command Set-GitIdentitySeed -ErrorAction SilentlyContinue) {
+        $gitIdTarget = Join-Path $ClaudeDir 'git-identity.md'
+        if (Set-GitIdentitySeed -Path $gitIdTarget) {
+            Write-Ok "git-identity.md: git config로 자동 채우기 완료 ($($script:SeededGitName) <$($script:SeededGitEmail)>)"
+        }
+    }
+
     # Language policy selection (Unified Language Profile)
     # Stored at script scope so the project-install path (Install-ProjectSettings)
     # can reuse the resolved values for rule-template rendering (issue #760).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -250,6 +250,14 @@ install_global() {
         fi
     done
 
+    # Auto-seed git identity from `git config --global` (issue #777). Shared
+    # with scripts/install.sh via seed_git_identity() in install-prompts.sh, so
+    # the later personalize_git_identity step becomes confirm-only whenever the
+    # user already has a global git identity configured.
+    if seed_git_identity "$CLAUDE_DIR/git-identity.md"; then
+        success "git-identity.md: git config로 자동 채우기 완료 (${SEED_GIT_IDENTITY_NAME} <${SEED_GIT_IDENTITY_EMAIL}>)"
+    fi
+
     # Language policy selection (Unified Language Profile)
     prompt_language_profile
 

--- a/global/git-identity.md
+++ b/global/git-identity.md
@@ -1,0 +1,18 @@
+# Git Identity
+
+Personal git identity Claude Code uses when authoring commits, issues, and PRs.
+
+The installer auto-seeds the two fields below from your `git config --global`
+(`user.name` / `user.email`) when both are set, so a fresh install usually
+needs no manual editing. If either git-config value is missing, replace the
+`YOUR NAME` / `YOUR EMAIL` placeholders by hand.
+
+name: YOUR NAME
+email: YOUR EMAIL
+
+## Notes
+
+- This file is deployed to `~/.claude/git-identity.md` and holds personal
+  information; it is not meant to be committed back to any repository.
+- To change your identity later, edit the two lines above and rerun nothing —
+  Claude Code reads this file directly.

--- a/global/token-management.md
+++ b/global/token-management.md
@@ -1,0 +1,18 @@
+# Token Management
+
+Personal notes on the access tokens and credential helpers Claude Code relies
+on. This file is deployed to `~/.claude/token-management.md` with `600`
+permissions and is intended for your own reference.
+
+Never paste real tokens, passwords, or secrets into this file. Record only
+*where* a credential lives and *how* to rotate it — not the value itself.
+
+## GitHub
+
+- Credential helper: <e.g. osxkeychain, gh auth, manager-core>
+- Required scopes: `repo`, `workflow`, `read:org`
+- Rotation policy: <cadence / expiry reminder>
+
+## Other services
+
+- <service>: <how the token is stored / where to rotate it>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -392,6 +392,16 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         }
     }
 
+    # Auto-seed git identity from `git config --global` (issue #777). Shared
+    # with bootstrap.ps1 via Set-GitIdentitySeed in InstallPrompts.psm1, so a
+    # fresh install produces a usable git-identity.md without manual editing.
+    if (Get-Command Set-GitIdentitySeed -ErrorAction SilentlyContinue) {
+        $gitIdTarget = Join-Path $claudeDir 'git-identity.md'
+        if (Set-GitIdentitySeed -Path $gitIdTarget) {
+            Write-Success "git-identity.md auto-filled from git config ($($script:SeededGitName) <$($script:SeededGitEmail)>)"
+        }
+    }
+
     # conversation-language.md template rendering.
     # $agentDisplayLang is populated by Show-LanguageProfilePrompt (derived
     # from $profileChoice); fall back to deriving from $agentLanguage if the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -635,38 +635,25 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         fi
     done
 
-    # Git identity auto-fill (issue #748).
-    # When git config --global user.name and user.email are both present,
-    # pre-fill ~/.claude/git-identity.md with those values so non-interactive
-    # installs produce a usable file without manual editing.
-    # Idempotent: only fills placeholder lines (YOUR NAME / YOUR EMAIL pattern)
-    # and only when the file exists — never overwrites a user-customized file.
+    # Git identity auto-fill (issue #748; extracted to shared lib in #777).
+    # seed_git_identity() lives in scripts/lib/install-prompts.sh so bootstrap.sh
+    # and install.sh share one implementation. It only patches placeholder
+    # lines and only when both git config values are present, never overwriting
+    # a user-customized file.
     _git_identity_target="$HOME/.claude/git-identity.md"
-    if [ -f "$_git_identity_target" ]; then
-        _git_name="$(git config --global user.name 2>/dev/null || true)"
-        _git_email="$(git config --global user.email 2>/dev/null || true)"
-        if [ -n "$_git_name" ] && [ -n "$_git_email" ]; then
-            # Only patch lines that still contain placeholder tokens.
-            # The heuristic: lines with "YOUR NAME" or "YOUR EMAIL" (case-insensitive)
-            # are treated as unfilled placeholders; lines with actual values are left alone.
-            if grep -qi "YOUR NAME\|YOUR EMAIL\|<your" "$_git_identity_target" 2>/dev/null; then
-                sed -i.bak \
-                    -e "s/YOUR NAME/$_git_name/g" \
-                    -e "s/YOUR EMAIL/$_git_email/g" \
-                    -e "s/<your[^>]*name[^>]*>/$_git_name/gi" \
-                    -e "s/<your[^>]*email[^>]*>/$_git_email/gi" \
-                    "$_git_identity_target" 2>/dev/null && \
-                    rm -f "$_git_identity_target.bak" && \
-                    success "git-identity.md: git global config로 자동 채우기 완료 (${_git_name} <${_git_email}>)" || \
-                    mv "$_git_identity_target.bak" "$_git_identity_target" 2>/dev/null || true
-            else
-                info "git-identity.md: 이미 사용자 정의 값 유지"
-            fi
+    if seed_git_identity "$_git_identity_target"; then
+        success "git-identity.md: git global config로 자동 채우기 완료 (${SEED_GIT_IDENTITY_NAME} <${SEED_GIT_IDENTITY_EMAIL}>)"
+    elif [ -f "$_git_identity_target" ]; then
+        # Not seeded: either the file was already customized, or git config is
+        # missing. Preserve the pre-extraction messaging for both cases.
+        if git config --global user.name >/dev/null 2>&1 \
+            && git config --global user.email >/dev/null 2>&1; then
+            info "git-identity.md: 이미 사용자 정의 값 유지"
         else
             warning "git config --global user.name / user.email 미설정 — git-identity.md를 수동으로 편집하세요"
         fi
     fi
-    unset _git_identity_target _git_name _git_email
+    unset _git_identity_target
 
     # conversation-language.md 템플릿 렌더링
     # AGENT_DISPLAY_LANG is populated by prompt_language_profile() in

--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -235,4 +235,37 @@ function Show-LegacySettingsWarning {
     return $true
 }
 
-Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Invoke-PolicyTemplate, Invoke-PolicyTemplatesInDir, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning
+function Set-GitIdentitySeed {
+    # Auto-fill the name/email placeholders in a deployed git-identity.md from
+    # `git config --global user.name` / `user.email`. PowerShell mirror of
+    # seed_git_identity() in scripts/lib/install-prompts.sh (issue #777).
+    #
+    # Idempotent and non-destructive: no-op when the file is absent, when git
+    # config lacks either value, or when no placeholder tokens remain. Uses
+    # literal String.Replace (not regex), so names/emails with special
+    # characters are substituted safely. Returns $true and sets
+    # $script:SeededGitName / $script:SeededGitEmail when values were seeded.
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+
+    $name  = (git config --global user.name  2>$null)
+    $email = (git config --global user.email 2>$null)
+    if ([string]::IsNullOrWhiteSpace($name) -or [string]::IsNullOrWhiteSpace($email)) {
+        return $false
+    }
+    $name  = $name.Trim()
+    $email = $email.Trim()
+
+    $content = Get-Content -Raw -LiteralPath $Path
+    if ($content -notmatch 'YOUR NAME|YOUR EMAIL') { return $false }
+
+    $seeded = $content.Replace('YOUR NAME', $name).Replace('YOUR EMAIL', $email)
+    Set-Content -LiteralPath $Path -Value $seeded -NoNewline
+    $script:SeededGitName  = $name
+    $script:SeededGitEmail = $email
+    return $true
+}
+
+Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Invoke-PolicyTemplate, Invoke-PolicyTemplatesInDir, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning, Set-GitIdentitySeed

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -215,3 +215,49 @@ detect_legacy_content_language() {
         *)                       return 1 ;;
     esac
 }
+
+# seed_git_identity <deployed_git_identity_md>
+# Auto-fill the name/email placeholders in a deployed git-identity.md from
+# `git config --global user.name` / `user.email`. Extracted from the #748
+# auto-fill block in scripts/install.sh so bootstrap.sh and install.sh share
+# one implementation (issue #777).
+#
+# Contract (idempotent, never destructive):
+#   - no-op (return 1) when the target file is absent,
+#   - no-op when git config lacks either user.name or user.email,
+#   - only rewrites lines that still hold the YOUR NAME / YOUR EMAIL
+#     placeholder tokens, so a user-customized file is left untouched.
+# On success, exports SEED_GIT_IDENTITY_NAME / SEED_GIT_IDENTITY_EMAIL so the
+# caller can print a confirmation, and returns 0.
+seed_git_identity() {
+    local target="${1:-}"
+    [ -f "$target" ] || return 1
+
+    local name email
+    name="$(git config --global user.name 2>/dev/null || true)"
+    email="$(git config --global user.email 2>/dev/null || true)"
+    [ -n "$name" ] && [ -n "$email" ] || return 1
+
+    # Only touch the file while placeholders remain — never clobber real values.
+    grep -q "YOUR NAME\|YOUR EMAIL" "$target" 2>/dev/null || return 1
+
+    # Escape sed replacement metacharacters (\ & and the | delimiter) so a
+    # name/email containing them cannot corrupt the substitution.
+    local esc_name esc_email
+    esc_name="$(printf '%s' "$name" | sed -e 's/[\\&|]/\\&/g')"
+    esc_email="$(printf '%s' "$email" | sed -e 's/[\\&|]/\\&/g')"
+
+    if sed -i.bak \
+        -e "s|YOUR NAME|${esc_name}|g" \
+        -e "s|YOUR EMAIL|${esc_email}|g" \
+        "$target" 2>/dev/null; then
+        rm -f "$target.bak"
+        SEED_GIT_IDENTITY_NAME="$name"
+        SEED_GIT_IDENTITY_EMAIL="$email"
+        return 0
+    fi
+
+    # Restore on failure so a partial write never leaves a corrupt file.
+    mv "$target.bak" "$target" 2>/dev/null || true
+    return 1
+}

--- a/tests/scripts/test-global-files-referenced-exist.sh
+++ b/tests/scripts/test-global-files-referenced-exist.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# test-global-files-referenced-exist.sh
+# Regression guard for issue #777.
+#
+# Every global/<file> that the installers copy into ~/.claude must actually
+# exist in the repo, as either the static <file> or its <file>.tmpl template
+# form. This prevents the silent-skip class of bug that #777 fixed, where the
+# bootstrap.sh / install.sh copy loops referenced git-identity.md and
+# token-management.md that had never been committed — so the copy loop's
+# `[ -f "$src" ] || continue` guard skipped them without any error, the
+# personalize step opened an empty buffer, and the #748 auto-fill had no file
+# to patch.
+#
+# Run: bash tests/scripts/test-global-files-referenced-exist.sh
+# Exit: 0 when all referenced files exist, 1 otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GLOBAL_DIR="$REPO_ROOT/global"
+
+PASS=0
+FAIL=0
+
+# Assert that global/<name> exists as a static file or a .tmpl template.
+assert_global_exists() {
+    local name="$1" src="$2"
+    if [ -f "$GLOBAL_DIR/$name" ] || [ -f "$GLOBAL_DIR/$name.tmpl" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name (referenced by $src)"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $name referenced by $src but missing from global/"
+    fi
+}
+
+echo "=== global/ referenced-file existence test (#777) ==="
+echo ""
+
+# 1) Bash copy loops: `for gf in CLAUDE.md commit-settings.md ... ; do`
+for installer in bootstrap.sh scripts/install.sh; do
+    while IFS= read -r line; do
+        files="$(echo "$line" | sed -E 's/.*for gf in //; s/;[[:space:]]*do.*//')"
+        for f in $files; do
+            [[ "$f" == *.md ]] || continue
+            assert_global_exists "$f" "$installer"
+        done
+    done < <(grep -E "for gf in .*\.md" "$REPO_ROOT/$installer")
+done
+
+# 2) PowerShell copy loops: `$globalFiles = @('CLAUDE.md', ...)`
+for installer in bootstrap.ps1 scripts/install.ps1; do
+    while IFS= read -r line; do
+        files="$(echo "$line" | grep -oE "'[^']+\.md'" | tr -d "'")"
+        for f in $files; do
+            assert_global_exists "$f" "$installer"
+        done
+    done < <(grep -E "globalFiles = @\(" "$REPO_ROOT/$installer")
+done
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #777
Part of #776

## What

Add the missing `global/git-identity.md` and `global/token-management.md`
templates and a shared git-identity auto-seed, so a fresh install produces a
usable `~/.claude/git-identity.md` with no manual retyping.

## Why

Both files were referenced by every installer copy loop but had never been
committed. The `[ -f "$src" ] || continue` guard therefore skipped them
silently: the personalize step opened an empty editor buffer yet still printed
success, and the `install.sh` #748 auto-fill had no file to patch. Users were
forced to retype an identity that already exists in `git config`.

## How

- **Templates**: ship both as static `.md` files. `git-identity.md` carries
  `name: YOUR NAME` / `email: YOUR EMAIL` lines that satisfy both the
  `bootstrap.sh` grep display and the `install.sh` sed token. `token-management.md`
  is a notes template (deployed `600`, no secrets).
- **Shared seed**: extract the `git config -> git-identity.md` fill into
  `seed_git_identity()` (bash, `scripts/lib/install-prompts.sh`) and
  `Set-GitIdentitySeed` (PowerShell, `scripts/lib/InstallPrompts.psm1`), wired
  into `bootstrap.sh`, `bootstrap.ps1`, `scripts/install.sh`, `scripts/install.ps1`.
  When `user.name` and `user.email` are both set, the seed runs with **no
  prompt** and personalize becomes confirm-only. The bash seed uses a `|` sed
  delimiter with `\ & |` escaping; the PowerShell seed uses literal
  `String.Replace` — both safe for names/emails with special characters.
- **Regression test**: `tests/scripts/test-global-files-referenced-exist.sh`
  asserts every `global/` file referenced by the installer copy loops exists as
  a static file or `.tmpl`.

## Where

- New: `global/git-identity.md`, `global/token-management.md`,
  `tests/scripts/test-global-files-referenced-exist.sh`
- Modified: `scripts/lib/install-prompts.sh`, `scripts/lib/InstallPrompts.psm1`,
  `bootstrap.sh`, `bootstrap.ps1`, `scripts/install.sh`, `scripts/install.ps1`

## Test plan

Verified locally (macOS):

- `bash -n` on all modified shell scripts — clean.
- `test-global-files-referenced-exist.sh` — 19/19 pass.
- `test-installer-prompt-drift.sh` — pass (PowerShell mirror keeps lib parity).
- `test-install-permissions-policy.sh` — pass.
- `test-language-policy-drift.sh` — 49/0 pass.
- `seed_git_identity` unit checks: seeds a name containing `& | /`
  correctly, is idempotent (second run is a no-op), and is a safe no-op on a
  missing file or when git config is unset (placeholders preserved).

No CI workflow path filter matches the touched paths (`global/*.md`,
`scripts/**`, `bootstrap.*`, `tests/scripts/**`), so this PR triggers no CI
checks; verification is the local suite above. PowerShell paths were reviewed
structurally (no local `pwsh`).
