### PR TITLE
docs(hooks): refresh ownership table

### DIFF
--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -1585,11 +1585,11 @@ documents:
     description: ""
     category: docs
     scope: docs
-    size: 4945
+    size: 7472
     tags: [docs,hook,hooks]
     sections:
-      - {h: "Ownership Table", l: 13, e: 56}
-      - {h: "Adding a new hook", l: 57, e: 66}
+      - {h: "Ownership Table", l: 13, e: 78}
+      - {h: "Adding a new hook", l: 79, e: 88}
   - path: "docs/install.md"
     title: "Install Behavior"
     description: ""

--- a/docs/hooks-ownership.md
+++ b/docs/hooks-ownership.md
@@ -15,28 +15,50 @@ that could be registered from multiple surfaces.
 | Hook event | Matcher | Hook script / inline | Owner file |
 |------------|---------|----------------------|------------|
 | `PreToolUse` | `Edit\|Write\|Read` | `sensitive-file-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `PreToolUse` | `Bash` | `dangerous-command-guard.{sh,ps1}` et al. | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Edit\|Write\|Read` | `pre-edit-read-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Edit\|Write\|Read` | `memory-write-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `dangerous-command-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `bash-sensitive-read-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `shell-env-secret-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `bash-write-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `gh-write-verb-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `github-api-preflight.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `markdown-anchor-validator.ps1` | `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `commit-message-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `traceability-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `conflict-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `pr-target-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `push-target-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `pr-language-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `merge-gate-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PreToolUse` | `Bash` | `attribution-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `PreToolUse` | `TeamCreate` | `team-limit-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `PreToolUse` | `Edit\|Write` | `pre-edit-read-guard.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `PreToolUse` | `Bash` | `markdown-anchor-validator.sh` | `project/.claude/settings.json` (project-only override) |
-| `SessionStart` | — | `session-logger`, `version-check` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionStart` | — | `session-logger.{sh,ps1} start` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionStart` | — | `version-check.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionStart` | — | `memory-integrity-check.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `SessionStart` | — | `export TZ=Asia/Seoul` | `project/.claude/settings.json` |
-| `SessionEnd` | — | `session-logger end` + `cleanup` | `global/settings.json` + `global/settings.windows.json` |
+| `SessionEnd` | — | `session-logger.{sh,ps1} end` + `cleanup.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `UserPromptSubmit` | — | `prompt-validator.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `Stop` | — | `session-logger stop` | `global/settings.json` + `global/settings.windows.json` |
+| `Stop` | — | `session-logger.{sh,ps1} stop` | `global/settings.json` + `global/settings.windows.json` |
 | `PostToolUse` | `Edit\|Write` | inline formatter (black/isort/prettier/clang-format/ktlint/gofmt/rustfmt) | **`plugin/hooks/hooks.json`** (canonical; do not duplicate in settings files) |
 | `PostToolUse` | `Task\|Agent` | `post-task-checkpoint.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `PostToolUse` | `Read` | `pre-edit-read-guard.{sh,ps1}` (tracker) | `global/settings.json` + `global/settings.windows.json` |
+| `PostToolUse` | `Read` | `memory-access-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `PostToolUseFailure` | `.*` | `tool-failure-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `SubagentStart`/`SubagentStop` | `.*` | `subagent-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `SubagentStart` | `.*` | `subagent-logger.{sh,ps1} start` | `global/settings.json` + `global/settings.windows.json` |
+| `SubagentStop` | `.*` | `subagent-logger.{sh,ps1} stop` | `global/settings.json` + `global/settings.windows.json` |
 | `PreCompact` | — | `pre-compact-snapshot.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `SessionStart` | `compact` | `post-compact-restore.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `InstructionsLoaded` | — | `instructions-loaded-reinforcer.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `TaskCreated` | — | `task-created-validator.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `WorktreeCreate`/`WorktreeRemove` | — | `worktree-create.{sh,ps1}` / `worktree-remove.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `WorktreeCreate` | — | `worktree-create.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `WorktreeRemove` | — | `worktree-remove.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `TaskCompleted` | — | `task-completed-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 | `ConfigChange` | — | `config-change-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
-| `TeammateIdle` | — | `session-logger teammate-idle` | `global/settings.json` + `global/settings.windows.json` |
+| `TeammateIdle` | — | `session-logger.{sh,ps1} teammate-idle` | `global/settings.json` + `global/settings.windows.json` |
+| `CwdChanged` | — | `cwd-change-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
+| `PermissionDenied` | — | `permission-denial-logger.{sh,ps1}` | `global/settings.json` + `global/settings.windows.json` |
 
 "`global/settings.json` + `global/settings.windows.json`" means the
 same hook is installed from either file depending on OS; only one of


### PR DESCRIPTION
## What

- Expand `docs/hooks-ownership.md` so the ownership table lists the hook registrations currently shipped by `global/settings.json` and `global/settings.windows.json`.
- Add the missing memory hooks, lifecycle loggers, and permission/cwd event loggers to the ownership table.
- Keep the Windows-only global `markdown-anchor-validator.ps1` registration separate from the POSIX project-owned `markdown-anchor-validator.sh` entry.
- Update the checked-in doc-index manifest metadata for the changed document.

## Why

Issue #803 identified drift between the ownership table and the canonical settings files. The table previously grouped most Bash hooks under `dangerous-command-guard et al.` and omitted newer registrations such as memory hooks, `cwd-change-logger`, and `permission-denial-logger`.

## Scope

- Documentation only.
- No hook behavior or settings wiring changed.
- Cross-analysis found no additional open follow-up gap beyond #803; #801 was already closed by #804, and #797/#798 were already merged into `develop`.

## Verification

- `ownership coverage: OK` from an inline PowerShell comparison of `global/settings.json`, `global/settings.windows.json`, and `docs/hooks-ownership.md`
- `bash scripts/validate-doc-index.sh`
- `bash scripts/gen-hooks-md.sh --check`
- `bash tests/scripts/test-windows-hooks-parity.sh`
- `bash scripts/check_references.sh`
- `bash scripts/diff-readme.sh`
- `bash tests/doc-index/test-validate-doc-index.sh`
- `bash tests/doc-index/test-extract-doc-description.sh`
- `git diff --check`

Closes #803.
Related: #776.