### PR TITLE
fix(cross-platform): close sh/ps1 and CI parity gaps

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -162,6 +162,15 @@ jobs:
         # Validates code-review skill frontmatter severity/finding_levels enums.
         run: bash tests/scripts/test-severity-enum.sh
 
+      - name: Run PowerShell hook behavior tests (pwsh)
+        # CI parity (#781): the .ps1 hook behavior tests under
+        # tests/hooks/test-runner.ps1 previously ran in no workflow, so the
+        # PowerShell guards had zero behavioral coverage and Windows users acted
+        # as the test runner. pwsh is preinstalled on the ubuntu/macos runners
+        # (already used by the install-manifest step above), so this is zero
+        # extra infra.
+        run: pwsh tests/hooks/test-runner.ps1
+
   shellcheck:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -84,8 +84,26 @@ Write-Host ""
 function Test-Dependencies {
     Write-Info "의존성 확인 중..."
 
-    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        Write-Fail "git이 설치되어 있지 않습니다. 먼저 git을 설치하세요."
+    # Hard requirements: parity with bootstrap.sh (git + gh). gh backs the
+    # PreToolUse merge/attribution guards and the batch issue/pr scripts, so a
+    # missing gh is a silent-failure trap on Windows just as on Unix (#781).
+    $missing = @()
+    foreach ($cmd in @('git', 'gh')) {
+        if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+            $missing += $cmd
+        }
+    }
+    if ($missing.Count -gt 0) {
+        Write-Fail "필수 도구가 설치되어 있지 않습니다: $($missing -join ', '). 설치 안내는 PREREQUISITES.md를 참고하세요."
+    }
+
+    # Soft requirements: jq / perl are used by bash-channel tooling. The native
+    # PowerShell hooks do not shell out to them, so warn rather than hard-fail
+    # (verifier-refined in #781).
+    foreach ($cmd in @('jq', 'perl')) {
+        if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+            Write-Warn "$cmd 미설치 — 일부 bash 계열 도구가 제한될 수 있습니다 (PREREQUISITES.md)."
+        }
     }
 
     Write-Ok "의존성 확인 완료"

--- a/hooks/install-hooks.ps1
+++ b/hooks/install-hooks.ps1
@@ -125,6 +125,17 @@ $validatorSrc = Join-Path $ScriptDir 'lib' 'validate-commit-message.sh'
 $validatorDst = Join-Path $libDstDir 'validate-commit-message.sh'
 Copy-Item -LiteralPath $validatorSrc -Destination $validatorDst -Force
 if (-not $IsWindows) { & chmod +x $validatorDst 2>$null }
+
+# Traceability cascade validator (issue #590). Sourced by the pre-push hook;
+# opt-in (no-op when docs/.index/graph.yaml is absent). Parity with
+# install-hooks.sh, which already copies it (#781).
+$traceSrc = Join-Path $ScriptDir 'lib' 'validate-traceability.sh'
+if (Test-Path -LiteralPath $traceSrc) {
+    $traceDst = Join-Path $libDstDir 'validate-traceability.sh'
+    Copy-Item -LiteralPath $traceSrc -Destination $traceDst -Force
+    if (-not $IsWindows) { & chmod +x $traceDst 2>$null }
+}
+
 Write-SuccessMessage "검증 라이브러리 설치 완료!"
 
 Write-Host ""

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -52,7 +52,7 @@ done
 # before pushing. Skipped silently by default to preserve prior behaviour.
 if [ "${CLAUDE_PREFLIGHT:-0}" = "1" ]; then
     REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-    PREFLIGHT="$REPO_ROOT/global/skills/preflight/scripts/run-all.sh"
+    PREFLIGHT="$REPO_ROOT/global/skills/_internal/preflight/scripts/run-all.sh"
     if [ -x "$PREFLIGHT" ] || [ -f "$PREFLIGHT" ]; then
         echo "pre-push: CLAUDE_PREFLIGHT=1 — running preflight checks" >&2
         if ! bash "$PREFLIGHT"; then
@@ -63,7 +63,10 @@ if [ "${CLAUDE_PREFLIGHT:-0}" = "1" ]; then
             exit 1
         fi
     else
-        echo "pre-push: CLAUDE_PREFLIGHT=1 but $PREFLIGHT is missing — skipping preflight." >&2
+        echo "pre-push: WARNING — CLAUDE_PREFLIGHT=1 but the preflight runner is missing:" >&2
+        echo "  $PREFLIGHT" >&2
+        echo "  Preflight is NOT running for this push. Verify your claude-config install" >&2
+        echo "  (the runner lives under global/skills/_internal/preflight/). CI still runs." >&2
     fi
 fi
 


### PR DESCRIPTION
Closes #781
Part of #776

## What

Close four independently verified cross-platform (sh/ps1) and CI parity gaps.

## How / acceptance criteria

- [x] **pre-push preflight path.** `hooks/pre-push` pointed at
  `global/skills/preflight/scripts/run-all.sh` (a D2-relocation stale path);
  the real runner is under `global/skills/_internal/preflight/`. So
  `CLAUDE_PREFLIGHT=1` pushes silently skipped preflight on macOS/Linux. Fixed
  the path and made the missing-runner branch a loud warning.
- [x] **CI PowerShell leg.** Added `run: pwsh tests/hooks/test-runner.ps1` to
  the `validate-hooks` test job so the PowerShell hook behavior tests get
  coverage. pwsh is already on the ubuntu/macos runners (the install-manifest
  step already uses it), so zero extra infra.
- [x] **bootstrap.ps1 dependency check.** Now hard-fails on missing `gh` at
  parity with `bootstrap.sh`; `jq`/`perl` are soft warnings only, because the
  native `.ps1` hooks do not shell out to them (verifier-refined).
- [x] **install-hooks.ps1 traceability.** Copies `validate-traceability.sh`,
  which `install-hooks.sh` already installs.

## Where

- `hooks/pre-push`, `bootstrap.ps1`, `hooks/install-hooks.ps1`,
  `.github/workflows/validate-hooks.yml`

## Test plan

Verified locally (macOS):

- `bash -n hooks/pre-push` clean; the corrected preflight path resolves to an
  existing file (`global/skills/_internal/preflight/scripts/run-all.sh`), and
  the old path is confirmed absent.
- `bootstrap.ps1` and `hooks/install-hooks.ps1` brace-balanced.
- `validate-hooks.yml` parses (ruby YAML); the new step is present with the
  expected `run` and the `shellcheck` job still parses.
- `test-windows-hooks-parity.sh` passes.

The new `pwsh tests/hooks/test-runner.ps1` step runs for the first time in this
PR's CI (no local `pwsh`); that CI run is the authoritative check for it.

The cross-analysis note (extend `test-windows-hooks-parity.sh` to "same hook
set per matcher") is left as a follow-up; this PR delivers the four verified
checkboxes.
