### PR TITLE
feat(install): non-interactive bootstrap with env/--yes and /dev/tty

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -84,6 +84,23 @@ curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.
 
 > **bootstrap이 자동으로 처리하는 것.** Claude Code CLI 미설치 시 사용자 동의 후 Anthropic 공식 native installer(`https://claude.ai/install.sh`)를 실행해 `claude` 바이너리를 `~/.local/bin/`에 배치하고 백그라운드 자동 업데이트를 활성화합니다. npm 패키지 `@anthropic-ai/claude-code`는 더 이상 사용되지 않습니다. PowerShell은 `claude.ai/install.ps1`로 동일하게 동작합니다. 자세한 내용은 [PREREQUISITES.md → Auto-installed by bootstrap](PREREQUISITES.md#auto-installed-by-bootstrap).
 
+### 비대화형 설치
+
+CI·무인 설치 환경에서는 `scripts/install.sh`와 동일한 환경 변수로 응답을 미리
+지정하거나(프롬프트 없음), `--yes`로 모든 기본값을 강제할 수 있습니다:
+
+```bash
+# 무인 설치: 설치 타입만 env로 지정하고 나머지는 기본값 사용
+curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | INSTALL_TYPE=3 bash
+
+# 모든 프롬프트를 기본값으로 강제
+curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | bash -s -- --yes
+```
+
+인식되는 오버라이드: `INSTALL_TYPE`, `PROJECT_DIR`, `INSTALL_NPM`, `OVERWRITE`,
+`AGENT_LANGUAGE`, `CONTENT_LANGUAGE`. `curl | bash`로 대화형 실행 시, bootstrap은
+스크립트 본문 대신 `/dev/tty`에서 응답을 읽습니다.
+
 ### Private Repository
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.
 
 > **What bootstrap does for you.** It checks for the Claude Code CLI and, on consent, runs Anthropic's native installer (`https://claude.ai/install.sh`) so the `claude` binary lands in `~/.local/bin/` and supports background auto-update. The npm package `@anthropic-ai/claude-code` is no longer used. PowerShell uses the parallel `claude.ai/install.ps1`. See [PREREQUISITES.md → Auto-installed by bootstrap](https://github.com/kcenon/claude-config/blob/develop/PREREQUISITES.md#auto-installed-by-bootstrap).
 
+### Non-interactive install
+
+For CI or unattended setups, pre-select answers with the same environment
+variables `scripts/install.sh` uses (no prompts), or force every default with
+`--yes`:
+
+```bash
+# Unattended: pick the install type via env, accept every other default
+curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | INSTALL_TYPE=3 bash
+
+# Force defaults for every prompt
+curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | bash -s -- --yes
+```
+
+Recognized overrides: `INSTALL_TYPE`, `PROJECT_DIR`, `INSTALL_NPM`, `OVERWRITE`,
+`AGENT_LANGUAGE`, `CONTENT_LANGUAGE`. When a prompt is reached interactively over
+`curl | bash`, bootstrap reads your answer from `/dev/tty` instead of consuming
+the piped script body.
+
 ### Private Repository
 
 ```bash

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -39,6 +39,29 @@ $AnthropicInstallerSha256 = if ($env:ANTHROPIC_INSTALLER_SHA256) { $env:ANTHROPI
 $InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { Join-Path $HOME 'claude_config_backup' }
 $ClaudeDir  = Join-Path $HOME '.claude'
 
+# ── Non-interactive prompt helper (issue #778) ───────────────────────────────
+# Parity with bootstrap.sh: resolve a prompt value by honoring, in order,
+#   1. a pre-set env override of the same name (install.sh vocabulary:
+#      INSTALL_TYPE / PROJECT_DIR / INSTALL_NPM / OVERWRITE / ...),
+#   2. $env:FORCE_MODE = '1' (unattended) -> the default with no prompt,
+#   3. an interactive Read-Host.
+# PowerShell's Read-Host reads the host console directly, so the bash /dev/tty
+# concern does not apply; env overrides are the unattended path for `irm | iex`.
+function Read-BootstrapValue {
+    param(
+        [Parameter(Mandatory)][string]$EnvName,
+        [Parameter(Mandatory)][string]$Prompt,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Default
+    )
+    $preset = [Environment]::GetEnvironmentVariable($EnvName)
+    if (-not [string]::IsNullOrEmpty($preset)) { return $preset }
+    if ($env:FORCE_MODE -eq '1') { return $Default }
+    $reply = Read-Host $Prompt
+    if ([string]::IsNullOrEmpty($reply)) { return $Default }
+    return $reply
+}
+# ─────────────────────────────────────────────────────────────────────────────
+
 # ── Inline helpers (module not yet available during bootstrap) ─
 
 function Write-Info    { param([string]$M) Write-Host "  $M" -ForegroundColor Cyan }
@@ -94,8 +117,7 @@ function Confirm-ClaudeCli {
     Write-Host "  의존하는 핵심 도구입니다. 미설치 상태에서는 일부 기능이 동작하지 않습니다."
     Write-Host ""
 
-    $installClaude = Read-Host "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]"
-    if ([string]::IsNullOrEmpty($installClaude)) { $installClaude = 'y' }
+    $installClaude = Read-BootstrapValue -EnvName 'INSTALL_CLAUDE' -Prompt "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]" -Default 'y'
 
     if ($installClaude -ne 'y') {
         Write-Warn "Claude Code CLI 설치 건너뜀. 추후 수동 설치:"
@@ -160,8 +182,7 @@ function Invoke-CloneRepository {
 
     if (Test-Path -LiteralPath $InstallDir -PathType Container) {
         Write-Warn "기존 설치 디렉토리가 존재합니다: $InstallDir"
-        $overwrite = Read-Host "덮어쓰시겠습니까? (y/n) [기본값: n]"
-        if ([string]::IsNullOrEmpty($overwrite)) { $overwrite = 'n' }
+        $overwrite = Read-BootstrapValue -EnvName 'OVERWRITE' -Prompt "덮어쓰시겠습니까? (y/n) [기본값: n]" -Default 'n'
 
         if ($overwrite -eq 'y') {
             Remove-Item -LiteralPath $InstallDir -Recurse -Force
@@ -346,8 +367,7 @@ function Install-GlobalSettings {
 
     # npm package installation (statusline dependencies)
     if (Get-Command npm -ErrorAction SilentlyContinue) {
-        $installNpm = Read-Host "Statusline npm 패키지를 설치하시겠습니까? (y/n) [기본값: y]"
-        if ([string]::IsNullOrEmpty($installNpm)) { $installNpm = 'y' }
+        $installNpm = Read-BootstrapValue -EnvName 'INSTALL_NPM' -Prompt "Statusline npm 패키지를 설치하시겠습니까? (y/n) [기본값: y]" -Default 'y'
         if ($installNpm -eq 'y') {
             try {
                 $null = & npm install -g ccstatusline claude-limitline 2>&1
@@ -393,8 +413,7 @@ function Invoke-PersonalizeGitIdentity {
     }
     Write-Host ""
 
-    $editNow = Read-Host "지금 수정하시겠습니까? (y/n) [기본값: n]"
-    if ([string]::IsNullOrEmpty($editNow)) { $editNow = 'n' }
+    $editNow = Read-BootstrapValue -EnvName 'EDIT_NOW' -Prompt "지금 수정하시겠습니까? (y/n) [기본값: n]" -Default 'n'
 
     if ($editNow -eq 'y') {
         $editor = $env:EDITOR
@@ -416,8 +435,7 @@ function Select-InstallType {
     Write-Host "  3) 둘 다 설치 (권장)"
     Write-Host "  4) 저장소만 클론 (수동 설치)"
     Write-Host ""
-    $selection = Read-Host "선택 (1-4) [기본값: 1]"
-    if ([string]::IsNullOrEmpty($selection)) { $selection = '1' }
+    $selection = Read-BootstrapValue -EnvName 'INSTALL_TYPE' -Prompt "선택 (1-4) [기본값: 1]" -Default '1'
     return $selection
 }
 
@@ -426,8 +444,7 @@ function Select-InstallType {
 function Install-ProjectSettings {
     Write-Host ""
     $defaultDir = (Get-Location).Path
-    $projDir = Read-Host "프로젝트 디렉토리 경로 [기본값: $defaultDir]"
-    if ([string]::IsNullOrEmpty($projDir)) { $projDir = $defaultDir }
+    $projDir = Read-BootstrapValue -EnvName 'PROJECT_DIR' -Prompt "프로젝트 디렉토리 경로 [기본값: $defaultDir]" -Default $defaultDir
 
     if (-not (Test-Path -LiteralPath $projDir -PathType Container)) {
         Write-Fail "디렉토리가 존재하지 않습니다: $projDir"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,6 +43,58 @@ ANTHROPIC_INSTALLER_SHA256="${ANTHROPIC_INSTALLER_SHA256:-b315b46925a9bfb9422f25
 
 # 설치 디렉토리
 INSTALL_DIR="${INSTALL_DIR:-$HOME/claude_config_backup}"
+
+# ── Argument parsing + non-interactive prompt helper (issue #778) ─────────────
+# Mirrors the scripts/install.sh FORCE_MODE / --type contract so the advertised
+# `curl ... | bash` one-liner keeps working: env overrides and --yes enable
+# fully unattended installs, and a /dev/tty fallback restores real prompts when
+# stdin is the piped script body rather than a keyboard.
+FORCE_MODE="${FORCE_MODE:-0}"
+_PENDING_TYPE=""
+_arg_prev=""
+for _arg in "$@"; do
+    if [ "$_arg_prev" = "--type" ]; then
+        _PENDING_TYPE="$_arg"; _arg_prev=""; continue
+    fi
+    case "$_arg" in
+        --yes|-y) FORCE_MODE=1 ;;
+        --type)   ;;  # value consumed on the next iteration via _arg_prev
+        -h|--help)
+            sed -n '3,12p' "${BASH_SOURCE[0]}" 2>/dev/null | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *)
+            echo "bootstrap.sh: unknown argument '$_arg'" >&2
+            echo "Run with --help for usage." >&2
+            exit 2 ;;
+    esac
+    _arg_prev="$_arg"
+done
+[ -n "$_PENDING_TYPE" ] && INSTALL_TYPE="${INSTALL_TYPE:-$_PENDING_TYPE}"
+unset _arg _arg_prev _PENDING_TYPE
+
+# bootstrap_read <varname> <prompt> <default>
+# Resolve a prompt value, in priority order:
+#   1. a pre-set non-empty env var of the same name (install.sh vocabulary:
+#      INSTALL_TYPE / PROJECT_DIR / INSTALL_NPM / OVERWRITE / ...),
+#   2. under FORCE_MODE (--yes/-y): the default, with no prompt,
+#   3. an interactive prompt, read from /dev/tty when stdin is not a terminal
+#      (the `curl | bash` case where stdin is the script body),
+#   4. the default when no terminal is available at all (CI / non-tty).
+# The `|| true` keeps an EOF read from aborting under `set -euo pipefail`.
+bootstrap_read() {
+    local __var="$1" __prompt="$2" __default="$3" __reply=""
+    if [ -n "${!__var:-}" ]; then return 0; fi
+    if [ "${FORCE_MODE:-0}" = "1" ]; then
+        printf -v "$__var" '%s' "$__default"; return 0
+    fi
+    if [ -t 0 ]; then
+        read -r -p "$__prompt" __reply || true
+    elif [ -r /dev/tty ]; then
+        read -r -p "$__prompt" __reply < /dev/tty || true
+    fi
+    printf -v "$__var" '%s' "${__reply:-$__default}"
+}
+# ──────────────────────────────────────────────────────────────────────────────
 CLAUDE_DIR="$HOME/.claude"
 
 echo -e "${BLUE}"
@@ -144,8 +196,7 @@ ensure_claude_cli() {
     echo "  의존하는 핵심 도구입니다. 미설치 상태에서는 일부 기능이 동작하지 않습니다."
     echo ""
 
-    read -p "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]: " INSTALL_CLAUDE
-    INSTALL_CLAUDE=${INSTALL_CLAUDE:-y}
+    bootstrap_read INSTALL_CLAUDE "Claude Code CLI를 지금 설치하시겠습니까? (y/n) [기본값: y]: " "y"
 
     if [ "$INSTALL_CLAUDE" != "y" ]; then
         warning "Claude Code CLI 설치 건너뜀. 추후 수동 설치 가이드:"
@@ -207,8 +258,7 @@ clone_repository() {
 
     if [ -d "$INSTALL_DIR" ]; then
         warning "기존 설치 디렉토리가 존재합니다: $INSTALL_DIR"
-        read -p "덮어쓰시겠습니까? (y/n) [기본값: n]: " OVERWRITE
-        OVERWRITE=${OVERWRITE:-n}
+        bootstrap_read OVERWRITE "덮어쓰시겠습니까? (y/n) [기본값: n]: " "n"
 
         if [ "$OVERWRITE" = "y" ]; then
             safe_rm_rf "$INSTALL_DIR"
@@ -332,8 +382,7 @@ install_global() {
 
     # npm 패키지 설치 (statusline 의존성)
     if command -v npm &> /dev/null; then
-        read -p "Statusline npm 패키지를 설치하시겠습니까? (y/n) [기본값: y]: " INSTALL_NPM
-        INSTALL_NPM=${INSTALL_NPM:-y}
+        bootstrap_read INSTALL_NPM "Statusline npm 패키지를 설치하시겠습니까? (y/n) [기본값: y]: " "y"
         if [ "$INSTALL_NPM" = "y" ]; then
             if npm install -g ccstatusline claude-limitline 2>/dev/null; then
                 success "npm 패키지 설치 완료 (ccstatusline, claude-limitline)"
@@ -360,8 +409,7 @@ personalize_git_identity() {
     echo "    vi ~/.claude/git-identity.md"
     echo ""
 
-    read -p "지금 수정하시겠습니까? (y/n) [기본값: n]: " EDIT_NOW
-    EDIT_NOW=${EDIT_NOW:-n}
+    bootstrap_read EDIT_NOW "지금 수정하시겠습니까? (y/n) [기본값: n]: " "n"
 
     if [ "$EDIT_NOW" = "y" ]; then
         ${EDITOR:-vi} "$CLAUDE_DIR/git-identity.md"
@@ -378,15 +426,13 @@ select_install_type() {
     echo "  3) 둘 다 설치 (권장)"
     echo "  4) 저장소만 클론 (수동 설치)"
     echo ""
-    read -p "선택 (1-4) [기본값: 1]: " INSTALL_TYPE
-    INSTALL_TYPE=${INSTALL_TYPE:-1}
+    bootstrap_read INSTALL_TYPE "선택 (1-4) [기본값: 1]: " "1"
 }
 
 # 프로젝트 설정 설치
 install_project() {
     echo ""
-    read -p "프로젝트 디렉토리 경로 [기본값: $(pwd)]: " PROJECT_DIR
-    PROJECT_DIR=${PROJECT_DIR:-$(pwd)}
+    bootstrap_read PROJECT_DIR "프로젝트 디렉토리 경로 [기본값: $(pwd)]: " "$(pwd)"
 
     if [ ! -d "$PROJECT_DIR" ]; then
         error "디렉토리가 존재하지 않습니다: $PROJECT_DIR"


### PR DESCRIPTION
Closes #778
Part of #776

## What

Make `bootstrap.sh` / `bootstrap.ps1` non-interactive-capable: env-var and
`--yes` overrides for unattended installs, plus a `/dev/tty` fallback so the
advertised `curl | bash` one-liner keeps real prompts alive.

## Why

`README` advertises `curl -sSL .../bootstrap.sh | bash` as the #1 install
method, but there stdin **is the script body** — the six `read -p` prompts
consumed subsequent script lines instead of user input, and there was no way
to pre-select answers or run unattended. `scripts/install.sh` already has
`--yes`/`FORCE_MODE`/`INSTALL_TYPE`; bootstrap had none.

## How

- **Shared resolution order** in a helper (`bootstrap_read` in bash,
  `Read-BootstrapValue` in PowerShell): pre-set env var of the same name as
  install.sh (`INSTALL_TYPE`, `PROJECT_DIR`, `INSTALL_NPM`, `OVERWRITE`) →
  `FORCE_MODE`/`--yes` default → interactive read (bash falls back to
  `/dev/tty` when stdin is the piped script) → documented default.
- **bash**: added `--yes`/`-y` and `--type N` argument parsing mirroring
  `install.sh`; `|| true` keeps an EOF read from aborting under
  `set -euo pipefail`, so no-tty contexts fall to the default rather than a
  random EOF value.
- **PowerShell**: `Read-Host` reads the host console directly (no `/dev/tty`
  concern); env overrides + `$env:FORCE_MODE` are the unattended path for
  `irm | iex`.
- **README**: documented the non-interactive one-liner in both languages.

## Where

- `bootstrap.sh` (arg parsing + helper + 6 prompts)
- `bootstrap.ps1` (helper + 6 prompts)
- `README.md`, `README.ko.md` (non-interactive section)

## Test plan

Verified locally (macOS):

- `bash -n bootstrap.sh` — clean.
- Unit test of the extracted real `bootstrap_read`: env override wins;
  `FORCE_MODE` returns the default with no prompt; non-tty stdin falls back to
  the default without aborting under `set -e` (the `/dev/tty` open failing is
  caught by `|| true`); spaced defaults preserved.
- `bootstrap.sh --help` exits 0 and prints the usage; unknown arg exits 2.
- Regression: `test-installer-robustness.sh`, `test-install-permissions-policy.sh`,
  `test-installer-prompt-drift.sh` all pass.

`bootstrap.sh` is shellchecked at error severity by `validate-hooks`. No local
`pwsh`, so the PowerShell mirror was reviewed structurally (helper +
call-site parity, brace balance).
