### PR TITLE
fix(install): close 776 audit gaps

### DIFF
--- a/.github/.issue-drafts/epic-776-closure.md
+++ b/.github/.issue-drafts/epic-776-closure.md
@@ -1,0 +1,48 @@
+## Epic closure audit update
+
+The first registered child-issue wave for #776 has been implemented and merged to `develop`, but the final closure audit found two remaining follow-up gaps that now have dedicated issues.
+
+### Child issue status
+
+| Scope | Issues | Status |
+|-------|--------|--------|
+| P0 input minimization | #777, #778, #779, #780 | Closed and merged |
+| P1 cross-platform and enforcement parity | #781, #782 | Closed and merged |
+| P2 maintenance and documentation | #783 | Closed and merged |
+| #783 split work | #790, #791, #792, #793, #794, #795 | Closed and merged through #796 |
+| Final audit follow-ups | #797, #798 | Open |
+
+### Final cross-check
+
+The final audit found three concrete gaps after the implementation work had landed:
+
+1. Git identity auto-seeding was implemented, but README, QUICKSTART, and installer next-step messages still described manual `git-identity.md` editing as required.
+2. #778 lacks executable non-tty bootstrap coverage for the advertised `curl ... | INSTALL_TYPE=3 bash` path; tracked by #797.
+3. #779 deployed bootstrap hooks but still ignores broad hook-copy failures after writing `settings.json`; tracked by #798.
+
+This PR closes the first gap and two small parity defects discovered during the audit:
+
+- fresh installs auto-fill `~/.claude/git-identity.md` from `git config --global user.name` and `git config --global user.email` when both values exist;
+- docs now ask users to verify the installed values instead of editing by default;
+- bootstrap and install scripts warn only when `YOUR NAME` / `YOUR EMAIL` placeholders remain.
+- PowerShell reinstall keeps the prior `.language` and `.env.CLAUDE_CONTENT_LANGUAGE` settings just like Bash;
+- `push-target-guard` now resolves bare `git push` through `@{upstream}` before falling back to the current branch.
+
+### Verification
+
+- `bash -n bootstrap.sh scripts/install.sh`
+- PowerShell parser check for `bootstrap.ps1` and `scripts/install.ps1`
+- `bash scripts/diff-readme.sh`
+- `bash tests/scripts/test-diff-readme.sh`
+- `pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1`
+- `pwsh -NoProfile -File tests/hooks/test-push-target-guard.ps1`
+- `bash tests/hooks/test-push-target-guard.sh` with a temporary local `jq` wrapper because WSL exposes `jq.exe`, while CI installs native `jq`
+- `git diff --check`
+
+### Closure decision
+
+#776 should remain open until #797 and #798 are complete. The rejected proposals in the epic body remain intentional non-goals:
+
+- do not infer the language default from `$LANG`;
+- do not unify the bootstrap install-type default with `scripts/install.sh`;
+- do not merge the Bash PreToolUse hooks into one dispatcher.

--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -24,6 +24,7 @@ on:
       - 'tests/scripts/test-install-permissions-policy.sh'
       - 'tests/scripts/test-language-policy-drift.sh'
       - 'tests/scripts/test-installer-prompt-drift.sh'
+      - 'tests/scripts/test-install-prompts-ps1.ps1'
       - 'tests/scripts/test-doc-prompt-lockstep.sh'
       - 'tests/scripts/test-language-override-contract.sh'
       - 'scripts/lib/**'
@@ -119,6 +120,11 @@ jobs:
         # scripts/lib/InstallPrompts.psm1 (PowerShell) - the single source
         # of truth for installer prompts and the policy phrase table.
         run: bash tests/scripts/test-installer-prompt-drift.sh
+
+      - name: Run PowerShell installer prompt tests
+        # Covers runtime PowerShell prompt-helper behavior that static drift
+        # extraction cannot validate, including reinstall language seeding.
+        run: pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1
 
       - name: Run doc/prompt lockstep test
         # Pins the live 3-option Language Profile Preset prompt as the

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -67,7 +67,21 @@ Select installation type:
 Selection (1-5) [default: 3]: 3
 ```
 
-### Step 3: Personalize (1 minute)
+### Step 3: Verify Git Identity (30 seconds)
+
+Installers auto-fill `~/.claude/git-identity.md` from `git config --global user.name` and `git config --global user.email` when both values exist. Check the installed values:
+
+**macOS/Linux:**
+```bash
+grep -E "^(name|email):" ~/.claude/git-identity.md
+```
+
+**Windows:**
+```powershell
+Get-Content $HOME\.claude\git-identity.md | Select-String '^(name|email):'
+```
+
+If the file still contains placeholders, edit it:
 
 **macOS/Linux:**
 ```bash
@@ -79,9 +93,8 @@ vi ~/.claude/git-identity.md
 notepad $HOME\.claude\git-identity.md
 ```
 
-**Example changes:**
+**Placeholder example:**
 ```yaml
-# Before
 name: "Your Name"      # <- Change this
 email: "you@email.com" # <- Change this
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,8 +35,8 @@
 # 1. 원라인 설치
 curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | bash
 
-# 2. Git identity 개인화 (필수!)
-vi ~/.claude/git-identity.md
+# 2. Git identity 확인 (가능하면 git config에서 자동 입력)
+grep -E "^(name|email):" ~/.claude/git-identity.md
 
 # 3. Claude Code 재시작 - 완료!
 ```
@@ -123,8 +123,8 @@ git clone https://github.com/kcenon/claude-config.git ~/claude_config_backup
 cd ~/claude_config_backup
 ./scripts/install.sh
 
-# 3. Git identity 개인화 (필수!)
-vi ~/.claude/git-identity.md
+# 3. Git identity 확인 (누락되었거나 틀린 경우에만 수정)
+grep -E "^(name|email):" ~/.claude/git-identity.md
 ```
 
 ### Plugin 설치 (Beta)
@@ -727,7 +727,7 @@ Create a team to implement the notification system:
 | `verify.sh` / `.ps1` | 백업 무결성과 완전성 확인 | `./scripts/verify.sh` |
 | `validate_skills.sh` / `.ps1` | SKILL.md 형식 준수 여부 검증 | `./scripts/validate_skills.sh` |
 
-설치 후, 반드시 `~/.claude/git-identity.md`를 개인 정보로 수정**해야** 합니다.
+설치 후 `~/.claude/git-identity.md`는 `git config --global user.name` 및 `git config --global user.email` 값이 모두 있으면 자동으로 채워집니다. 값이 누락되었거나 틀린 경우에만 수정하세요.
 기존 파일은 `.backup_YYYYMMDD_HHMMSS` 형식으로 자동 백업됩니다.
 
 ---
@@ -803,8 +803,8 @@ cd ~/claude_config_backup
 ./scripts/install.sh
 # 타입: 3 (둘 다)
 
-# Git identity 수정
-vi ~/.claude/git-identity.md
+# Git identity 확인; 누락되었거나 틀린 경우에만 수정
+grep -E "^(name|email):" ~/.claude/git-identity.md
 ```
 
 ---
@@ -911,11 +911,11 @@ bash -c "$(curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main
 
 ### Q1: Git identity를 왜 개인화해야 하나요?
 
-**A:** `git-identity.md`는 개인 정보(이름, 이메일)를 포함하므로, 각 사용자가 자신의 정보로 수정해야 합니다.
+**A:** `git-identity.md`는 개인 정보(이름, 이메일)를 포함하므로, 각 설치는 사용자 본인의 값을 사용해야 합니다. 설치 프로그램은 `git config --global user.name` 및 `git config --global user.email` 값이 모두 있으면 자동으로 채우며, 값이 누락되었거나 틀린 경우에만 파일을 수정하면 됩니다.
 
 ```bash
 vi ~/.claude/git-identity.md
-# name과 email을 자신의 정보로 변경
+# 설치된 값이 누락되었거나 틀린 경우에만 name과 email 변경
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Get up and running in 3 minutes:
 # 1. One-line installation
 curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main/bootstrap.sh | bash
 
-# 2. Personalize Git identity (Required!)
-vi ~/.claude/git-identity.md
+# 2. Verify Git identity (auto-filled from git config when available)
+grep -E "^(name|email):" ~/.claude/git-identity.md
 
 # 3. Restart Claude Code - Done!
 ```
@@ -125,8 +125,8 @@ git clone https://github.com/kcenon/claude-config.git ~/claude_config_backup
 cd ~/claude_config_backup
 ./scripts/install.sh
 
-# 3. Personalize Git identity (Required!)
-vi ~/.claude/git-identity.md
+# 3. Verify Git identity (edit only if missing or wrong)
+grep -E "^(name|email):" ~/.claude/git-identity.md
 ```
 
 ### Windows (PowerShell)
@@ -139,8 +139,8 @@ git clone https://github.com/kcenon/claude-config.git ~\claude_config_backup
 cd ~\claude_config_backup
 .\scripts\install.ps1
 
-# 3. Personalize Git identity (Required!)
-notepad $HOME\.claude\git-identity.md
+# 3. Verify Git identity (edit only if missing or wrong)
+Get-Content $HOME\.claude\git-identity.md | Select-String '^(name|email):'
 ```
 
 > **Note**: Requires PowerShell 7+ (`pwsh`). Install via `winget install Microsoft.PowerShell`.
@@ -751,7 +751,7 @@ The `.mcp.json` template provides common MCP server configurations.
 | `verify.sh` / `.ps1` | Check backup integrity and completeness | `./scripts/verify.sh` |
 | `validate_skills.sh` / `.ps1` | Validate SKILL.md format compliance | `./scripts/validate_skills.sh` |
 
-After installation, you **must** edit `~/.claude/git-identity.md` with your personal info.
+After installation, `~/.claude/git-identity.md` is auto-filled from `git config --global user.name` and `git config --global user.email` when both values exist. Edit it only if the values are missing or wrong.
 Existing files are automatically backed up with `.backup_YYYYMMDD_HHMMSS` format.
 
 ---
@@ -829,8 +829,8 @@ cd ~/claude_config_backup
 ./scripts/install.sh
 # Type: 3 (Both)
 
-# Modify Git identity
-vi ~/.claude/git-identity.md
+# Verify Git identity; edit only if missing or wrong
+grep -E "^(name|email):" ~/.claude/git-identity.md
 ```
 
 ---
@@ -948,11 +948,11 @@ bash -c "$(curl -sSL https://raw.githubusercontent.com/kcenon/claude-config/main
 
 ### Q1: Why do I need to personalize Git identity?
 
-**A:** `git-identity.md` contains personal information (name, email), so each user must modify it with their own information.
+**A:** `git-identity.md` contains personal information (name, email), so each installation must use the operator's own values. The installer auto-fills it from `git config --global user.name` and `git config --global user.email` when both values exist; edit the file only if those values are missing or wrong.
 
 ```bash
 vi ~/.claude/git-identity.md
-# Change name and email to your information
+# Change name and email only when the installed values are missing or wrong
 ```
 
 ---

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -280,7 +280,17 @@ function Install-GlobalSettings {
     # Language policy selection (Unified Language Profile)
     # Stored at script scope so the project-install path (Install-ProjectSettings)
     # can reuse the resolved values for rule-template rendering (issue #760).
-    $profileChoice = Show-LanguageProfilePrompt
+    $settingsPath = Join-Path $ClaudeDir 'settings.json'
+    $seededPolicy = $null
+    if (Get-Command Seed-LanguageFromSettings -ErrorAction SilentlyContinue) {
+        $seededPolicy = Seed-LanguageFromSettings -SettingsPath $settingsPath
+    }
+    if ($seededPolicy) {
+        $profileChoice = Show-LanguageProfilePrompt -AgentLanguage $seededPolicy.AgentLanguage -ContentLanguage $seededPolicy.ContentLanguage
+    }
+    else {
+        $profileChoice = Show-LanguageProfilePrompt
+    }
     $script:agentLanguage = $profileChoice.AgentLanguage
     $script:displayLang = $profileChoice.AgentDisplay
     $script:contentLanguage = $profileChoice.ContentLanguage
@@ -445,10 +455,19 @@ function Install-GlobalSettings {
 
 function Invoke-PersonalizeGitIdentity {
     Write-Host ""
-    Write-Warn "중요: Git Identity를 개인 정보로 수정해야 합니다!"
+    $gitIdFile = Join-Path $ClaudeDir 'git-identity.md'
+    $needsGitIdentityEdit = $false
+    if (Test-Path $gitIdFile) {
+        $needsGitIdentityEdit = [bool](Select-String -Path $gitIdFile -Pattern 'YOUR NAME|YOUR EMAIL' -Quiet)
+    }
+    if ($needsGitIdentityEdit) {
+        Write-Warn "Git Identity에 기본 placeholder가 남아 있습니다. 개인 정보로 수정하세요."
+    }
+    else {
+        Write-Info "Git Identity가 준비되었습니다. 필요하면 값을 확인하거나 수정하세요."
+    }
     Write-Host ""
     Write-Host "  현재 설정:"
-    $gitIdFile = Join-Path $ClaudeDir 'git-identity.md'
     if (Test-Path $gitIdFile) {
         Get-Content $gitIdFile | Where-Object { $_ -match '^(name|email):' } | ForEach-Object {
             Write-Host "    $_"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -428,7 +428,11 @@ install_global() {
 # Git identity 개인화 안내
 personalize_git_identity() {
     echo ""
-    warning "중요: Git Identity를 개인 정보로 수정해야 합니다!"
+    if grep -qE "YOUR NAME|YOUR EMAIL" "$CLAUDE_DIR/git-identity.md" 2>/dev/null; then
+        warning "Git Identity에 기본 placeholder가 남아 있습니다. 개인 정보로 수정하세요."
+    else
+        info "Git Identity가 준비되었습니다. 필요하면 값을 확인하거나 수정하세요."
+    fi
     echo ""
     echo "  현재 설정:"
     grep -E "^(name|email):" "$CLAUDE_DIR/git-identity.md" 2>/dev/null || true

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -191,33 +191,33 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 4750
+    size: 5170
     tags: []
     sections:
       - {h: "Contents", l: 7, e: 23}
       - {h: "3-Minute Installation", l: 24, e: 25}
       - {h: "Step 1: Copy (30 seconds)", l: 26, e: 41}
       - {h: "Step 2: Install (1 minute)", l: 42, e: 69}
-      - {h: "Step 3: Personalize (1 minute)", l: 70, e: 88}
-      - {h: "Step 4: Restart (30 seconds)", l: 89, e: 97}
-      - {h: "Verification", l: 98, e: 109}
-      - {h: "Daily Usage", l: 110, e: 111}
-      - {h: "Backup (after settings change)", l: 112, e: 119}
-      - {h: "Sync (between multiple systems)", l: 120, e: 130}
-      - {h: "Troubleshooting", l: 131, e: 132}
-      - {h: "Scripts won't run", l: 133, e: 144}
-      - {h: "File not found", l: 145, e: 152}
-      - {h: "Worried about overwriting", l: 153, e: 162}
-      - {h: "Learn More", l: 163, e: 171}
-      - {h: "What's Next", l: 172, e: 173}
-      - {h: "Try a skill", l: 174, e: 187}
-      - {h: "Choose your path", l: 188, e: 201}
+      - {h: "Step 3: Verify Git Identity (30 seconds)", l: 70, e: 101}
+      - {h: "Step 4: Restart (30 seconds)", l: 102, e: 110}
+      - {h: "Verification", l: 111, e: 122}
+      - {h: "Daily Usage", l: 123, e: 124}
+      - {h: "Backup (after settings change)", l: 125, e: 132}
+      - {h: "Sync (between multiple systems)", l: 133, e: 143}
+      - {h: "Troubleshooting", l: 144, e: 145}
+      - {h: "Scripts won't run", l: 146, e: 157}
+      - {h: "File not found", l: 158, e: 165}
+      - {h: "Worried about overwriting", l: 166, e: 175}
+      - {h: "Learn More", l: 176, e: 184}
+      - {h: "What's Next", l: 185, e: 186}
+      - {h: "Try a skill", l: 187, e: 200}
+      - {h: "Choose your path", l: 201, e: 214}
   - path: "README.ko.md"
     title: "Claude Configuration Backup & Deployment System"
     description: ""
     category: root
     scope: root
-    size: 45694
+    size: 46262
     tags: [config,readme]
     sections:
       - {h: "빠른 시작", l: 30, e: 58}
@@ -296,7 +296,7 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 43957
+    size: 44484
     tags: [config,readme]
     sections:
       - {h: "Quick Start", l: 30, e: 58}

--- a/global/hooks/push-target-guard.ps1
+++ b/global/hooks/push-target-guard.ps1
@@ -63,9 +63,18 @@ if (-not $dryRun) {
         # `src:dst` -> dst; a bare `branch` -> branch.
         $dst = @($positionals[1] -split ':')[-1]
     } else {
-        # No refspec: the push targets the current branch's upstream (the
-        # current branch). Resolve it; fail open if git cannot (not a repo).
-        try { $dst = (& git rev-parse --abbrev-ref HEAD 2>$null) } catch {}
+        # No refspec: bare `git push` targets the current branch's upstream
+        # when one exists. Resolve that destination first, then fall back to the
+        # current branch for repos without an upstream.
+        $upstream = $null
+        try { $upstream = (& git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>$null) } catch {}
+        if ($upstream) {
+            $upstreamText = "$upstream".Trim()
+            $dst = @($upstreamText -split '/', 2)[-1]
+        }
+        else {
+            try { $dst = (& git rev-parse --abbrev-ref HEAD 2>$null) } catch {}
+        }
         if ($dst) { $dst = ("$dst").Trim() }
     }
 

--- a/global/hooks/push-target-guard.sh
+++ b/global/hooks/push-target-guard.sh
@@ -45,6 +45,7 @@ fi
 if [ -z "$CMD" ]; then
     CMD="${CLAUDE_TOOL_INPUT:-}"
 fi
+CMD="${CMD//$'\r'/}"
 
 # --- Scope gate: only inspect `git push` commands ---
 if ! echo "$CMD" | grep -qE 'git[[:space:]]+push'; then
@@ -92,9 +93,15 @@ if [ "$DRY_RUN" -eq 0 ]; then
         # `src:dst` -> dst; a bare `branch` -> branch.
         DST="${REFSPEC##*:}"
     else
-        # No refspec: the push targets the current branch's upstream, which is
-        # the current branch. Resolve it; fail open if git cannot (not a repo).
-        DST=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        # No refspec: bare `git push` targets the current branch's upstream
+        # when one exists. Resolve that destination first, then fall back to the
+        # current branch for repos without an upstream.
+        UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+        if [ -n "$UPSTREAM" ]; then
+            DST="${UPSTREAM#*/}"
+        else
+            DST=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        fi
     fi
 
     # Normalize: strip a leading '+' (force refspec) and a refs/heads/ prefix.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -308,13 +308,15 @@ if ([string]::IsNullOrEmpty($installType)) { $installType = '3' }
 $promptsModule = Join-Path $ScriptDir 'lib' 'InstallPrompts.psm1'
 Import-Module $promptsModule -Force -DisableNameChecking
 
-$profileChoice = Show-LanguageProfilePrompt
+$settingsPath = Join-Path $HOME '.claude/settings.json'
+$seededPolicy = Seed-LanguageFromSettings -SettingsPath $settingsPath
+$profileChoice = Show-LanguageProfilePrompt -AgentLanguage $seededPolicy.AgentLanguage -ContentLanguage $seededPolicy.ContentLanguage
 $agentLanguage = $profileChoice.AgentLanguage
 $agentDisplayLang = $profileChoice.AgentDisplay
 $contentLanguage = $profileChoice.ContentLanguage
 
 # Legacy settings.json migration warning (informational only).
-$null = Show-LegacySettingsWarning -SettingsPath (Join-Path $HOME '.claude/settings.json') -NewSelection $contentLanguage
+$null = Show-LegacySettingsWarning -SettingsPath $settingsPath -NewSelection $contentLanguage
 
 # ── Enterprise CLAUDE.md conflict detection (issue #411) ───────
 # Enterprise policy takes the highest precedence; warn when the chosen
@@ -670,8 +672,19 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
 
     # Git identity personalization notice
     Write-Host ""
-    Write-Warn "Important: Modify git-identity.md with your personal info!"
-    Write-Host "  Edit: notepad `$HOME\.claude\git-identity.md"
+    $gitIdentityPath = Join-Path $claudeDir 'git-identity.md'
+    $needsGitIdentityEdit = $false
+    if (Test-Path $gitIdentityPath) {
+        $needsGitIdentityEdit = [bool](Select-String -Path $gitIdentityPath -Pattern 'YOUR NAME|YOUR EMAIL' -Quiet)
+    }
+    if ($needsGitIdentityEdit) {
+        Write-Warn "git-identity.md still contains default placeholders. Edit it with your personal info."
+        Write-Host "  Edit: notepad `$HOME\.claude\git-identity.md"
+    }
+    else {
+        Write-Info "git-identity.md is ready. Review or edit it only if needed."
+        Write-Host "  Check: Get-Content `$HOME\.claude\git-identity.md | Select-String '^(name|email):'"
+    }
 }
 
 # ── Project settings installation ─────────────────────────────
@@ -835,8 +848,9 @@ Write-Host "======================================================"
 Write-Info "Next steps"
 Write-Host "======================================================"
 Write-Host ""
-Write-Host "1. Personalize Git identity (Required!):"
-Write-Host "     notepad `$HOME\.claude\git-identity.md"
+Write-Host "1. Verify Git identity:"
+Write-Host "     Get-Content `$HOME\.claude\git-identity.md | Select-String '^(name|email):'"
+Write-Host "     # Edit with notepad `$HOME\.claude\git-identity.md if placeholders remain"
 Write-Host ""
 Write-Host "2. Set PowerShell execution policy (if needed):"
 Write-Host "     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -891,8 +891,13 @@ PY
 
     # Git identity 개인화 안내
     echo ""
-    warning "중요: git-identity.md를 개인 정보로 수정하세요!"
-    echo "  편집: vi ~/.claude/git-identity.md"
+    if grep -qE "YOUR NAME|YOUR EMAIL" "$HOME/.claude/git-identity.md" 2>/dev/null; then
+        warning "git-identity.md에 기본 placeholder가 남아 있습니다. 개인 정보로 수정하세요."
+        echo "  편집: vi ~/.claude/git-identity.md"
+    else
+        info "git-identity.md가 준비되었습니다. 필요하면 값을 확인하거나 수정하세요."
+        echo "  확인: grep -E \"^(name|email):\" ~/.claude/git-identity.md"
+    fi
 fi
 
 # 프로젝트 설정 설치
@@ -1050,8 +1055,9 @@ echo "======================================================"
 info "다음 단계"
 echo "======================================================"
 echo ""
-echo "1. ⚙️  Git identity 개인화 (필수!):"
-echo "     vi ~/.claude/git-identity.md"
+echo "1. ⚙️  Git identity 확인:"
+echo "     grep -E \"^(name|email):\" ~/.claude/git-identity.md"
+echo "     # placeholder가 남으면 vi ~/.claude/git-identity.md"
 echo ""
 echo "2. 🔄 Claude Code 재시작:"
 echo "     새 터미널을 열거나 현재 세션 종료 후 재시작"

--- a/scripts/lib/InstallPrompts.psm1
+++ b/scripts/lib/InstallPrompts.psm1
@@ -213,6 +213,76 @@ function Read-SettingsContentLanguage {
     }
 }
 
+function Read-SettingsAgentLanguage {
+    # Reads the current top-level ".language" value from a settings.json file.
+    # Returns empty string when missing or unparseable. Mirrors
+    # Read-SettingsContentLanguage for PowerShell reinstall parity with bash
+    # read_settings_agent_language (issue #780).
+    [CmdletBinding()]
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return '' }
+    try {
+        $json = Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json -ErrorAction Stop
+        if ($json.language) {
+            return [string]$json.language
+        }
+        return ''
+    } catch {
+        $line = (Select-String -LiteralPath $Path -Pattern '"language"\s*:\s*"([^"]*)"' -List).Matches
+        if ($line) { return $line[0].Groups[1].Value }
+        return ''
+    }
+}
+
+function Seed-LanguageFromSettings {
+    # Reinstall helper (issue #780). Fills AGENT_LANGUAGE / CONTENT_LANGUAGE
+    # equivalents from an existing settings.json when they are unset, so a
+    # PowerShell reinstall keeps the previously chosen policy instead of
+    # resetting to the Hybrid default. Explicit env overrides win because only
+    # unset values are filled. Returns the resolved values for callers to pass
+    # to Show-LanguageProfilePrompt.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SettingsPath,
+        [string]$AgentLanguage = $env:AGENT_LANGUAGE,
+        [string]$ContentLanguage = $env:CONTENT_LANGUAGE
+    )
+
+    $resolvedAgent = $AgentLanguage
+    $resolvedContent = $ContentLanguage
+    $seeded = $false
+
+    if (Test-Path -LiteralPath $SettingsPath) {
+        if ([string]::IsNullOrEmpty($resolvedAgent)) {
+            $existingAgent = Read-SettingsAgentLanguage -Path $SettingsPath
+            if (-not [string]::IsNullOrEmpty($existingAgent)) {
+                $resolvedAgent = $existingAgent
+                $seeded = $true
+            }
+        }
+        if ([string]::IsNullOrEmpty($resolvedContent)) {
+            $existingContent = Read-SettingsContentLanguage -Path $SettingsPath
+            if (-not [string]::IsNullOrEmpty($existingContent)) {
+                $resolvedContent = $existingContent
+                $seeded = $true
+            }
+        }
+    }
+
+    if ($seeded) {
+        $agentMsg = if ([string]::IsNullOrEmpty($resolvedAgent)) { '?' } else { $resolvedAgent }
+        $contentMsg = if ([string]::IsNullOrEmpty($resolvedContent)) { '?' } else { $resolvedContent }
+        Script:Write-PromptInfo "Existing language policy kept from settings.json (agent=$agentMsg, content=$contentMsg). Override with AGENT_LANGUAGE/CONTENT_LANGUAGE env or edit ~/.claude/settings.json."
+    }
+
+    return [pscustomobject]@{
+        AgentLanguage = $resolvedAgent
+        ContentLanguage = $resolvedContent
+        Seeded = $seeded
+    }
+}
+
 function Show-LegacySettingsWarning {
     # Prints a warning when settings.json holds a legacy CLAUDE_CONTENT_LANGUAGE
     # value the simplified UI no longer surfaces. Returns $true when warned.
@@ -268,4 +338,4 @@ function Set-GitIdentitySeed {
     return $true
 }
 
-Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Invoke-PolicyTemplate, Invoke-PolicyTemplatesInDir, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Show-LegacySettingsWarning, Set-GitIdentitySeed
+Export-ModuleMember -Function Show-LanguageProfilePrompt, Get-PolicyPhrase, Invoke-PolicyTemplate, Invoke-PolicyTemplatesInDir, Get-AllPolicyValues, Test-LegacyContentLanguage, Read-SettingsContentLanguage, Read-SettingsAgentLanguage, Seed-LanguageFromSettings, Show-LegacySettingsWarning, Set-GitIdentitySeed

--- a/tests/hooks/test-push-target-guard.ps1
+++ b/tests/hooks/test-push-target-guard.ps1
@@ -62,6 +62,30 @@ Assert-Allow 'git push origin feature/x'     'push feature/x -> allow'
 Assert-Allow 'git push origin main:feature'  'push main:feature (dst feature) -> allow'
 
 Write-Host ''
+Write-Host '[bare push resolves configured upstream]'
+$tmpRepo = Join-Path ([System.IO.Path]::GetTempPath()) "push-target-guard-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $tmpRepo | Out-Null
+try {
+    Push-Location $tmpRepo
+    & git init -q
+    & git checkout -q -b feature/upstream-main
+    & git config user.email 'test@example.com'
+    & git config user.name 'Test'
+    Set-Content -LiteralPath (Join-Path $tmpRepo 'seed.txt') -Value 'seed' -NoNewline
+    & git add seed.txt
+    & git commit -q -m 'test: seed'
+    & git remote add origin https://example.invalid/repo.git
+    & git update-ref refs/remotes/origin/main HEAD
+    & git config branch.feature/upstream-main.remote origin
+    & git config branch.feature/upstream-main.merge refs/heads/main
+    Assert-Deny 'git push' 'bare push to upstream main -> deny'
+}
+finally {
+    Pop-Location
+    Remove-Item -LiteralPath $tmpRepo -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
 Write-Host '[--no-verify -> deny; dry-run -> allow]'
 Assert-Deny  'git push --no-verify origin feature/x' 'push --no-verify -> deny'
 Assert-Allow 'git push -n origin main'               'push -n (dry-run) main -> allow'

--- a/tests/hooks/test-push-target-guard.sh
+++ b/tests/hooks/test-push-target-guard.sh
@@ -3,6 +3,7 @@
 # Run: bash tests/hooks/test-push-target-guard.sh
 
 HOOK="global/hooks/push-target-guard.sh"
+HOOK_ABS="$(pwd)/$HOOK"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -53,6 +54,31 @@ echo "[non-protected targets → allow]"
 assert_allow '{"tool_input":{"command":"git push origin feature/x"}}' "push feature/x → allow"
 assert_allow '{"tool_input":{"command":"git push -u origin fix/issue-1"}}' "push fix/issue-1 → allow"
 assert_allow '{"tool_input":{"command":"git push origin main:feature"}}' "push main:feature (dst feature) → allow"
+
+echo ""
+echo "[bare push resolves configured upstream]"
+TMP_REPO="$(mktemp -d)"
+trap 'rm -rf "$TMP_REPO"' EXIT
+(
+    cd "$TMP_REPO" || exit 1
+    git init -q
+    git checkout -q -b feature/upstream-main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo seed > seed.txt
+    git add seed.txt
+    git commit -q -m "test: seed"
+    git remote add origin https://example.invalid/repo.git
+    git update-ref refs/remotes/origin/main HEAD
+    git config branch.feature/upstream-main.remote origin
+    git config branch.feature/upstream-main.merge refs/heads/main
+    result=$(echo '{"tool_input":{"command":"git push"}}' | bash "$HOOK_ABS" 2>/dev/null)
+    if echo "$result" | grep -q '"deny"'; then
+        PASS=$((PASS + 1)); echo "  PASS: bare push to upstream main → deny"
+    else
+        FAIL=$((FAIL + 1)); ERRORS+=("FAIL: bare push to upstream main — expected deny, got: $result"); echo "  FAIL: bare push to upstream main"
+    fi
+)
 
 echo ""
 echo "[--no-verify defeats pre-push hook → deny]"

--- a/tests/scripts/test-install-prompts-ps1.ps1
+++ b/tests/scripts/test-install-prompts-ps1.ps1
@@ -1,0 +1,99 @@
+#Requires -Version 7.0
+<#
+Regression tests for the PowerShell installer prompt helpers.
+
+Run:
+  pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$RootDir = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$ModulePath = Join-Path $RootDir 'scripts/lib/InstallPrompts.psm1'
+Import-Module $ModulePath -Force -DisableNameChecking
+
+$script:Passed = 0
+$script:Failed = 0
+$script:Errors = [System.Collections.Generic.List[string]]::new()
+
+function Check-Equal {
+    param(
+        [string]$Name,
+        [string]$Expected,
+        [AllowNull()][string]$Actual
+    )
+    if ($Expected -eq $Actual) {
+        $script:Passed++
+        Write-Host "  PASS: $Name" -ForegroundColor Green
+    }
+    else {
+        $script:Failed++
+        $script:Errors.Add("FAIL: ${Name}: expected '$Expected', got '$Actual'")
+        Write-Host "  FAIL: $Name" -ForegroundColor Red
+        Write-Host "    expected: $Expected"
+        Write-Host "    actual:   $Actual"
+    }
+}
+
+function Check-True {
+    param([string]$Name, [bool]$Actual)
+    Check-Equal -Name $Name -Expected 'True' -Actual ([string]$Actual)
+}
+
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "install-prompts-ps1-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+try {
+    $settings = Join-Path $tmpDir 'settings.json'
+    @'
+{
+  "language": "english",
+  "env": {
+    "CLAUDE_CONTENT_LANGUAGE": "exclusive_bilingual"
+  }
+}
+'@ | Set-Content -LiteralPath $settings -NoNewline
+
+    Write-Host '=== InstallPrompts.psm1 language seed tests ==='
+    Write-Host ''
+
+    Write-Host '[settings readers]'
+    Check-Equal 'read agent language' 'english' (Read-SettingsAgentLanguage -Path $settings)
+    Check-Equal 'read content language' 'exclusive_bilingual' (Read-SettingsContentLanguage -Path $settings)
+
+    Write-Host ''
+    Write-Host '[reinstall seed]'
+    $seed = Seed-LanguageFromSettings -SettingsPath $settings -AgentLanguage '' -ContentLanguage ''
+    Check-True 'seed reports changed values' $seed.Seeded
+    Check-Equal 'seed agent from settings' 'english' $seed.AgentLanguage
+    Check-Equal 'seed content from settings' 'exclusive_bilingual' $seed.ContentLanguage
+
+    $profile = Show-LanguageProfilePrompt -AgentLanguage $seed.AgentLanguage -ContentLanguage $seed.ContentLanguage
+    Check-Equal 'profile keeps seeded agent' 'english' $profile.AgentLanguage
+    Check-Equal 'profile keeps seeded content' 'exclusive_bilingual' $profile.ContentLanguage
+    Check-Equal 'profile display follows seeded agent' 'English' $profile.AgentDisplay
+
+    Write-Host ''
+    Write-Host '[env override wins independently]'
+    $seed = Seed-LanguageFromSettings -SettingsPath $settings -AgentLanguage 'korean' -ContentLanguage ''
+    Check-Equal 'explicit agent preserved' 'korean' $seed.AgentLanguage
+    Check-Equal 'unset content seeded' 'exclusive_bilingual' $seed.ContentLanguage
+
+    Write-Host ''
+    Write-Host '[regex fallback on invalid JSON]'
+    Set-Content -LiteralPath $settings -NoNewline -Value '{ "language": "korean", "env": { "CLAUDE_CONTENT_LANGUAGE": "english" }'
+    Check-Equal 'fallback reads agent language' 'korean' (Read-SettingsAgentLanguage -Path $settings)
+    Check-Equal 'fallback reads content language' 'english' (Read-SettingsContentLanguage -Path $settings)
+}
+finally {
+    Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host "=== Results: $($script:Passed) passed, $($script:Failed) failed ==="
+if ($script:Errors.Count -gt 0) {
+    Write-Host ''
+    foreach ($err in $script:Errors) { Write-Host "  $err" }
+    exit 1
+}
+exit 0


### PR DESCRIPTION
## Summary

- Align README, QUICKSTART, bootstrap, and installer next-step guidance with the implemented git identity auto-seed behavior.
- Add PowerShell reinstall language seeding parity from existing `settings.json`, plus runtime tests and CI wiring.
- Fix `push-target-guard` bare `git push` handling so it resolves the configured upstream destination before falling back to the current branch.
- Add an #776 closure audit draft and update the epic tracker with new follow-up issues #797 and #798.
- Refresh the doc-index manifest metadata for the edited onboarding docs.

## Cross-Analysis

- Rechecked completed #777-#783 and #790-#795 against current docs and tooling.
- Created #797 for the remaining non-tty bootstrap smoke coverage gap from #778.
- Created #798 for the remaining bootstrap settings/hooks atomicity gap from #779.
- #776 should remain open until #797 and #798 are complete.

## Verification

- `bash -n bootstrap.sh scripts/install.sh global/hooks/push-target-guard.sh tests/hooks/test-push-target-guard.sh`
- `pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1`
- `pwsh -NoProfile -File tests/hooks/test-push-target-guard.ps1`
- `bash scripts/diff-readme.sh && bash tests/scripts/test-diff-readme.sh`
- `bash tests/scripts/test-installer-prompt-drift.sh && bash tests/scripts/test-language-override-contract.sh`
- `bash tests/scripts/test-global-files-referenced-exist.sh && bash tests/scripts/test-installer-robustness.sh && bash tests/scripts/test-install-permissions-policy.sh`
- `bash scripts/validate-doc-index.sh && bash tests/doc-index/test-validate-doc-index.sh`
- `bash tests/hooks/test-push-target-guard.sh` with a temporary local `jq` wrapper because this WSL environment exposes `jq.exe`; CI installs native `jq`
- `git diff --check`

Refs #776
Refs #797
Refs #798