### PR TITLE
security(hooks): block --no-verify and protected-branch push at PreToolUse

### DIFF
--- a/ENFORCEMENT.md
+++ b/ENFORCEMENT.md
@@ -41,14 +41,14 @@ These run on GitHub Actions and gate the PR independently of the local hooks abo
 
 ## Fail-policy quick reference
 
-- **Fail-closed**: `pr-target-guard`, `commit-message-guard`, `pre-push`, `dangerous-command-guard`, `bash-sensitive-read-guard`, `bash-write-guard`, `pre-edit-read-guard`, `attribution-guard` (on extracted bodies).
+- **Fail-closed**: `pr-target-guard`, `push-target-guard`, `commit-message-guard`, `pre-push`, `dangerous-command-guard`, `bash-sensitive-read-guard`, `bash-write-guard`, `pre-edit-read-guard`, `attribution-guard` (on extracted bodies).
 - **Fail-open** (gate is best-effort; transient tooling failures should not block legit work): `merge-gate-guard`, `pr-language-guard` (on heredoc/file-based bodies), `task-created-validator` (on missing parser), `conflict-guard` (when `git` is missing).
 - **Non-blocking** (informational / lifecycle): `session-logger`, `cleanup`, `version-check`, `subagent-logger`, `tool-failure-logger`, `pre-compact-snapshot`, `post-compact-restore`, `instructions-loaded-reinforcer`, `post-task-checkpoint`.
 
 ## Bypass
 
-- `git commit --no-verify` bypasses the `commit-msg` git hook only — the `commit-message-guard` PreToolUse hook still gates Claude's tool calls.
-- `git push --no-verify` bypasses `pre-push` — forbidden by project policy.
+- `git commit --no-verify` (and its short form `-n`) is denied at the PreToolUse layer by `commit-message-guard` (issue #782), so a Claude-driven commit cannot reach the point of skipping the `commit-msg` git hook. The git hook remains the second, terminal layer for commits made outside Claude.
+- `git push --no-verify` is denied at the PreToolUse layer by `push-target-guard` (issue #782), which also blocks direct pushes to `main`/`develop` (explicit target or resolved upstream). `git push -n`/`--dry-run` is allowed — it performs no real push. The terminal-side `pre-push` hook remains the second layer.
 - `GH_WRITE_VERB_GUARD_AUDIT_ONLY=1` downgrades all `deny` decisions to `allow` (telemetry-only mode for rollout).
 
 ## See also

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1082,6 +1082,7 @@ this catalog for the canonical hook inventory.
 | [`pre-compact-snapshot.sh`](#pre-compact-snapshot) | PreCompact (async) | yes |
 | [`pre-edit-read-guard.sh`](#pre-edit-read-guard) | PreToolUse (Edit|Write) + PostToolUse (Read) | yes |
 | [`prompt-validator.sh`](#prompt-validator) | UserPromptSubmit | yes |
+| [`push-target-guard.sh`](#push-target-guard) | PreToolUse (Bash) | yes |
 | [`sensitive-file-guard.sh`](#sensitive-file-guard) | PreToolUse (Edit|Write|Read) | yes |
 | [`session-logger.sh`](#session-logger) | SessionStart, SessionEnd, Stop, TeammateIdle | yes |
 | [`shell-env-secret-guard.sh`](#shell-env-secret-guard) | PreToolUse (Bash) | yes |
@@ -1095,7 +1096,7 @@ this catalog for the canonical hook inventory.
 | [`worktree-create.sh`](#worktree-create) | WorktreeCreate (synchronous, type: command only) | yes |
 | [`worktree-remove.sh`](#worktree-remove) | WorktreeRemove (async, type: command only) | yes |
 
-_Total: 37 bash hooks, 37 with PowerShell counterparts._
+_Total: 38 bash hooks, 38 with PowerShell counterparts._
 
 ### Hook Details
 
@@ -1526,6 +1527,23 @@ Validates user prompts for dangerous operations
 | Response format | hookSpecificOutput with additionalContext (UserPromptSubmit) |
 | PowerShell counterpart | present (`prompt-validator.ps1`) |
 | Source | `global/hooks/prompt-validator.sh` |
+
+### push-target-guard
+
+_File:_ `push-target-guard.sh`
+
+_Anchor:_ `#push-target-guard`
+
+Blocks git pushes that bypass the two-layer defense (issue #782): 1. `git push --no-verify ...` — defeats the terminal-side pre-push hook. 2. Direct push to a protected branch (main / master / develop) — whether the target is explicit (`git push origin main`, `... HEAD:main`) or the resolved upstream of the current branch (`git push` while on main).
+
+| Field | Value |
+|---|---|
+| Hook Type | PreToolUse (Bash) |
+| Trigger / Matcher | Bash |
+| Exit codes | 0 (always — decision is in JSON) |
+| Response format | — |
+| PowerShell counterpart | present (`push-target-guard.ps1`) |
+| Source | `global/hooks/push-target-guard.sh` |
 
 ### sensitive-file-guard
 

--- a/global/hooks/commit-message-guard.ps1
+++ b/global/hooks/commit-message-guard.ps1
@@ -40,19 +40,42 @@ if ($CMD -notmatch 'git\s+commit') {
     exit 0
 }
 
+# Deny --no-verify / -n (issue #782). `git commit --no-verify` (short form -n)
+# skips the commit-msg hook, the terminal-side half of the defense. Strip
+# quoted substrings first so a flag inside the message (e.g. -m "fix -n bug")
+# cannot false-trigger. For git commit only `-n` carries an 'n', so any
+# single-dash cluster containing 'n' is --no-verify.
+$dequoted = $CMD -replace '"[^"]*"', '' -replace "'[^']*'", ''
+if ($dequoted -match '(?:^|\s)--no-verify(?:\s|$)') {
+    New-HookDenyResponse -Reason "git commit --no-verify is blocked: it skips the commit-msg hook that enforces the commit-message policy (no attribution, Conventional Commits). Commit without --no-verify."
+    exit 0
+}
+if ($dequoted -match '(?:^|\s)-[A-Za-z]*n[A-Za-z]*(?:\s|$)') {
+    New-HookDenyResponse -Reason "git commit -n (--no-verify) is blocked: it skips the commit-msg hook that enforces the commit-message policy. Commit without -n."
+    exit 0
+}
+
 # Skip command substitution cases — cannot parse reliably
 if ($CMD -match '-a?m\s+"\$\(') {
     New-HookAllowResponse
     exit 0
 }
 
-# Extract message from -m "...", -am "...", or --message="..."
+# Extract message from -m "...", -am "...", or --message="..." (double-quoted),
+# then the single-quoted forms (issue #782). Single quotes suppress shell
+# expansion, so there is no command-substitution case to skip for them.
 $msg = $null
 if ($CMD -match '(?:^|\s)-m\s+"([^"]*)"') {
     $msg = $Matches[1]
 } elseif ($CMD -match '(?:^|\s)-am\s+"([^"]*)"') {
     $msg = $Matches[1]
 } elseif ($CMD -match '--message[=\s]+"([^"]*)"') {
+    $msg = $Matches[1]
+} elseif ($CMD -match "(?:^|\s)-m\s+'([^']*)'") {
+    $msg = $Matches[1]
+} elseif ($CMD -match "(?:^|\s)-am\s+'([^']*)'") {
+    $msg = $Matches[1]
+} elseif ($CMD -match "--message[=\s]+'([^']*)'") {
     $msg = $Matches[1]
 }
 

--- a/global/hooks/commit-message-guard.sh
+++ b/global/hooks/commit-message-guard.sh
@@ -83,6 +83,21 @@ if ! echo "$CMD" | grep -qE 'git[[:space:]]+commit'; then
     allow_response
 fi
 
+# --- Deny --no-verify / -n (issue #782) ---
+# `git commit --no-verify` (and its short form `-n`) skips the commit-msg git
+# hook, the terminal-side half of the attribution/format defense. Deny both so
+# the PreToolUse layer cannot be bypassed on the way to the git hook. Strip
+# quoted substrings first so a flag inside the message (e.g. -m "fix -n bug")
+# cannot false-trigger. Short-flag cluster: for git commit only `-n` carries an
+# 'n', so any single-dash cluster containing 'n' is --no-verify.
+_DEQUOTED=$(printf '%s' "$CMD" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")
+if printf '%s' "$_DEQUOTED" | grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)'; then
+    deny_response "git commit --no-verify is blocked: it skips the commit-msg hook that enforces the commit-message policy (no attribution, Conventional Commits). Commit without --no-verify."
+fi
+if printf '%s' "$_DEQUOTED" | grep -qE '(^|[[:space:]])-[A-Za-z]*n[A-Za-z]*([[:space:]]|$)'; then
+    deny_response "git commit -n (--no-verify) is blocked: it skips the commit-msg hook that enforces the commit-message policy. Commit without -n."
+fi
+
 # --- Skip command substitution cases ---
 # Example: git commit -m "$(cat <<'EOF' ... EOF\n)"
 # These cannot be parsed reliably with regex — defer to commit-msg hook (#242).
@@ -98,6 +113,18 @@ if [ -z "$MSG" ]; then
 fi
 if [ -z "$MSG" ]; then
     MSG=$(printf '%s' "$CMD" | sed -nE 's/.*--message[[:space:]=]+"([^"]*)".*/\1/p' | head -n1)
+fi
+# Single-quoted forms (issue #782): -m '...', -am '...', --message='...'.
+# Single quotes suppress shell expansion, so there is no command-substitution
+# case to skip here — the content is literal and safe to validate.
+if [ -z "$MSG" ]; then
+    MSG=$(printf '%s' "$CMD" | sed -nE "s/.*[[:space:]]-m[[:space:]]+'([^']*)'.*/\1/p" | head -n1)
+fi
+if [ -z "$MSG" ]; then
+    MSG=$(printf '%s' "$CMD" | sed -nE "s/.*[[:space:]]-am[[:space:]]+'([^']*)'.*/\1/p" | head -n1)
+fi
+if [ -z "$MSG" ]; then
+    MSG=$(printf '%s' "$CMD" | sed -nE "s/.*--message[[:space:]=]+'([^']*)'.*/\1/p" | head -n1)
 fi
 
 # If no -m argument found, git will open $EDITOR — nothing to validate here.

--- a/global/hooks/push-target-guard.ps1
+++ b/global/hooks/push-target-guard.ps1
@@ -1,0 +1,82 @@
+#Requires -Version 7.0
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'lib' 'CommonHelpers.psm1') -Force -WarningAction SilentlyContinue
+
+# push-target-guard.ps1
+# Blocks git pushes that bypass the two-layer defense (issue #782):
+#   1. `git push --no-verify ...`  - defeats the terminal-side pre-push hook.
+#   2. Direct push to a protected branch (main / master / develop), whether the
+#      target is explicit (`git push origin main`, `... HEAD:main`) or the
+#      resolved upstream of the current branch (`git push` while on main).
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always - decision is in JSON)
+#
+# `git push -n` / `--dry-run` is intentionally NOT treated as --no-verify and
+# not blocked on target: it performs no real push (verifier note, #782).
+# PowerShell mirror of push-target-guard.sh.
+
+# Read input from stdin
+$json = Read-HookInput
+
+# Fail-closed: deny if stdin is empty or missing
+if (-not $json) {
+    New-HookDenyResponse -Reason 'Failed to parse hook input — denying for safety (fail-closed)'
+    exit 0
+}
+
+# Extract command
+$CMD = $null
+try { $CMD = $json.tool_input.command } catch {}
+if (-not $CMD) { $CMD = $env:CLAUDE_TOOL_INPUT }
+
+# Scope gate: only inspect `git push` commands
+if ($CMD -notmatch 'git\s+push') {
+    New-HookAllowResponse
+    exit 0
+}
+
+# Strip quoted substrings so a flag-looking token inside a quoted argument
+# cannot false-trigger the flag checks below.
+$dequoted = $CMD -replace '"[^"]*"', '' -replace "'[^']*'", ''
+
+# Check A: --no-verify defeats the pre-push hook
+if ($dequoted -match '(?:^|\s)--no-verify(?:\s|$)') {
+    New-HookDenyResponse -Reason 'git push --no-verify is blocked: it bypasses the pre-push hook, the terminal-side half of the two-layer protected-branch defense. Push without --no-verify.'
+    exit 0
+}
+
+# Dry-run is harmless: skip the protected-target check (issue #782)
+$dryRun = $dequoted -match '(?:^|\s)(?:-n|--dry-run)(?:\s|$)'
+
+if (-not $dryRun) {
+    # Isolate the `git push` arguments, stopping at the first shell operator.
+    $pm = [regex]::Match($dequoted, 'git\s+push\s*(.*)')
+    $pushArgs = if ($pm.Success) { $pm.Groups[1].Value } else { '' }
+    $pushArgs = @($pushArgs -split '&&|;|\|')[0]
+
+    # Positional (non-flag) args: [remote] [refspec].
+    $tokens = @($pushArgs -split '\s+' | Where-Object { $_ -ne '' })
+    $positionals = @($tokens | Where-Object { $_ -notmatch '^-' })
+
+    $dst = ''
+    if ($positionals.Count -ge 2) {
+        # `src:dst` -> dst; a bare `branch` -> branch.
+        $dst = @($positionals[1] -split ':')[-1]
+    } else {
+        # No refspec: the push targets the current branch's upstream (the
+        # current branch). Resolve it; fail open if git cannot (not a repo).
+        try { $dst = (& git rev-parse --abbrev-ref HEAD 2>$null) } catch {}
+        if ($dst) { $dst = ("$dst").Trim() }
+    }
+
+    # Normalize: strip a leading '+' (force refspec) and a refs/heads/ prefix.
+    $dst = $dst -replace '^\+', '' -replace '^refs/heads/', ''
+
+    if ($dst -eq 'main' -or $dst -eq 'master' -or $dst -eq 'develop') {
+        New-HookDenyResponse -Reason "Direct push to protected branch '$dst' is blocked by branching policy. Open a PR into 'develop' (feature/fix branches) or use the /release skill (develop -> main). If you must, push from a work branch instead."
+        exit 0
+    }
+}
+
+New-HookAllowResponse
+exit 0

--- a/global/hooks/push-target-guard.sh
+++ b/global/hooks/push-target-guard.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# push-target-guard.sh
+# Blocks git pushes that bypass the two-layer defense (issue #782):
+#   1. `git push --no-verify ...`  — defeats the terminal-side pre-push hook.
+#   2. Direct push to a protected branch (main / master / develop) — whether
+#      the target is explicit (`git push origin main`, `... HEAD:main`) or the
+#      resolved upstream of the current branch (`git push` while on main).
+# Hook Type: PreToolUse (Bash)
+# Exit codes: 0 (always — decision is in JSON)
+#
+# `git push -n` / `--dry-run` is intentionally NOT treated as --no-verify and
+# not blocked on target: it performs no real push (verifier note, #782).
+#
+# Modeled on pr-target-guard.sh (same jq response + fail-closed input parsing).
+
+set -euo pipefail
+
+deny_response() {
+    local reason="$1"
+    jq -nc \
+        --arg reason "$reason" \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+    exit 0
+}
+
+allow_response() {
+    jq -nc \
+        '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "allow"}}'
+    exit 0
+}
+
+# --- Read input from stdin (Claude Code passes JSON) ---
+INPUT=$(cat)
+
+# Fail-closed: deny if stdin is empty or missing.
+if [ -z "$INPUT" ]; then
+    deny_response "Failed to parse hook input — denying for safety (fail-closed)"
+fi
+
+JQ_RC=0
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || JQ_RC=$?
+if [ "$JQ_RC" -ne 0 ]; then
+    deny_response "Failed to parse hook input JSON — denying for safety (fail-closed)"
+fi
+if [ -z "$CMD" ]; then
+    CMD="${CLAUDE_TOOL_INPUT:-}"
+fi
+
+# --- Scope gate: only inspect `git push` commands ---
+if ! echo "$CMD" | grep -qE 'git[[:space:]]+push'; then
+    allow_response
+fi
+
+# Strip quoted substrings so a flag-looking token inside a quoted argument
+# cannot false-trigger the flag checks below.
+DEQUOTED=$(printf '%s' "$CMD" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")
+
+# --- Check A: --no-verify defeats the pre-push hook ---
+if printf '%s' "$DEQUOTED" | grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)'; then
+    deny_response "git push --no-verify is blocked: it bypasses the pre-push hook, the terminal-side half of the two-layer protected-branch defense. Push without --no-verify."
+fi
+
+# --- Dry-run is harmless: skip the protected-target check for it (#782) ---
+DRY_RUN=0
+if printf '%s' "$DEQUOTED" | grep -qE '(^|[[:space:]])(-n|--dry-run)([[:space:]]|$)'; then
+    DRY_RUN=1
+fi
+
+# --- Check B: direct push to a protected branch ---
+if [ "$DRY_RUN" -eq 0 ]; then
+    # Isolate the `git push` invocation's arguments, stopping at the first
+    # shell operator so a following `&& ...` cannot leak in as positionals.
+    PUSH_ARGS=$(printf '%s' "$DEQUOTED" | sed -nE 's/.*git[[:space:]]+push[[:space:]]*(.*)/\1/p' | head -1)
+    PUSH_ARGS="${PUSH_ARGS%%&&*}"
+    PUSH_ARGS="${PUSH_ARGS%%;*}"
+    PUSH_ARGS="${PUSH_ARGS%%|*}"
+
+    # Collect positional (non-flag) args: [remote] [refspec].
+    read -ra _tokens <<< "$PUSH_ARGS"
+    positionals=()
+    for _t in "${_tokens[@]:-}"; do
+        [ -n "$_t" ] || continue
+        case "$_t" in
+            -*) continue ;;
+            *)  positionals+=("$_t") ;;
+        esac
+    done
+
+    REFSPEC="${positionals[1]:-}"
+    DST=""
+    if [ -n "$REFSPEC" ]; then
+        # `src:dst` -> dst; a bare `branch` -> branch.
+        DST="${REFSPEC##*:}"
+    else
+        # No refspec: the push targets the current branch's upstream, which is
+        # the current branch. Resolve it; fail open if git cannot (not a repo).
+        DST=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    fi
+
+    # Normalize: strip a leading '+' (force refspec) and a refs/heads/ prefix.
+    DST="${DST#+}"
+    DST="${DST#refs/heads/}"
+
+    case "$DST" in
+        main|master|develop)
+            deny_response "Direct push to protected branch '${DST}' is blocked by branching policy. Open a PR into 'develop' (feature/fix branches) or use the /release skill (develop -> main). If you must, push from a work branch instead."
+            ;;
+    esac
+fi
+
+allow_response

--- a/global/settings.json
+++ b/global/settings.json
@@ -216,6 +216,11 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/push-target-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/pr-language-guard.sh",
             "timeout": 5
           },

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -147,6 +147,11 @@
           },
           {
             "type": "command",
+            "command": "pwsh -NoProfile -File ~/.claude/hooks/push-target-guard.ps1",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "pwsh -NoProfile -File ~/.claude/hooks/pr-language-guard.ps1",
             "timeout": 5
           },

--- a/tests/hooks/test-commit-message-guard.ps1
+++ b/tests/hooks/test-commit-message-guard.ps1
@@ -63,6 +63,38 @@ Assert-Deny 'Feat: capitalized conventional type' 'capitalized type -> deny (cas
 Assert-Deny 'FIX: uppercase type'                 'uppercase type -> deny (case-sensitive)'
 Assert-Deny 'feat: trailing period.'            'trailing period -> deny'
 
+function Invoke-Raw {
+    param([string]$Cmd)
+    $json = (@{ tool_input = @{ command = $Cmd } } | ConvertTo-Json -Compress)
+    return ($json | & pwsh -NoProfile -File $script:HookPath 2>$null)
+}
+function Assert-RawDeny {
+    param([string]$Cmd, [string]$Label)
+    $r = Invoke-Raw $Cmd
+    if ($r -match '"deny"') {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - got: $r"); Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+function Assert-RawAllow {
+    param([string]$Cmd, [string]$Label)
+    $r = Invoke-Raw $Cmd
+    if ($r -match '"allow"' -or [string]::IsNullOrEmpty($r)) {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - got: $r"); Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host ''
+Write-Host '[--no-verify / -n and single-quote extraction (issue #782)]'
+Assert-RawDeny  'git commit --no-verify -m "feat: x"'          'commit --no-verify -> deny'
+Assert-RawDeny  'git commit -n -m "feat: x"'                   'commit -n -> deny'
+Assert-RawDeny  "git commit -m 'added no type prefix'"         'single-quote no-type -> deny'
+Assert-RawAllow "git commit -m 'feat: valid single-quoted'"    'single-quote valid -> allow'
+Assert-RawAllow 'git commit -m "fix: handle -n flag parsing"'  '-n inside message text -> allow'
+
 Write-Host ''
 Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
 if ($script:Errors.Count -gt 0) {

--- a/tests/hooks/test-commit-message-guard.sh
+++ b/tests/hooks/test-commit-message-guard.sh
@@ -117,6 +117,21 @@ assert_allow '{"tool_input":{"command":"git commit -m \"$(cat <<EOF\nfeat: multi
 assert_allow '' "empty input → allow"
 
 echo ""
+echo "[--no-verify / -n bypass blocked (issue #782)]"
+assert_deny '{"tool_input":{"command":"git commit --no-verify -m \"feat: x\""}}' "commit --no-verify → deny"
+assert_deny '{"tool_input":{"command":"git commit -n -m \"feat: x\""}}' "commit -n → deny"
+assert_deny '{"tool_input":{"command":"git commit -nm \"feat: x\""}}' "commit -nm (bundled short flags) → deny"
+assert_allow '{"tool_input":{"command":"git commit -m \"fix: handle -n flag parsing\""}}' "-n inside message text → allow (not a flag)"
+assert_allow '{"tool_input":{"command":"git commit --amend --no-edit -m \"feat: x\""}}' "--no-edit → allow (not --no-verify)"
+
+echo ""
+echo "[single-quoted -m extraction reaches validator (issue #782)]"
+assert_allow "{\"tool_input\":{\"command\":\"git commit -m 'feat: valid single-quoted'\"}}" "single-quote valid → allow"
+assert_deny "{\"tool_input\":{\"command\":\"git commit -m 'added no type prefix'\"}}" "single-quote no-type → deny"
+assert_deny "{\"tool_input\":{\"command\":\"git commit -am 'update: bad type'\"}}" "single-quote -am bad type → deny"
+assert_deny "{\"tool_input\":{\"command\":\"git commit --message='feat: Uppercase First'\"}}" "single-quote --message= uppercase → deny"
+
+echo ""
 echo "[determinism — same input yields same output across 3 runs]"
 TEST_INPUT='{"tool_input":{"command":"git commit -m \"feat: deterministic check\""}}'
 R1=$(echo "$TEST_INPUT" | bash "$HOOK" 2>/dev/null)

--- a/tests/hooks/test-push-target-guard.ps1
+++ b/tests/hooks/test-push-target-guard.ps1
@@ -1,0 +1,77 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+# Tests for push-target-guard.ps1 (issue #782). PowerShell parity with
+# tests/hooks/test-push-target-guard.sh.
+# Run: pwsh tests/hooks/test-push-target-guard.ps1
+
+$ErrorActionPreference = 'Stop'
+
+$script:RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$script:HookPath = Join-Path $script:RepoRoot 'global' 'hooks' 'push-target-guard.ps1'
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-Push {
+    param([string]$Cmd)
+    $json = (@{ tool_input = @{ command = $Cmd } } | ConvertTo-Json -Compress)
+    return ($json | & pwsh -NoProfile -File $script:HookPath 2>$null)
+}
+
+function Assert-Allow {
+    param([string]$Cmd, [string]$Label)
+    $r = Invoke-Push $Cmd
+    if ($r -match '"allow"') {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected allow, got: $r")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+function Assert-Deny {
+    param([string]$Cmd, [string]$Label)
+    $r = Invoke-Push $Cmd
+    if ($r -match '"deny"') {
+        $script:Passed++; Write-Host "  PASS: $Label" -ForegroundColor Green
+    } else {
+        $script:Failed++; $script:Errors.Add("FAIL: $Label - expected deny, got: $r")
+        Write-Host "  FAIL: $Label" -ForegroundColor Red
+    }
+}
+
+Write-Host '=== push-target-guard.ps1 tests ==='
+Write-Host ''
+Write-Host '[non-push commands pass through]'
+Assert-Allow 'git status'              'git status -> allow'
+Assert-Allow 'git commit -m "feat: x"' 'git commit -> allow'
+
+Write-Host ''
+Write-Host '[direct push to a protected branch -> deny]'
+Assert-Deny 'git push origin main'            'push origin main -> deny'
+Assert-Deny 'git push origin develop'         'push origin develop -> deny'
+Assert-Deny 'git push origin master'          'push origin master -> deny'
+Assert-Deny 'git push -u origin main'         'push -u origin main -> deny'
+Assert-Deny 'git push --force origin develop' 'push --force develop -> deny'
+Assert-Deny 'git push origin HEAD:main'       'push HEAD:main -> deny'
+Assert-Deny 'git push origin +main'           'push +main -> deny'
+
+Write-Host ''
+Write-Host '[non-protected targets -> allow]'
+Assert-Allow 'git push origin feature/x'     'push feature/x -> allow'
+Assert-Allow 'git push origin main:feature'  'push main:feature (dst feature) -> allow'
+
+Write-Host ''
+Write-Host '[--no-verify -> deny; dry-run -> allow]'
+Assert-Deny  'git push --no-verify origin feature/x' 'push --no-verify -> deny'
+Assert-Allow 'git push -n origin main'               'push -n (dry-run) main -> allow'
+Assert-Allow 'git push --dry-run origin develop'     'push --dry-run develop -> allow'
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0

--- a/tests/hooks/test-push-target-guard.sh
+++ b/tests/hooks/test-push-target-guard.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Test suite for push-target-guard.sh (issue #782)
+# Run: bash tests/hooks/test-push-target-guard.sh
+
+HOOK="global/hooks/push-target-guard.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+cd "$(dirname "$0")/../.." || exit 1
+
+assert_deny() {
+    local input="$1" label="$2" result
+    result=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        PASS=$((PASS + 1)); echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $label — expected deny, got: $result"); echo "  FAIL: $label"
+    fi
+}
+
+assert_allow() {
+    local input="$1" label="$2" result
+    result=$(echo "$input" | bash "$HOOK" 2>/dev/null)
+    if echo "$result" | grep -q '"allow"'; then
+        PASS=$((PASS + 1)); echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $label — expected allow, got: $result"); echo "  FAIL: $label"
+    fi
+}
+
+echo "=== push-target-guard.sh tests ==="
+echo ""
+
+echo "[non-push commands pass through]"
+assert_allow '{"tool_input":{"command":"git status"}}' "git status → allow"
+assert_allow '{"tool_input":{"command":"git commit -m \"feat: x\""}}' "git commit → allow"
+assert_allow '{"tool_input":{"command":"ls -la"}}' "ls -la → allow"
+
+echo ""
+echo "[direct push to a protected branch → deny]"
+assert_deny '{"tool_input":{"command":"git push origin main"}}' "push origin main → deny"
+assert_deny '{"tool_input":{"command":"git push origin master"}}' "push origin master → deny"
+assert_deny '{"tool_input":{"command":"git push origin develop"}}' "push origin develop → deny"
+assert_deny '{"tool_input":{"command":"git push -u origin main"}}' "push -u origin main → deny"
+assert_deny '{"tool_input":{"command":"git push --force origin develop"}}' "push --force origin develop → deny"
+assert_deny '{"tool_input":{"command":"git push origin HEAD:main"}}' "push HEAD:main → deny"
+assert_deny '{"tool_input":{"command":"git push origin +main"}}' "push +main (force refspec) → deny"
+assert_deny '{"tool_input":{"command":"git push origin refs/heads/develop"}}' "push refs/heads/develop → deny"
+
+echo ""
+echo "[non-protected targets → allow]"
+assert_allow '{"tool_input":{"command":"git push origin feature/x"}}' "push feature/x → allow"
+assert_allow '{"tool_input":{"command":"git push -u origin fix/issue-1"}}' "push fix/issue-1 → allow"
+assert_allow '{"tool_input":{"command":"git push origin main:feature"}}' "push main:feature (dst feature) → allow"
+
+echo ""
+echo "[--no-verify defeats pre-push hook → deny]"
+assert_deny '{"tool_input":{"command":"git push --no-verify origin feature/x"}}' "push --no-verify (non-protected) → deny"
+assert_deny '{"tool_input":{"command":"git push origin feature/x --no-verify"}}' "push ... --no-verify (trailing) → deny"
+
+echo ""
+echo "[dry-run is harmless — -n is NOT --no-verify for push (issue #782)]"
+assert_allow '{"tool_input":{"command":"git push -n origin main"}}' "push -n origin main (dry-run) → allow"
+assert_allow '{"tool_input":{"command":"git push --dry-run origin develop"}}' "push --dry-run develop → allow"
+
+echo ""
+echo "[quoted-arg false-trigger guard]"
+assert_allow '{"tool_input":{"command":"git push origin feature/no-verify-docs"}}' "branch name containing 'no-verify' → allow"
+
+echo ""
+echo "[fail-closed on unparseable input]"
+assert_deny '' "empty input → deny (fail-closed)"
+
+echo ""
+echo "[determinism — same input yields same output across 3 runs]"
+TI='{"tool_input":{"command":"git push origin main"}}'
+R1=$(echo "$TI" | bash "$HOOK" 2>/dev/null); R2=$(echo "$TI" | bash "$HOOK" 2>/dev/null); R3=$(echo "$TI" | bash "$HOOK" 2>/dev/null)
+if [ "$R1" = "$R2" ] && [ "$R2" = "$R3" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: deterministic across 3 runs"
+else
+    FAIL=$((FAIL + 1)); ERRORS+=("FAIL: non-deterministic output"); echo "  FAIL: non-deterministic"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    for err in "${ERRORS[@]}"; do echo "  $err"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #782
Part of #776

## What

Add PreToolUse guards so Claude-driven git cannot bypass the advertised
two-layer (PreToolUse + git-hook) defense.

## Why

- `git push --no-verify origin main` passed with **no** PreToolUse block — the
  only guard was the terminal `pre-push` hook, which `--no-verify` defeats.
- `commit-message-guard` extracted only double-quoted `-m "..."`, so
  `git commit -m 'msg' --no-verify` slipped through the PreToolUse layer and
  then bypassed the git hook — one path through both layers.

## How / acceptance criteria

- [x] **PreToolUse denies `--no-verify`** on `git commit` (and `-n`) via
  `commit-message-guard`, and on `git push` via the new `push-target-guard`.
  `git push -n` (`--dry-run`) is **not** denied — it performs no real push.
- [x] **`push-target-guard` denies direct push to `main`/`master`/`develop`**,
  parsing the explicit refspec (`origin main`, `HEAD:main`, `+main`,
  `refs/heads/...`) or the resolved upstream of the current branch.
- [x] **Single-quoted `-m '...'` / `-am '...'` / `--message='...'` extraction**
  added to `commit-message-guard`, closing the PreToolUse single-quote seam.
- [x] **Regression fixtures** under `tests/hooks` (`.sh` + `.ps1` for both).

Quoted substrings are stripped before flag matching, so a flag inside a commit
message (`-m "fix -n bug"`) cannot false-trigger. Both guards ship a
PowerShell mirror wired into `settings.windows.json` (parity is CI-gated).

## Where

- New: `global/hooks/push-target-guard.{sh,ps1}`,
  `tests/hooks/test-push-target-guard.{sh,ps1}`
- Modified: `global/hooks/commit-message-guard.{sh,ps1}`,
  `global/settings.json`, `global/settings.windows.json`,
  `tests/hooks/test-commit-message-guard.{sh,ps1}`, `ENFORCEMENT.md`, `HOOKS.md`

## Test plan

Verified locally (macOS):

- `test-push-target-guard.sh` — 21/21; `test-commit-message-guard.sh` — 46/46
  (including the new --no-verify/-n and single-quote cases).
- `bash -n` clean; both `settings.json`/`settings.windows.json` valid JSON;
  `test-windows-hooks-parity.sh` passes (the new guard has a matching basename
  in both settings files).
- `gen-hooks-md.sh --check` passes (HOOKS.md regenerated: 38 hooks).
- Full `tests/hooks/test-runner.sh`: the only failures are the pre-existing
  `markdown-anchor-validator` cases that require bash 4+ (this box has macOS
  bash 3.2; CI installs bash 4+). All push/commit guard suites pass.

The PowerShell guards and tests run for real in CI via the `pwsh
tests/hooks/test-runner.ps1` step added in #781 (no local `pwsh`).
