### PR TITLE
fix(install): seed language policy from settings.json on reinstall

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -308,6 +308,9 @@ install_global() {
         success "git-identity.md: git config로 자동 채우기 완료 (${SEED_GIT_IDENTITY_NAME} <${SEED_GIT_IDENTITY_EMAIL}>)"
     fi
 
+    # Reinstall: keep the previously chosen language policy (issue #780).
+    seed_language_from_settings "$HOME/.claude/settings.json"
+
     # Language policy selection (Unified Language Profile)
     prompt_language_profile
 
@@ -474,6 +477,8 @@ install_project() {
     #     재프롬프트하지 않도록 미설정일 때만 prompt_language_profile 호출
     # shellcheck disable=SC1091
     source "$INSTALL_DIR/scripts/lib/install-prompts.sh"
+    # Reinstall: keep the previously chosen language policy (issue #780).
+    seed_language_from_settings "$HOME/.claude/settings.json"
     if [ -z "${AGENT_LANGUAGE:-}" ] || [ -z "${CONTENT_LANGUAGE:-}" ]; then
         prompt_language_profile
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -565,6 +565,9 @@ fi
 # the dispatcher at its default and skips writing settings.json.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/install-prompts.sh"
+# Reinstall: seed the prior language policy from an existing settings.json so a
+# re-run keeps the previous choice instead of resetting to Hybrid (issue #780).
+seed_language_from_settings "$HOME/.claude/settings.json"
 prompt_language_profile
 
 # Legacy settings.json migration warning (informational only).

--- a/scripts/lib/install-prompts.sh
+++ b/scripts/lib/install-prompts.sh
@@ -67,6 +67,10 @@ _prompts_warn() {
 # (AGENT_LANGUAGE=korean / CONTENT_LANGUAGE=english) rather than being clobbered.
 prompt_language_profile() {
     # Capture which vars the caller preset BEFORE the prompt may overwrite them.
+    # Installers call seed_language_from_settings() just before this to keep a
+    # prior policy on reinstall (issue #780); that seeding stays out of this
+    # function so the pure prompt contract (tested by
+    # test-language-override-contract.sh) is unchanged.
     local _agent_preset="" _content_preset=""
     [ -n "${AGENT_LANGUAGE:-}" ]   && _agent_preset="$AGENT_LANGUAGE"
     [ -n "${CONTENT_LANGUAGE:-}" ] && _content_preset="$CONTENT_LANGUAGE"
@@ -182,6 +186,49 @@ read_settings_content_language() {
             | sed -E 's/.*"CLAUDE_CONTENT_LANGUAGE"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
             | head -1
     fi
+}
+
+# read_settings_agent_language <settings_json_path>
+# Echoes the current top-level ".language" value (agent conversation language)
+# stored in settings.json, or empty string when absent / unparseable. Mirrors
+# read_settings_content_language. The grep fallback anchors on the quoted key so
+# it does not collide with "CLAUDE_CONTENT_LANGUAGE".
+read_settings_agent_language() {
+    local file="${1:-}"
+    [ -f "$file" ] || { echo ""; return 0; }
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.language // empty' "$file" 2>/dev/null
+    else
+        grep -oE '"language"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" 2>/dev/null \
+            | sed -E 's/.*"language"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
+            | head -1
+    fi
+}
+
+# seed_language_from_settings <settings_json_path>
+# Reinstall helper (issue #780). Fills AGENT_LANGUAGE / CONTENT_LANGUAGE from an
+# existing settings.json when they are unset, so prompt_language_profile keeps
+# the previously chosen policy instead of resetting to the Hybrid default.
+# Each variable is seeded independently (they are orthogonal per #762); there is
+# no reverse-map to a preset menu number. An explicit env override wins because
+# only unset variables are filled. Emits one info line when it seeds so the
+# behavior is discoverable, not silent.
+seed_language_from_settings() {
+    local file="${1:-}"
+    [ -f "$file" ] || return 0
+    local seeded=0 a c
+    if [ -z "${AGENT_LANGUAGE:-}" ]; then
+        a="$(read_settings_agent_language "$file")"
+        [ -n "$a" ] && { AGENT_LANGUAGE="$a"; seeded=1; }
+    fi
+    if [ -z "${CONTENT_LANGUAGE:-}" ]; then
+        c="$(read_settings_content_language "$file")"
+        [ -n "$c" ] && { CONTENT_LANGUAGE="$c"; seeded=1; }
+    fi
+    if [ "$seeded" = "1" ]; then
+        _prompts_info "Existing language policy kept from settings.json (agent=${AGENT_LANGUAGE:-?}, content=${CONTENT_LANGUAGE:-?}). Override with AGENT_LANGUAGE/CONTENT_LANGUAGE env or edit ~/.claude/settings.json."
+    fi
+    return 0
 }
 
 # warn_legacy_settings_value <settings_json_path>


### PR DESCRIPTION
Closes #780
Part of #776

## What

On reinstall, seed the language-policy default from the existing
`~/.claude/settings.json` instead of always resetting to the Hybrid default.

## Why

A user who first chose e.g. English Unified and re-ran the installer hit the
language prompt's EOF/default path and silently reverted to Hybrid (Korean
conversation). Nothing read the prior policy; `warn_legacy_settings_value`
only warns, and it runs *after* the prompt.

## How

- Add `read_settings_agent_language` (reads top-level `.language`) and
  `seed_language_from_settings` to `scripts/lib/install-prompts.sh`.
- Call the seeder **just before** `prompt_language_profile` at both bash call
  sites (`scripts/install.sh`, `bootstrap.sh` global + project-only paths).
- The seeder fills only unset `AGENT_LANGUAGE` / `CONTENT_LANGUAGE`, each
  independently (per #762 — **no** reverse-map to a preset menu number). With
  both filled, `prompt_language_profile` skips the prompt, so a re-run keeps
  the previous policy ("choose once, never asked again"). It emits one info
  line so the behavior is discoverable, not silent.

Design note: the seeding lives at the call sites, **not** inside
`prompt_language_profile`, so the pure prompt contract asserted by
`test-language-override-contract.sh` is unchanged (an earlier in-function
version broke that test by reading the ambient settings.json).

## Where

- `scripts/lib/install-prompts.sh` (two new helpers)
- `scripts/install.sh`, `bootstrap.sh` (seed before the prompt)

Scope: bash only, matching the issue. The PowerShell reinstall-reseed parity
belongs with the cross-platform track (#781).

## Test plan

Verified locally (macOS):

- `bash -n` on all three files — clean.
- Installer flow with an existing `settings.json` (English Unified): seeder
  keeps `agent=english / content=english` and the prompt is skipped.
- No settings.json: seeder is a no-op, prompt falls to the Hybrid default
  (`korean / english`).
- Explicit env override survives the seed (agent stays the overridden value,
  content seeded from settings).
- Regression: `test-language-override-contract.sh`, `test-doc-prompt-lockstep.sh`,
  `test-installer-prompt-drift.sh`, `test-language-policy-drift.sh` all pass.
