### PR TITLE
release: v1.11.0 metadata

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 # Claude Configuration Backup & Deployment System
 
 <p align="center">
-  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.10.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.11.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-green.svg" alt="License"></a>
   <a href="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml"><img src="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml/badge.svg" alt="CI"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claude Configuration Backup & Deployment System
 
 <p align="center">
-  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.10.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/kcenon/claude-config/releases"><img src="https://img.shields.io/badge/version-1.11.0-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-green.svg" alt="License"></a>
   <a href="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml"><img src="https://github.com/kcenon/claude-config/actions/workflows/validate-skills.yml/badge.svg" alt="CI"></a>
 </p>

--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -18,7 +18,7 @@
 # To bump a version: edit the field here, then run scripts/sync_versions.sh
 # (or /release <field> <new-version>) to propagate to consumers.
 
-suite: 1.10.0
+suite: 1.11.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
 settings-schema: 1.17.0


### PR DESCRIPTION
## Summary

Bump the suite release metadata to `1.11.0` before publishing the release tag.

## Scope

- Update `VERSION_MAP.yml` suite from `1.10.0` to `1.11.0`.
- Sync README and README.ko.md version badges to `1.11.0`.

## Verification

- `bash scripts/check_versions.sh`
- `bash scripts/diff-readme.sh`

## Risk

Low. This is a release metadata-only update with no runtime behavior changes.