### PR TITLE
fix(install): make clone installer atomic

### DIFF
--- a/.github/workflows/validate-hooks.yml
+++ b/.github/workflows/validate-hooks.yml
@@ -21,6 +21,7 @@ on:
       - 'bootstrap.ps1'
       - 'tests/scripts/test-bootstrap-non-tty-smoke.sh'
       - 'tests/scripts/test-bootstrap-atomic-deploy.*'
+      - 'tests/scripts/test-install-atomic-deploy.*'
       - 'tests/scripts/test-plugin-*.sh'
       - 'tests/scripts/test-install-manifest-helpers.*'
       - 'tests/scripts/test-install-permissions-policy.sh'
@@ -171,6 +172,16 @@ jobs:
         # Mirrors the Bash atomic settings/hooks deployment contract for
         # bootstrap.ps1 using an isolated fake INSTALL_DIR and HOME.
         run: pwsh tests/scripts/test-bootstrap-atomic-deploy.ps1
+
+      - name: Run clone installer atomic deploy test
+        # Proves scripts/install.sh publishes settings.json only after
+        # runtime hook deployment succeeds.
+        run: bash tests/scripts/test-install-atomic-deploy.sh
+
+      - name: Run clone installer atomic deploy test (PowerShell)
+        # Mirrors the Bash clone installer settings/hooks deployment contract
+        # for scripts/install.ps1 using an isolated fixture and HOME.
+        run: pwsh tests/scripts/test-install-atomic-deploy.ps1
 
       - name: Run hook-wiring parity test (settings.json <-> settings.windows.json)
         # Catches dormant guards: a .ps1 hook present in global/hooks/ but not

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -1597,7 +1597,7 @@ documents:
     description: ""
     category: docs
     scope: docs
-    size: 6605
+    size: 6664
     tags: [docs]
     sections:
       - {h: "Manifest", l: 7, e: 29}

--- a/docs/install.md
+++ b/docs/install.md
@@ -144,14 +144,14 @@ entirely so policy attributes (`.language`,
 the values and removes them when the policy returns to the default
 ("english"), keeping the file idempotent.
 
-Bootstrap publishes `settings.json` together with the runtime hooks it
-references. `bootstrap.sh` stages `global/settings.json` in a temp file
-and `bootstrap.ps1` stages `global/settings.windows.json`; both apply the
-language policy to the staged file, deploy the required hook scripts and
-hook libraries, and only then replace `~/.claude/settings.json`. If hook
-deployment or required runtime-library validation fails, the staged
-settings file is removed and the existing `settings.json` is left
-unchanged.
+Bootstrap and clone installers publish `settings.json` together with the
+runtime hooks it references. `bootstrap.sh` and `scripts/install.sh` stage
+`global/settings.json`; `bootstrap.ps1` and `scripts/install.ps1` stage
+`global/settings.windows.json`. Each path applies the language policy to
+the staged file, deploys the required hook scripts and hook libraries, and
+only then replaces `~/.claude/settings.json`. If hook deployment or
+required runtime-library validation fails, the staged settings file is
+removed and the existing `settings.json` is left unchanged.
 
 ## Tracked Files
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -56,6 +56,170 @@ function Install-BashScript {
     [System.IO.File]::WriteAllText($DestinationPath, $content, $utf8NoBom)
 }
 
+function Ensure-InstallDirectory {
+    param([Parameter(Mandatory)][string]$Dir)
+
+    if (Test-Path -LiteralPath $Dir -PathType Container) { return }
+    if (Test-Path -LiteralPath $Dir) {
+        throw "path exists but is not a directory: $Dir"
+    }
+    New-Item -ItemType Directory -Path $Dir -Force -ErrorAction Stop | Out-Null
+}
+
+function Copy-InstallHookFiles {
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir,
+        [Parameter(Mandatory)][string[]]$Filters
+    )
+
+    if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) { return }
+    Ensure-InstallDirectory -Dir $DestinationDir
+
+    foreach ($filter in $Filters) {
+        Get-ChildItem -LiteralPath $SourceDir -Filter $filter -File -ErrorAction SilentlyContinue | ForEach-Object {
+            $dest = Join-Path $DestinationDir $_.Name
+            if ($_.Extension -eq '.sh') {
+                Install-BashScript -SourcePath $_.FullName -DestinationPath $dest
+            } else {
+                Copy-Item -LiteralPath $_.FullName -Destination $dest -Force -ErrorAction Stop
+            }
+        }
+    }
+}
+
+function Deploy-InstallHooks {
+    param([Parameter(Mandatory)][string]$ClaudeDir)
+
+    $hooksSource = Join-Path $BackupDir "global/hooks"
+    if (-not (Test-Path -LiteralPath $hooksSource -PathType Container)) {
+        throw "hook source directory missing: $hooksSource"
+    }
+
+    $hooksDir = Join-Path $ClaudeDir "hooks"
+    # Windows hooks use `pwsh -File ...ps1`; .sh/.json are deployed for WSL and
+    # parity with container-side command rewriting.
+    Copy-InstallHookFiles -SourceDir $hooksSource -DestinationDir $hooksDir -Filters @('*.ps1', '*.sh', '*.json')
+
+    # Deploy global/hooks/lib/ shared libraries. The top-level hook copy is
+    # non-recursive, and several runtime guards source these libraries.
+    $hooksLibSource = Join-Path $hooksSource 'lib'
+    if (Test-Path -LiteralPath $hooksLibSource -PathType Container) {
+        $hooksLibDir = Join-Path $hooksDir 'lib'
+        Copy-InstallHookFiles -SourceDir $hooksLibSource -DestinationDir $hooksLibDir -Filters @('*.ps1', '*.psm1', '*.sh')
+    }
+
+    # Shared bash validator libraries used by deployed bash hook variants.
+    $sharedLibSource = Join-Path $BackupDir 'hooks/lib'
+    if (Test-Path -LiteralPath $sharedLibSource -PathType Container) {
+        $hooksLibDir = Join-Path $hooksDir 'lib'
+        Copy-InstallHookFiles -SourceDir $sharedLibSource -DestinationDir $hooksLibDir -Filters @(
+            'validate-commit-message.sh',
+            'validate-language.sh',
+            'validate-traceability.sh'
+        )
+    }
+
+    $requiredLibs = @(
+        'tokenize-shell.sh',
+        'path-utils.sh',
+        'timeout-wrapper.sh',
+        'rotate.sh',
+        'CommonHelpers.psm1',
+        'LanguageValidator.psm1',
+        'AttributionValidator.psm1',
+        'validate-commit-message.sh',
+        'validate-language.sh',
+        'validate-traceability.sh'
+    )
+    foreach ($lib in $requiredLibs) {
+        if (-not (Test-Path -LiteralPath (Join-Path $hooksDir 'lib' $lib) -PathType Leaf)) {
+            throw "required hook runtime library missing after deploy: hooks/lib/$lib"
+        }
+    }
+}
+
+function Write-FullSuiteProbe {
+    param([Parameter(Mandatory)][string]$ClaudeDir)
+
+    $hooksDir = Join-Path $ClaudeDir "hooks"
+    $probeFile = Join-Path $ClaudeDir ".full-suite-active"
+    $probeTmp  = Join-Path $ClaudeDir ".full-suite-active.tmp"
+    $probeDoc  = [ordered]@{
+        schema = 1
+        hooks  = [ordered]@{
+            'sensitive-file-guard'    = (Test-Path (Join-Path $hooksDir 'sensitive-file-guard.sh'))
+            'dangerous-command-guard' = (Test-Path (Join-Path $hooksDir 'dangerous-command-guard.sh'))
+        }
+    }
+
+    try {
+        ($probeDoc | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $probeTmp -Encoding UTF8
+        Move-Item -LiteralPath $probeTmp -Destination $probeFile -Force
+        Write-Success "Full-suite probe written (.full-suite-active)"
+    }
+    catch {
+        Write-Warn "Failed to write full-suite probe: $_"
+        if (Test-Path $probeTmp) { Remove-Item -LiteralPath $probeTmp -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+function Install-GlobalSettingsAndHooks {
+    param([Parameter(Mandatory)][string]$ClaudeDir)
+
+    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
+    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
+    # Update-ClaudeSettingsJson injects them into a staged file first; the
+    # final settings.json is published only after hook deployment succeeds.
+    $settingsSource = Join-Path $BackupDir "global/settings.windows.json"
+    if (-not (Test-Path -LiteralPath $settingsSource)) {
+        $hooksSource = Join-Path $BackupDir "global/hooks"
+        if (Test-Path -LiteralPath $hooksSource -PathType Container) {
+            try {
+                Deploy-InstallHooks -ClaudeDir $ClaudeDir
+                Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"
+                Write-FullSuiteProbe -ClaudeDir $ClaudeDir
+            }
+            catch {
+                Write-Err "Hook scripts deployment failed. $_"
+                exit 1
+            }
+        }
+        return
+    }
+
+    $destSettings = Join-Path $ClaudeDir "settings.json"
+    $settingsTmp = Join-Path $ClaudeDir ".settings.json.tmp.$PID"
+    $settingsUpdated = $false
+
+    try {
+        Remove-Item -LiteralPath $settingsTmp -Force -ErrorAction SilentlyContinue
+        Copy-Item -LiteralPath $settingsSource -Destination $settingsTmp -Force -ErrorAction Stop
+
+        $settingsUpdated = Update-ClaudeSettingsJson -SettingsPath $settingsTmp -AgentLang $agentLanguage -ContentLang $contentLanguage
+
+        Deploy-InstallHooks -ClaudeDir $ClaudeDir
+
+        Move-Item -LiteralPath $settingsTmp -Destination $destSettings -Force -ErrorAction Stop
+    }
+    catch {
+        Remove-Item -LiteralPath $settingsTmp -Force -ErrorAction SilentlyContinue
+        Write-Err "Hook scripts deployment or settings publish failed. settings.json을 변경하지 않았습니다. $_"
+        exit 1
+    }
+
+    Write-Success "Hook settings (settings.json) installed! [Windows version]"
+    if ($settingsUpdated) {
+        Write-Success "settings.json updated with language=$agentLanguage and CLAUDE_CONTENT_LANGUAGE=$contentLanguage"
+    } else {
+        Write-Warn "Failed to automatically update settings.json"
+        Write-Host "  Please update ~/.claude/settings.json manually with language settings."
+    }
+
+    Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"
+    Write-FullSuiteProbe -ClaudeDir $ClaudeDir
+}
+
 function New-LocalClaude {
     param([string]$ProjectDir)
     $localFile = Join-Path $ProjectDir "CLAUDE.local.md"
@@ -421,128 +585,9 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         }
     }
 
-    # Install settings.windows.json as settings.json
-    # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
-    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
-    # Update-ClaudeSettingsJson (below) injects them and is responsible
-    # for idempotent reset when the policy returns to default ("english").
-    $settingsSource = Join-Path $BackupDir "global/settings.windows.json"
-    if (Test-Path $settingsSource) {
-        $destSettings = Join-Path $claudeDir "settings.json"
-        Copy-Item -Path $settingsSource -Destination $destSettings -Force
-        Write-Success "Hook settings (settings.json) installed! [Windows version]"
-
-        # Write CLAUDE_CONTENT_LANGUAGE under env, and update agent language
-        if (Update-ClaudeSettingsJson -SettingsPath $destSettings -AgentLang $agentLanguage -ContentLang $contentLanguage) {
-            Write-Success "settings.json updated with language=$agentLanguage and CLAUDE_CONTENT_LANGUAGE=$contentLanguage"
-        } else {
-            Write-Warn "Failed to automatically update settings.json"
-            Write-Host "  Please update ~/.claude/settings.json manually with language settings."
-        }
-    }
-
-    # Install hook scripts — dual-variant deployment.
-    #
-    # Why both .ps1 and .sh (Issue #407): When the Windows host's ~/.claude is
-    # bind-mounted into a Linux Claude Code container (claude-docker), the
-    # container entrypoint rewrites every `pwsh ... -File foo.ps1` command to
-    # `foo.sh`. The rewrite only works when the matching .sh file is present.
-    # Shipping .ps1 alone leaves every hook reporting "not found" inside the
-    # container even though the host works correctly.
-    $hooksSource = Join-Path $BackupDir "global/hooks"
-    if (Test-Path $hooksSource) {
-        $hooksDir = Join-Path $claudeDir "hooks"
-        Ensure-Directory $hooksDir
-
-        try {
-            $ps1Items = Get-ChildItem -Path $hooksSource -Filter '*.ps1' -File
-            if ($ps1Items.Count -gt 0) {
-                Copy-Item -Path "$hooksSource\*.ps1" -Destination $hooksDir -Force -ErrorAction Stop
-            }
-        } catch {
-            Write-Err "Failed to copy hook scripts: $_"
-        }
-        Get-ChildItem -Path $hooksSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
-            Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksDir $_.Name)
-        }
-
-        # Deploy global/hooks/lib/ shared libraries (.sh, .ps1, .psm1).
-        # PARITY: install.sh:617-627 must mirror this block. Both installers
-        # share the same destination ~/.claude/hooks/lib/. See issue #586 —
-        # install.sh previously skipped this directory because its top-level
-        # *.sh glob is non-recursive. Do not remove either side without a
-        # cross-platform regression check (see scripts/verify.{sh,ps1}).
-        $hooksLibSource = Join-Path $hooksSource 'lib'
-        if (Test-Path $hooksLibSource) {
-            $hooksLibDir = Join-Path $hooksDir 'lib'
-            Ensure-Directory $hooksLibDir
-            try {
-                $ps1Items = Get-ChildItem -Path $hooksLibSource -Filter '*.ps1' -File
-                if ($ps1Items.Count -gt 0) {
-                    Copy-Item -Path "$hooksLibSource\*.ps1" -Destination $hooksLibDir -Force -ErrorAction Stop
-                }
-                $psm1Items = Get-ChildItem -Path $hooksLibSource -Filter '*.psm1' -File
-                if ($psm1Items.Count -gt 0) {
-                    Copy-Item -Path "$hooksLibSource\*.psm1" -Destination $hooksLibDir -Force -ErrorAction Stop
-                }
-            } catch {
-                Write-Err "Failed to copy hook lib scripts: $_"
-            }
-            Get-ChildItem -Path $hooksLibSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
-                Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $hooksLibDir $_.Name)
-            }
-        }
-
-        # Shared bash validator library (issue #447 Phase 1). Mirrors the
-        # install.sh block that copies repo-root hooks/lib/*.sh into
-        # ~/.claude/hooks/lib/. pr-language-guard.sh and commit-message-guard.sh
-        # source this library at runtime; without it the hooks fall back to the
-        # inline english-only dispatcher regardless of CLAUDE_CONTENT_LANGUAGE.
-        $sharedLibSource = Join-Path $BackupDir 'hooks/lib'
-        if (Test-Path $sharedLibSource) {
-            $hooksLibDir = Join-Path $hooksDir 'lib'
-            Ensure-Directory $hooksLibDir
-            foreach ($lib in @('validate-commit-message.sh', 'validate-language.sh')) {
-                $libSrc = Join-Path $sharedLibSource $lib
-                if (Test-Path $libSrc) {
-                    Install-BashScript -SourcePath $libSrc -DestinationPath (Join-Path $hooksLibDir $lib)
-                }
-            }
-        }
-
-        try {
-            $jsonItems = Get-ChildItem -Path $hooksSource -Filter '*.json' -File
-            if ($jsonItems.Count -gt 0) {
-                Copy-Item -Path "$hooksSource\*.json" -Destination $hooksDir -Force -ErrorAction Stop
-            }
-        } catch {
-            Write-Err "Failed to copy json configurations: $_"
-        }
-
-        Write-Success "Hook scripts installed (hooks/*.ps1 + *.sh + lib/ + *.json)!"
-
-        # Full-suite probe (issue #423): advertise which canonical guards the
-        # plugin surface should stand down for. Written atomically via
-        # Move-Item so a partial write cannot produce a half-valid probe.
-        $probeFile = Join-Path $claudeDir ".full-suite-active"
-        $probeTmp  = Join-Path $claudeDir ".full-suite-active.tmp"
-        $probeDoc  = [ordered]@{
-            schema = 1
-            hooks  = [ordered]@{
-                'sensitive-file-guard'    = (Test-Path (Join-Path $hooksDir 'sensitive-file-guard.sh'))
-                'dangerous-command-guard' = (Test-Path (Join-Path $hooksDir 'dangerous-command-guard.sh'))
-            }
-        }
-        try {
-            ($probeDoc | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $probeTmp -Encoding UTF8
-            Move-Item -LiteralPath $probeTmp -Destination $probeFile -Force
-            Write-Success "Full-suite probe written (.full-suite-active)"
-        }
-        catch {
-            Write-Warn "Failed to write full-suite probe: $_"
-            if (Test-Path $probeTmp) { Remove-Item -LiteralPath $probeTmp -Force -ErrorAction SilentlyContinue }
-        }
-    }
+    # settings.json + hooks directory install. The Windows settings file points
+    # at runtime hooks, so publish settings only after hook deployment succeeds.
+    Install-GlobalSettingsAndHooks -ClaudeDir $claudeDir
 
     # Install utility scripts — dual-variant, same rationale as hooks.
     $scriptsSource = Join-Path $BackupDir "global/scripts"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -242,6 +242,169 @@ create_local_claude() {
     fi
 }
 
+ensure_install_dir() {
+    local dir="$1"
+    [ -d "$dir" ] && return 0
+    mkdir -p "$dir"
+}
+
+copy_install_files() {
+    local src_dir="$1" dest_dir="$2" pattern="$3" executable="${4:-0}"
+    local src dest
+
+    [ -d "$src_dir" ] || return 0
+    ensure_install_dir "$dest_dir" || return 1
+
+    for src in "$src_dir"/$pattern; do
+        [ -f "$src" ] || continue
+        dest="$dest_dir/$(basename "$src")"
+        cp "$src" "$dest" || return 1
+        if [ "$executable" = "1" ]; then
+            chmod +x "$dest" || return 1
+        fi
+    done
+
+    return 0
+}
+
+deploy_install_hooks() {
+    local hooks_src="$BACKUP_DIR/global/hooks"
+    local hooks_dst="$HOME/.claude/hooks"
+    local hooks_lib_src="$hooks_src/lib"
+    local shared_lib_src="$BACKUP_DIR/hooks/lib"
+    local lib
+
+    if [ ! -d "$hooks_src" ]; then
+        echo "hook source directory missing: $hooks_src" >&2
+        return 1
+    fi
+
+    copy_install_files "$hooks_src" "$hooks_dst" "*.sh" 1 || return 1
+
+    # Deploy global/hooks/lib/*.sh. The top-level *.sh copy is non-recursive,
+    # and several runtime guards source these libraries.
+    if [ -d "$hooks_lib_src" ]; then
+        copy_install_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 || return 1
+    fi
+
+    # Shared validator libraries used by commit/language/traceability guards.
+    if [ -d "$shared_lib_src" ]; then
+        for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+            if [ -f "$shared_lib_src/$lib" ]; then
+                copy_install_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 || return 1
+            fi
+        done
+    fi
+
+    for lib in \
+        tokenize-shell.sh \
+        path-utils.sh \
+        timeout-wrapper.sh \
+        rotate.sh \
+        validate-commit-message.sh \
+        validate-language.sh \
+        validate-traceability.sh; do
+        if [ ! -f "$hooks_dst/lib/$lib" ]; then
+            echo "required hook runtime library missing after deploy: hooks/lib/$lib" >&2
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+write_full_suite_probe() {
+    local probe_dir="$HOME/.claude"
+    local probe_file="$probe_dir/.full-suite-active"
+    local tmp_probe sens_guard=false dang_guard=false
+
+    [ -f "$HOME/.claude/hooks/sensitive-file-guard.sh" ] && sens_guard=true
+    [ -f "$HOME/.claude/hooks/dangerous-command-guard.sh" ] && dang_guard=true
+
+    if command -v python3 >/dev/null 2>&1; then
+        tmp_probe="$(mktemp "${TMPDIR:-/tmp}/claude-probe.XXXXXX")"
+        if SENS="$sens_guard" DANG="$dang_guard" python3 - "$tmp_probe" <<'PY' 2>/dev/null
+import json, os, sys
+path = sys.argv[1]
+def flag(name):
+    return os.environ.get(name, "false").lower() == "true"
+doc = {
+    "schema": 1,
+    "hooks": {
+        "sensitive-file-guard": flag("SENS"),
+        "dangerous-command-guard": flag("DANG"),
+    },
+}
+with open(path, "w") as f:
+    json.dump(doc, f)
+    f.write("\n")
+PY
+        then
+            if mv "$tmp_probe" "$probe_file"; then
+                chmod 644 "$probe_file" 2>/dev/null || true
+                success "Full-suite probe 작성됨 (.full-suite-active)"
+            fi
+        else
+            rm -f "$tmp_probe"
+            warning "Full-suite probe 작성 실패 (python3 JSON 직렬화 오류)"
+        fi
+    else
+        warning "python3 부재로 Full-suite probe 건너뜀 (플러그인 가드는 계속 활성화됨)"
+    fi
+}
+
+install_global_settings_and_hooks() {
+    local settings_src="$BACKUP_DIR/global/settings.json"
+    local settings_dst="$HOME/.claude/settings.json"
+    local settings_tmp="$HOME/.claude/.settings.json.tmp.$$"
+    local settings_updated=0
+
+    if [ ! -f "$settings_src" ]; then
+        if [ -d "$BACKUP_DIR/global/hooks" ]; then
+            deploy_install_hooks || error "Hook 스크립트 배포 실패."
+            success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+            write_full_suite_probe
+        fi
+        return 0
+    fi
+
+    # Stage settings first, then publish only after hook deployment succeeds.
+    # This prevents settings.json from pointing at missing runtime hooks.
+    rm -f "$settings_tmp"
+    cp "$settings_src" "$settings_tmp" || error "settings.json 스테이징 실패"
+
+    # CLAUDE_CONTENT_LANGUAGE env 주입 및 Agent Language 속성 업데이트
+    if update_claude_settings_json "$settings_tmp" "$AGENT_LANGUAGE" "$CONTENT_LANGUAGE"; then
+        settings_updated=1
+    fi
+
+    if ! deploy_install_hooks; then
+        rm -f "$settings_tmp"
+        error "Hook 스크립트 배포 실패. settings.json을 변경하지 않았습니다."
+    fi
+
+    mv -f "$settings_tmp" "$settings_dst" || {
+        rm -f "$settings_tmp"
+        error "settings.json 게시 실패"
+    }
+
+    success "Hook 설정 (settings.json) 설치 완료!"
+    if [ "$settings_updated" = "1" ]; then
+        success "settings.json: language=$AGENT_LANGUAGE, CLAUDE_CONTENT_LANGUAGE=$CONTENT_LANGUAGE 업데이트 완료."
+    else
+        warning "jq가 설치되어 있지 않아 settings.json을 자동 업데이트할 수 없습니다."
+        if [ "$CONTENT_LANGUAGE" != "english" ]; then
+            echo "  수동으로 ~/.claude/settings.json 의 env 섹션에 다음을 추가하세요:"
+            echo "    \"CLAUDE_CONTENT_LANGUAGE\": \"$CONTENT_LANGUAGE\""
+        fi
+        echo "  그리고 루트 레벨에 다음을 추가/수정하세요:"
+        echo "    \"language\": \"$AGENT_LANGUAGE\""
+    fi
+
+    success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
+    write_full_suite_probe
+}
+
 # Note: get_policy_phrase, render_policy_tmpl, and render_policy_tmpls_in_dir
 # are provided by scripts/lib/install-prompts.sh, which is sourced before any
 # callers (the prompt section sources it explicitly). The render helpers were
@@ -679,113 +842,11 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         fi
     fi
 
-    # settings.json install (Hook configuration)
-    # Intentionally bypasses guarded_copy: policy attributes (.language,
-    # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
-    # update_claude_settings_json (below) injects them and is responsible
-    # for idempotent reset when the policy returns to default ("english").
-    if [ -f "$BACKUP_DIR/global/settings.json" ]; then
-        cp "$BACKUP_DIR/global/settings.json" "$HOME/.claude/"
-        success "Hook 설정 (settings.json) 설치 완료!"
-
-        # CLAUDE_CONTENT_LANGUAGE env 주입 및 Agent Language 속성 업데이트
-        if update_claude_settings_json "$HOME/.claude/settings.json" "$AGENT_LANGUAGE" "$CONTENT_LANGUAGE"; then
-            success "settings.json: language=$AGENT_LANGUAGE, CLAUDE_CONTENT_LANGUAGE=$CONTENT_LANGUAGE 업데이트 완료."
-        else
-            warning "jq가 설치되어 있지 않아 settings.json을 자동 업데이트할 수 없습니다."
-            if [ "$CONTENT_LANGUAGE" != "english" ]; then
-                echo "  수동으로 ~/.claude/settings.json 의 env 섹션에 다음을 추가하세요:"
-                echo "    \"CLAUDE_CONTENT_LANGUAGE\": \"$CONTENT_LANGUAGE\""
-            fi
-            echo "  그리고 루트 레벨에 다음을 추가/수정하세요:"
-            echo "    \"language\": \"$AGENT_LANGUAGE\""
-        fi
-    fi
-
-    # hooks 디렉토리 설치 (외부 스크립트)
-    if [ -d "$BACKUP_DIR/global/hooks" ]; then
-        ensure_dir "$HOME/.claude/hooks"
-        cp "$BACKUP_DIR/global/hooks"/*.sh "$HOME/.claude/hooks/" 2>/dev/null || true
-        chmod +x "$HOME/.claude/hooks/"*.sh 2>/dev/null || true
-
-        # Deploy global/hooks/lib/*.sh (issue #586). Mirrors install.ps1:481-500.
-        # The *.sh glob above is non-recursive, so without this block the four
-        # shared libraries (tokenize-shell.sh, path-utils.sh, timeout-wrapper.sh,
-        # rotate.sh) are silently dropped. dangerous-command-guard.sh,
-        # gh-write-verb-guard.sh, bash-write-guard.sh, and
-        # bash-sensitive-read-guard.sh source tokenize-shell.sh at runtime.
-        if [ -d "$BACKUP_DIR/global/hooks/lib" ]; then
-            ensure_dir "$HOME/.claude/hooks/lib"
-            cp "$BACKUP_DIR/global/hooks/lib"/*.sh "$HOME/.claude/hooks/lib/" 2>/dev/null || true
-            chmod +x "$HOME/.claude/hooks/lib/"*.sh 2>/dev/null || true
-
-            # Post-copy regression guard for #586. tokenize-shell.sh is the
-            # canonical sub-command splitter (see #476); its absence weakens
-            # four Bash-channel guards. Surface a loud warning at install time
-            # so the regression cannot reach a user session silently.
-            if [ ! -f "$HOME/.claude/hooks/lib/tokenize-shell.sh" ]; then
-                warning "hooks/lib/tokenize-shell.sh 미설치 - Bash 가드가 약화됩니다 (issue #586)"
-            fi
-        fi
-
-        success "Hook 스크립트 (hooks/ + lib/) 설치 완료!"
-
-        # Full-suite probe (issue #423): advertise which canonical guards the
-        # plugin surface should stand down for. Plugin/hooks.json inspects this
-        # file at runtime so its inline guards only activate in standalone
-        # deployments. Listed hooks reflect the ones that overlap with plugin
-        # inline guards. Atomic write (tmp + mv) so a partial write cannot
-        # produce a half-valid probe.
-        PROBE_DIR="$HOME/.claude"
-        PROBE_FILE="$PROBE_DIR/.full-suite-active"
-        SENS_GUARD=false
-        DANG_GUARD=false
-        [ -f "$HOME/.claude/hooks/sensitive-file-guard.sh" ] && SENS_GUARD=true
-        [ -f "$HOME/.claude/hooks/dangerous-command-guard.sh" ] && DANG_GUARD=true
-        if command -v python3 >/dev/null 2>&1; then
-            TMP_PROBE="$(mktemp "${TMPDIR:-/tmp}/claude-probe.XXXXXX")"
-            if SENS="$SENS_GUARD" DANG="$DANG_GUARD" python3 - "$TMP_PROBE" <<'PY' 2>/dev/null
-import json, os, sys
-path = sys.argv[1]
-def flag(name):
-    return os.environ.get(name, "false").lower() == "true"
-doc = {
-    "schema": 1,
-    "hooks": {
-        "sensitive-file-guard": flag("SENS"),
-        "dangerous-command-guard": flag("DANG"),
-    },
-}
-with open(path, "w") as f:
-    json.dump(doc, f)
-    f.write("\n")
-PY
-            then
-                if mv "$TMP_PROBE" "$PROBE_FILE"; then
-                    chmod 644 "$PROBE_FILE" 2>/dev/null || true
-                    success "Full-suite probe 작성됨 (.full-suite-active)"
-                fi
-            else
-                rm -f "$TMP_PROBE"
-                warning "Full-suite probe 작성 실패 (python3 JSON 직렬화 오류)"
-            fi
-        else
-            warning "python3 부재로 Full-suite probe 건너뜀 (플러그인 가드는 계속 활성화됨)"
-        fi
-    fi
-
-    # 공유 검증 라이브러리 설치 (commit-message-guard.sh, pr-language-guard.sh,
-    # traceability-guard.sh가 사용)
-    if [ -d "$BACKUP_DIR/hooks/lib" ]; then
-        ensure_dir "$HOME/.claude/hooks/lib"
-        for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
-            if [ -f "$BACKUP_DIR/hooks/lib/$lib" ]; then
-                cp "$BACKUP_DIR/hooks/lib/$lib" "$HOME/.claude/hooks/lib/"
-                chmod +x "$HOME/.claude/hooks/lib/$lib"
-            fi
-        done
-        success "공유 검증 라이브러리 설치 완료!"
-    fi
+    # settings.json + hooks 디렉토리 설치 (settings.json이 참조하는 런타임 가드)
+    # settings.json은 ~/.claude/hooks/*.sh 가드 다수를 참조하므로, 설정 게시와
+    # 훅/라이브러리 배포 사이의 실패 공백을 막는다. Hook 배포 실패 시
+    # settings.json은 게시하지 않는다.
+    install_global_settings_and_hooks
 
     # scripts 디렉토리 설치 (statusline 등)
     if [ -d "$BACKUP_DIR/global/scripts" ]; then

--- a/tests/scripts/test-install-atomic-deploy.ps1
+++ b/tests/scripts/test-install-atomic-deploy.ps1
@@ -1,0 +1,242 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Regression test for scripts/install.ps1 settings/hooks atomic deployment (#813).
+
+.DESCRIPTION
+    Runs install.ps1 in global-only mode against an isolated scratch HOME and a
+    minimal fixture. The success case proves settings.json is published after
+    hook deployment. Failure cases prove an existing settings.json is preserved
+    when hook deployment fails.
+#>
+
+$ErrorActionPreference = 'Continue'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+
+$script:PASS = 0
+$script:FAIL = 0
+$script:ERRORS = @()
+
+function Pass {
+    param([string]$Message)
+    $script:PASS++
+    Write-Host "  PASS: $Message"
+}
+
+function Fail {
+    param([string]$Message)
+    $script:FAIL++
+    $script:ERRORS += $Message
+    Write-Host "  FAIL: $Message" -ForegroundColor Red
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) { Pass $Message } else { Fail $Message }
+}
+
+function New-FakeBin {
+    param([Parameter(Mandatory)][string]$Path)
+
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    $claudeSh = Join-Path $Path 'claude'
+    Set-Content -LiteralPath $claudeSh -Value "#!/bin/sh`necho claude test`n" -NoNewline
+    if (-not ($IsWindows -or ($env:OS -eq 'Windows_NT'))) {
+        & chmod +x $claudeSh
+    }
+
+    $claudeCmd = Join-Path $Path 'claude.cmd'
+    Set-Content -LiteralPath $claudeCmd -Value "@echo off`r`necho claude test`r`n" -NoNewline
+}
+
+function New-Fixture {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $scripts = Join-Path $Path 'scripts'
+    $scriptLib = Join-Path $scripts 'lib'
+    $hooks = Join-Path $Path 'global' 'hooks'
+    $hooksLib = Join-Path $hooks 'lib'
+    $sharedLib = Join-Path $Path 'hooks' 'lib'
+    New-Item -ItemType Directory -Path $scriptLib, $hooksLib, $sharedLib -Force | Out-Null
+
+    Copy-Item -LiteralPath (Join-Path $RootDir 'scripts' 'install.ps1') -Destination $scripts -Force
+    Copy-Item -LiteralPath (Join-Path $RootDir 'scripts' 'install-manifest.ps1') -Destination $scripts -Force
+    Copy-Item -LiteralPath (Join-Path $RootDir 'scripts' 'lib' 'InstallPrompts.psm1') -Destination $scriptLib -Force
+
+    Set-Content -LiteralPath (Join-Path $Path 'global' 'settings.windows.json') -Value @'
+{
+  "fixture": "powershell"
+}
+'@ -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'example.ps1') -Value 'exit 0' -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'example.sh') -Value "#!/bin/sh`nexit 0`n" -NoNewline
+    Set-Content -LiteralPath (Join-Path $hooks 'known-issues.json') -Value '{}' -NoNewline
+
+    foreach ($name in @('CommonHelpers.psm1', 'LanguageValidator.psm1', 'AttributionValidator.psm1')) {
+        Set-Content -LiteralPath (Join-Path $hooksLib $name) -Value '' -NoNewline
+    }
+    foreach ($name in @('tokenize-shell.sh', 'path-utils.sh', 'timeout-wrapper.sh', 'rotate.sh')) {
+        Set-Content -LiteralPath (Join-Path $hooksLib $name) -Value "#!/bin/sh`nreturn 0 2>/dev/null || exit 0`n" -NoNewline
+    }
+    foreach ($name in @('validate-commit-message.sh', 'validate-language.sh', 'validate-traceability.sh')) {
+        Set-Content -LiteralPath (Join-Path $sharedLib $name) -Value "#!/bin/sh`nreturn 0 2>/dev/null || exit 0`n" -NoNewline
+    }
+}
+
+function Invoke-Install {
+    param(
+        [Parameter(Mandatory)][string]$HomeDir,
+        [Parameter(Mandatory)][string]$Fixture,
+        [Parameter(Mandatory)][string]$FakeBin
+    )
+
+    $origHome = $env:HOME
+    $origUserProfile = $env:USERPROFILE
+    $origPath = $env:PATH
+    $origAgentLanguage = $env:AGENT_LANGUAGE
+    $origContentLanguage = $env:CONTENT_LANGUAGE
+
+    try {
+        $env:HOME = $HomeDir
+        $env:USERPROFILE = $HomeDir
+        $env:PATH = "$FakeBin$([System.IO.Path]::PathSeparator)$origPath"
+        $env:AGENT_LANGUAGE = 'english'
+        $env:CONTENT_LANGUAGE = 'english'
+
+        $installer = Join-Path $Fixture 'scripts' 'install.ps1'
+        $inputs = "1`nn`n"
+        $output = $inputs | pwsh -NoProfile -File $installer 2>&1 | Out-String
+        return [PSCustomObject]@{
+            ExitCode = $LASTEXITCODE
+            Output = $output
+        }
+    }
+    finally {
+        $env:HOME = $origHome
+        $env:USERPROFILE = $origUserProfile
+        $env:PATH = $origPath
+        $env:AGENT_LANGUAGE = $origAgentLanguage
+        $env:CONTENT_LANGUAGE = $origContentLanguage
+    }
+}
+
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) "install-atomic-ps1-$([guid]::NewGuid())"
+New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+
+try {
+    Write-Host "=== Clone installer atomic deploy test (PowerShell, #813) ==="
+    Write-Host ""
+
+    $fakeBin = Join-Path $scratch 'fake-bin'
+    New-FakeBin -Path $fakeBin
+
+    $successFixture = Join-Path $scratch 'success-fixture'
+    $successHome = Join-Path $scratch 'success-home'
+    New-Fixture -Path $successFixture
+    New-Item -ItemType Directory -Path $successHome -Force | Out-Null
+
+    $result = Invoke-Install -HomeDir $successHome -Fixture $successFixture -FakeBin $fakeBin
+    if ($result.ExitCode -eq 0) {
+        Pass 'successful hook deployment exits 0'
+    } else {
+        Fail 'successful hook deployment exits 0'
+        Write-Host ($result.Output -replace '(?m)^', '    ')
+    }
+
+    $successClaude = Join-Path $successHome '.claude'
+    Assert-True (Select-String -LiteralPath (Join-Path $successClaude 'settings.json') -Pattern '"fixture": "powershell"' -Quiet) `
+        'settings.json published after successful hook deployment'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'example.ps1')) `
+        'PowerShell hook deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'example.sh')) `
+        'bash hook variant deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'lib' 'tokenize-shell.sh')) `
+        'hook lib deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'lib' 'CommonHelpers.psm1')) `
+        'PowerShell hook module deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'lib' 'validate-traceability.sh')) `
+        'shared validator lib deployed'
+    $settingsJson = Get-Content -Raw -LiteralPath (Join-Path $successClaude 'settings.json') | ConvertFrom-Json
+    Assert-True ($settingsJson.language -eq 'english') 'staged settings receive agent language update'
+
+    $failureFixture = Join-Path $scratch 'failure-fixture'
+    $failureHome = Join-Path $scratch 'failure-home'
+    New-Fixture -Path $failureFixture
+    $failureClaude = Join-Path $failureHome '.claude'
+    New-Item -ItemType Directory -Path $failureClaude -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $failureClaude 'settings.json') -Value '{"sentinel":"keep"}' -NoNewline
+    Set-Content -LiteralPath (Join-Path $failureClaude 'hooks') -Value 'not a directory' -NoNewline
+
+    $result = Invoke-Install -HomeDir $failureHome -Fixture $failureFixture -FakeBin $fakeBin
+    if ($result.ExitCode -ne 0) {
+        Pass 'failed hook deployment exits non-zero'
+    } else {
+        Fail 'failed hook deployment exits non-zero'
+    }
+
+    Assert-True (Select-String -LiteralPath (Join-Path $failureClaude 'settings.json') -Pattern '"sentinel":"keep"' -Quiet) `
+        'existing settings.json preserved when hook deployment fails'
+    $temps = @(Get-ChildItem -LiteralPath $failureClaude -Filter '.settings.json.tmp.*' -File -ErrorAction SilentlyContinue)
+    Assert-True ($temps.Count -eq 0) 'staged settings temp removed after hook deployment failure'
+    Assert-True ($result.Output -match 'settings\.json을 변경하지 않았습니다') `
+        'hook deployment failure reports blocked settings publication'
+
+    $missingLibFixture = Join-Path $scratch 'missing-lib-fixture'
+    $missingLibHome = Join-Path $scratch 'missing-lib-home'
+    New-Fixture -Path $missingLibFixture
+    Remove-Item -LiteralPath (Join-Path $missingLibFixture 'global' 'hooks' 'lib' 'tokenize-shell.sh') -Force
+    $missingLibClaude = Join-Path $missingLibHome '.claude'
+    New-Item -ItemType Directory -Path $missingLibClaude -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $missingLibClaude 'settings.json') -Value '{"sentinel":"missing-lib"}' -NoNewline
+
+    $result = Invoke-Install -HomeDir $missingLibHome -Fixture $missingLibFixture -FakeBin $fakeBin
+    if ($result.ExitCode -ne 0) {
+        Pass 'missing required runtime lib exits non-zero'
+    } else {
+        Fail 'missing required runtime lib exits non-zero'
+    }
+
+    Assert-True (Select-String -LiteralPath (Join-Path $missingLibClaude 'settings.json') -Pattern '"sentinel":"missing-lib"' -Quiet) `
+        'existing settings.json preserved when required runtime lib is missing'
+    Assert-True ($result.Output -match 'settings\.json을 변경하지 않았습니다') `
+        'missing runtime lib failure reports blocked settings publication'
+
+    $missingModuleFixture = Join-Path $scratch 'missing-module-fixture'
+    $missingModuleHome = Join-Path $scratch 'missing-module-home'
+    New-Fixture -Path $missingModuleFixture
+    Remove-Item -LiteralPath (Join-Path $missingModuleFixture 'global' 'hooks' 'lib' 'CommonHelpers.psm1') -Force
+    $missingModuleClaude = Join-Path $missingModuleHome '.claude'
+    New-Item -ItemType Directory -Path $missingModuleClaude -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $missingModuleClaude 'settings.json') -Value '{"sentinel":"missing-module"}' -NoNewline
+
+    $result = Invoke-Install -HomeDir $missingModuleHome -Fixture $missingModuleFixture -FakeBin $fakeBin
+    if ($result.ExitCode -ne 0) {
+        Pass 'missing required PowerShell module exits non-zero'
+    } else {
+        Fail 'missing required PowerShell module exits non-zero'
+    }
+
+    Assert-True (Select-String -LiteralPath (Join-Path $missingModuleClaude 'settings.json') -Pattern '"sentinel":"missing-module"' -Quiet) `
+        'existing settings.json preserved when required PowerShell module is missing'
+    Assert-True ($result.Output -match 'settings\.json을 변경하지 않았습니다') `
+        'missing PowerShell module failure reports blocked settings publication'
+}
+finally {
+    Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "=== Results: $($script:PASS) passed, $($script:FAIL) failed ==="
+
+if ($script:FAIL -gt 0) {
+    Write-Host ""
+    Write-Host "Errors:"
+    foreach ($err in $script:ERRORS) {
+        Write-Host "  - $err"
+    }
+    exit 1
+}
+
+exit 0

--- a/tests/scripts/test-install-atomic-deploy.sh
+++ b/tests/scripts/test-install-atomic-deploy.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Regression test for issue #813.
+#
+# Verifies that scripts/install.sh publishes ~/.claude/settings.json only after
+# runtime hook deployment succeeds. A hook deployment failure must leave the
+# previously installed settings.json untouched.
+#
+# Run: bash tests/scripts/test-install-atomic-deploy.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$1")
+    echo "  FAIL: $1"
+}
+
+assert_true() {
+    local label="$1"
+    if eval "$2"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+make_fake_bin() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/claude" <<'SH'
+#!/bin/sh
+echo "claude test"
+SH
+    chmod +x "$dir/claude"
+}
+
+make_fixture() {
+    local fixture="$1"
+    local lib
+
+    mkdir -p \
+        "$fixture/scripts/lib" \
+        "$fixture/global/hooks/lib" \
+        "$fixture/hooks/lib"
+
+    cp "$REPO_ROOT/scripts/install.sh" "$fixture/scripts/install.sh"
+    cp "$REPO_ROOT/scripts/install-manifest.sh" "$fixture/scripts/install-manifest.sh"
+    cp "$REPO_ROOT/scripts/lib/install-prompts.sh" "$fixture/scripts/lib/install-prompts.sh"
+
+    cat > "$fixture/global/settings.json" <<'JSON'
+{
+  "fixture": "bash"
+}
+JSON
+    cat > "$fixture/global/hooks/example.sh" <<'SH'
+#!/bin/sh
+exit 0
+SH
+    for lib in tokenize-shell.sh path-utils.sh timeout-wrapper.sh rotate.sh; do
+        cat > "$fixture/global/hooks/lib/$lib" <<'SH'
+#!/bin/sh
+return 0 2>/dev/null || exit 0
+SH
+    done
+    for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+        cat > "$fixture/hooks/lib/$lib" <<'SH'
+#!/bin/sh
+return 0 2>/dev/null || exit 0
+SH
+    done
+}
+
+run_install() {
+    local home_dir="$1" fixture="$2" fake_bin="$3"
+    env \
+        HOME="$home_dir" \
+        USERPROFILE="$home_dir" \
+        PATH="$fake_bin:$PATH" \
+        AGENT_LANGUAGE=english \
+        CONTENT_LANGUAGE=english \
+        INSTALL_NPM=n \
+        bash "$fixture/scripts/install.sh" --type 1 --yes >"$OUTPUT" 2>&1
+}
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/install-atomic.XXXXXX" 2>/dev/null || mktemp -d)"
+OUTPUT="$WORK/install-atomic-bash.out"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== Clone installer atomic deploy test (bash, #813) ==="
+echo ""
+
+fake_bin="$WORK/fake-bin"
+make_fake_bin "$fake_bin"
+
+success_fixture="$WORK/success-fixture"
+success_home="$WORK/success-home"
+make_fixture "$success_fixture"
+mkdir -p "$success_home"
+
+if run_install "$success_home" "$success_fixture" "$fake_bin"; then
+    pass "successful hook deployment exits 0"
+else
+    fail "successful hook deployment exits 0"
+    sed 's/^/    /' "$OUTPUT"
+fi
+
+assert_true "settings.json published after successful hook deployment" \
+    "grep -q '\"fixture\": \"bash\"' '$success_home/.claude/settings.json'"
+assert_true "top-level hook deployed executable" \
+    "[ -x '$success_home/.claude/hooks/example.sh' ]"
+assert_true "hook lib deployed executable" \
+    "[ -x '$success_home/.claude/hooks/lib/tokenize-shell.sh' ]"
+assert_true "shared validator lib deployed executable" \
+    "[ -x '$success_home/.claude/hooks/lib/validate-traceability.sh' ]"
+if command -v jq >/dev/null 2>&1; then
+    assert_true "staged settings receive agent language update" \
+        "[ \"\$(jq -r '.language' '$success_home/.claude/settings.json')\" = 'english' ]"
+fi
+
+failure_fixture="$WORK/failure-fixture"
+failure_home="$WORK/failure-home"
+make_fixture "$failure_fixture"
+mkdir -p "$failure_home/.claude"
+printf '%s\n' '{"sentinel":"keep"}' > "$failure_home/.claude/settings.json"
+printf '%s\n' 'not a directory' > "$failure_home/.claude/hooks"
+
+set +e
+run_install "$failure_home" "$failure_fixture" "$fake_bin"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    pass "failed hook deployment exits non-zero"
+else
+    fail "failed hook deployment exits non-zero"
+fi
+
+assert_true "existing settings.json preserved when hook deployment fails" \
+    "grep -q '\"sentinel\":\"keep\"' '$failure_home/.claude/settings.json'"
+assert_true "staged settings temp removed after hook deployment failure" \
+    "! find '$failure_home/.claude' -maxdepth 1 -name '.settings.json.tmp.*' | grep -q ."
+assert_true "hook deployment failure reports blocked settings publication" \
+    "grep -q 'settings.json을 변경하지 않았습니다' '$OUTPUT'"
+
+missing_lib_fixture="$WORK/missing-lib-fixture"
+missing_lib_home="$WORK/missing-lib-home"
+make_fixture "$missing_lib_fixture"
+rm -f "$missing_lib_fixture/global/hooks/lib/tokenize-shell.sh"
+mkdir -p "$missing_lib_home/.claude"
+printf '%s\n' '{"sentinel":"missing-lib"}' > "$missing_lib_home/.claude/settings.json"
+
+set +e
+run_install "$missing_lib_home" "$missing_lib_fixture" "$fake_bin"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+    pass "missing required runtime lib exits non-zero"
+else
+    fail "missing required runtime lib exits non-zero"
+fi
+
+assert_true "existing settings.json preserved when required runtime lib is missing" \
+    "grep -q '\"sentinel\":\"missing-lib\"' '$missing_lib_home/.claude/settings.json'"
+assert_true "missing runtime lib failure reports blocked settings publication" \
+    "grep -q 'settings.json을 변경하지 않았습니다' '$OUTPUT'"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Errors:"
+    for err in "${ERRORS[@]}"; do
+        echo "  - $err"
+    done
+    exit 1
+fi
+
+exit 0

--- a/tests/scripts/test-install-deploys-bash-lib.sh
+++ b/tests/scripts/test-install-deploys-bash-lib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Regression test for issue #447 Phase 1 / #448.
 #
-# Asserts that the shared bash validator library (hooks/lib/validate-*.sh)
+# Asserts that the shared bash validator libraries (hooks/lib/validate-*.sh)
 # is deployed to ~/.claude/hooks/lib/ by both installers. Without this,
 # pr-language-guard.sh falls through to its inline english-only fallback
 # regardless of CLAUDE_CONTENT_LANGUAGE.
@@ -16,7 +16,7 @@
 #                         using Install-BashScript for CRLF/exec-bit
 #                         normalization (regression guard for the #448 fix).
 #   4. Functional:        replay the install.sh block against a temp HOME
-#                         and verify both libs land, are non-empty, and
+#                         and verify the libs land, are non-empty, and
 #                         the dispatcher is defined when sourced.
 #
 # Run: bash tests/scripts/test-install-deploys-bash-lib.sh
@@ -47,7 +47,7 @@ fail() {
 # ---------------------------------------------------------------------------
 echo "=== Source libs in repo-root hooks/lib/ ==="
 
-for lib in validate-commit-message.sh validate-language.sh; do
+for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
     src="$REPO_ROOT/hooks/lib/$lib"
     if [ ! -f "$src" ]; then
         fail "$lib missing from repo hooks/lib/"
@@ -83,11 +83,13 @@ else
     pass "install.sh references \$BACKUP_DIR/hooks/lib"
 fi
 
-if grep -q 'validate-commit-message.sh validate-language.sh' "$INSTALL_SH"; then
-    pass "install.sh iterates both shared libs"
-else
-    fail "install.sh shared-lib loop does not cover both libs"
-fi
+for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+    if grep -q "$lib" "$INSTALL_SH"; then
+        pass "install.sh deploys $lib"
+    else
+        fail "install.sh shared-lib loop does not cover $lib"
+    fi
+done
 
 # ---------------------------------------------------------------------------
 # 3. install.ps1: deployment block present (regression guard for #448)
@@ -104,16 +106,19 @@ else
     pass "install.ps1 references repo-root hooks/lib"
 fi
 
-if grep -q "validate-commit-message.sh.*validate-language.sh\|'validate-commit-message.sh', 'validate-language.sh'" "$INSTALL_PS1"; then
-    pass "install.ps1 iterates both shared libs"
-else
-    fail "install.ps1 shared-lib list does not cover both libs"
-fi
+for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
+    if grep -q "$lib" "$INSTALL_PS1"; then
+        pass "install.ps1 deploys $lib"
+    else
+        fail "install.ps1 shared-lib list does not cover $lib"
+    fi
+done
 
-if grep -q 'Install-BashScript.*sharedLibSource\|Install-BashScript -SourcePath \$libSrc' "$INSTALL_PS1"; then
-    pass "install.ps1 uses Install-BashScript for CRLF normalization"
+if grep -q 'Copy-InstallHookFiles -SourceDir \$sharedLibSource' "$INSTALL_PS1" \
+    && grep -q 'Install-BashScript -SourcePath' "$INSTALL_PS1"; then
+    pass "install.ps1 routes shared libs through Install-BashScript normalization"
 else
-    fail "install.ps1 does not use Install-BashScript for shared-lib copy"
+    fail "install.ps1 does not route shared libs through Install-BashScript"
 fi
 
 # ---------------------------------------------------------------------------
@@ -143,7 +148,7 @@ BACKUP_DIR="$REPO_ROOT"
 HOME="$HOME_TMP"
 if [ -d "$BACKUP_DIR/hooks/lib" ]; then
     ensure_dir "$HOME/.claude/hooks/lib"
-    for lib in validate-commit-message.sh validate-language.sh; do
+    for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
         if [ -f "$BACKUP_DIR/hooks/lib/$lib" ]; then
             cp "$BACKUP_DIR/hooks/lib/$lib" "$HOME/.claude/hooks/lib/"
             chmod +x "$HOME/.claude/hooks/lib/$lib"
@@ -151,7 +156,7 @@ if [ -d "$BACKUP_DIR/hooks/lib" ]; then
     done
 fi
 
-for lib in validate-commit-message.sh validate-language.sh; do
+for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
     deployed="$HOME/.claude/hooks/lib/$lib"
     if [ ! -f "$deployed" ]; then
         fail "$lib not deployed to temp \$HOME"


### PR DESCRIPTION
Closes #813

## What

- Stages clone-installer `settings.json` writes and publishes them only after runtime hook deployment succeeds.
- Makes `scripts/install.sh` and `scripts/install.ps1` fail loudly on hook or required library deployment failures before replacing existing settings.
- Adds Bash and PowerShell clone-installer atomic deployment regression tests and wires them into `validate-hooks`.
- Updates install behavior docs and the doc-index manifest for the expanded atomic deployment contract.

## Why

Bootstrap already had the atomic settings/runtime-hook contract from #798. The clone installers still copied settings before hook deployment and could leave settings pointing at missing runtime hooks after a later copy failure.

## Verification

- `bash tests/scripts/test-install-atomic-deploy.sh`
- `pwsh -NoProfile -File tests/scripts/test-install-atomic-deploy.ps1`
- `bash tests/scripts/test-install-deploys-bash-lib.sh`
- `bash tests/scripts/test-installer-robustness.sh`
- `bash tests/scripts/test-bootstrap-atomic-deploy.sh`
- `pwsh -NoProfile -File tests/scripts/test-bootstrap-atomic-deploy.ps1`
- `bash tests/scripts/test-windows-hooks-parity.sh`
- `bash tests/scripts/test-install-permissions-policy.sh`
- `bash tests/scripts/test-global-files-referenced-exist.sh`
- `bash tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash tests/scripts/test-windows-powershell-permissions.sh`
- `bash tests/scripts/test-hook-ordering.sh`
- `pwsh -NoProfile -File tests/scripts/test-install-dual-variant.ps1`
- `pwsh -NoProfile -File tests/scripts/test-install-prompts-ps1.ps1`
- `bash tests/scripts/test-doc-prompt-lockstep.sh`
- `bash tests/scripts/test-language-policy-drift.sh`
- `bash scripts/validate-doc-index.sh`
- `bash tests/doc-index/test-validate-doc-index.sh`
- `bash -n scripts/install.sh`
- PowerShell parser check for `scripts/install.ps1`
- `git diff --cached --check`

Local note: `bash tests/scripts/test-install-manifest-helpers.sh` and `bash tests/hooks/test-runner.sh` were attempted but not accepted as local pass signals because this Git Bash environment has no `jq`. The GitHub workflow installs `jq` before those checks.

## Risk

Medium. This changes installer failure behavior: hook and required library deployment failures now stop the global install before settings are published. Existing customization behavior is preserved because settings still bypass the manifest only for policy enforcement, but now through a staged file.