### PR TITLE
docs(readme): point hooks tree to catalog

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -232,7 +232,7 @@ claude_config_backup/
 │   ├── ccstatusline/           # 상태줄 설정
 │   ├── commands/               # 글로벌 명령어 정책
 │   │   └── _policy.md         # 모든 명령어 공통 정책
-│   ├── hooks/                  # 총 37개 훅 스크립트 (.sh + .ps1) — 전체 목록은 HOOKS.md 참조
+│   ├── hooks/                  # 훅 스크립트(.sh + .ps1) — 전체 정본 목록은 HOOKS.md 참조
 │   │   └── lib/               # 공유 라이브러리
 │   │       ├── AttributionValidator.psm1
 │   │       ├── CommonHelpers.psm1  # PowerShell 공유 모듈

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ claude_config_backup/
 │   │   └── settings.json      # Status line display settings
 │   ├── commands/               # Global command policies
 │   │   └── _policy.md         # Shared policies for all commands
-│   ├── hooks/                  # 35 hook scripts, each in .sh + .ps1 — see HOOKS.md for the full catalog
+│   ├── hooks/                  # Hook scripts, each in .sh + .ps1 — authoritative catalog: HOOKS.md
 │   │   └── lib/               # Shared libraries
 │   │       ├── AttributionValidator.psm1
 │   │       ├── CommonHelpers.psm1  # PowerShell shared module

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -217,7 +217,7 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 46262
+    size: 46258
     tags: [config,readme]
     sections:
       - {h: "빠른 시작", l: 30, e: 58}
@@ -296,7 +296,7 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 44484
+    size: 44479
     tags: [config,readme]
     sections:
       - {h: "Quick Start", l: 30, e: 58}


### PR DESCRIPTION
## What

- Remove fixed hook counts from the English and Korean README directory trees.
- Point readers to `HOOKS.md` as the authoritative hook catalog.
- Update the checked-in doc-index manifest sizes for the changed README files.

## Why

The README directory trees drifted from `global/hooks` and the generated `HOOKS.md` catalog after the latest hook expansion. Avoiding a fixed count in the tree reduces future inventory drift.

## Scope

- Documentation only.
- No hook behavior or settings wiring changed.
- Cross-analysis follow-up: opened #803 for a separate `docs/hooks-ownership.md` ownership-table drift and updated #776 to reflect #798 completion plus #803 tracking.

## Verification

- `bash scripts/validate-doc-index.sh`
- `bash scripts/diff-readme.sh`
- `bash tests/scripts/test-diff-readme.sh`
- `bash tests/doc-index/test-validate-doc-index.sh`
- `bash tests/doc-index/test-extract-doc-description.sh`
- `bash scripts/gen-hooks-md.sh --check`
- `bash scripts/check_references.sh`
- `git diff --check`
- `rg -n "35 hook scripts|37개 훅|총 [0-9]+개 훅|[0-9]+ hook scripts" README.md README.ko.md` returns no fixed README hook counts

Closes #801.
Related: #776, #803.