### PR TITLE
fix(install): publish bootstrap settings last

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -20,6 +20,7 @@ on:
       - 'bootstrap.sh'
       - 'bootstrap.ps1'
       - 'tests/scripts/test-bootstrap-non-tty-smoke.sh'
+      - 'tests/scripts/test-bootstrap-atomic-deploy.*'
       - 'tests/scripts/test-plugin-*.sh'
       - 'tests/scripts/test-install-manifest-helpers.*'
       - 'tests/scripts/test-install-permissions-policy.sh'
@@ -153,6 +154,17 @@ jobs:
         # Exercises the advertised `curl ... | INSTALL_TYPE=3 bash` entrypoint
         # shape without network access or a real install.
         run: bash tests/scripts/test-bootstrap-non-tty-smoke.sh
+
+      - name: Run bootstrap atomic deploy test
+        # Proves settings.json is published only after runtime hook deployment
+        # succeeds, so a failed hook copy cannot leave settings pointing at
+        # missing hooks.
+        run: bash tests/scripts/test-bootstrap-atomic-deploy.sh
+
+      - name: Run bootstrap atomic deploy test (PowerShell)
+        # Mirrors the Bash atomic settings/hooks deployment contract for
+        # bootstrap.ps1 using an isolated fake INSTALL_DIR and HOME.
+        run: pwsh tests/scripts/test-bootstrap-atomic-deploy.ps1
 
       - name: Run hook-wiring parity test (settings.json <-> settings.windows.json)
         # Catches dormant guards: a .ps1 hook present in global/hooks/ but not

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -223,6 +223,113 @@ function Invoke-CloneRepository {
     Write-Ok "저장소 클론 완료: $InstallDir (ref: $GitHubRef)"
 }
 
+function Copy-BootstrapHookFiles {
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir,
+        [Parameter(Mandatory)][string[]]$Filters
+    )
+
+    if (-not (Test-Path -LiteralPath $DestinationDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $DestinationDir -Force -ErrorAction Stop | Out-Null
+    }
+
+    foreach ($filter in $Filters) {
+        $items = @(Get-ChildItem -LiteralPath $SourceDir -Filter $filter -File -ErrorAction Stop)
+        foreach ($item in $items) {
+            Copy-Item -LiteralPath $item.FullName -Destination (Join-Path $DestinationDir $item.Name) -Force -ErrorAction Stop
+        }
+    }
+}
+
+function Deploy-BootstrapHooks {
+    $hooksSrc = Join-Path $InstallDir 'global' 'hooks'
+    if (-not (Test-Path -LiteralPath $hooksSrc -PathType Container)) {
+        throw "hook source directory missing: $hooksSrc"
+    }
+
+    $hooksDst = Join-Path $ClaudeDir 'hooks'
+    # Windows 훅은 `pwsh -File ...ps1`; .sh/.json은 WSL/parity 목적으로 함께 복사.
+    Copy-BootstrapHookFiles -SourceDir $hooksSrc -DestinationDir $hooksDst -Filters @('*.ps1', '*.sh', '*.json')
+
+    # global/hooks/lib/* 배포 (issue #586): 공유 라이브러리는 top-level glob에
+    # 잡히지 않으므로 별도 복사한다. 없으면 4개 Bash 가드가 약화된다.
+    $hooksLibSrc = Join-Path $hooksSrc 'lib'
+    if (Test-Path -LiteralPath $hooksLibSrc -PathType Container) {
+        $hooksLibDst = Join-Path $hooksDst 'lib'
+        Copy-BootstrapHookFiles -SourceDir $hooksLibSrc -DestinationDir $hooksLibDst -Filters @('*.ps1', '*.psm1', '*.sh')
+    }
+
+    # Shared bash validator libraries used by the deployed Bash hook variants.
+    # Mirrors scripts/install.sh so native Windows and WSL/container mounts get
+    # the same runtime library set before settings.json is published.
+    $sharedLibSrc = Join-Path $InstallDir 'hooks' 'lib'
+    if (Test-Path -LiteralPath $sharedLibSrc -PathType Container) {
+        $hooksLibDst = Join-Path $hooksDst 'lib'
+        Copy-BootstrapHookFiles -SourceDir $sharedLibSrc -DestinationDir $hooksLibDst -Filters @(
+            'validate-commit-message.sh',
+            'validate-language.sh',
+            'validate-traceability.sh'
+        )
+    }
+
+    $requiredLibs = @(
+        'tokenize-shell.sh',
+        'path-utils.sh',
+        'timeout-wrapper.sh',
+        'rotate.sh',
+        'validate-commit-message.sh',
+        'validate-language.sh',
+        'validate-traceability.sh'
+    )
+    foreach ($lib in $requiredLibs) {
+        if (-not (Test-Path -LiteralPath (Join-Path $hooksDst 'lib' $lib) -PathType Leaf)) {
+            throw "required hook runtime library missing after deploy: hooks/lib/$lib"
+        }
+    }
+}
+
+function Install-BootstrapSettingsAndHooks {
+    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # Update-ClaudeSettingsJson injects them into a staged file first; the
+    # final settings.json is published only after hook deployment succeeds.
+    # PARITY: scripts/install.ps1 selects global/settings.windows.json on this
+    # PowerShell installer — its hooks invoke `pwsh -File ...ps1`. Using
+    # global/settings.json here would ship bare `.sh` hook commands that native
+    # Windows cannot execute. Destination filename stays settings.json.
+    $settingsSrc = Join-Path $InstallDir 'global' 'settings.windows.json'
+    if (-not (Test-Path -LiteralPath $settingsSrc)) { return }
+
+    $settingsDst = Join-Path $ClaudeDir 'settings.json'
+    $settingsTmp = Join-Path $ClaudeDir ".settings.json.tmp.$PID"
+    $agentLanguage = if ($script:agentLanguage) { $script:agentLanguage } else { 'korean' }
+    $contentLanguage = if ($script:contentLanguage) { $script:contentLanguage } else { 'english' }
+    $settingsUpdated = $false
+
+    try {
+        Remove-Item -LiteralPath $settingsTmp -Force -ErrorAction SilentlyContinue
+        Copy-Item -LiteralPath $settingsSrc -Destination $settingsTmp -Force -ErrorAction Stop
+
+        $settingsUpdated = Update-ClaudeSettingsJson -SettingsPath $settingsTmp -AgentLang $agentLanguage -ContentLang $contentLanguage
+
+        Deploy-BootstrapHooks
+
+        Move-Item -LiteralPath $settingsTmp -Destination $settingsDst -Force -ErrorAction Stop
+    }
+    catch {
+        Remove-Item -LiteralPath $settingsTmp -Force -ErrorAction SilentlyContinue
+        Write-Fail "Hook 스크립트 배포 실패. settings.json을 변경하지 않았습니다. $_"
+    }
+
+    if ($settingsUpdated) {
+        Write-Ok "settings.json (에이전트: $agentLanguage, 컨텐츠: $contentLanguage) 설치 완료"
+    } else {
+        Write-Ok "settings.json 설치 완료 (기본값)"
+    }
+    Write-Ok "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+}
+
 # ── Install global settings ──────────────────────────────────
 
 function Install-GlobalSettings {
@@ -372,59 +479,11 @@ function Install-GlobalSettings {
         Write-Ok "ccstatusline 설정 설치 완료"
     }
 
-    # settings.json (Claude Code)
-    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
-    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
-    # Update-ClaudeSettingsJson (below) injects them and is responsible
-    # for idempotent reset when the policy returns to default ("english").
-    # PARITY: scripts/install.ps1 selects global/settings.windows.json on this
-    # PowerShell installer — its hooks invoke `pwsh -File ...ps1`. Using
-    # global/settings.json here would ship bare `.sh` hook commands that native
-    # Windows cannot execute. Destination filename stays settings.json.
-    $settingsSrc = Join-Path $InstallDir 'global' 'settings.windows.json'
-    if (Test-Path -LiteralPath $settingsSrc) {
-        $settingsDst = Join-Path $ClaudeDir 'settings.json'
-        Copy-Item -Path $settingsSrc -Destination $settingsDst -Force
-
-        if (Update-ClaudeSettingsJson -SettingsPath $settingsDst -AgentLang $script:agentLanguage -ContentLang $contentLanguage) {
-            Write-Ok "settings.json (에이전트: $($script:agentLanguage), 컨텐츠: $contentLanguage) 설치 완료"
-        } else {
-            Write-Ok "settings.json 설치 완료 (기본값)"
-        }
-    }
-
-    # hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드) — issue #779.
+    # settings.json + hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드)
     # settings.windows.json은 `pwsh -File ...ps1` 훅 다수를 참조하므로, 설정 복사와
     # 훅 배포를 한 트랜잭션으로 처리해 "설정은 있는데 훅이 없는" 조용한 보안 공백을
-    # 막는다. scripts/install.ps1의 hooks + hooks/lib 배포 블록과 동일.
-    $hooksSrc = Join-Path $InstallDir 'global' 'hooks'
-    if (Test-Path -LiteralPath $hooksSrc -PathType Container) {
-        $hooksDst = Join-Path $ClaudeDir 'hooks'
-        if (-not (Test-Path $hooksDst)) {
-            New-Item -ItemType Directory -Path $hooksDst -Force | Out-Null
-        }
-        # Windows 훅은 `pwsh -File ...ps1`; .sh/.json은 WSL/parity 목적으로 함께 복사.
-        Copy-Item -Path "$hooksSrc\*.ps1"  -Destination $hooksDst -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$hooksSrc\*.sh"   -Destination $hooksDst -Force -ErrorAction SilentlyContinue
-        Copy-Item -Path "$hooksSrc\*.json" -Destination $hooksDst -Force -ErrorAction SilentlyContinue
-
-        # global/hooks/lib/* 배포 (issue #586): 공유 라이브러리는 top-level glob에
-        # 잡히지 않으므로 별도 복사한다. 없으면 4개 Bash 가드가 약화된다.
-        $hooksLibSrc = Join-Path $hooksSrc 'lib'
-        if (Test-Path -LiteralPath $hooksLibSrc -PathType Container) {
-            $hooksLibDst = Join-Path $hooksDst 'lib'
-            if (-not (Test-Path $hooksLibDst)) {
-                New-Item -ItemType Directory -Path $hooksLibDst -Force | Out-Null
-            }
-            Copy-Item -Path "$hooksLibSrc\*" -Destination $hooksLibDst -Recurse -Force -ErrorAction SilentlyContinue
-
-            if (-not (Test-Path (Join-Path $hooksLibDst 'tokenize-shell.sh'))) {
-                Write-Warn "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
-            }
-        }
-
-        Write-Ok "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
-    }
+    # 막는다. Hook 배포 실패 시 settings.json은 게시하지 않는다.
+    Install-BootstrapSettingsAndHooks
 
     # npm package installation (statusline dependencies)
     if (Get-Command npm -ErrorAction SilentlyContinue) {
@@ -662,4 +721,17 @@ function Invoke-Main {
 }
 
 # Execute
+if ($env:CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE -eq 'atomic-deploy') {
+    if (-not (Test-Path $ClaudeDir)) {
+        New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
+    }
+    $manifestHelper = Join-Path $InstallDir 'scripts' 'install-manifest.ps1'
+    if (-not (Test-Path -LiteralPath $manifestHelper)) {
+        Write-Fail "install-manifest.ps1 not found for atomic-deploy test mode"
+    }
+    . $manifestHelper
+    Install-BootstrapSettingsAndHooks
+    exit 0
+}
+
 Invoke-Main

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -291,6 +291,110 @@ clone_repository() {
     success "저장소 클론 완료: $INSTALL_DIR (ref: $GITHUB_REF)"
 }
 
+# copy_bootstrap_files <source_dir> <dest_dir> <glob> <executable:0|1>
+copy_bootstrap_files() {
+    local src_dir="$1" dest_dir="$2" pattern="$3" executable="$4"
+    local src dest
+
+    mkdir -p "$dest_dir" || return 1
+
+    for src in "$src_dir"/$pattern; do
+        [ -f "$src" ] || continue
+        dest="$dest_dir/$(basename "$src")"
+        cp "$src" "$dest" || return 1
+        if [ "$executable" = "1" ]; then
+            chmod +x "$dest" || return 1
+        fi
+    done
+
+    return 0
+}
+
+deploy_bootstrap_hooks() {
+    local hooks_src="$INSTALL_DIR/global/hooks"
+    local hooks_dst="$CLAUDE_DIR/hooks"
+    local hooks_lib_src="$hooks_src/lib"
+    local shared_lib_src="$INSTALL_DIR/hooks/lib"
+    local lib
+
+    if [ ! -d "$hooks_src" ]; then
+        echo "hook source directory missing: $hooks_src" >&2
+        return 1
+    fi
+
+    copy_bootstrap_files "$hooks_src" "$hooks_dst" "*.sh" 1 || return 1
+
+    # global/hooks/lib/*.sh 배포 (issue #586). 위 *.sh glob은 비재귀적이라
+    # tokenize-shell.sh 등 공유 라이브러리는 별도 복사 없이는 누락된다.
+    # dangerous-command-guard 등 4개 Bash 가드가 런타임에 이를 source한다.
+    if [ -d "$hooks_lib_src" ]; then
+        copy_bootstrap_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 || return 1
+    fi
+
+    # 공유 검증 라이브러리 설치 (commit-message-guard.sh, pr-language-guard.sh,
+    # traceability-guard.sh가 사용). scripts/install.sh와 같은 런타임 계약.
+    if [ -d "$shared_lib_src" ]; then
+        for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+            if [ -f "$shared_lib_src/$lib" ]; then
+                copy_bootstrap_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 || return 1
+            fi
+        done
+    fi
+
+    for lib in \
+        tokenize-shell.sh \
+        path-utils.sh \
+        timeout-wrapper.sh \
+        rotate.sh \
+        validate-commit-message.sh \
+        validate-language.sh \
+        validate-traceability.sh; do
+        if [ ! -f "$hooks_dst/lib/$lib" ]; then
+            echo "required hook runtime library missing after deploy: hooks/lib/$lib" >&2
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+install_bootstrap_settings_and_hooks() {
+    local settings_src="$INSTALL_DIR/global/settings.json"
+    local settings_dst="$CLAUDE_DIR/settings.json"
+    local settings_tmp="$CLAUDE_DIR/.settings.json.tmp.$$"
+    local agent_language="${AGENT_LANGUAGE:-korean}"
+    local content_language="${CONTENT_LANGUAGE:-english}"
+    local settings_updated=0
+
+    [ -f "$settings_src" ] || return 0
+
+    # Stage settings first, then publish only after hook deployment succeeds.
+    # This keeps ~/.claude/settings.json from pointing at missing runtime hooks.
+    rm -f "$settings_tmp"
+    cp "$settings_src" "$settings_tmp" || error "settings.json 스테이징 실패"
+
+    if update_claude_settings_json "$settings_tmp" "$agent_language" "$content_language"; then
+        settings_updated=1
+    fi
+
+    if ! deploy_bootstrap_hooks; then
+        rm -f "$settings_tmp"
+        error "Hook 스크립트 배포 실패. settings.json을 변경하지 않았습니다."
+    fi
+
+    mv -f "$settings_tmp" "$settings_dst" || {
+        rm -f "$settings_tmp"
+        error "settings.json 게시 실패"
+    }
+
+    if [ "$settings_updated" = "1" ]; then
+        success "settings.json (에이전트: $agent_language, 컨텐츠: $content_language) 설치 완료"
+    else
+        success "settings.json 설치 완료 (기본값)"
+    fi
+    success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+}
+
 # 글로벌 설정 설치
 install_global() {
     info "글로벌 설정 설치 중..."
@@ -354,45 +458,11 @@ install_global() {
     # Legacy settings.json migration warning (informational only).
     warn_legacy_settings_value "$HOME/.claude/settings.json" || true
 
-    # settings.json install (Claude Code settings)
-    # Intentionally bypasses guarded_copy: policy attributes (.language,
-    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
-    # update_claude_settings_json (below) injects them and is responsible
-    # for idempotent reset when the policy returns to default ("english").
-    if [ -f "$INSTALL_DIR/global/settings.json" ]; then
-        cp "$INSTALL_DIR/global/settings.json" "$HOME/.claude/settings.json"
-
-        if update_claude_settings_json "$HOME/.claude/settings.json" "${AGENT_LANGUAGE:-korean}" "$CONTENT_LANGUAGE"; then
-            success "settings.json (에이전트: ${AGENT_LANGUAGE:-korean}, 컨텐츠: $CONTENT_LANGUAGE) 설치 완료"
-        else
-            success "settings.json 설치 완료 (기본값)"
-        fi
-    fi
-
-    # hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드) — issue #779.
+    # settings.json + hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드)
     # settings.json은 ~/.claude/hooks/*.sh 가드 다수를 참조하므로, 설정 복사와
     # 훅 배포를 한 트랜잭션으로 처리해 "설정은 있는데 훅이 없는" 조용한 보안
-    # 공백을 막는다. scripts/install.sh의 hooks + hooks/lib 배포 블록과 동일.
-    if [ -d "$INSTALL_DIR/global/hooks" ]; then
-        mkdir -p "$CLAUDE_DIR/hooks"
-        cp "$INSTALL_DIR/global/hooks"/*.sh "$CLAUDE_DIR/hooks/" 2>/dev/null || true
-        chmod +x "$CLAUDE_DIR/hooks/"*.sh 2>/dev/null || true
-
-        # global/hooks/lib/*.sh 배포 (issue #586). 위 *.sh glob은 비재귀적이라
-        # tokenize-shell.sh 등 공유 라이브러리는 별도 복사 없이는 누락된다.
-        # dangerous-command-guard 등 4개 Bash 가드가 런타임에 이를 source한다.
-        if [ -d "$INSTALL_DIR/global/hooks/lib" ]; then
-            mkdir -p "$CLAUDE_DIR/hooks/lib"
-            cp "$INSTALL_DIR/global/hooks/lib"/*.sh "$CLAUDE_DIR/hooks/lib/" 2>/dev/null || true
-            chmod +x "$CLAUDE_DIR/hooks/lib/"*.sh 2>/dev/null || true
-
-            if [ ! -f "$CLAUDE_DIR/hooks/lib/tokenize-shell.sh" ]; then
-                warning "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
-            fi
-        fi
-
-        success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
-    fi
+    # 공백을 막는다. Hook 배포 실패 시 settings.json은 게시하지 않는다.
+    install_bootstrap_settings_and_hooks
 
     # 글로벌 skills 및 commands 설치
     # `_internal/` 하위 격리 + `disable-model-invocation: true`가 적용된 스킬군은
@@ -576,6 +646,14 @@ main() {
 
     success "Happy Coding with Claude! 🎉"
 }
+
+if [ "${CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE:-}" = "atomic-deploy" ]; then
+    mkdir -p "$CLAUDE_DIR"
+    # shellcheck disable=SC1091
+    source "$INSTALL_DIR/scripts/install-manifest.sh"
+    install_bootstrap_settings_and_hooks
+    exit 0
+fi
 
 # 스크립트 실행
 main "$@"

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -1595,16 +1595,16 @@ documents:
     description: ""
     category: docs
     scope: docs
-    size: 4881
+    size: 5390
     tags: [docs]
     sections:
       - {h: "Manifest", l: 7, e: 29}
       - {h: "Copy Decision", l: 30, e: 57}
       - {h: "Non-Interactive Override", l: 58, e: 72}
       - {h: "Toolchain Fallback", l: 73, e: 83}
-      - {h: "Template Files", l: 84, e: 115}
-      - {h: "Tracked Files", l: 116, e: 131}
-      - {h: "Regression Test", l: 132, e: 143}
+      - {h: "Template Files", l: 84, e: 124}
+      - {h: "Tracked Files", l: 125, e: 140}
+      - {h: "Regression Test", l: 141, e: 152}
   - path: "docs/loop-patterns.md"
     title: "Loop-Safety Patterns for Skills"
     description: ""

--- a/docs/install.md
+++ b/docs/install.md
@@ -113,6 +113,15 @@ entirely so policy attributes (`.language`,
 the values and removes them when the policy returns to the default
 ("english"), keeping the file idempotent.
 
+Bootstrap publishes `settings.json` together with the runtime hooks it
+references. `bootstrap.sh` stages `global/settings.json` in a temp file
+and `bootstrap.ps1` stages `global/settings.windows.json`; both apply the
+language policy to the staged file, deploy the required hook scripts and
+hook libraries, and only then replace `~/.claude/settings.json`. If hook
+deployment or required runtime-library validation fails, the staged
+settings file is removed and the existing `settings.json` is left
+unchanged.
+
 ## Tracked Files
 
 The manifest currently tracks these entries (see `bootstrap.sh`

--- a/tests/scripts/test-bootstrap-atomic-deploy.ps1
+++ b/tests/scripts/test-bootstrap-atomic-deploy.ps1
@@ -1,0 +1,189 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Regression test for bootstrap.ps1 settings/hooks atomic deployment (#798).
+
+.DESCRIPTION
+    Runs bootstrap.ps1 in an isolated test mode with a fake INSTALL_DIR. The
+    success case proves settings.json is published after hook deployment. The
+    failure case proves an existing settings.json is preserved when hook
+    deployment fails.
+#>
+
+$ErrorActionPreference = 'Continue'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$Bootstrap = Join-Path $RootDir 'bootstrap.ps1'
+
+$script:PASS = 0
+$script:FAIL = 0
+$script:ERRORS = @()
+
+function Pass {
+    param([string]$Message)
+    $script:PASS++
+    Write-Host "  PASS: $Message"
+}
+
+function Fail {
+    param([string]$Message)
+    $script:FAIL++
+    $script:ERRORS += $Message
+    Write-Host "  FAIL: $Message" -ForegroundColor Red
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { Pass $Message } else { Fail $Message }
+}
+
+function New-Fixture {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $hooks = Join-Path $Path 'global' 'hooks'
+    $lib = Join-Path $hooks 'lib'
+    $sharedLib = Join-Path $Path 'hooks' 'lib'
+    $scripts = Join-Path $Path 'scripts'
+    New-Item -ItemType Directory -Path $lib -Force | Out-Null
+    New-Item -ItemType Directory -Path $sharedLib -Force | Out-Null
+    New-Item -ItemType Directory -Path $scripts -Force | Out-Null
+
+    Copy-Item -LiteralPath (Join-Path $RootDir 'scripts' 'install-manifest.ps1') -Destination $scripts -Force
+    Set-Content -LiteralPath (Join-Path $Path 'global' 'settings.windows.json') -Value @'
+{
+  "fixture": "powershell"
+}
+'@ -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'example.ps1') -Value 'exit 0' -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'example.sh') -Value "#!/bin/sh`nexit 0`n" -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'known-issues.json') -Value '{}' -NoNewline
+    Set-Content -LiteralPath (Join-Path $lib 'CommonHelpers.psm1') -Value '' -NoNewline
+    foreach ($name in @('tokenize-shell.sh', 'path-utils.sh', 'timeout-wrapper.sh', 'rotate.sh')) {
+        Set-Content -LiteralPath (Join-Path $lib $name) -Value "#!/bin/sh`nreturn 0 2>/dev/null || exit 0`n" -NoNewline
+    }
+    foreach ($name in @('validate-commit-message.sh', 'validate-language.sh', 'validate-traceability.sh')) {
+        Set-Content -LiteralPath (Join-Path $sharedLib $name) -Value "#!/bin/sh`nreturn 0 2>/dev/null || exit 0`n" -NoNewline
+    }
+}
+
+function Invoke-AtomicDeploy {
+    param(
+        [Parameter(Mandatory)][string]$HomeDir,
+        [Parameter(Mandatory)][string]$Fixture
+    )
+
+    $env:HOME = $HomeDir
+    $env:USERPROFILE = $HomeDir
+    $env:INSTALL_DIR = $Fixture
+    $env:CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE = 'atomic-deploy'
+    $env:AGENT_LANGUAGE = 'english'
+    $env:CONTENT_LANGUAGE = 'english'
+
+    $output = & pwsh -NoProfile -File $Bootstrap 2>&1 | Out-String
+    return [PSCustomObject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = $output
+    }
+}
+
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) "bootstrap-atomic-ps1-$([guid]::NewGuid())"
+New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+
+$origHome = $env:HOME
+$origUserProfile = $env:USERPROFILE
+$origInstallDir = $env:INSTALL_DIR
+$origMode = $env:CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE
+$origAgentLanguage = $env:AGENT_LANGUAGE
+$origContentLanguage = $env:CONTENT_LANGUAGE
+
+try {
+    Write-Host "=== Bootstrap atomic deploy test (PowerShell, #798) ==="
+    Write-Host ""
+
+    $successFixture = Join-Path $scratch 'success-fixture'
+    $successHome = Join-Path $scratch 'success-home'
+    New-Fixture -Path $successFixture
+    New-Item -ItemType Directory -Path $successHome -Force | Out-Null
+
+    $result = Invoke-AtomicDeploy -HomeDir $successHome -Fixture $successFixture
+    if ($result.ExitCode -eq 0) {
+        Pass 'successful hook deployment exits 0'
+    } else {
+        Fail 'successful hook deployment exits 0'
+        Write-Host ($result.Output -replace '(?m)^', '    ')
+    }
+
+    $successClaude = Join-Path $successHome '.claude'
+    Assert-True (Select-String -LiteralPath (Join-Path $successClaude 'settings.json') -Pattern '"fixture": "powershell"' -Quiet) `
+        'settings.json published after successful hook deployment'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'example.ps1')) `
+        'PowerShell hook deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'example.sh')) `
+        'bash hook variant deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'lib' 'tokenize-shell.sh')) `
+        'hook lib deployed'
+
+    $failureFixture = Join-Path $scratch 'failure-fixture'
+    $failureHome = Join-Path $scratch 'failure-home'
+    New-Fixture -Path $failureFixture
+    $failureClaude = Join-Path $failureHome '.claude'
+    New-Item -ItemType Directory -Path $failureClaude -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $failureClaude 'settings.json') -Value '{"sentinel":"keep"}' -NoNewline
+    Set-Content -LiteralPath (Join-Path $failureClaude 'hooks') -Value 'not a directory' -NoNewline
+
+    $result = Invoke-AtomicDeploy -HomeDir $failureHome -Fixture $failureFixture
+    if ($result.ExitCode -ne 0) {
+        Pass 'failed hook deployment exits non-zero'
+    } else {
+        Fail 'failed hook deployment exits non-zero'
+    }
+
+    Assert-True (Select-String -LiteralPath (Join-Path $failureClaude 'settings.json') -Pattern '"sentinel":"keep"' -Quiet) `
+        'existing settings.json preserved when hook deployment fails'
+    $temps = @(Get-ChildItem -LiteralPath $failureClaude -Filter '.settings.json.tmp.*' -File -ErrorAction SilentlyContinue)
+    Assert-True ($temps.Count -eq 0) 'staged settings temp removed after hook deployment failure'
+
+    $missingLibFixture = Join-Path $scratch 'missing-lib-fixture'
+    $missingLibHome = Join-Path $scratch 'missing-lib-home'
+    New-Fixture -Path $missingLibFixture
+    Remove-Item -LiteralPath (Join-Path $missingLibFixture 'global' 'hooks' 'lib' 'tokenize-shell.sh') -Force
+    $missingLibClaude = Join-Path $missingLibHome '.claude'
+    New-Item -ItemType Directory -Path $missingLibClaude -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $missingLibClaude 'settings.json') -Value '{"sentinel":"missing-lib"}' -NoNewline
+
+    $result = Invoke-AtomicDeploy -HomeDir $missingLibHome -Fixture $missingLibFixture
+    if ($result.ExitCode -ne 0) {
+        Pass 'missing required runtime lib exits non-zero'
+    } else {
+        Fail 'missing required runtime lib exits non-zero'
+    }
+
+    Assert-True (Select-String -LiteralPath (Join-Path $missingLibClaude 'settings.json') -Pattern '"sentinel":"missing-lib"' -Quiet) `
+        'existing settings.json preserved when required runtime lib is missing'
+    Assert-True ($result.Output -match 'settings\.json을 변경하지 않았습니다') `
+        'missing runtime lib failure reports blocked settings publication'
+}
+finally {
+    $env:HOME = $origHome
+    $env:USERPROFILE = $origUserProfile
+    $env:INSTALL_DIR = $origInstallDir
+    $env:CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE = $origMode
+    $env:AGENT_LANGUAGE = $origAgentLanguage
+    $env:CONTENT_LANGUAGE = $origContentLanguage
+    Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== Results: $($script:PASS) passed, $($script:FAIL) failed ==="
+
+if ($script:FAIL -gt 0) {
+    Write-Host ""
+    Write-Host "Errors:"
+    foreach ($err in $script:ERRORS) {
+        Write-Host "  - $err"
+    }
+    exit 1
+}
+
+exit 0

--- a/tests/scripts/test-bootstrap-atomic-deploy.sh
+++ b/tests/scripts/test-bootstrap-atomic-deploy.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# test-bootstrap-atomic-deploy.sh
+# Regression test for issue #798.
+#
+# Verifies that bootstrap.sh publishes ~/.claude/settings.json only after
+# runtime hook deployment succeeds. A hook deployment failure must leave the
+# previously installed settings.json untouched.
+#
+# Run: bash tests/scripts/test-bootstrap-atomic-deploy.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BOOTSTRAP="$REPO_ROOT/bootstrap.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$1")
+    echo "  FAIL: $1"
+}
+
+assert_true() {
+    local label="$1"
+    if eval "$2"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+make_fixture() {
+    local fixture="$1"
+    local lib
+    mkdir -p "$fixture/global/hooks/lib" "$fixture/hooks/lib" "$fixture/scripts"
+    cp "$REPO_ROOT/scripts/install-manifest.sh" "$fixture/scripts/install-manifest.sh"
+
+    cat > "$fixture/global/settings.json" <<'JSON'
+{
+  "fixture": "bash"
+}
+JSON
+    cat > "$fixture/global/hooks/example.sh" <<'SH'
+#!/bin/sh
+exit 0
+SH
+    for lib in tokenize-shell.sh path-utils.sh timeout-wrapper.sh rotate.sh; do
+        cat > "$fixture/global/hooks/lib/$lib" <<'SH'
+#!/bin/sh
+return 0 2>/dev/null || exit 0
+SH
+    done
+    for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+        cat > "$fixture/hooks/lib/$lib" <<'SH'
+#!/bin/sh
+return 0 2>/dev/null || exit 0
+SH
+    done
+}
+
+run_atomic_deploy() {
+    local home_dir="$1" fixture="$2"
+    env \
+        HOME="$home_dir" \
+        USERPROFILE="$home_dir" \
+        INSTALL_DIR="$fixture" \
+        AGENT_LANGUAGE=english \
+        CONTENT_LANGUAGE=english \
+        CLAUDE_CONFIG_BOOTSTRAP_TEST_MODE=atomic-deploy \
+        bash "$BOOTSTRAP" >"$OUTPUT" 2>&1
+}
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-atomic.XXXXXX" 2>/dev/null || mktemp -d)"
+OUTPUT="$WORK/bootstrap-atomic-bash.out"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== Bootstrap atomic deploy test (bash, #798) ==="
+echo ""
+
+success_fixture="$WORK/success-fixture"
+success_home="$WORK/success-home"
+make_fixture "$success_fixture"
+mkdir -p "$success_home"
+
+if run_atomic_deploy "$success_home" "$success_fixture"; then
+    pass "successful hook deployment exits 0"
+else
+    fail "successful hook deployment exits 0"
+    sed 's/^/    /' "$OUTPUT"
+fi
+
+assert_true "settings.json published after successful hook deployment" \
+    "grep -q '\"fixture\": \"bash\"' '$success_home/.claude/settings.json'"
+assert_true "top-level hook deployed executable" \
+    "[ -x '$success_home/.claude/hooks/example.sh' ]"
+assert_true "hook lib deployed executable" \
+    "[ -x '$success_home/.claude/hooks/lib/tokenize-shell.sh' ]"
+
+failure_fixture="$WORK/failure-fixture"
+failure_home="$WORK/failure-home"
+make_fixture "$failure_fixture"
+mkdir -p "$failure_home/.claude"
+printf '%s\n' '{"sentinel":"keep"}' > "$failure_home/.claude/settings.json"
+printf '%s\n' 'not a directory' > "$failure_home/.claude/hooks"
+
+set +e
+run_atomic_deploy "$failure_home" "$failure_fixture"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    pass "failed hook deployment exits non-zero"
+else
+    fail "failed hook deployment exits non-zero"
+fi
+
+assert_true "existing settings.json preserved when hook deployment fails" \
+    "grep -q '\"sentinel\":\"keep\"' '$failure_home/.claude/settings.json'"
+assert_true "staged settings temp removed after hook deployment failure" \
+    "! find '$failure_home/.claude' -maxdepth 1 -name '.settings.json.tmp.*' | grep -q ."
+
+missing_lib_fixture="$WORK/missing-lib-fixture"
+missing_lib_home="$WORK/missing-lib-home"
+make_fixture "$missing_lib_fixture"
+rm -f "$missing_lib_fixture/global/hooks/lib/tokenize-shell.sh"
+mkdir -p "$missing_lib_home/.claude"
+printf '%s\n' '{"sentinel":"missing-lib"}' > "$missing_lib_home/.claude/settings.json"
+
+set +e
+run_atomic_deploy "$missing_lib_home" "$missing_lib_fixture"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    pass "missing required runtime lib exits non-zero"
+else
+    fail "missing required runtime lib exits non-zero"
+fi
+
+assert_true "existing settings.json preserved when required runtime lib is missing" \
+    "grep -q '\"sentinel\":\"missing-lib\"' '$missing_lib_home/.claude/settings.json'"
+assert_true "missing runtime lib failure reports blocked settings publication" \
+    "grep -q 'settings.json을 변경하지 않았습니다' '$OUTPUT'"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What

Closes #798
Refs #776
Refs #801

This changes the bootstrap global install paths so `settings.json` is staged first and published only after runtime hook deployment succeeds.

## Why

The previous Bash and PowerShell bootstraps wrote `~/.claude/settings.json` before copying hooks, then ignored broad hook copy failures. That could leave a new settings file pointing at hooks or hook libraries that were never installed.

## Scope

- Adds Bash and PowerShell bootstrap helpers that copy hooks with fail-loud behavior.
- Deploys both `global/hooks/lib` runtime libraries and root `hooks/lib/validate-*.sh` libraries before publishing settings.
- Validates required runtime libraries before replacing `~/.claude/settings.json`.
- Adds isolated Bash and PowerShell regression tests for successful deployment, hook deployment failure, and missing required runtime libraries.
- Wires the new tests into `validate-hooks.yml` and documents the atomic settings/hooks publication contract in `docs/install.md`.

## Cross-Analysis

#798 can be completed in one PR because the acceptance criteria are fully covered by equivalent Bash and PowerShell bootstrap contracts. No #798 subissue was needed.

A separate README hook-count drift was found during the docs/issues cross-analysis. That is tracked separately in #801 to keep this PR focused on install atomicity.

## Verification

- `bash -n bootstrap.sh tests/scripts/test-bootstrap-atomic-deploy.sh tests/scripts/test-bootstrap-non-tty-smoke.sh`
- PowerShell parser check for `bootstrap.ps1` and `tests/scripts/test-bootstrap-atomic-deploy.ps1`
- `bash tests/scripts/test-bootstrap-atomic-deploy.sh`
- `pwsh -NoProfile -File tests/scripts/test-bootstrap-atomic-deploy.ps1`
- `bash tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash tests/scripts/test-installer-robustness.sh`
- `bash tests/scripts/test-install-deploys-bash-lib.sh`
- `bash scripts/validate-doc-index.sh`
- `shellcheck --severity=error -e SC2086 bootstrap.sh tests/scripts/test-bootstrap-atomic-deploy.sh`
- `bash tests/scripts/test-windows-hooks-parity.sh`
- `bash tests/scripts/test-installer-prompt-drift.sh && bash tests/scripts/test-language-override-contract.sh && bash tests/scripts/test-doc-prompt-lockstep.sh`
- `pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1`
- `bash tests/scripts/test-hook-ordering.sh && bash tests/scripts/test-windows-powershell-permissions.sh && bash tests/scripts/test-severity-enum.sh`
- `pwsh -NoProfile -File tests/hooks/test-runner.ps1`
- `git diff --check`

Local note: `bash tests/hooks/test-runner.sh` was attempted once and failed because `jq` is not on the Git Bash PATH in this Windows environment. The GitHub Actions job installs `jq` before running the suite.