### PR TITLE
test(install): cover non-tty bootstrap

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -19,6 +19,7 @@ on:
       - 'scripts/install-manifest.ps1'
       - 'bootstrap.sh'
       - 'bootstrap.ps1'
+      - 'tests/scripts/test-bootstrap-non-tty-smoke.sh'
       - 'tests/scripts/test-plugin-*.sh'
       - 'tests/scripts/test-install-manifest-helpers.*'
       - 'tests/scripts/test-install-permissions-policy.sh'
@@ -141,6 +142,11 @@ jobs:
         # settings.json), install.sh error() being terminal, and the
         # backup.sh/.ps1 copy-then-swap staging (silent-data-loss fix).
         run: bash tests/scripts/test-installer-robustness.sh
+
+      - name: Run bootstrap non-tty smoke test
+        # Exercises the advertised `curl ... | INSTALL_TYPE=3 bash` entrypoint
+        # shape without network access or a real install.
+        run: bash tests/scripts/test-bootstrap-non-tty-smoke.sh
 
       - name: Run hook-wiring parity test (settings.json <-> settings.windows.json)
         # Catches dormant guards: a .ps1 hook present in global/hooks/ but not

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -94,6 +94,22 @@ bootstrap_read() {
     fi
     printf -v "$__var" '%s' "${__reply:-$__default}"
 }
+
+# Test-only prompt-resolution mode for CI smoke tests. It runs after argument
+# parsing and bootstrap_read are loaded, but before dependency checks, cloning,
+# or filesystem installation, so tests can exercise the piped non-tty entry
+# point hermetically.
+if [ "${CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE:-}" = "prompt-resolution" ]; then
+    bootstrap_read INSTALL_TYPE "선택 (1-4) [기본값: 1]: " "1"
+    printf 'FORCE_MODE=%s\n' "${FORCE_MODE:-0}"
+    printf 'INSTALL_TYPE=%s\n' "${INSTALL_TYPE:-}"
+    if [ -t 0 ]; then
+        printf 'STDIN_TTY=1\n'
+    else
+        printf 'STDIN_TTY=0\n'
+    fi
+    exit 0
+fi
 # ──────────────────────────────────────────────────────────────────────────────
 CLAUDE_DIR="$HOME/.claude"
 

--- a/tests/scripts/test-bootstrap-non-tty-smoke.sh
+++ b/tests/scripts/test-bootstrap-non-tty-smoke.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# test-bootstrap-non-tty-smoke.sh
+# Smoke test for issue #797.
+#
+# The test feeds the real bootstrap.sh body to bash on stdin, matching the
+# advertised `curl ... | bash` shape. It uses
+# CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE=prompt-resolution, a test-only early exit
+# that runs after bootstrap argument/prompt resolution and before dependency
+# checks, network access, cloning, or installation.
+#
+# Run: bash tests/scripts/test-bootstrap-non-tty-smoke.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-non-tty.XXXXXX" 2>/dev/null || mktemp -d)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+PASS=0
+FAIL=0
+
+check_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo "  FAIL: $label"
+        echo "    expected:"
+        printf '%s\n' "$expected" | sed 's/^/      /'
+        echo "    actual:"
+        printf '%s\n' "$actual" | sed 's/^/      /'
+    fi
+}
+
+run_piped_bootstrap() {
+    cat "$BOOTSTRAP" | env \
+        -u INSTALL_TYPE \
+        -u FORCE_MODE \
+        -u PROJECT_DIR \
+        -u INSTALL_CLAUDE \
+        -u INSTALL_NPM \
+        -u OVERWRITE \
+        -u EDIT_NOW \
+        HOME="$TEST_HOME" \
+        USERPROFILE="$TEST_HOME" \
+        CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE=prompt-resolution \
+        "$@" 2>&1
+}
+
+echo "=== Bootstrap non-tty smoke test (#797) ==="
+echo ""
+
+output="$(run_piped_bootstrap INSTALL_TYPE=3 bash)"
+check_eq "piped INSTALL_TYPE=3 overrides non-tty default" \
+    $'FORCE_MODE=0\nINSTALL_TYPE=3\nSTDIN_TTY=0' "$output"
+
+output="$(run_piped_bootstrap bash -s -- --yes)"
+check_eq "--yes resolves the documented bootstrap default without prompting" \
+    $'FORCE_MODE=1\nINSTALL_TYPE=1\nSTDIN_TTY=0' "$output"
+
+output="$(run_piped_bootstrap bash -s -- --type 3 --yes)"
+check_eq "--type 3 combines with --yes in piped mode" \
+    $'FORCE_MODE=1\nINSTALL_TYPE=3\nSTDIN_TTY=0' "$output"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #797
Refs #776

## Summary

- Add a narrowly gated bootstrap prompt-resolution test mode that exits before dependency checks, cloning, network access, or installation.
- Add a hermetic smoke test that pipes the real `bootstrap.sh` body into `bash`, matching the advertised `curl ... | bash` shape.
- Verify the unattended non-tty paths for `INSTALL_TYPE=3`, `--yes`, and `--type 3 --yes`, and wire the smoke test into `validate-hooks`.

## Cross-Analysis

- #778 already implemented the non-interactive bootstrap behavior; #797 only needs executable regression coverage for that path.
- README and README.ko already document the non-interactive Bash examples, so no doc-body update is needed.
- No new subissues are needed for #797. #798 remains separate because it covers atomic settings/hooks deployment, not prompt routing.
- #776 should remain open until both #797 and #798 are complete.

## Verification

- `bash tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash -n bootstrap.sh tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `shellcheck --severity=error -e SC2086 bootstrap.sh tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash tests/scripts/test-installer-robustness.sh`
- `bash tests/scripts/test-installer-prompt-drift.sh && bash tests/scripts/test-language-override-contract.sh`
- `git diff --check`