### PR TITLE
fix(bootstrap): deploy statusline scripts

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -289,6 +289,17 @@ function Deploy-BootstrapHooks {
     }
 }
 
+function Deploy-BootstrapUtilityScripts {
+    $scriptsSrc = Join-Path $InstallDir 'global' 'scripts'
+    if (-not (Test-Path -LiteralPath $scriptsSrc -PathType Container)) { return }
+
+    $scriptsDst = Join-Path $ClaudeDir 'scripts'
+    if (-not (Test-Path -LiteralPath $scriptsDst -PathType Container)) {
+        New-Item -ItemType Directory -Path $scriptsDst -Force -ErrorAction Stop | Out-Null
+    }
+    Copy-Item -Path (Join-Path $scriptsSrc '*') -Destination $scriptsDst -Force -ErrorAction Stop
+}
+
 function Install-BootstrapSettingsAndHooks {
     # Intentionally bypasses Invoke-GuardedCopy: policy attributes (.language,
     # .env.CLAUDE_CONTENT_LANGUAGE) must be enforced on every install.
@@ -314,6 +325,7 @@ function Install-BootstrapSettingsAndHooks {
         $settingsUpdated = Update-ClaudeSettingsJson -SettingsPath $settingsTmp -AgentLang $agentLanguage -ContentLang $contentLanguage
 
         Deploy-BootstrapHooks
+        Deploy-BootstrapUtilityScripts
 
         Move-Item -LiteralPath $settingsTmp -Destination $settingsDst -Force -ErrorAction Stop
     }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -358,6 +358,16 @@ deploy_bootstrap_hooks() {
     return 0
 }
 
+deploy_bootstrap_scripts() {
+    local scripts_src="$INSTALL_DIR/global/scripts"
+    local scripts_dst="$CLAUDE_DIR/scripts"
+
+    [ -d "$scripts_src" ] || return 0
+    copy_bootstrap_files "$scripts_src" "$scripts_dst" "*.sh" 1 || return 1
+
+    return 0
+}
+
 install_bootstrap_settings_and_hooks() {
     local settings_src="$INSTALL_DIR/global/settings.json"
     local settings_dst="$CLAUDE_DIR/settings.json"
@@ -380,6 +390,11 @@ install_bootstrap_settings_and_hooks() {
     if ! deploy_bootstrap_hooks; then
         rm -f "$settings_tmp"
         error "Hook 스크립트 배포 실패. settings.json을 변경하지 않았습니다."
+    fi
+
+    if ! deploy_bootstrap_scripts; then
+        rm -f "$settings_tmp"
+        error "Utility 스크립트 배포 실패. settings.json을 변경하지 않았습니다."
     fi
 
     mv -f "$settings_tmp" "$settings_dst" || {

--- a/tests/scripts/test-bootstrap-atomic-deploy.ps1
+++ b/tests/scripts/test-bootstrap-atomic-deploy.ps1
@@ -45,9 +45,11 @@ function New-Fixture {
     $lib = Join-Path $hooks 'lib'
     $sharedLib = Join-Path $Path 'hooks' 'lib'
     $scripts = Join-Path $Path 'scripts'
+    $globalScripts = Join-Path $Path 'global' 'scripts'
     New-Item -ItemType Directory -Path $lib -Force | Out-Null
     New-Item -ItemType Directory -Path $sharedLib -Force | Out-Null
     New-Item -ItemType Directory -Path $scripts -Force | Out-Null
+    New-Item -ItemType Directory -Path $globalScripts -Force | Out-Null
 
     Copy-Item -LiteralPath (Join-Path $RootDir 'scripts' 'install-manifest.ps1') -Destination $scripts -Force
     Set-Content -LiteralPath (Join-Path $Path 'global' 'settings.windows.json') -Value @'
@@ -65,6 +67,8 @@ function New-Fixture {
     foreach ($name in @('validate-commit-message.sh', 'validate-language.sh', 'validate-traceability.sh')) {
         Set-Content -LiteralPath (Join-Path $sharedLib $name) -Value "#!/bin/sh`nreturn 0 2>/dev/null || exit 0`n" -NoNewline
     }
+    Set-Content -LiteralPath (Join-Path $globalScripts 'statusline-command.ps1') -Value 'Write-Output "statusline"' -NoNewline
+    Set-Content -LiteralPath (Join-Path $globalScripts 'statusline-command.sh') -Value "#!/bin/sh`necho statusline`n" -NoNewline
 }
 
 function Invoke-AtomicDeploy {
@@ -123,6 +127,10 @@ try {
         'bash hook variant deployed'
     Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'hooks' 'lib' 'tokenize-shell.sh')) `
         'hook lib deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'scripts' 'statusline-command.ps1')) `
+        'statusline PowerShell utility script deployed'
+    Assert-True (Test-Path -LiteralPath (Join-Path $successClaude 'scripts' 'statusline-command.sh')) `
+        'statusline bash utility script deployed'
 
     $failureFixture = Join-Path $scratch 'failure-fixture'
     $failureHome = Join-Path $scratch 'failure-home'

--- a/tests/scripts/test-bootstrap-atomic-deploy.sh
+++ b/tests/scripts/test-bootstrap-atomic-deploy.sh
@@ -41,7 +41,7 @@ assert_true() {
 make_fixture() {
     local fixture="$1"
     local lib
-    mkdir -p "$fixture/global/hooks/lib" "$fixture/hooks/lib" "$fixture/scripts"
+    mkdir -p "$fixture/global/hooks/lib" "$fixture/global/scripts" "$fixture/hooks/lib" "$fixture/scripts"
     cp "$REPO_ROOT/scripts/install-manifest.sh" "$fixture/scripts/install-manifest.sh"
 
     cat > "$fixture/global/settings.json" <<'JSON'
@@ -65,6 +65,10 @@ SH
 return 0 2>/dev/null || exit 0
 SH
     done
+    cat > "$fixture/global/scripts/statusline-command.sh" <<'SH'
+#!/bin/sh
+echo statusline
+SH
 }
 
 run_atomic_deploy() {
@@ -104,6 +108,8 @@ assert_true "top-level hook deployed executable" \
     "[ -x '$success_home/.claude/hooks/example.sh' ]"
 assert_true "hook lib deployed executable" \
     "[ -x '$success_home/.claude/hooks/lib/tokenize-shell.sh' ]"
+assert_true "statusline utility script deployed executable" \
+    "[ -x '$success_home/.claude/scripts/statusline-command.sh' ]"
 
 failure_fixture="$WORK/failure-fixture"
 failure_home="$WORK/failure-home"


### PR DESCRIPTION
## Summary

Restore statusline script deployment for clean bootstrap installs.

## Root Cause

The release settings include a `statusLine` command that points to `~/.claude/scripts/statusline-command.*`, but the bootstrap installers deployed settings and hooks without copying `global/scripts`. A clean install therefore published a valid `settings.json` whose statusline command referenced a missing file.

## Changes

- Deploy bootstrap utility scripts before publishing `settings.json`.
- Apply the fix to both Bash and PowerShell bootstrap paths.
- Extend bootstrap atomic deployment tests to assert statusline script deployment.

## Verification

- `pwsh -NoProfile -File tests/scripts/test-bootstrap-atomic-deploy.ps1`
- `bash tests/scripts/test-bootstrap-atomic-deploy.sh`
- `bash tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash -n bootstrap.sh`
- PowerShell parser check for `bootstrap.ps1`
- `git diff --check`

## Risk

Low. The change only copies existing utility scripts during bootstrap and preserves the existing settings publication gate.