### PR TITLE
fix(install): bootstrap deploys runtime hooks, not just settings.json

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -365,6 +365,39 @@ function Install-GlobalSettings {
         }
     }
 
+    # hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드) — issue #779.
+    # settings.windows.json은 `pwsh -File ...ps1` 훅 다수를 참조하므로, 설정 복사와
+    # 훅 배포를 한 트랜잭션으로 처리해 "설정은 있는데 훅이 없는" 조용한 보안 공백을
+    # 막는다. scripts/install.ps1의 hooks + hooks/lib 배포 블록과 동일.
+    $hooksSrc = Join-Path $InstallDir 'global' 'hooks'
+    if (Test-Path -LiteralPath $hooksSrc -PathType Container) {
+        $hooksDst = Join-Path $ClaudeDir 'hooks'
+        if (-not (Test-Path $hooksDst)) {
+            New-Item -ItemType Directory -Path $hooksDst -Force | Out-Null
+        }
+        # Windows 훅은 `pwsh -File ...ps1`; .sh/.json은 WSL/parity 목적으로 함께 복사.
+        Copy-Item -Path "$hooksSrc\*.ps1"  -Destination $hooksDst -Force -ErrorAction SilentlyContinue
+        Copy-Item -Path "$hooksSrc\*.sh"   -Destination $hooksDst -Force -ErrorAction SilentlyContinue
+        Copy-Item -Path "$hooksSrc\*.json" -Destination $hooksDst -Force -ErrorAction SilentlyContinue
+
+        # global/hooks/lib/* 배포 (issue #586): 공유 라이브러리는 top-level glob에
+        # 잡히지 않으므로 별도 복사한다. 없으면 4개 Bash 가드가 약화된다.
+        $hooksLibSrc = Join-Path $hooksSrc 'lib'
+        if (Test-Path -LiteralPath $hooksLibSrc -PathType Container) {
+            $hooksLibDst = Join-Path $hooksDst 'lib'
+            if (-not (Test-Path $hooksLibDst)) {
+                New-Item -ItemType Directory -Path $hooksLibDst -Force | Out-Null
+            }
+            Copy-Item -Path "$hooksLibSrc\*" -Destination $hooksLibDst -Recurse -Force -ErrorAction SilentlyContinue
+
+            if (-not (Test-Path (Join-Path $hooksLibDst 'tokenize-shell.sh'))) {
+                Write-Warn "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
+            }
+        }
+
+        Write-Ok "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+    }
+
     # npm package installation (statusline dependencies)
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         $installNpm = Read-BootstrapValue -EnvName 'INSTALL_NPM' -Prompt "Statusline npm 패키지를 설치하시겠습니까? (y/n) [기본값: y]" -Default 'y'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -350,6 +350,31 @@ install_global() {
         fi
     fi
 
+    # hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드) — issue #779.
+    # settings.json은 ~/.claude/hooks/*.sh 가드 다수를 참조하므로, 설정 복사와
+    # 훅 배포를 한 트랜잭션으로 처리해 "설정은 있는데 훅이 없는" 조용한 보안
+    # 공백을 막는다. scripts/install.sh의 hooks + hooks/lib 배포 블록과 동일.
+    if [ -d "$INSTALL_DIR/global/hooks" ]; then
+        mkdir -p "$CLAUDE_DIR/hooks"
+        cp "$INSTALL_DIR/global/hooks"/*.sh "$CLAUDE_DIR/hooks/" 2>/dev/null || true
+        chmod +x "$CLAUDE_DIR/hooks/"*.sh 2>/dev/null || true
+
+        # global/hooks/lib/*.sh 배포 (issue #586). 위 *.sh glob은 비재귀적이라
+        # tokenize-shell.sh 등 공유 라이브러리는 별도 복사 없이는 누락된다.
+        # dangerous-command-guard 등 4개 Bash 가드가 런타임에 이를 source한다.
+        if [ -d "$INSTALL_DIR/global/hooks/lib" ]; then
+            mkdir -p "$CLAUDE_DIR/hooks/lib"
+            cp "$INSTALL_DIR/global/hooks/lib"/*.sh "$CLAUDE_DIR/hooks/lib/" 2>/dev/null || true
+            chmod +x "$CLAUDE_DIR/hooks/lib/"*.sh 2>/dev/null || true
+
+            if [ ! -f "$CLAUDE_DIR/hooks/lib/tokenize-shell.sh" ]; then
+                warning "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
+            fi
+        fi
+
+        success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+    fi
+
     # 글로벌 skills 및 commands 설치
     # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
     # Claude Code 슬래시 카탈로그에 노출되지 않으며, 글로벌 CLAUDE.md의


### PR DESCRIPTION
Closes #779
Part of #776

## What

Deploy the runtime hooks in `bootstrap.sh` / `bootstrap.ps1`, in the same
transaction as the `settings.json` copy.

## Why

`bootstrap`'s `install_global` copied `settings.json` — which references dozens
of `~/.claude/hooks/*.sh` guards — but never deployed the hooks themselves.
One-line installer users therefore got settings wired to guards that did not
exist on disk. Because hooks fail open individually, the effect is a **silent
PreToolUse enforcement hole**, not a hard failure, until the user separately
discovered `hooks/install-hooks.sh`.

## How

- **bash**: after the `settings.json` copy, deploy `global/hooks/*.sh` ->
  `~/.claude/hooks/` (`chmod +x`) plus the non-recursive `hooks/lib/*.sh`
  shared libraries, mirroring `scripts/install.sh`. The `*.sh` glob excludes
  AppleDouble `._*.sh` files (bash does not glob dotfiles). Preserves the
  `tokenize-shell.sh` missing-lib warning (#586).
- **PowerShell**: mirrors the block for `settings.windows.json`, copying the
  `.ps1`/`.sh`/`.json` hooks plus `lib/`, with the same warning.

## Where

- `bootstrap.sh` (install_global, after settings.json)
- `bootstrap.ps1` (Install-GlobalSettings, after settings.windows.json)

## Test plan

Verified locally (macOS):

- `bash -n bootstrap.sh` — clean; `bootstrap.ps1` brace-balanced.
- Reproduced the exact deploy commands into a temp dir: 37 real hooks land and
  are executable, `hooks/lib/tokenize-shell.sh` and `dangerous-command-guard.sh`
  are present, and the 11 AppleDouble `._*.sh` source files are correctly
  excluded (0 deployed).
- `test-installer-robustness.sh` passes.

`bootstrap.sh` is shellchecked at error severity by `validate-hooks`; no local
`pwsh`, so the PowerShell mirror was reviewed structurally.
