### PR TITLE
fix(install): Prune removed managed install files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Installers now record managed-file hashes for global and project install
+  trees and prune removed upstream files only when the deployed copy still
+  matches the managed hash. Locally edited removed files are preserved and
+  reported, and legacy command files removed before directory manifests are
+  pruned only when they match known upstream hashes (#820).
 - Default installer `GITHUB_REF` pins in `bootstrap.sh`, `bootstrap.ps1`, and
   README one-line examples now track `VERSION_MAP.yml` `suite` (`v1.11.0`);
   `check_versions` and `sync_versions` cover those pins.

--- a/README.md
+++ b/README.md
@@ -768,6 +768,7 @@ The `.mcp.json` template provides common MCP server configurations.
 
 After installation, `~/.claude/git-identity.md` is auto-filled from `git config --global user.name` and `git config --global user.email` when both values exist. Edit it only if the values are missing or wrong.
 On reinstall, the installer keeps the existing language policy defaults from `~/.claude/settings.json` unless `AGENT_LANGUAGE` or `CONTENT_LANGUAGE` is explicitly set.
+Reinstalls also prune removed managed files when their local hash still matches the install manifest; locally edited removed files are preserved and reported. See [docs/install.md](docs/install.md) for the manifest and prune rules.
 Existing files are automatically backed up with `.backup_YYYYMMDD_HHMMSS` format.
 
 ---

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -227,7 +227,8 @@ function Copy-BootstrapHookFiles {
     param(
         [Parameter(Mandatory)][string]$SourceDir,
         [Parameter(Mandatory)][string]$DestinationDir,
-        [Parameter(Mandatory)][string[]]$Filters
+        [Parameter(Mandatory)][string[]]$Filters,
+        [string]$KeyPrefix = ''
     )
 
     if (-not (Test-Path -LiteralPath $DestinationDir -PathType Container)) {
@@ -237,7 +238,13 @@ function Copy-BootstrapHookFiles {
     foreach ($filter in $Filters) {
         $items = @(Get-ChildItem -LiteralPath $SourceDir -Filter $filter -File -ErrorAction Stop)
         foreach ($item in $items) {
-            Copy-Item -LiteralPath $item.FullName -Destination (Join-Path $DestinationDir $item.Name) -Force -ErrorAction Stop
+            $dest = Join-Path $DestinationDir $item.Name
+            if ($KeyPrefix -and (Get-Command Invoke-ManifestTrackedCopy -ErrorAction SilentlyContinue)) {
+                $key = (($KeyPrefix, $item.Name) -join '/') -replace '\\', '/'
+                $null = Invoke-ManifestTrackedCopy -Src $item.FullName -Dest $dest -Key $key
+            } else {
+                Copy-Item -LiteralPath $item.FullName -Destination $dest -Force -ErrorAction Stop
+            }
         }
     }
 }
@@ -250,14 +257,14 @@ function Deploy-BootstrapHooks {
 
     $hooksDst = Join-Path $ClaudeDir 'hooks'
     # Windows 훅은 `pwsh -File ...ps1`; .sh/.json은 WSL/parity 목적으로 함께 복사.
-    Copy-BootstrapHookFiles -SourceDir $hooksSrc -DestinationDir $hooksDst -Filters @('*.ps1', '*.sh', '*.json')
+    Copy-BootstrapHookFiles -SourceDir $hooksSrc -DestinationDir $hooksDst -Filters @('*.ps1', '*.sh', '*.json') -KeyPrefix 'hooks'
 
     # global/hooks/lib/* 배포 (issue #586): 공유 라이브러리는 top-level glob에
     # 잡히지 않으므로 별도 복사한다. 없으면 4개 Bash 가드가 약화된다.
     $hooksLibSrc = Join-Path $hooksSrc 'lib'
     if (Test-Path -LiteralPath $hooksLibSrc -PathType Container) {
         $hooksLibDst = Join-Path $hooksDst 'lib'
-        Copy-BootstrapHookFiles -SourceDir $hooksLibSrc -DestinationDir $hooksLibDst -Filters @('*.ps1', '*.psm1', '*.sh')
+        Copy-BootstrapHookFiles -SourceDir $hooksLibSrc -DestinationDir $hooksLibDst -Filters @('*.ps1', '*.psm1', '*.sh') -KeyPrefix 'hooks/lib'
     }
 
     # Shared bash validator libraries used by the deployed Bash hook variants.
@@ -270,7 +277,7 @@ function Deploy-BootstrapHooks {
             'validate-commit-message.sh',
             'validate-language.sh',
             'validate-traceability.sh'
-        )
+        ) -KeyPrefix 'hooks/lib'
     }
 
     $requiredLibs = @(
@@ -297,7 +304,11 @@ function Deploy-BootstrapUtilityScripts {
     if (-not (Test-Path -LiteralPath $scriptsDst -PathType Container)) {
         New-Item -ItemType Directory -Path $scriptsDst -Force -ErrorAction Stop | Out-Null
     }
-    Copy-Item -Path (Join-Path $scriptsSrc '*') -Destination $scriptsDst -Force -ErrorAction Stop
+    if (Get-Command Copy-ManifestFiles -ErrorAction SilentlyContinue) {
+        Copy-ManifestFiles -SourceDir $scriptsSrc -DestinationDir $scriptsDst -KeyPrefix 'scripts' -Filters @('*.ps1', '*.sh')
+    } else {
+        Copy-Item -Path (Join-Path $scriptsSrc '*') -Destination $scriptsDst -Force -ErrorAction Stop
+    }
 }
 
 function Install-BootstrapSettingsAndHooks {
@@ -356,6 +367,7 @@ function Install-GlobalSettings {
     $manifestHelper = Join-Path $InstallDir 'scripts' 'install-manifest.ps1'
     if (Test-Path -LiteralPath $manifestHelper) {
         . $manifestHelper
+        Reset-ManifestManagedKeys
     }
 
     # Load shared installer prompts (single source of truth, mirrored at
@@ -372,8 +384,8 @@ function Install-GlobalSettings {
         $dest = Join-Path $ClaudeDir $gf
         if (-not (Test-Path -LiteralPath $src)) { continue }
 
-        if (Get-Command Invoke-GuardedCopy -ErrorAction SilentlyContinue) {
-            if (Invoke-GuardedCopy -Src $src -Dest $dest -Key $gf) {
+        if (Get-Command Invoke-ManifestTrackedCopy -ErrorAction SilentlyContinue) {
+            if (Invoke-ManifestTrackedCopy -Src $src -Dest $dest -Key $gf) {
                 Write-Ok "$gf 설치됨"
             }
             else {
@@ -421,8 +433,10 @@ function Install-GlobalSettings {
     if (Test-Path -LiteralPath $tmplPath) {
         $dest = Join-Path $ClaudeDir "conversation-language.md"
         if (Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest $dest -Key "conversation-language.md" -DisplayLang $displayLang) {
+            Add-ManifestManagedKey -Key 'conversation-language.md'
             Write-Ok "conversation-language.md 설치됨 (언어: $displayLang)"
         } else {
+            Add-ManifestManagedKey -Key 'conversation-language.md'
             Write-Info "conversation-language.md 로컬 변경 유지"
         }
     } else {
@@ -434,8 +448,10 @@ function Install-GlobalSettings {
         if (Test-Path -LiteralPath $staticMd) {
             $dest = Join-Path $ClaudeDir 'conversation-language.md'
             if (Invoke-GuardedCopy -Src $staticMd -Dest $dest -Key "conversation-language.md") {
+                Add-ManifestManagedKey -Key 'conversation-language.md'
                 Write-Ok "conversation-language.md 설치됨"
             } else {
+                Add-ManifestManagedKey -Key 'conversation-language.md'
                 Write-Info "conversation-language.md 로컬 변경 유지"
             }
         }
@@ -454,7 +470,7 @@ function Install-GlobalSettings {
         if (-not (Test-Path $globalSkillsDst)) {
             New-Item -ItemType Directory -Path $globalSkillsDst -Force | Out-Null
         }
-        Copy-Item -Path "$globalSkillsSrc\*" -Destination $globalSkillsDst -Recurse -Force
+        Copy-ManifestTree -SourceDir $globalSkillsSrc -DestinationDir $globalSkillsDst -KeyPrefix 'skills'
         $skillCount = (Get-ChildItem -Path $globalSkillsDst -Filter SKILL.md -Recurse -ErrorAction SilentlyContinue).Count
         Write-Ok "글로벌 skills 설치 완료 ($skillCount 개)"
     }
@@ -464,7 +480,7 @@ function Install-GlobalSettings {
         if (-not (Test-Path $globalCommandsDst)) {
             New-Item -ItemType Directory -Path $globalCommandsDst -Force | Out-Null
         }
-        Copy-Item -Path "$globalCommandsSrc\*" -Destination $globalCommandsDst -Recurse -Force
+        Copy-ManifestTree -SourceDir $globalCommandsSrc -DestinationDir $globalCommandsDst -KeyPrefix 'commands'
         Write-Ok "글로벌 commands 설치 완료"
     }
 
@@ -496,6 +512,17 @@ function Install-GlobalSettings {
     # 훅 배포를 한 트랜잭션으로 처리해 "설정은 있는데 훅이 없는" 조용한 보안 공백을
     # 막는다. Hook 배포 실패 시 settings.json은 게시하지 않는다.
     Install-BootstrapSettingsAndHooks
+
+    Add-RetiredManagedManifestEntries -Root $ClaudeDir -Entries @{
+        'commands/branch-cleanup.md' = '3e7fc38c324cfc9cea639e95394d7819e7768364d12023ec0b36b91f9230b09d'
+        'commands/doc-review.md' = 'be659114c43ef29423c74d7b33e0f594b80c134b38fb7c5b61e6935cae88c26f'
+        'commands/implement-all-levels.md' = 'b675f8e689e8aca71eb67e8666acc98018ad70b746d16655476b5939380737be'
+        'commands/issue-create.md' = 'c654ab412f320b9d97553f92a510cf5de13a5d0a7ed5e14212ca62534887ae71'
+        'commands/issue-work.md' = '048a26140b03862c5b10630853115ee656056f45cedfd0a0b6ec814bf7225684'
+        'commands/pr-work.md' = '2ecf1a78271c553e2310b57b2a1deb026a07ae01b84c1f856638293ab41f1199'
+        'commands/release.md' = '93fd6d2f7800deada2868b97b65ef486f42482b5e2f1224c35f732ebfeb1c013'
+    }
+    $null = Invoke-ManifestPruneTracked -Root $ClaudeDir
 
     # npm package installation (statusline dependencies)
     if (Get-Command npm -ErrorAction SilentlyContinue) {
@@ -614,51 +641,76 @@ function Install-ProjectSettings {
         }
     }
 
-    # Copy files
-    Copy-Item -Path (Join-Path $InstallDir 'project' 'CLAUDE.md') -Destination $projDir -Force
-
     # .claude directory
     $projClaudeDir = Join-Path $projDir '.claude'
     if (-not (Test-Path $projClaudeDir)) {
         New-Item -ItemType Directory -Path $projClaudeDir -Force | Out-Null
     }
+    $manifestHelper = Join-Path $InstallDir 'scripts' 'install-manifest.ps1'
+    if (-not (Get-Command Invoke-ManifestTrackedCopy -ErrorAction SilentlyContinue) -and (Test-Path -LiteralPath $manifestHelper)) {
+        . $manifestHelper
+    }
+    $previousManifestPath = $env:MANIFEST_PATH
+    $env:MANIFEST_PATH = Join-Path $projClaudeDir '.install-manifest.json'
+    Reset-ManifestManagedKeys
+
+    # Copy files
+    $null = Invoke-ManifestTrackedCopy -Src (Join-Path $InstallDir 'project' 'CLAUDE.md') -Dest (Join-Path $projDir 'CLAUDE.md') -Key 'CLAUDE.md'
 
     $rulesDir = Join-Path $InstallDir 'project' '.claude' 'rules'
     if (Test-Path $rulesDir) {
-        Copy-Item -Path $rulesDir -Destination $projClaudeDir -Recurse -Force
+        $rulesTmp = Join-Path ([System.IO.Path]::GetTempPath()) "claude-rules-$([guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $rulesTmp -Force | Out-Null
+        Copy-Item -Path (Join-Path $rulesDir '*') -Destination $rulesTmp -Recurse -Force
         # issue #760: render any .md.tmpl under the copied rules/ via the same
         # single-source function install.ps1 uses. Unset language values fall
         # back to safe defaults inside Invoke-PolicyTemplate.
         if (Get-Command Invoke-PolicyTemplatesInDir -ErrorAction SilentlyContinue) {
-            Invoke-PolicyTemplatesInDir -Path (Join-Path $projClaudeDir 'rules') `
+            Invoke-PolicyTemplatesInDir -Path $rulesTmp `
                 -ContentLanguage $script:contentLanguage -AgentDisplay $script:displayLang -AgentLanguage $script:agentLanguage
         }
+        Copy-ManifestTree -SourceDir $rulesTmp -DestinationDir (Join-Path $projClaudeDir 'rules') -KeyPrefix '.claude/rules'
+        Remove-Item -LiteralPath $rulesTmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    $referenceDir = Join-Path $InstallDir 'project' '.claude' 'reference'
+    if (Test-Path $referenceDir) {
+        Copy-ManifestTree -SourceDir $referenceDir -DestinationDir (Join-Path $projClaudeDir 'reference') -KeyPrefix '.claude/reference'
     }
 
     $skillsDir = Join-Path $InstallDir 'project' '.claude' 'skills'
     if (Test-Path $skillsDir) {
-        Copy-Item -Path $skillsDir -Destination $projClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $skillsDir -DestinationDir (Join-Path $projClaudeDir 'skills') -KeyPrefix '.claude/skills'
     }
 
     $commandsDir = Join-Path $InstallDir 'project' '.claude' 'commands'
     if (Test-Path $commandsDir) {
-        Copy-Item -Path $commandsDir -Destination $projClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $commandsDir -DestinationDir (Join-Path $projClaudeDir 'commands') -KeyPrefix '.claude/commands'
     }
 
     $agentsDir = Join-Path $InstallDir 'project' '.claude' 'agents'
     if (Test-Path $agentsDir) {
-        Copy-Item -Path $agentsDir -Destination $projClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $agentsDir -DestinationDir (Join-Path $projClaudeDir 'agents') -KeyPrefix '.claude/agents'
     }
 
     $settingsJson = Join-Path $InstallDir 'project' '.claude' 'settings.json'
     if (Test-Path $settingsJson) {
-        Copy-Item -Path $settingsJson -Destination $projClaudeDir -Force
+        $null = Invoke-ManifestTrackedCopy -Src $settingsJson -Dest (Join-Path $projClaudeDir 'settings.json') -Key '.claude/settings.json'
     }
 
     $claudeIgnore = Join-Path $InstallDir 'project' '.claudeignore'
     if (Test-Path $claudeIgnore) {
-        Copy-Item -Path $claudeIgnore -Destination $projDir -Force
+        $null = Invoke-ManifestTrackedCopy -Src $claudeIgnore -Dest (Join-Path $projDir '.claudeignore') -Key '.claudeignore'
     }
+
+    Add-RetiredManagedManifestEntries -Root $projDir -Entries @{
+        '.claude/commands/_policy.md' = '7144bf54352362eb3d523d05a1712732aec8e82fc95ea9db0cbc79269e2bf9b1'
+        '.claude/commands/code-quality.md' = '8c1e6ca0470582936fb96491d4aff7e23706da45b96ba38c51d43ba255f8f544'
+        '.claude/commands/git-status.md' = '4602f6ea8ffb18b05d5698c85d060b3d6f01913a4258e778bd6b898611ca9d33'
+        '.claude/commands/pr-review.md' = '3dbd7d788b1e19b1d04654e03eaf8531c933e6b7462120ffdc03d5d7f9658711'
+    }
+    $null = Invoke-ManifestPruneTracked -Root $projDir
+    $env:MANIFEST_PATH = $previousManifestPath
 
     Write-Ok "프로젝트 설정 설치 완료"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -291,12 +291,17 @@ clone_repository() {
     success "저장소 클론 완료: $INSTALL_DIR (ref: $GITHUB_REF)"
 }
 
-# copy_bootstrap_files <source_dir> <dest_dir> <glob> <executable:0|1>
+# copy_bootstrap_files <source_dir> <dest_dir> <glob> <executable:0|1> [manifest_key_prefix]
 copy_bootstrap_files() {
-    local src_dir="$1" dest_dir="$2" pattern="$3" executable="$4"
+    local src_dir="$1" dest_dir="$2" pattern="$3" executable="$4" key_prefix="${5:-}"
     local src dest
 
     mkdir -p "$dest_dir" || return 1
+
+    if [ -n "$key_prefix" ] && type manifest_copy_files >/dev/null 2>&1; then
+        manifest_copy_files "$src_dir" "$dest_dir" "$key_prefix" "$pattern" "$executable"
+        return 0
+    fi
 
     for src in "$src_dir"/$pattern; do
         [ -f "$src" ] || continue
@@ -322,13 +327,13 @@ deploy_bootstrap_hooks() {
         return 1
     fi
 
-    copy_bootstrap_files "$hooks_src" "$hooks_dst" "*.sh" 1 || return 1
+    copy_bootstrap_files "$hooks_src" "$hooks_dst" "*.sh" 1 "hooks" || return 1
 
     # global/hooks/lib/*.sh 배포 (issue #586). 위 *.sh glob은 비재귀적이라
     # tokenize-shell.sh 등 공유 라이브러리는 별도 복사 없이는 누락된다.
     # dangerous-command-guard 등 4개 Bash 가드가 런타임에 이를 source한다.
     if [ -d "$hooks_lib_src" ]; then
-        copy_bootstrap_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 || return 1
+        copy_bootstrap_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 "hooks/lib" || return 1
     fi
 
     # 공유 검증 라이브러리 설치 (commit-message-guard.sh, pr-language-guard.sh,
@@ -336,7 +341,7 @@ deploy_bootstrap_hooks() {
     if [ -d "$shared_lib_src" ]; then
         for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
             if [ -f "$shared_lib_src/$lib" ]; then
-                copy_bootstrap_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 || return 1
+                copy_bootstrap_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 "hooks/lib" || return 1
             fi
         done
     fi
@@ -363,7 +368,7 @@ deploy_bootstrap_scripts() {
     local scripts_dst="$CLAUDE_DIR/scripts"
 
     [ -d "$scripts_src" ] || return 0
-    copy_bootstrap_files "$scripts_src" "$scripts_dst" "*.sh" 1 || return 1
+    copy_bootstrap_files "$scripts_src" "$scripts_dst" "*.sh" 1 "scripts" || return 1
 
     return 0
 }
@@ -420,6 +425,7 @@ install_global() {
     # 설치 매니페스트 헬퍼 로드 (SHA-256 해시 기반 로컬 변경 보존)
     # shellcheck disable=SC1091
     source "$INSTALL_DIR/scripts/install-manifest.sh"
+    manifest_reset_managed_keys
     # shellcheck disable=SC1091
     source "$INSTALL_DIR/scripts/lib/install-prompts.sh"
 
@@ -428,7 +434,7 @@ install_global() {
         src="$INSTALL_DIR/global/$gf"
         dest="$CLAUDE_DIR/$gf"
         [ -f "$src" ] || continue
-        if guarded_copy "$src" "$dest" "$gf"; then
+        if manifest_copy_file "$src" "$dest" "$gf"; then
             success "$gf 설치됨"
         else
             info "$gf 로컬 변경 유지"
@@ -452,8 +458,10 @@ install_global() {
     # conversation-language.md 템플릿 처리
     if [ -f "$INSTALL_DIR/global/conversation-language.md.tmpl" ]; then
         if guarded_template_copy "$INSTALL_DIR/global/conversation-language.md.tmpl" "$CLAUDE_DIR/conversation-language.md" "conversation-language.md" "$AGENT_DISPLAY_LANG"; then
+            manifest_track_key "conversation-language.md"
             success "conversation-language.md 설치됨 (언어: $AGENT_DISPLAY_LANG)"
         else
+            manifest_track_key "conversation-language.md"
             info "conversation-language.md 로컬 변경 유지"
         fi
     else
@@ -463,8 +471,10 @@ install_global() {
         # their file via guarded_copy instead of silently dropping it.
         if [ -f "$INSTALL_DIR/global/conversation-language.md" ]; then
             if guarded_copy "$INSTALL_DIR/global/conversation-language.md" "$CLAUDE_DIR/conversation-language.md" "conversation-language.md"; then
+                manifest_track_key "conversation-language.md"
                 success "conversation-language.md 설치됨"
             else
+                manifest_track_key "conversation-language.md"
                 info "conversation-language.md 로컬 변경 유지"
             fi
         fi
@@ -485,15 +495,25 @@ install_global() {
     # "Skill Aliases" 표에 따라 leading keyword 호출로만 실행된다.
     if [ -d "$INSTALL_DIR/global/skills" ]; then
         mkdir -p "$CLAUDE_DIR/skills"
-        cp -r "$INSTALL_DIR/global/skills"/. "$CLAUDE_DIR/skills/"
+        manifest_copy_tree "$INSTALL_DIR/global/skills" "$CLAUDE_DIR/skills" "skills"
         skill_count=$(find "$CLAUDE_DIR/skills" -name "SKILL.md" | wc -l | tr -d ' ')
         success "글로벌 skills 설치 완료 (${skill_count}개)"
     fi
     if [ -d "$INSTALL_DIR/global/commands" ]; then
         mkdir -p "$CLAUDE_DIR/commands"
-        cp -r "$INSTALL_DIR/global/commands"/. "$CLAUDE_DIR/commands/"
+        manifest_copy_tree "$INSTALL_DIR/global/commands" "$CLAUDE_DIR/commands" "commands"
         success "글로벌 commands 설치 완료"
     fi
+
+    manifest_seed_retired_managed "$CLAUDE_DIR" \
+        "commands/branch-cleanup.md" "3e7fc38c324cfc9cea639e95394d7819e7768364d12023ec0b36b91f9230b09d" \
+        "commands/doc-review.md" "be659114c43ef29423c74d7b33e0f594b80c134b38fb7c5b61e6935cae88c26f" \
+        "commands/implement-all-levels.md" "b675f8e689e8aca71eb67e8666acc98018ad70b746d16655476b5939380737be" \
+        "commands/issue-create.md" "c654ab412f320b9d97553f92a510cf5de13a5d0a7ed5e14212ca62534887ae71" \
+        "commands/issue-work.md" "048a26140b03862c5b10630853115ee656056f45cedfd0a0b6ec814bf7225684" \
+        "commands/pr-work.md" "2ecf1a78271c553e2310b57b2a1deb026a07ae01b84c1f856638293ab41f1199" \
+        "commands/release.md" "93fd6d2f7800deada2868b97b65ef486f42482b5e2f1224c35f732ebfeb1c013"
+    manifest_prune_tracked "$CLAUDE_DIR"
 
     # tmux 설정 설치
     if [ -f "$INSTALL_DIR/global/tmux.conf" ]; then
@@ -588,22 +608,49 @@ install_project() {
         prompt_language_profile
     fi
 
+    if ! type manifest_copy_file >/dev/null 2>&1; then
+        # shellcheck disable=SC1091
+        source "$INSTALL_DIR/scripts/install-manifest.sh"
+    fi
+
+    local previous_manifest_path="${MANIFEST_PATH:-}"
+
     # 파일 복사
-    cp "$INSTALL_DIR/project/CLAUDE.md" "$PROJECT_DIR/"
+    mkdir -p "$PROJECT_DIR/.claude"
+    MANIFEST_PATH="$PROJECT_DIR/.claude/.install-manifest.json"
+    manifest_reset_managed_keys
+
+    if manifest_copy_file "$INSTALL_DIR/project/CLAUDE.md" "$PROJECT_DIR/CLAUDE.md" "CLAUDE.md"; then
+        success "프로젝트 CLAUDE.md 설치 완료"
+    else
+        info "프로젝트 CLAUDE.md 로컬 변경 유지"
+    fi
 
     # .claude 디렉토리 설치
-    mkdir -p "$PROJECT_DIR/.claude"
     if [ -d "$INSTALL_DIR/project/.claude/rules" ]; then
-        cp -r "$INSTALL_DIR/project/.claude/rules" "$PROJECT_DIR/.claude/"
+        local rules_tmp
+        rules_tmp=$(mktemp -d)
+        cp -R "$INSTALL_DIR/project/.claude/rules"/. "$rules_tmp/"
         # issue #760: 복사된 rules/ 안의 .md.tmpl을 정책 phrase로 치환
         # (install.sh와 동일한 single-source 렌더 함수)
-        render_policy_tmpls_in_dir "$PROJECT_DIR/.claude/rules"
+        render_policy_tmpls_in_dir "$rules_tmp"
+        manifest_copy_tree "$rules_tmp" "$PROJECT_DIR/.claude/rules" ".claude/rules"
+        rm -rf "$rules_tmp"
     fi
-    [ -d "$INSTALL_DIR/project/.claude/skills" ] && cp -r "$INSTALL_DIR/project/.claude/skills" "$PROJECT_DIR/.claude/"
-    [ -d "$INSTALL_DIR/project/.claude/commands" ] && cp -r "$INSTALL_DIR/project/.claude/commands" "$PROJECT_DIR/.claude/"
-    [ -d "$INSTALL_DIR/project/.claude/agents" ] && cp -r "$INSTALL_DIR/project/.claude/agents" "$PROJECT_DIR/.claude/"
-    [ -f "$INSTALL_DIR/project/.claude/settings.json" ] && cp "$INSTALL_DIR/project/.claude/settings.json" "$PROJECT_DIR/.claude/"
-    [ -f "$INSTALL_DIR/project/.claudeignore" ] && cp "$INSTALL_DIR/project/.claudeignore" "$PROJECT_DIR/"
+    [ -d "$INSTALL_DIR/project/.claude/reference" ] && manifest_copy_tree "$INSTALL_DIR/project/.claude/reference" "$PROJECT_DIR/.claude/reference" ".claude/reference"
+    [ -d "$INSTALL_DIR/project/.claude/skills" ] && manifest_copy_tree "$INSTALL_DIR/project/.claude/skills" "$PROJECT_DIR/.claude/skills" ".claude/skills"
+    [ -d "$INSTALL_DIR/project/.claude/commands" ] && manifest_copy_tree "$INSTALL_DIR/project/.claude/commands" "$PROJECT_DIR/.claude/commands" ".claude/commands"
+    [ -d "$INSTALL_DIR/project/.claude/agents" ] && manifest_copy_tree "$INSTALL_DIR/project/.claude/agents" "$PROJECT_DIR/.claude/agents" ".claude/agents"
+    [ -f "$INSTALL_DIR/project/.claude/settings.json" ] && manifest_copy_file "$INSTALL_DIR/project/.claude/settings.json" "$PROJECT_DIR/.claude/settings.json" ".claude/settings.json" || true
+    [ -f "$INSTALL_DIR/project/.claudeignore" ] && manifest_copy_file "$INSTALL_DIR/project/.claudeignore" "$PROJECT_DIR/.claudeignore" ".claudeignore" || true
+
+    manifest_seed_retired_managed "$PROJECT_DIR" \
+        ".claude/commands/_policy.md" "7144bf54352362eb3d523d05a1712732aec8e82fc95ea9db0cbc79269e2bf9b1" \
+        ".claude/commands/code-quality.md" "8c1e6ca0470582936fb96491d4aff7e23706da45b96ba38c51d43ba255f8f544" \
+        ".claude/commands/git-status.md" "4602f6ea8ffb18b05d5698c85d060b3d6f01913a4258e778bd6b898611ca9d33" \
+        ".claude/commands/pr-review.md" "3dbd7d788b1e19b1d04654e03eaf8531c933e6b7462120ffdc03d5d7f9658711"
+    manifest_prune_tracked "$PROJECT_DIR"
+    MANIFEST_PATH="$previous_manifest_path"
 
     success "프로젝트 설정 설치 완료"
 }

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -10,28 +10,28 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 17612
+    size: 17973
     tags: []
     sections:
       - {h: "Changelog", l: 1, e: 7}
       - {h: "[Unreleased]", l: 8, e: 9}
-      - {h: "Fixed", l: 10, e: 15}
-      - {h: "1.11.0 - 2026-07-03", l: 16, e: 17}
-      - {h: "Fixed", l: 18, e: 31}
-      - {h: "Security", l: 32, e: 109}
-      - {h: "Added", l: 110, e: 138}
-      - {h: "Changed", l: 139, e: 185}
-      - {h: "1.10.0 - 2026-04-20", l: 186, e: 194}
-      - {h: "1.9.0 - 2026-04-13", l: 195, e: 204}
-      - {h: "1.8.0 - 2026-04-13", l: 205, e: 210}
-      - {h: "1.7.0 - 2026-04-06", l: 211, e: 225}
-      - {h: "1.6.0 - 2026-04-03", l: 226, e: 238}
-      - {h: "1.5.0 - 2026-03-21", l: 239, e: 257}
-      - {h: "1.4.0 - 2026-01-22", l: 258, e: 263}
-      - {h: "1.3.0 - 2026-01-15", l: 264, e: 272}
-      - {h: "1.2.0 - 2026-01-15", l: 273, e: 281}
-      - {h: "1.1.0 - 2025-01-15", l: 282, e: 292}
-      - {h: "1.0.0 - 2025-12-03", l: 293, e: 299}
+      - {h: "Fixed", l: 10, e: 20}
+      - {h: "1.11.0 - 2026-07-03", l: 21, e: 22}
+      - {h: "Fixed", l: 23, e: 36}
+      - {h: "Security", l: 37, e: 114}
+      - {h: "Added", l: 115, e: 143}
+      - {h: "Changed", l: 144, e: 190}
+      - {h: "1.10.0 - 2026-04-20", l: 191, e: 199}
+      - {h: "1.9.0 - 2026-04-13", l: 200, e: 209}
+      - {h: "1.8.0 - 2026-04-13", l: 210, e: 215}
+      - {h: "1.7.0 - 2026-04-06", l: 216, e: 230}
+      - {h: "1.6.0 - 2026-04-03", l: 231, e: 243}
+      - {h: "1.5.0 - 2026-03-21", l: 244, e: 262}
+      - {h: "1.4.0 - 2026-01-22", l: 263, e: 268}
+      - {h: "1.3.0 - 2026-01-15", l: 269, e: 277}
+      - {h: "1.2.0 - 2026-01-15", l: 278, e: 286}
+      - {h: "1.1.0 - 2025-01-15", l: 287, e: 297}
+      - {h: "1.0.0 - 2025-12-03", l: 298, e: 304}
   - path: "COMPATIBILITY.md"
     title: "Compatibility Guide"
     description: ""
@@ -351,7 +351,7 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 45917
+    size: 46149
     tags: [config,readme]
     sections:
       - {h: "Claude Configuration Backup & Deployment System", l: 1, e: 29}
@@ -426,57 +426,57 @@ documents:
       - {h: "MCP Configuration", l: 737, e: 740}
       - {h: "Available Servers", l: 741, e: 750}
       - {h: "Setup", l: 751, e: 758}
-      - {h: "Scripts", l: 759, e: 774}
-      - {h: "Git Hooks", l: 775, e: 785}
-      - {h: "Pre-commit Hook", l: 786, e: 791}
-      - {h: "Commit-msg Hook", l: 792, e: 797}
-      - {h: "Pre-push Hook", l: 798, e: 805}
-      - {h: "Use Cases", l: 806, e: 807}
-      - {h: "Use Case A: Sync Work + Home Computers", l: 808, e: 810}
-      - {h: "At work (initial setup)", l: 811, e: 816}
-      - {h: "At home", l: 817, e: 820}
-      - {h: "Select: 1 (Backup → System)", l: 821, e: 825}
-      - {h: "Use Case B: Share Team Project Settings", l: 826, e: 828}
-      - {h: "Project leader", l: 829, e: 833}
-      - {h: "Type: 2 (Project only)", l: 834, e: 835}
-      - {h: "Team member", l: 836, e: 839}
-      - {h: "Type: 2 (Project only)", l: 840, e: 844}
-      - {h: "Use Case C: New Development Machine Setup", l: 845, e: 847}
-      - {h: "One-line installation", l: 848, e: 850}
-      - {h: "Or manual installation", l: 851, e: 854}
-      - {h: "Type: 3 (Both)", l: 855, e: 856}
-      - {h: "Verify Git identity; edit only if missing or wrong", l: 857, e: 862}
-      - {h: "Use Case D: Batch-Process Open Issues or Failing PRs", l: 863, e: 881}
-      - {h: "Process up to 5 open issues in a repo (default limit)", l: 882, e: 884}
-      - {h: "Process up to 3 open issues", l: 885, e: 887}
-      - {h: "Process failing PRs instead", l: 888, e: 892}
-      - {h: "PowerShell equivalents", l: 893, e: 913}
-      - {h: "Advanced Usage", l: 914, e: 915}
-      - {h: "GitHub Actions Auto-Sync", l: 916, e: 937}
-      - {h: "Backup Specific Files Only", l: 938, e: 940}
-      - {h: "Backup global CLAUDE.md only", l: 941, e: 943}
-      - {h: "Backup project settings only", l: 944, e: 947}
-      - {h: "Customize with Environment Variables", l: 948, e: 950}
-      - {h: "When using bootstrap.sh", l: 951, e: 971}
-      - {h: "FAQ", l: 972, e: 973}
-      - {h: "Q1: Why do I need to personalize Git identity?", l: 974, e: 979}
-      - {h: "Change name and email only when the installed values are missing or wrong", l: 980, e: 984}
-      - {h: "Q2: How to manage backups across multiple locations?", l: 985, e: 997}
-      - {h: "Q3: I want different settings for each project", l: 998, e: 1003}
-      - {h: "Modify project A settings", l: 1004, e: 1007}
-      - {h: "Modify project B settings", l: 1008, e: 1013}
-      - {h: "Q4: Scripts won't run", l: 1014, e: 1020}
-      - {h: "Or run directly", l: 1021, e: 1026}
-      - {h: "Q5: I want to use a private repo", l: 1027, e: 1031}
-      - {h: "Create token: GitHub Settings > Developer settings > Personal access tokens", l: 1032, e: 1033}
-      - {h: "Installation", l: 1034, e: 1040}
-      - {h: "Memory sync (multi-machine)", l: 1041, e: 1053}
-      - {h: "Additional Resources", l: 1054, e: 1065}
-      - {h: "Version", l: 1066, e: 1073}
-      - {h: "Contributing", l: 1074, e: 1085}
-      - {h: "Related Projects", l: 1086, e: 1087}
-      - {h: "AD-SDLC (Agent-Driven Software Development Lifecycle)", l: 1088, e: 1096}
-      - {h: "License", l: 1097, e: 1105}
+      - {h: "Scripts", l: 759, e: 775}
+      - {h: "Git Hooks", l: 776, e: 786}
+      - {h: "Pre-commit Hook", l: 787, e: 792}
+      - {h: "Commit-msg Hook", l: 793, e: 798}
+      - {h: "Pre-push Hook", l: 799, e: 806}
+      - {h: "Use Cases", l: 807, e: 808}
+      - {h: "Use Case A: Sync Work + Home Computers", l: 809, e: 811}
+      - {h: "At work (initial setup)", l: 812, e: 817}
+      - {h: "At home", l: 818, e: 821}
+      - {h: "Select: 1 (Backup → System)", l: 822, e: 826}
+      - {h: "Use Case B: Share Team Project Settings", l: 827, e: 829}
+      - {h: "Project leader", l: 830, e: 834}
+      - {h: "Type: 2 (Project only)", l: 835, e: 836}
+      - {h: "Team member", l: 837, e: 840}
+      - {h: "Type: 2 (Project only)", l: 841, e: 845}
+      - {h: "Use Case C: New Development Machine Setup", l: 846, e: 848}
+      - {h: "One-line installation", l: 849, e: 851}
+      - {h: "Or manual installation", l: 852, e: 855}
+      - {h: "Type: 3 (Both)", l: 856, e: 857}
+      - {h: "Verify Git identity; edit only if missing or wrong", l: 858, e: 863}
+      - {h: "Use Case D: Batch-Process Open Issues or Failing PRs", l: 864, e: 882}
+      - {h: "Process up to 5 open issues in a repo (default limit)", l: 883, e: 885}
+      - {h: "Process up to 3 open issues", l: 886, e: 888}
+      - {h: "Process failing PRs instead", l: 889, e: 893}
+      - {h: "PowerShell equivalents", l: 894, e: 914}
+      - {h: "Advanced Usage", l: 915, e: 916}
+      - {h: "GitHub Actions Auto-Sync", l: 917, e: 938}
+      - {h: "Backup Specific Files Only", l: 939, e: 941}
+      - {h: "Backup global CLAUDE.md only", l: 942, e: 944}
+      - {h: "Backup project settings only", l: 945, e: 948}
+      - {h: "Customize with Environment Variables", l: 949, e: 951}
+      - {h: "When using bootstrap.sh", l: 952, e: 972}
+      - {h: "FAQ", l: 973, e: 974}
+      - {h: "Q1: Why do I need to personalize Git identity?", l: 975, e: 980}
+      - {h: "Change name and email only when the installed values are missing or wrong", l: 981, e: 985}
+      - {h: "Q2: How to manage backups across multiple locations?", l: 986, e: 998}
+      - {h: "Q3: I want different settings for each project", l: 999, e: 1004}
+      - {h: "Modify project A settings", l: 1005, e: 1008}
+      - {h: "Modify project B settings", l: 1009, e: 1014}
+      - {h: "Q4: Scripts won't run", l: 1015, e: 1021}
+      - {h: "Or run directly", l: 1022, e: 1027}
+      - {h: "Q5: I want to use a private repo", l: 1028, e: 1032}
+      - {h: "Create token: GitHub Settings > Developer settings > Personal access tokens", l: 1033, e: 1034}
+      - {h: "Installation", l: 1035, e: 1041}
+      - {h: "Memory sync (multi-machine)", l: 1042, e: 1054}
+      - {h: "Additional Resources", l: 1055, e: 1066}
+      - {h: "Version", l: 1067, e: 1074}
+      - {h: "Contributing", l: 1075, e: 1086}
+      - {h: "Related Projects", l: 1087, e: 1088}
+      - {h: "AD-SDLC (Agent-Driven Software Development Lifecycle)", l: 1089, e: 1097}
+      - {h: "License", l: 1098, e: 1106}
   - path: "THIRD_PARTY_NOTICES.md"
     title: "Third-Party Notices"
     description: ""
@@ -1709,16 +1709,22 @@ documents:
     description: ""
     category: docs
     scope: docs
-    size: 6664
+    size: 8631
     tags: [docs]
     sections:
-      - {h: "Manifest", l: 7, e: 29}
-      - {h: "Copy Decision", l: 30, e: 57}
-      - {h: "Non-Interactive Override", l: 58, e: 98}
-      - {h: "Toolchain Fallback", l: 99, e: 109}
-      - {h: "Template Files", l: 110, e: 155}
-      - {h: "Tracked Files", l: 156, e: 171}
-      - {h: "Regression Test", l: 172, e: 183}
+      - {h: "Install Behavior", l: 1, e: 6}
+      - {h: "Manifest", l: 7, e: 36}
+      - {h: "Copy Decision", l: 37, e: 64}
+      - {h: "Prune Decision", l: 65, e: 84}
+      - {h: "Non-Interactive Override", l: 85, e: 91}
+      - {h: "Pick the install type and accept every other default.", l: 92, e: 94}
+      - {h: "Force bootstrap defaults. The bootstrap default install type is 1.", l: 95, e: 99}
+      - {h: "Pick the install type and accept every other default.", l: 100, e: 102}
+      - {h: "Force bootstrap defaults. The bootstrap default install type is 1.", l: 103, e: 125}
+      - {h: "Toolchain Fallback", l: 126, e: 136}
+      - {h: "Template Files", l: 137, e: 182}
+      - {h: "Tracked Files", l: 183, e: 201}
+      - {h: "Regression Test", l: 202, e: 225}
   - path: "docs/loop-patterns.md"
     title: "Loop-Safety Patterns for Skills"
     description: ""

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,15 @@
 # Install Behavior
 
-`bootstrap.sh` (POSIX) and `bootstrap.ps1` (Windows) preserve local
-customizations of global rule files across re-installs by recording a
-SHA-256 manifest.
+`bootstrap.sh`, `bootstrap.ps1`, `scripts/install.sh`, and
+`scripts/install.ps1` preserve local customizations across re-installs by
+recording SHA-256 manifests for managed install trees.
 
 ## Manifest
 
-Location: `~/.claude/.install-manifest.json`
+Locations:
+
+- Global install tree: `~/.claude/.install-manifest.json`
+- Project install tree: `<project>/.claude/.install-manifest.json`
 
 Format:
 
@@ -18,21 +21,25 @@ Format:
     "commit-settings.md": "sha256-hex",
     "conversation-language.md": "sha256-hex",
     "git-identity.md": "sha256-hex",
-    "token-management.md": "sha256-hex"
+    "token-management.md": "sha256-hex",
+    "hooks/sensitive-file-guard.sh": "sha256-hex",
+    "skills/_internal/issue-work/SKILL.md": "sha256-hex"
   }
 }
 ```
 
-The manifest is written on successful copy and updated whenever the
-installer replaces a file. It is created on first install and survives
-across re-runs.
+The manifest is written on successful managed copies and updated whenever
+the installer replaces a file. It is created on first install and survives
+across re-runs. Project manifests use paths relative to the project root
+(`CLAUDE.md`, `.claude/rules/...`, `.claude/skills/...`), while global
+manifests use paths relative to `~/.claude`.
 
 ## Copy Decision
 
 On each run, the installer compares three hashes per tracked file:
 
-- `src_hash` — the hash of the incoming file under `$INSTALL_DIR/global/<file>` (if a `.tmpl` exists, this is the hash of the dynamically rendered output, e.g. for `conversation-language.md`)
-- `dest_hash` — the hash of the current `~/.claude/<file>`
+- `src_hash` — the hash of the incoming managed file or rendered output
+- `dest_hash` — the hash of the current deployed file
 - `stored_hash` — the hash recorded in `.install-manifest.json`
 
 | Condition | Outcome |
@@ -54,6 +61,26 @@ Pressing `Enter` keeps the local file unchanged. The manifest is not
 updated in this case, so subsequent re-installs will prompt again until
 the user either overwrites or aligns their local file with an upstream
 version.
+
+## Prune Decision
+
+After the current managed set is copied, installers compare the manifest
+against the current managed keys for that root.
+
+| Condition | Outcome |
+|-----------|---------|
+| key is still in the current managed set | keep |
+| key is absent, deployed file is missing | remove the stale manifest entry |
+| key is absent, `dest_hash == stored_hash` | delete the removed managed file and remove the manifest entry |
+| key is absent, `dest_hash != stored_hash` | preserve the local file and report it as locally edited |
+| key points outside the install root | preserve and report as unsafe |
+
+This is the deletion counterpart to guarded copy: repository removals are
+propagated only when the deployed file still matches the last managed hash.
+The installers also carry a small retired-file ownership table for legacy
+command files removed before directory manifests existed. Those files are
+seeded into the manifest only when their current bytes match a known
+upstream hash; edited copies are preserved.
 
 ## Non-Interactive Override
 
@@ -155,29 +182,44 @@ removed and the existing `settings.json` is left unchanged.
 
 ## Tracked Files
 
-The manifest currently tracks these entries (see `bootstrap.sh`
-`install_global` and `bootstrap.ps1` `Install-GlobalSettings`):
+The global manifest tracks guarded files under `~/.claude`, including:
 
-- `CLAUDE.md`
-- `commit-settings.md`
-- `conversation-language.md` *(rendered from `.tmpl` — see Template Files above)*
-- `git-identity.md`
-- `token-management.md`
+- Core markdown files: `CLAUDE.md`, `commit-settings.md`,
+  `conversation-language.md`, `git-identity.md`, `token-management.md`
+- Runtime trees: `hooks/`, `hooks/lib/`, `scripts/`
+- Catalog trees: `skills/`, `commands/`
+- Optional in-tree artifacts when present, such as `.claudeignore` and
+  `policies/`
 
-Other installed artifacts (`tmux.conf`, `ccstatusline/settings.json`,
-plugin resources, project templates) remain unconditional copies — add
-them to the manifest block in future issues if their customizations
-need to be preserved.
+The project manifest tracks files relative to the project root, including
+`CLAUDE.md`, `.claude/settings.json`, `.claude/rules/`,
+`.claude/reference/`, `.claude/skills/`, `.claude/commands/`,
+`.claude/agents/`, and `.claudeignore`.
+
+Artifacts deployed outside those roots, such as `~/.tmux.conf` and
+`~/.config/ccstatusline/settings.json`, remain outside manifest pruning.
 
 ## Regression Test
 
-`tests/scripts/test-install-preserves-customization.sh` covers the
-keep / overwrite / force-flag paths of the manifest helper directly.
-Run it from the repository root:
+`tests/scripts/test-install-preserves-customization.sh` covers keep,
+overwrite, force, prune, and retired-file seeding paths for the Bash
+helper. `tests/scripts/test-install-manifest-helpers.sh` and
+`tests/scripts/test-install-manifest-helpers.ps1` cover template copies,
+tree copies, tracked prune, and settings mutation helpers.
+
+Run the focused Bash tests from the repository root:
 
 ```bash
 bash tests/scripts/test-install-preserves-customization.sh
+bash tests/scripts/test-install-manifest-helpers.sh
 ```
 
-The test is skipped on systems without `python3`/`python` — on such
-systems the installer itself also falls back to unconditional copy.
+Run the PowerShell helper test where `pwsh` is available:
+
+```powershell
+pwsh -NoProfile -File tests/scripts/test-install-manifest-helpers.ps1
+```
+
+The Bash manifest tests are skipped on systems without `python3`/`python`;
+on such systems the POSIX installer itself also falls back to unconditional
+copy.

--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -12,6 +12,7 @@
 #   BOOTSTRAP_FORCE  "1" bypasses the divergence prompt and overwrites
 
 $script:ManifestSchema = 1
+$script:ManifestManagedKeys = @()
 
 function Get-ManifestPath {
     if ($env:MANIFEST_PATH) { return $env:MANIFEST_PATH }
@@ -20,35 +21,52 @@ function Get-ManifestPath {
 
 function Get-FileSha256 {
     param([Parameter(Mandatory)][string]$Path)
-    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
     return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLower()
+}
+
+function Get-FileSha256LfNormalized {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+    $content = [System.IO.File]::ReadAllText($Path)
+    $normalized = $content -replace "`r", ''
+    $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($normalized)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return (($sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '')
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Test-ManifestWindowsPlatform {
+    $isWindowsVariable = Get-Variable -Name IsWindows -Scope Global -ErrorAction SilentlyContinue
+    if ($isWindowsVariable) { return [bool]$isWindowsVariable.Value }
+    return ($env:OS -eq 'Windows_NT')
+}
+
+function Reset-ManifestManagedKeys {
+    $script:ManifestManagedKeys = @()
+}
+
+function Add-ManifestManagedKey {
+    param([Parameter(Mandatory)][string]$Key)
+    if (-not [string]::IsNullOrWhiteSpace($Key)) {
+        $script:ManifestManagedKeys += $Key
+    }
 }
 
 function Read-ManifestEntry {
     param([Parameter(Mandatory)][string]$Key)
-    $manifestPath = Get-ManifestPath
-    if (-not (Test-Path -LiteralPath $manifestPath)) { return '' }
-    try {
-        $m = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -ErrorAction Stop
-        if ($m.files -and $m.files.PSObject.Properties.Name -contains $Key) {
-            return [string]$m.files.$Key
-        }
-    }
-    catch { }
+    $files = Get-ManifestFiles
+    if ($files.ContainsKey($Key)) { return [string]$files[$Key] }
     return ''
 }
 
-function Write-ManifestEntry {
-    param(
-        [Parameter(Mandatory)][string]$Key,
-        [Parameter(Mandatory)][string]$Sha
-    )
+function Get-ManifestFiles {
     $manifestPath = Get-ManifestPath
-    $dir = Split-Path -Parent $manifestPath
-    if (-not (Test-Path -LiteralPath $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
+    $files = @{}
     $manifest = $null
     if (Test-Path -LiteralPath $manifestPath) {
         try {
@@ -58,20 +76,274 @@ function Write-ManifestEntry {
         catch { $manifest = $null }
     }
 
-    # Rebuild into a hashtable so updates are deterministic.
-    $files = @{}
     if ($manifest -and $manifest.files) {
         foreach ($prop in $manifest.files.PSObject.Properties) {
             $files[$prop.Name] = [string]$prop.Value
         }
     }
-    $files[$Key] = $Sha
+    return $files
+}
+
+function Write-ManifestFiles {
+    param([Parameter(Mandatory)][hashtable]$Files)
+
+    $manifestPath = Get-ManifestPath
+    $dir = Split-Path -Parent $manifestPath
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    $orderedFiles = [ordered]@{}
+    foreach ($key in ($Files.Keys | Sort-Object)) {
+        $orderedFiles[$key] = [string]$Files[$key]
+    }
 
     $out = [ordered]@{
         schema = $script:ManifestSchema
-        files  = $files
+        files  = $orderedFiles
     }
     $out | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+}
+
+function Write-ManifestEntry {
+    param(
+        [Parameter(Mandatory)][string]$Key,
+        [Parameter(Mandatory)][string]$Sha
+    )
+    $files = Get-ManifestFiles
+    $files[$Key] = $Sha
+    Write-ManifestFiles -Files $files
+}
+
+function Join-ManagedManifestPath {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string]$Key
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Key)) { return $null }
+
+    $rootFull = [System.IO.Path]::GetFullPath($Root)
+    $candidate = [System.IO.Path]::GetFullPath((Join-Path $rootFull $Key))
+    $comparison = if (Test-ManifestWindowsPlatform) {
+        [System.StringComparison]::OrdinalIgnoreCase
+    } else {
+        [System.StringComparison]::Ordinal
+    }
+
+    if ([string]::Equals($candidate, $rootFull, $comparison)) { return $candidate }
+
+    $rootPrefix = $rootFull.TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    ) + [System.IO.Path]::DirectorySeparatorChar
+
+    if ($candidate.StartsWith($rootPrefix, $comparison)) { return $candidate }
+    return $null
+}
+
+function Invoke-ManifestPrune {
+    <#
+    .SYNOPSIS
+    Removes obsolete managed files when they are unchanged from the previous
+    manifest entry, preserving locally edited files.
+    .OUTPUTS
+    PSCustomObject with Deleted, Preserved, Missing, Unsafe, and RemovedEntries.
+    #>
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][string[]]$ManagedKeys
+    )
+
+    if (-not $ManagedKeys -or $ManagedKeys.Count -eq 0) {
+        Write-Host 'Manifest prune: skipped; no current managed files'
+        return [pscustomobject]@{ Deleted = 0; Preserved = 0; Missing = 0; Unsafe = 0; RemovedEntries = 0 }
+    }
+
+    $manifestPath = Get-ManifestPath
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        return [pscustomobject]@{ Deleted = 0; Preserved = 0; Missing = 0; Unsafe = 0; RemovedEntries = 0 }
+    }
+
+    $files = Get-ManifestFiles
+    if ($files.Count -eq 0) {
+        return [pscustomobject]@{ Deleted = 0; Preserved = 0; Missing = 0; Unsafe = 0; RemovedEntries = 0 }
+    }
+
+    $comparison = if (Test-ManifestWindowsPlatform) {
+        [System.StringComparer]::OrdinalIgnoreCase
+    } else {
+        [System.StringComparer]::Ordinal
+    }
+    $managed = [System.Collections.Generic.HashSet[string]]::new($comparison)
+    foreach ($key in $ManagedKeys) {
+        if (-not [string]::IsNullOrWhiteSpace($key)) { [void]$managed.Add($key) }
+    }
+
+    $deleted = 0
+    $preserved = 0
+    $missing = 0
+    $unsafe = 0
+    $removedEntries = 0
+    $changed = $false
+
+    foreach ($key in @($files.Keys | Sort-Object)) {
+        if ($managed.Contains($key)) { continue }
+
+        $path = Join-ManagedManifestPath -Root $Root -Key $key
+        if (-not $path) {
+            Write-Host "Manifest prune: skipped unsafe obsolete path: $key"
+            $unsafe++
+            continue
+        }
+
+        if (-not (Test-Path -LiteralPath $path)) {
+            Write-Host "Manifest prune: removed stale manifest entry for missing file: $key"
+            $files.Remove($key)
+            $missing++
+            $removedEntries++
+            $changed = $true
+            continue
+        }
+
+        $currentSha = Get-FileSha256 -Path $path
+        $storedSha = [string]$files[$key]
+        if ($currentSha -and $storedSha -and ($currentSha -eq $storedSha)) {
+            Remove-Item -LiteralPath $path -Force
+            Write-Host "Manifest prune: deleted obsolete managed file: $key"
+            $files.Remove($key)
+            $deleted++
+            $removedEntries++
+            $changed = $true
+        } else {
+            Write-Host "Manifest prune: preserved locally modified obsolete file: $key"
+            $preserved++
+        }
+    }
+
+    if ($changed) { Write-ManifestFiles -Files $files }
+
+    return [pscustomobject]@{
+        Deleted        = $deleted
+        Preserved      = $preserved
+        Missing        = $missing
+        Unsafe         = $unsafe
+        RemovedEntries = $removedEntries
+    }
+}
+
+function Invoke-ManifestPruneTracked {
+    param([Parameter(Mandatory)][string]$Root)
+    return Invoke-ManifestPrune -Root $Root -ManagedKeys $script:ManifestManagedKeys
+}
+
+function Invoke-ManifestTrackedCopy {
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string]$Src,
+        [Parameter(Mandatory)][string]$Dest,
+        [Parameter(Mandatory)][string]$Key
+    )
+
+    if (-not (Test-Path -LiteralPath $Src -PathType Leaf)) { return $true }
+    $destDir = Split-Path -Parent $Dest
+    if ($destDir -and -not (Test-Path -LiteralPath $destDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+
+    $result = Invoke-GuardedCopy -Src $Src -Dest $Dest -Key $Key
+    Add-ManifestManagedKey -Key $Key
+    return $result
+}
+
+function Copy-ManifestFiles {
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir,
+        [Parameter(Mandatory)][string]$KeyPrefix,
+        [Parameter(Mandatory)][string[]]$Filters
+    )
+
+    if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) { return }
+    if (-not (Test-Path -LiteralPath $DestinationDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $DestinationDir -Force | Out-Null
+    }
+
+    foreach ($filter in $Filters) {
+        Get-ChildItem -LiteralPath $SourceDir -Filter $filter -File -ErrorAction SilentlyContinue | ForEach-Object {
+            $key = if ([string]::IsNullOrEmpty($KeyPrefix)) {
+                $_.Name
+            } else {
+                (($KeyPrefix, $_.Name) -join '/') -replace '\\', '/'
+            }
+            $null = Invoke-ManifestTrackedCopy -Src $_.FullName -Dest (Join-Path $DestinationDir $_.Name) -Key $key
+        }
+    }
+}
+
+function Copy-ManifestTree {
+    param(
+        [Parameter(Mandatory)][string]$SourceDir,
+        [Parameter(Mandatory)][string]$DestinationDir,
+        [Parameter(Mandatory)][string]$KeyPrefix
+    )
+
+    if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) { return }
+    if (-not (Test-Path -LiteralPath $DestinationDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $DestinationDir -Force | Out-Null
+    }
+
+    $sourceRoot = [System.IO.Path]::GetFullPath($SourceDir).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+    Get-ChildItem -LiteralPath $SourceDir -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+        $full = [System.IO.Path]::GetFullPath($_.FullName)
+        $rel = $full.Substring($sourceRoot.Length).TrimStart(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        )
+        $relKey = $rel -replace '\\', '/'
+        $key = if ([string]::IsNullOrEmpty($KeyPrefix)) {
+            $relKey
+        } else {
+            (($KeyPrefix, $relKey) -join '/') -replace '\\', '/'
+        }
+        $dest = Join-Path $DestinationDir $rel
+        $null = Invoke-ManifestTrackedCopy -Src $_.FullName -Dest $dest -Key $key
+    }
+}
+
+function Add-RetiredManagedManifestEntries {
+    param(
+        [Parameter(Mandatory)][string]$Root,
+        [Parameter(Mandatory)][hashtable]$Entries
+    )
+
+    foreach ($key in ($Entries.Keys | Sort-Object)) {
+        if (Read-ManifestEntry -Key $key) { continue }
+
+        $path = Join-ManagedManifestPath -Root $Root -Key $key
+        if (-not $path) {
+            Write-Host "Manifest prune: skipped unsafe retired path: $key"
+            continue
+        }
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { continue }
+
+        $currentSha = Get-FileSha256 -Path $path
+        $currentLfSha = Get-FileSha256LfNormalized -Path $path
+        $retiredSha = [string]$Entries[$key]
+        if ($currentSha -and ($currentSha -eq $retiredSha)) {
+            Write-ManifestEntry -Key $key -Sha $retiredSha
+            Write-Host "Manifest prune: matched retired managed file: $key"
+        } elseif ($currentSha -and $currentLfSha -and ($currentLfSha -eq $retiredSha)) {
+            Write-ManifestEntry -Key $key -Sha $currentSha
+            Write-Host "Manifest prune: matched retired managed file: $key"
+        } else {
+            Write-Host "Manifest prune: preserved locally edited retired file: $key"
+        }
+    }
 }
 
 function Invoke-GuardedCopy {

--- a/scripts/install-manifest.ps1
+++ b/scripts/install-manifest.ps1
@@ -261,7 +261,7 @@ function Copy-ManifestFiles {
     param(
         [Parameter(Mandatory)][string]$SourceDir,
         [Parameter(Mandatory)][string]$DestinationDir,
-        [Parameter(Mandatory)][string]$KeyPrefix,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$KeyPrefix,
         [Parameter(Mandatory)][string[]]$Filters
     )
 
@@ -286,7 +286,7 @@ function Copy-ManifestTree {
     param(
         [Parameter(Mandatory)][string]$SourceDir,
         [Parameter(Mandatory)][string]$DestinationDir,
-        [Parameter(Mandatory)][string]$KeyPrefix
+        [Parameter(Mandatory)][AllowEmptyString()][string]$KeyPrefix
     )
 
     if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) { return }

--- a/scripts/install-manifest.sh
+++ b/scripts/install-manifest.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 MANIFEST_PATH="${MANIFEST_PATH:-$HOME/.claude/.install-manifest.json}"
 MANIFEST_SCHEMA=1
+MANIFEST_MANAGED_KEYS=()
 
 # Detect an available JSON tool (python3 preferred, python fallback).
 _manifest_json_tool=""
@@ -26,6 +27,16 @@ fi
 
 manifest_available() {
     [ -n "$_manifest_json_tool" ]
+}
+
+manifest_reset_managed_keys() {
+    MANIFEST_MANAGED_KEYS=()
+}
+
+manifest_track_key() {
+    local key="$1"
+    [ -n "$key" ] || return 0
+    MANIFEST_MANAGED_KEYS+=("$key")
 }
 
 _manifest_hash() {
@@ -79,6 +90,208 @@ with open(p, "w") as f:
     json.dump(m, f, indent=2, sort_keys=True)
     f.write("\n")
 PY
+}
+
+# manifest_prune_removed <dest_root> <managed_key>...
+# Deletes files that were tracked by a previous manifest but are absent from
+# the current managed set, provided the deployed file still matches the stored
+# hash. Locally edited files are preserved.
+manifest_prune_removed() {
+    local dest_root="$1"
+    shift || true
+
+    [ -d "$dest_root" ] || return 0
+    [ -f "$MANIFEST_PATH" ] || return 0
+
+    if [ "$#" -eq 0 ]; then
+        echo "  Manifest prune skipped: no current managed files"
+        return 0
+    fi
+
+    if ! manifest_available; then
+        echo "  Manifest prune skipped: no JSON tool available"
+        return 0
+    fi
+
+    MANIFEST_PATH="$MANIFEST_PATH" DEST_ROOT="$dest_root" "$_manifest_json_tool" - "$@" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+manifest_path = os.environ["MANIFEST_PATH"]
+dest_root = os.path.realpath(os.environ["DEST_ROOT"])
+managed = set(sys.argv[1:])
+
+try:
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+except Exception:
+    print("  Manifest prune skipped: manifest unreadable")
+    sys.exit(0)
+
+files = manifest.get("files")
+if not isinstance(files, dict):
+    sys.exit(0)
+
+changed = False
+for key, stored_sha in sorted(list(files.items())):
+    if key in managed:
+        continue
+
+    normalized = os.path.normpath(key)
+    if (
+        os.path.isabs(key)
+        or normalized == os.pardir
+        or normalized.startswith(os.pardir + os.sep)
+    ):
+        print("  Preserved removed managed entry with unsafe path: {}".format(key))
+        continue
+
+    dest = os.path.realpath(os.path.join(dest_root, normalized))
+    if dest != dest_root and not dest.startswith(dest_root + os.sep):
+        print("  Preserved removed managed entry outside install root: {}".format(key))
+        continue
+
+    if not os.path.exists(dest):
+        del files[key]
+        changed = True
+        print("  Removed stale manifest entry for missing file: {}".format(key))
+        continue
+
+    if not os.path.isfile(dest):
+        print("  Preserved removed managed path because it is not a file: {}".format(key))
+        continue
+
+    try:
+        with open(dest, "rb") as f:
+            current_sha = hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        print("  Preserved removed managed file; unable to read: {}".format(key))
+        continue
+
+    if current_sha == stored_sha:
+        try:
+            os.remove(dest)
+        except OSError:
+            print("  Preserved removed managed file; unable to delete: {}".format(key))
+            continue
+        del files[key]
+        changed = True
+        print("  Pruned removed managed file: {}".format(key))
+    else:
+        print("  Preserved locally edited removed managed file: {}".format(key))
+
+if changed:
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+PY
+}
+
+manifest_prune_tracked() {
+    local dest_root="$1"
+    manifest_prune_removed "$dest_root" "${MANIFEST_MANAGED_KEYS[@]}"
+}
+
+_manifest_safe_dest() {
+    local dest_root="$1" key="$2"
+    case "$key" in
+        /*|../*|*/../*|..)
+            return 1
+            ;;
+    esac
+    printf '%s/%s\n' "$dest_root" "$key"
+}
+
+# manifest_seed_retired_managed <dest_root> (<key> <sha256>)...
+# Adds manifest ownership for known retired files only when the deployed file
+# still byte-matches the historical upstream copy. The next prune pass can then
+# remove it while locally edited retired files remain untouched.
+manifest_seed_retired_managed() {
+    local dest_root="$1"
+    shift || true
+
+    [ -d "$dest_root" ] || return 0
+    manifest_available || return 0
+
+    while [ "$#" -ge 2 ]; do
+        local key="$1" retired_sha="$2" dest current_sha current_lf_sha stored_sha
+        shift 2
+
+        stored_sha=$(_manifest_read "$key")
+        [ -n "$stored_sha" ] && continue
+
+        dest=$(_manifest_safe_dest "$dest_root" "$key") || {
+            echo "  Manifest prune: skipped unsafe retired path: $key"
+            continue
+        }
+        [ -f "$dest" ] || continue
+
+        current_sha=$(_manifest_hash "$dest") || current_sha=""
+        current_lf_sha=""
+        if command -v shasum >/dev/null 2>&1; then
+            current_lf_sha=$(tr -d '\r' < "$dest" | shasum -a 256 2>/dev/null | awk '{print $1}')
+        elif command -v sha256sum >/dev/null 2>&1; then
+            current_lf_sha=$(tr -d '\r' < "$dest" | sha256sum 2>/dev/null | awk '{print $1}')
+        fi
+        if [ -n "$current_sha" ] && [ "$current_sha" = "$retired_sha" ]; then
+            _manifest_write "$key" "$retired_sha"
+            echo "  Manifest prune: matched retired managed file: $key"
+        elif [ -n "$current_lf_sha" ] && [ "$current_lf_sha" = "$retired_sha" ]; then
+            _manifest_write "$key" "$current_sha"
+            echo "  Manifest prune: matched retired managed file: $key"
+        else
+            echo "  Manifest prune: preserved locally edited retired file: $key"
+        fi
+    done
+}
+
+manifest_copy_file() {
+    local src="$1" dest="$2" key="$3" executable="${4:-0}"
+    [ -f "$src" ] || return 0
+    mkdir -p "$(dirname "$dest")"
+
+    if guarded_copy "$src" "$dest" "$key"; then
+        [ "$executable" = "1" ] && chmod +x "$dest"
+        manifest_track_key "$key"
+        return 0
+    fi
+
+    manifest_track_key "$key"
+    return 1
+}
+
+manifest_copy_files() {
+    local src_dir="$1" dest_dir="$2" key_prefix="$3" pattern="${4:-*}" executable="${5:-0}"
+    local src base key dest
+
+    [ -d "$src_dir" ] || return 0
+    mkdir -p "$dest_dir"
+
+    for src in "$src_dir"/$pattern; do
+        [ -f "$src" ] || continue
+        base="$(basename "$src")"
+        key="${key_prefix:+$key_prefix/}$base"
+        dest="$dest_dir/$base"
+        manifest_copy_file "$src" "$dest" "$key" "$executable" || true
+    done
+}
+
+manifest_copy_tree() {
+    local src_dir="$1" dest_dir="$2" key_prefix="$3" executable="${4:-0}"
+    local src rel key dest
+
+    [ -d "$src_dir" ] || return 0
+    mkdir -p "$dest_dir"
+
+    while IFS= read -r src; do
+        [ -f "$src" ] || continue
+        rel="${src#$src_dir/}"
+        key="${key_prefix:+$key_prefix/}$rel"
+        dest="$dest_dir/$rel"
+        manifest_copy_file "$src" "$dest" "$key" "$executable" || true
+    done < <(find "$src_dir" -type f 2>/dev/null)
 }
 
 # guarded_copy <src> <dest> <key>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -70,7 +70,8 @@ function Copy-InstallHookFiles {
     param(
         [Parameter(Mandatory)][string]$SourceDir,
         [Parameter(Mandatory)][string]$DestinationDir,
-        [Parameter(Mandatory)][string[]]$Filters
+        [Parameter(Mandatory)][string[]]$Filters,
+        [string]$KeyPrefix = ''
     )
 
     if (-not (Test-Path -LiteralPath $SourceDir -PathType Container)) { return }
@@ -79,10 +80,22 @@ function Copy-InstallHookFiles {
     foreach ($filter in $Filters) {
         Get-ChildItem -LiteralPath $SourceDir -Filter $filter -File -ErrorAction SilentlyContinue | ForEach-Object {
             $dest = Join-Path $DestinationDir $_.Name
-            if ($_.Extension -eq '.sh') {
-                Install-BashScript -SourcePath $_.FullName -DestinationPath $dest
+            if ($KeyPrefix -and (Get-Command Invoke-ManifestTrackedCopy -ErrorAction SilentlyContinue)) {
+                $key = (($KeyPrefix, $_.Name) -join '/') -replace '\\', '/'
+                if ($_.Extension -eq '.sh') {
+                    $tmpScript = Join-Path ([System.IO.Path]::GetTempPath()) "claude-script-$([guid]::NewGuid()).sh"
+                    Install-BashScript -SourcePath $_.FullName -DestinationPath $tmpScript
+                    $null = Invoke-ManifestTrackedCopy -Src $tmpScript -Dest $dest -Key $key
+                    Remove-Item -LiteralPath $tmpScript -Force -ErrorAction SilentlyContinue
+                } else {
+                    $null = Invoke-ManifestTrackedCopy -Src $_.FullName -Dest $dest -Key $key
+                }
             } else {
-                Copy-Item -LiteralPath $_.FullName -Destination $dest -Force -ErrorAction Stop
+                if ($_.Extension -eq '.sh') {
+                    Install-BashScript -SourcePath $_.FullName -DestinationPath $dest
+                } else {
+                    Copy-Item -LiteralPath $_.FullName -Destination $dest -Force -ErrorAction Stop
+                }
             }
         }
     }
@@ -99,14 +112,14 @@ function Deploy-InstallHooks {
     $hooksDir = Join-Path $ClaudeDir "hooks"
     # Windows hooks use `pwsh -File ...ps1`; .sh/.json are deployed for WSL and
     # parity with container-side command rewriting.
-    Copy-InstallHookFiles -SourceDir $hooksSource -DestinationDir $hooksDir -Filters @('*.ps1', '*.sh', '*.json')
+    Copy-InstallHookFiles -SourceDir $hooksSource -DestinationDir $hooksDir -Filters @('*.ps1', '*.sh', '*.json') -KeyPrefix 'hooks'
 
     # Deploy global/hooks/lib/ shared libraries. The top-level hook copy is
     # non-recursive, and several runtime guards source these libraries.
     $hooksLibSource = Join-Path $hooksSource 'lib'
     if (Test-Path -LiteralPath $hooksLibSource -PathType Container) {
         $hooksLibDir = Join-Path $hooksDir 'lib'
-        Copy-InstallHookFiles -SourceDir $hooksLibSource -DestinationDir $hooksLibDir -Filters @('*.ps1', '*.psm1', '*.sh')
+        Copy-InstallHookFiles -SourceDir $hooksLibSource -DestinationDir $hooksLibDir -Filters @('*.ps1', '*.psm1', '*.sh') -KeyPrefix 'hooks/lib'
     }
 
     # Shared bash validator libraries used by deployed bash hook variants.
@@ -117,7 +130,7 @@ function Deploy-InstallHooks {
             'validate-commit-message.sh',
             'validate-language.sh',
             'validate-traceability.sh'
-        )
+        ) -KeyPrefix 'hooks/lib'
     }
 
     $requiredLibs = @(
@@ -531,6 +544,7 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         throw "install-manifest.ps1 helper not found at: $manifestHelper"
     }
     . $manifestHelper
+    Reset-ManifestManagedKeys
 
     # Copy configuration files (manifest-guarded)
     $globalFiles = @('CLAUDE.md', 'commit-settings.md', 'git-identity.md', 'token-management.md')
@@ -543,14 +557,14 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
             $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) "policy_$([guid]::NewGuid()).md"
             Invoke-PolicyTemplate -Source $srcTmpl -Destination $tmpFile `
                 -ContentLanguage $script:contentLanguage -AgentDisplay $script:agentDisplayLang -AgentLanguage $script:agentLanguage
-            if (Invoke-GuardedCopy -Src $tmpFile -Dest (Join-Path $claudeDir $gf) -Key $gf) {
+            if (Invoke-ManifestTrackedCopy -Src $tmpFile -Dest (Join-Path $claudeDir $gf) -Key $gf) {
                 Write-Success "$gf installed (policy phrase: $(Get-PolicyPhrase -Policy $script:contentLanguage))"
             } else {
                 Write-Info "$gf local changes preserved"
             }
             Remove-Item -LiteralPath $tmpFile -Force -ErrorAction SilentlyContinue
         } elseif (Test-Path $src) {
-            if (Invoke-GuardedCopy -Src $src -Dest (Join-Path $claudeDir $gf) -Key $gf) {
+            if (Invoke-ManifestTrackedCopy -Src $src -Dest (Join-Path $claudeDir $gf) -Key $gf) {
                 Write-Success "$gf installed"
             } else {
                 Write-Info "$gf local changes preserved"
@@ -579,8 +593,10 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         }
 
         if (Invoke-GuardedTemplateCopy -SrcTmpl $tmplPath -Dest (Join-Path $claudeDir "conversation-language.md") -Key "conversation-language.md" -DisplayLang $agentDisplayLang) {
+            Add-ManifestManagedKey -Key 'conversation-language.md'
             Write-Success "conversation-language.md installed (Language: $agentDisplayLang)"
         } else {
+            Add-ManifestManagedKey -Key 'conversation-language.md'
             Write-Info "conversation-language.md local changes preserved"
         }
     }
@@ -598,13 +614,18 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         try {
             $ps1Items = Get-ChildItem -Path $scriptsSource -Filter '*.ps1' -File
             if ($ps1Items.Count -gt 0) {
-                Copy-Item -Path "$scriptsSource\*.ps1" -Destination $scriptsDir -Force -ErrorAction Stop
+                foreach ($item in $ps1Items) {
+                    $null = Invoke-ManifestTrackedCopy -Src $item.FullName -Dest (Join-Path $scriptsDir $item.Name) -Key "scripts/$($item.Name)"
+                }
             }
         } catch {
             Write-Err "Failed to copy utility scripts: $_"
         }
         Get-ChildItem -Path $scriptsSource -Filter '*.sh' -File -ErrorAction SilentlyContinue | ForEach-Object {
-            Install-BashScript -SourcePath $_.FullName -DestinationPath (Join-Path $scriptsDir $_.Name)
+            $tmpScript = Join-Path ([System.IO.Path]::GetTempPath()) "claude-script-$([guid]::NewGuid()).sh"
+            Install-BashScript -SourcePath $_.FullName -DestinationPath $tmpScript
+            $null = Invoke-ManifestTrackedCopy -Src $tmpScript -Dest (Join-Path $scriptsDir $_.Name) -Key "scripts/$($_.Name)"
+            Remove-Item -LiteralPath $tmpScript -Force -ErrorAction SilentlyContinue
         }
 
         Write-Success "Utility scripts installed (scripts/*.ps1 + *.sh)!"
@@ -618,7 +639,9 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         try {
             $jsonItems = Get-ChildItem -Path $policiesSource -Filter '*.json' -File
             if ($jsonItems.Count -gt 0) {
-                Copy-Item -Path "$policiesSource\*.json" -Destination $policiesDir -Force -ErrorAction Stop
+                foreach ($item in $jsonItems) {
+                    $null = Invoke-ManifestTrackedCopy -Src $item.FullName -Dest (Join-Path $policiesDir $item.Name) -Key "policies/$($item.Name)"
+                }
             }
             Write-Success "Policy files (policies/*.json) installed!"
         } catch {
@@ -654,7 +677,7 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         $skillsDir = Join-Path $claudeDir "skills"
         Ensure-Directory $skillsDir
         try {
-            Copy-Item -Path "$skillsSource\*" -Destination $skillsDir -Recurse -Force -ErrorAction Stop
+            Copy-ManifestTree -SourceDir $skillsSource -DestinationDir $skillsDir -KeyPrefix 'skills'
             $skillCount = (Get-ChildItem -Path $skillsDir -Filter SKILL.md -Recurse -ErrorAction SilentlyContinue).Count
             Write-Success "Global Skills ($skillCount) installed!"
         } catch {
@@ -668,12 +691,23 @@ if ($installType -eq '1' -or $installType -eq '3' -or $installType -eq '5') {
         $commandsDir = Join-Path $claudeDir "commands"
         Ensure-Directory $commandsDir
         try {
-            Copy-Item -Path "$commandsSource\*" -Destination $commandsDir -Recurse -Force -ErrorAction Stop
+            Copy-ManifestTree -SourceDir $commandsSource -DestinationDir $commandsDir -KeyPrefix 'commands'
             Write-Success "Global Commands installed!"
         } catch {
             Write-Err "Failed to copy global commands: $_"
         }
     }
+
+    Add-RetiredManagedManifestEntries -Root $claudeDir -Entries @{
+        'commands/branch-cleanup.md' = '3e7fc38c324cfc9cea639e95394d7819e7768364d12023ec0b36b91f9230b09d'
+        'commands/doc-review.md' = 'be659114c43ef29423c74d7b33e0f594b80c134b38fb7c5b61e6935cae88c26f'
+        'commands/implement-all-levels.md' = 'b675f8e689e8aca71eb67e8666acc98018ad70b746d16655476b5939380737be'
+        'commands/issue-create.md' = 'c654ab412f320b9d97553f92a510cf5de13a5d0a7ed5e14212ca62534887ae71'
+        'commands/issue-work.md' = '048a26140b03862c5b10630853115ee656056f45cedfd0a0b6ec814bf7225684'
+        'commands/pr-work.md' = '2ecf1a78271c553e2310b57b2a1deb026a07ae01b84c1f856638293ab41f1199'
+        'commands/release.md' = '93fd6d2f7800deada2868b97b65ef486f42482b5e2f1224c35f732ebfeb1c013'
+    }
+    $null = Invoke-ManifestPruneTracked -Root $claudeDir
 
     # Install ccstatusline settings (~/.config/ccstatusline/ — ccstatusline default settings path)
     $ccstatuslineSource = Join-Path $BackupDir "global/ccstatusline"
@@ -753,64 +787,87 @@ if ($installType -eq '2' -or $installType -eq '3' -or $installType -eq '5') {
 
     Write-Info "Install path: $projectDir"
 
-    # Copy files
-    Copy-Item -Path (Join-Path $BackupDir "project/CLAUDE.md") -Destination $projectDir -Force
-
     # .claude directory
     $projectClaudeDir = Join-Path $projectDir ".claude"
     Ensure-Directory $projectClaudeDir
+    if (-not (Get-Command Invoke-ManifestTrackedCopy -ErrorAction SilentlyContinue)) {
+        $manifestHelper = Join-Path $BackupDir 'scripts\install-manifest.ps1'
+        if (-not (Test-Path -LiteralPath $manifestHelper)) {
+            throw "install-manifest.ps1 helper not found at: $manifestHelper"
+        }
+        . $manifestHelper
+    }
+    $previousManifestPath = $env:MANIFEST_PATH
+    $env:MANIFEST_PATH = Join-Path $projectClaudeDir ".install-manifest.json"
+    Reset-ManifestManagedKeys
+
+    # Copy files
+    $null = Invoke-ManifestTrackedCopy -Src (Join-Path $BackupDir "project/CLAUDE.md") -Dest (Join-Path $projectDir "CLAUDE.md") -Key "CLAUDE.md"
 
     # settings.json
     $projectSettings = Join-Path $BackupDir "project/.claude/settings.json"
     if (Test-Path $projectSettings) {
-        Copy-Item -Path $projectSettings -Destination $projectClaudeDir -Force
+        $null = Invoke-ManifestTrackedCopy -Src $projectSettings -Dest (Join-Path $projectClaudeDir "settings.json") -Key ".claude/settings.json"
         Write-Success "Project hook settings (.claude/settings.json) installed!"
     }
 
     # rules directory
     $sourceRules = Join-Path $BackupDir "project/.claude/rules"
     if (Test-Path $sourceRules) {
-        Copy-Item -Path $sourceRules -Destination $projectClaudeDir -Recurse -Force
+        $rulesTmp = Join-Path ([System.IO.Path]::GetTempPath()) "claude-rules-$([guid]::NewGuid())"
+        New-Item -ItemType Directory -Path $rulesTmp -Force | Out-Null
+        Copy-Item -Path (Join-Path $sourceRules '*') -Destination $rulesTmp -Recurse -Force
         # Issue #411: render any .md.tmpl found under rules/ with the chosen policy phrase.
-        Invoke-PolicyTemplatesInDir -Path (Join-Path $projectClaudeDir 'rules') `
+        Invoke-PolicyTemplatesInDir -Path $rulesTmp `
             -ContentLanguage $script:contentLanguage -AgentDisplay $script:agentDisplayLang -AgentLanguage $script:agentLanguage
+        Copy-ManifestTree -SourceDir $rulesTmp -DestinationDir (Join-Path $projectClaudeDir 'rules') -KeyPrefix '.claude/rules'
+        Remove-Item -LiteralPath $rulesTmp -Recurse -Force -ErrorAction SilentlyContinue
         Write-Success "Rules directory installed! (policy phrase: $(Get-PolicyPhrase -Policy $script:contentLanguage))"
     }
 
     # reference directory (on-demand docs relocated out of rules/ -- issue #714)
     $sourceReference = Join-Path $BackupDir "project/.claude/reference"
     if (Test-Path $sourceReference) {
-        Copy-Item -Path $sourceReference -Destination $projectClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $sourceReference -DestinationDir (Join-Path $projectClaudeDir 'reference') -KeyPrefix '.claude/reference'
         Write-Success "Reference directory installed!"
     }
 
     # Skills directory
     $sourceSkills = Join-Path $BackupDir "project/.claude/skills"
     if (Test-Path $sourceSkills) {
-        Copy-Item -Path $sourceSkills -Destination $projectClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $sourceSkills -DestinationDir (Join-Path $projectClaudeDir 'skills') -KeyPrefix '.claude/skills'
         Write-Success "Skills directory installed!"
     }
 
     # commands directory
     $sourceCommands = Join-Path $BackupDir "project/.claude/commands"
     if (Test-Path $sourceCommands) {
-        Copy-Item -Path $sourceCommands -Destination $projectClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $sourceCommands -DestinationDir (Join-Path $projectClaudeDir 'commands') -KeyPrefix '.claude/commands'
         Write-Success "Commands directory installed!"
     }
 
     # agents directory
     $sourceAgents = Join-Path $BackupDir "project/.claude/agents"
     if (Test-Path $sourceAgents) {
-        Copy-Item -Path $sourceAgents -Destination $projectClaudeDir -Recurse -Force
+        Copy-ManifestTree -SourceDir $sourceAgents -DestinationDir (Join-Path $projectClaudeDir 'agents') -KeyPrefix '.claude/agents'
         Write-Success "Agents directory installed!"
     }
 
     # .claudeignore (token optimization)
     $claudeIgnore = Join-Path $BackupDir "project/.claudeignore"
     if (Test-Path $claudeIgnore) {
-        Copy-Item -Path $claudeIgnore -Destination $projectDir -Force
+        $null = Invoke-ManifestTrackedCopy -Src $claudeIgnore -Dest (Join-Path $projectDir ".claudeignore") -Key ".claudeignore"
         Write-Success ".claudeignore installed!"
     }
+
+    Add-RetiredManagedManifestEntries -Root $projectDir -Entries @{
+        '.claude/commands/_policy.md' = '7144bf54352362eb3d523d05a1712732aec8e82fc95ea9db0cbc79269e2bf9b1'
+        '.claude/commands/code-quality.md' = '8c1e6ca0470582936fb96491d4aff7e23706da45b96ba38c51d43ba255f8f544'
+        '.claude/commands/git-status.md' = '4602f6ea8ffb18b05d5698c85d060b3d6f01913a4258e778bd6b898611ca9d33'
+        '.claude/commands/pr-review.md' = '3dbd7d788b1e19b1d04654e03eaf8531c933e6b7462120ffdc03d5d7f9658711'
+    }
+    $null = Invoke-ManifestPruneTracked -Root $projectDir
+    $env:MANIFEST_PATH = $previousManifestPath
 
     # CLAUDE.local.md creation
     Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,11 +249,16 @@ ensure_install_dir() {
 }
 
 copy_install_files() {
-    local src_dir="$1" dest_dir="$2" pattern="$3" executable="${4:-0}"
+    local src_dir="$1" dest_dir="$2" pattern="$3" executable="${4:-0}" key_prefix="${5:-}"
     local src dest
 
     [ -d "$src_dir" ] || return 0
     ensure_install_dir "$dest_dir" || return 1
+
+    if [ -n "$key_prefix" ] && type manifest_copy_files >/dev/null 2>&1; then
+        manifest_copy_files "$src_dir" "$dest_dir" "$key_prefix" "$pattern" "$executable"
+        return 0
+    fi
 
     for src in "$src_dir"/$pattern; do
         [ -f "$src" ] || continue
@@ -279,19 +284,19 @@ deploy_install_hooks() {
         return 1
     fi
 
-    copy_install_files "$hooks_src" "$hooks_dst" "*.sh" 1 || return 1
+    copy_install_files "$hooks_src" "$hooks_dst" "*.sh" 1 "hooks" || return 1
 
     # Deploy global/hooks/lib/*.sh. The top-level *.sh copy is non-recursive,
     # and several runtime guards source these libraries.
     if [ -d "$hooks_lib_src" ]; then
-        copy_install_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 || return 1
+        copy_install_files "$hooks_lib_src" "$hooks_dst/lib" "*.sh" 1 "hooks/lib" || return 1
     fi
 
     # Shared validator libraries used by commit/language/traceability guards.
     if [ -d "$shared_lib_src" ]; then
         for lib in validate-commit-message.sh validate-language.sh validate-traceability.sh; do
             if [ -f "$shared_lib_src/$lib" ]; then
-                copy_install_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 || return 1
+                copy_install_files "$shared_lib_src" "$hooks_dst/lib" "$lib" 1 "hooks/lib" || return 1
             fi
         done
     fi
@@ -784,11 +789,12 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # 설치 매니페스트 헬퍼 로드
     # shellcheck disable=SC1091
     source "$BACKUP_DIR/scripts/install-manifest.sh"
+    manifest_reset_managed_keys
 
     # 파일 설치 (매니페스트 가드 사용)
     for gf in CLAUDE.md commit-settings.md git-identity.md token-management.md; do
         if [ -f "$BACKUP_DIR/global/$gf" ]; then
-            if guarded_copy "$BACKUP_DIR/global/$gf" "$HOME/.claude/$gf" "$gf"; then
+            if manifest_copy_file "$BACKUP_DIR/global/$gf" "$HOME/.claude/$gf" "$gf"; then
                 if [ "$gf" = "git-identity.md" ] || [ "$gf" = "token-management.md" ]; then
                     chmod 600 "$HOME/.claude/$gf"
                 else
@@ -835,9 +841,11 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
         fi
 
         if guarded_template_copy "$BACKUP_DIR/global/conversation-language.md.tmpl" "$HOME/.claude/conversation-language.md" "conversation-language.md" "$AGENT_DISPLAY_LANG"; then
+            manifest_track_key "conversation-language.md"
             chmod 644 "$HOME/.claude/conversation-language.md"
             success "conversation-language.md 설치됨 (언어: $AGENT_DISPLAY_LANG)"
         else
+            manifest_track_key "conversation-language.md"
             info "conversation-language.md 로컬 변경 유지"
         fi
     fi
@@ -851,7 +859,7 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # scripts 디렉토리 설치 (statusline 등)
     if [ -d "$BACKUP_DIR/global/scripts" ]; then
         ensure_dir "$HOME/.claude/scripts"
-        cp "$BACKUP_DIR/global/scripts"/*.sh "$HOME/.claude/scripts/" 2>/dev/null || true
+        manifest_copy_files "$BACKUP_DIR/global/scripts" "$HOME/.claude/scripts" "scripts" "*.sh" 1
         chmod +x "$HOME/.claude/scripts/"*.sh 2>/dev/null || true
         success "Statusline 스크립트 (scripts/) 설치 완료!"
     fi
@@ -859,16 +867,23 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # commit-settings.md 설치 (CLAUDE.md에서 @./commit-settings.md로 참조)
     # issue #411: .tmpl이 있으면 정책 phrase를 치환해서 생성. 없으면 원본 복사.
     if [ -f "$BACKUP_DIR/global/commit-settings.md.tmpl" ]; then
-        render_policy_tmpl "$BACKUP_DIR/global/commit-settings.md.tmpl" "$HOME/.claude/commit-settings.md"
-        success "commit-settings.md 설치 완료 (policy phrase: $(get_policy_phrase))"
+        tmp_commit_settings=$(mktemp)
+        render_policy_tmpl "$BACKUP_DIR/global/commit-settings.md.tmpl" "$tmp_commit_settings"
+        if manifest_copy_file "$tmp_commit_settings" "$HOME/.claude/commit-settings.md" "commit-settings.md"; then
+            chmod 644 "$HOME/.claude/commit-settings.md"
+            success "commit-settings.md 설치 완료 (policy phrase: $(get_policy_phrase))"
+        else
+            info "commit-settings.md 로컬 변경 유지"
+        fi
+        rm -f "$tmp_commit_settings"
     elif [ -f "$BACKUP_DIR/global/commit-settings.md" ]; then
-        cp "$BACKUP_DIR/global/commit-settings.md" "$HOME/.claude/"
+        manifest_copy_file "$BACKUP_DIR/global/commit-settings.md" "$HOME/.claude/commit-settings.md" "commit-settings.md" || true
         success "commit-settings.md 설치 완료!"
     fi
 
     # .claudeignore 설치
     if [ -f "$BACKUP_DIR/global/.claudeignore" ]; then
-        cp "$BACKUP_DIR/global/.claudeignore" "$HOME/.claude/"
+        manifest_copy_file "$BACKUP_DIR/global/.claudeignore" "$HOME/.claude/.claudeignore" ".claudeignore" || true
         success ".claudeignore 설치 완료!"
     fi
 
@@ -881,7 +896,7 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # policies 디렉토리 설치 (있는 경우 정책 JSON 파일 배포)
     if [ -d "$BACKUP_DIR/global/policies" ]; then
         ensure_dir "$HOME/.claude/policies"
-        cp "$BACKUP_DIR/global/policies"/*.json "$HOME/.claude/policies/" 2>/dev/null || true
+        manifest_copy_files "$BACKUP_DIR/global/policies" "$HOME/.claude/policies" "policies" "*.json" 0
         success "정책 파일 (policies/) 설치 완료!"
     fi
 
@@ -892,16 +907,27 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
     # `cp -r src/. dst/` 점 트릭으로 _policy.md 같은 루트 레벨 파일까지 복사한다.
     if [ -d "$BACKUP_DIR/global/skills" ]; then
         mkdir -p "$HOME/.claude/skills"
-        cp -r "$BACKUP_DIR/global/skills"/. "$HOME/.claude/skills/"
+        manifest_copy_tree "$BACKUP_DIR/global/skills" "$HOME/.claude/skills" "skills"
         skill_count=$(find "$HOME/.claude/skills" -name "SKILL.md" | wc -l | tr -d ' ')
         success "Global Skills (${skill_count}개) 설치 완료!"
     fi
 
     # commands 디렉토리 설치
     if [ -d "$BACKUP_DIR/global/commands" ]; then
-        cp -r "$BACKUP_DIR/global/commands" "$HOME/.claude/"
+        mkdir -p "$HOME/.claude/commands"
+        manifest_copy_tree "$BACKUP_DIR/global/commands" "$HOME/.claude/commands" "commands"
         success "Commands 디렉토리 설치 완료!"
     fi
+
+    manifest_seed_retired_managed "$HOME/.claude" \
+        "commands/branch-cleanup.md" "3e7fc38c324cfc9cea639e95394d7819e7768364d12023ec0b36b91f9230b09d" \
+        "commands/doc-review.md" "be659114c43ef29423c74d7b33e0f594b80c134b38fb7c5b61e6935cae88c26f" \
+        "commands/implement-all-levels.md" "b675f8e689e8aca71eb67e8666acc98018ad70b746d16655476b5939380737be" \
+        "commands/issue-create.md" "c654ab412f320b9d97553f92a510cf5de13a5d0a7ed5e14212ca62534887ae71" \
+        "commands/issue-work.md" "048a26140b03862c5b10630853115ee656056f45cedfd0a0b6ec814bf7225684" \
+        "commands/pr-work.md" "2ecf1a78271c553e2310b57b2a1deb026a07ae01b84c1f856638293ab41f1199" \
+        "commands/release.md" "93fd6d2f7800deada2868b97b65ef486f42482b5e2f1224c35f732ebfeb1c013"
+    manifest_prune_tracked "$HOME/.claude"
 
     # ccstatusline 설정 복사 (~/.config/ccstatusline/ — ccstatusline의 기본 설정 경로)
     if [ -d "$BACKUP_DIR/global/ccstatusline" ]; then
@@ -988,55 +1014,78 @@ if [ "$INSTALL_TYPE" = "2" ] || [ "$INSTALL_TYPE" = "3" ] || [ "$INSTALL_TYPE" =
 
     info "설치 경로: $PROJECT_DIR"
 
+    ensure_dir "$PROJECT_DIR/.claude"
+    if ! type manifest_copy_file >/dev/null 2>&1; then
+        # shellcheck disable=SC1091
+        source "$BACKUP_DIR/scripts/install-manifest.sh"
+    fi
+    previous_manifest_path="${MANIFEST_PATH:-}"
+    MANIFEST_PATH="$PROJECT_DIR/.claude/.install-manifest.json"
+    manifest_reset_managed_keys
+
     # 파일 복사
-    cp "$BACKUP_DIR/project/CLAUDE.md" "$PROJECT_DIR/"
+    if manifest_copy_file "$BACKUP_DIR/project/CLAUDE.md" "$PROJECT_DIR/CLAUDE.md" "CLAUDE.md"; then
+        success "프로젝트 CLAUDE.md 설치 완료!"
+    else
+        info "프로젝트 CLAUDE.md 로컬 변경 유지"
+    fi
 
     # .claude 디렉토리 설치
-    ensure_dir "$PROJECT_DIR/.claude"
 
     # settings.json 설치 (Hook 설정)
     if [ -f "$BACKUP_DIR/project/.claude/settings.json" ]; then
-        cp "$BACKUP_DIR/project/.claude/settings.json" "$PROJECT_DIR/.claude/"
+        manifest_copy_file "$BACKUP_DIR/project/.claude/settings.json" "$PROJECT_DIR/.claude/settings.json" ".claude/settings.json" || true
         success "프로젝트 Hook 설정 (.claude/settings.json) 설치 완료!"
     fi
 
     # rules 디렉토리 설치
     if [ -d "$BACKUP_DIR/project/.claude/rules" ]; then
-        cp -r "$BACKUP_DIR/project/.claude/rules" "$PROJECT_DIR/.claude/"
+        rules_tmp=$(mktemp -d)
+        cp -R "$BACKUP_DIR/project/.claude/rules"/. "$rules_tmp/"
         # issue #411: rules/ 안의 .md.tmpl을 정책 phrase로 치환
-        render_policy_tmpls_in_dir "$PROJECT_DIR/.claude/rules"
+        render_policy_tmpls_in_dir "$rules_tmp"
+        manifest_copy_tree "$rules_tmp" "$PROJECT_DIR/.claude/rules" ".claude/rules"
+        rm -rf "$rules_tmp"
         success "Rules 디렉토리 설치 완료! (policy phrase: $(get_policy_phrase))"
     fi
 
     # reference 디렉토리 설치 (on-demand docs, rules/ 밖으로 이전 — issue #714)
     if [ -d "$BACKUP_DIR/project/.claude/reference" ]; then
-        cp -r "$BACKUP_DIR/project/.claude/reference" "$PROJECT_DIR/.claude/"
+        manifest_copy_tree "$BACKUP_DIR/project/.claude/reference" "$PROJECT_DIR/.claude/reference" ".claude/reference"
         success "Reference 디렉토리 설치 완료!"
     fi
 
     # Skills 디렉토리 설치
     if [ -d "$BACKUP_DIR/project/.claude/skills" ]; then
-        cp -r "$BACKUP_DIR/project/.claude/skills" "$PROJECT_DIR/.claude/"
+        manifest_copy_tree "$BACKUP_DIR/project/.claude/skills" "$PROJECT_DIR/.claude/skills" ".claude/skills"
         success "Skills 디렉토리 설치 완료!"
     fi
 
     # commands 디렉토리 설치
     if [ -d "$BACKUP_DIR/project/.claude/commands" ]; then
-        cp -r "$BACKUP_DIR/project/.claude/commands" "$PROJECT_DIR/.claude/"
+        manifest_copy_tree "$BACKUP_DIR/project/.claude/commands" "$PROJECT_DIR/.claude/commands" ".claude/commands"
         success "Commands 디렉토리 설치 완료!"
     fi
 
     # agents 디렉토리 설치
     if [ -d "$BACKUP_DIR/project/.claude/agents" ]; then
-        cp -r "$BACKUP_DIR/project/.claude/agents" "$PROJECT_DIR/.claude/"
+        manifest_copy_tree "$BACKUP_DIR/project/.claude/agents" "$PROJECT_DIR/.claude/agents" ".claude/agents"
         success "Agents 디렉토리 설치 완료!"
     fi
 
     # .claudeignore 설치 (token optimization)
     if [ -f "$BACKUP_DIR/project/.claudeignore" ]; then
-        cp "$BACKUP_DIR/project/.claudeignore" "$PROJECT_DIR/"
+        manifest_copy_file "$BACKUP_DIR/project/.claudeignore" "$PROJECT_DIR/.claudeignore" ".claudeignore" || true
         success ".claudeignore 설치 완료!"
     fi
+
+    manifest_seed_retired_managed "$PROJECT_DIR" \
+        ".claude/commands/_policy.md" "7144bf54352362eb3d523d05a1712732aec8e82fc95ea9db0cbc79269e2bf9b1" \
+        ".claude/commands/code-quality.md" "8c1e6ca0470582936fb96491d4aff7e23706da45b96ba38c51d43ba255f8f544" \
+        ".claude/commands/git-status.md" "4602f6ea8ffb18b05d5698c85d060b3d6f01913a4258e778bd6b898611ca9d33" \
+        ".claude/commands/pr-review.md" "3dbd7d788b1e19b1d04654e03eaf8531c933e6b7462120ffdc03d5d7f9658711"
+    manifest_prune_tracked "$PROJECT_DIR"
+    MANIFEST_PATH="$previous_manifest_path"
 
     # CLAUDE.local.md 생성 (개인 설정용)
     echo ""

--- a/tests/scripts/test-install-manifest-helpers.ps1
+++ b/tests/scripts/test-install-manifest-helpers.ps1
@@ -54,6 +54,107 @@ try {
 
     Write-Host "Invoke-GuardedTemplateCopy: PASS"
 
+    # Test Invoke-ManifestPrune
+    $pruneRoot = Join-Path $testDir "prune-root"
+    New-Item -ItemType Directory -Path $pruneRoot | Out-Null
+
+    $obsoleteClean = Join-Path $pruneRoot "obsolete-clean.md"
+    $obsoleteEdited = Join-Path $pruneRoot "obsolete-edited.md"
+    $currentManaged = Join-Path $pruneRoot "current.md"
+    $outsideFile = Join-Path $testDir "outside.md"
+
+    "old managed content" | Set-Content -LiteralPath $obsoleteClean -Encoding UTF8
+    "user baseline content" | Set-Content -LiteralPath $obsoleteEdited -Encoding UTF8
+    "current managed content" | Set-Content -LiteralPath $currentManaged -Encoding UTF8
+    "outside content" | Set-Content -LiteralPath $outsideFile -Encoding UTF8
+
+    Write-ManifestEntry -Key "obsolete-clean.md" -Sha (Get-FileSha256 -Path $obsoleteClean)
+    Write-ManifestEntry -Key "obsolete-edited.md" -Sha (Get-FileSha256 -Path $obsoleteEdited)
+    Write-ManifestEntry -Key "missing-old.md" -Sha "abc123"
+    Write-ManifestEntry -Key "current.md" -Sha (Get-FileSha256 -Path $currentManaged)
+    Write-ManifestEntry -Key "../outside.md" -Sha (Get-FileSha256 -Path $outsideFile)
+
+    "user edited content" | Set-Content -LiteralPath $obsoleteEdited -Encoding UTF8
+
+    $pruneResult = Invoke-ManifestPrune -Root $pruneRoot -ManagedKeys @("current.md")
+    if ($pruneResult.Deleted -ne 1) {
+        throw "FAIL: prune did not delete exactly one unchanged obsolete file"
+    }
+    if ($pruneResult.Preserved -ne 1) {
+        throw "FAIL: prune did not preserve exactly one locally edited obsolete file"
+    }
+    if ($pruneResult.Missing -ne 1) {
+        throw "FAIL: prune did not remove exactly one missing stale manifest entry"
+    }
+    if ($pruneResult.Unsafe -ne 1) {
+        throw "FAIL: prune did not report exactly one unsafe obsolete path"
+    }
+    if (Test-Path -LiteralPath $obsoleteClean) {
+        throw "FAIL: prune left unchanged obsolete file on disk"
+    }
+    if (-not (Test-Path -LiteralPath $obsoleteEdited)) {
+        throw "FAIL: prune removed locally edited obsolete file"
+    }
+    if (-not (Test-Path -LiteralPath $currentManaged)) {
+        throw "FAIL: prune removed current managed file"
+    }
+    if (-not (Test-Path -LiteralPath $outsideFile)) {
+        throw "FAIL: prune removed file outside managed root"
+    }
+
+    $manifestAfterPrune = Get-Content -Raw -LiteralPath $manifestPath
+    if ($manifestAfterPrune -match "obsolete-clean.md") {
+        throw "FAIL: prune left deleted obsolete file in manifest"
+    }
+    if (-not ($manifestAfterPrune -match "obsolete-edited.md")) {
+        throw "FAIL: prune removed preserved obsolete file from manifest"
+    }
+    if ($manifestAfterPrune -match "missing-old.md") {
+        throw "FAIL: prune left missing file in manifest"
+    }
+    if (-not ($manifestAfterPrune -match "current.md")) {
+        throw "FAIL: prune removed current managed file from manifest"
+    }
+    Write-Host "Invoke-ManifestPrune: PASS"
+
+    # Test Copy-ManifestTree + Invoke-ManifestPruneTracked
+    $treeRoot = Join-Path $testDir "tree-root"
+    $treeSource = Join-Path $testDir "tree-source"
+    New-Item -ItemType Directory -Path (Join-Path $treeSource "nested") -Force | Out-Null
+    New-Item -ItemType Directory -Path $treeRoot -Force | Out-Null
+    "active" | Set-Content -LiteralPath (Join-Path $treeSource "nested/active.md") -Encoding UTF8
+    "stale" | Set-Content -LiteralPath (Join-Path $treeRoot "stale.md") -Encoding UTF8
+    Write-ManifestEntry -Key "stale.md" -Sha (Get-FileSha256 -Path (Join-Path $treeRoot "stale.md"))
+    Reset-ManifestManagedKeys
+    Copy-ManifestTree -SourceDir $treeSource -DestinationDir $treeRoot -KeyPrefix ""
+    Invoke-ManifestPruneTracked -Root $treeRoot | Out-Null
+    if (-not (Test-Path -LiteralPath (Join-Path $treeRoot "nested/active.md"))) {
+        throw "FAIL: Copy-ManifestTree did not copy active file"
+    }
+    if (Test-Path -LiteralPath (Join-Path $treeRoot "stale.md")) {
+        throw "FAIL: Invoke-ManifestPruneTracked did not prune stale managed file"
+    }
+    Write-Host "Copy-ManifestTree/Invoke-ManifestPruneTracked: PASS"
+
+    # Test retired ownership seeding
+    $retiredRoot = Join-Path $testDir "retired-root"
+    $retiredCommands = Join-Path $retiredRoot "commands"
+    New-Item -ItemType Directory -Path $retiredCommands -Force | Out-Null
+    $retiredFile = Join-Path $retiredCommands "old-command.md"
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText($retiredFile, "retired upstream command`n", $utf8NoBom)
+    $retiredSha = Get-FileSha256 -Path $retiredFile
+    [System.IO.File]::WriteAllText($retiredFile, "retired upstream command`r`n", $utf8NoBom)
+    $previousManifestPath = $env:MANIFEST_PATH
+    $env:MANIFEST_PATH = Join-Path $retiredRoot ".install-manifest.json"
+    Add-RetiredManagedManifestEntries -Root $retiredRoot -Entries @{ 'commands/old-command.md' = $retiredSha }
+    Invoke-ManifestPrune -Root $retiredRoot -ManagedKeys @('commands/_policy.md') | Out-Null
+    $env:MANIFEST_PATH = $previousManifestPath
+    if (Test-Path -LiteralPath $retiredFile) {
+        throw "FAIL: retired ownership seed did not enable pruning"
+    }
+    Write-Host "Add-RetiredManagedManifestEntries: PASS"
+
     # Idempotent reset: english policy must remove .env.CLAUDE_CONTENT_LANGUAGE
     # and prune an empty .env object left over from a prior non-default selection.
     '{"test": 1}' | Set-Content -LiteralPath $settingsPath -Encoding UTF8

--- a/tests/scripts/test-install-manifest-helpers.ps1
+++ b/tests/scripts/test-install-manifest-helpers.ps1
@@ -57,6 +57,7 @@ try {
     # Test Invoke-ManifestPrune
     $pruneRoot = Join-Path $testDir "prune-root"
     New-Item -ItemType Directory -Path $pruneRoot | Out-Null
+    $env:MANIFEST_PATH = Join-Path $pruneRoot ".install-manifest.json"
 
     $obsoleteClean = Join-Path $pruneRoot "obsolete-clean.md"
     $obsoleteEdited = Join-Path $pruneRoot "obsolete-edited.md"
@@ -102,7 +103,7 @@ try {
         throw "FAIL: prune removed file outside managed root"
     }
 
-    $manifestAfterPrune = Get-Content -Raw -LiteralPath $manifestPath
+    $manifestAfterPrune = Get-Content -Raw -LiteralPath $env:MANIFEST_PATH
     if ($manifestAfterPrune -match "obsolete-clean.md") {
         throw "FAIL: prune left deleted obsolete file in manifest"
     }
@@ -120,6 +121,7 @@ try {
     # Test Copy-ManifestTree + Invoke-ManifestPruneTracked
     $treeRoot = Join-Path $testDir "tree-root"
     $treeSource = Join-Path $testDir "tree-source"
+    $env:MANIFEST_PATH = Join-Path $treeRoot ".install-manifest.json"
     New-Item -ItemType Directory -Path (Join-Path $treeSource "nested") -Force | Out-Null
     New-Item -ItemType Directory -Path $treeRoot -Force | Out-Null
     "active" | Set-Content -LiteralPath (Join-Path $treeSource "nested/active.md") -Encoding UTF8

--- a/tests/scripts/test-install-manifest-helpers.sh
+++ b/tests/scripts/test-install-manifest-helpers.sh
@@ -54,6 +54,31 @@ fi
 
 echo "guarded_template_copy: PASS"
 
+# Test manifest_copy_tree + manifest_prune_tracked
+manifest_reset_managed_keys
+mkdir -p "$TEST_DIR/tree-src/nested" "$TEST_DIR/tree-dest/nested"
+echo "active" > "$TEST_DIR/tree-src/nested/active.md"
+echo "stale" > "$TEST_DIR/tree-dest/stale.md"
+_manifest_write "stale.md" "$(_manifest_hash "$TEST_DIR/tree-dest/stale.md")"
+
+manifest_copy_tree "$TEST_DIR/tree-src" "$TEST_DIR/tree-dest" ""
+manifest_prune_tracked "$TEST_DIR/tree-dest" >/dev/null
+
+if [ ! -f "$TEST_DIR/tree-dest/nested/active.md" ]; then
+    echo "FAIL: manifest_copy_tree did not copy active file"
+    exit 1
+fi
+if [ -e "$TEST_DIR/tree-dest/stale.md" ]; then
+    echo "FAIL: manifest_prune_tracked did not prune stale managed file"
+    exit 1
+fi
+if ! grep -q "nested/active.md" "$TEST_DIR/.claude/.install-manifest.json"; then
+    echo "FAIL: manifest_copy_tree did not track active key"
+    exit 1
+fi
+
+echo "manifest_copy_tree/prune: PASS"
+
 # Test idempotent reset: english policy must remove .env.CLAUDE_CONTENT_LANGUAGE
 # left over from a prior non-default selection.
 if command -v jq >/dev/null 2>&1; then

--- a/tests/scripts/test-install-preserves-customization.sh
+++ b/tests/scripts/test-install-preserves-customization.sh
@@ -60,6 +60,26 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label: unexpected '$needle' found in output")
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_missing() {
+    local label="$1" path="$2"
+    if [ ! -e "$path" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$label: expected missing path: $path")
+    fi
+}
+
 # --- Case 1: first install records the hash -------------------------------
 new_case "first-install"
 src="$CASE_DIR/source.md"
@@ -117,6 +137,58 @@ printf 'locally edited\n' > "$dest"
 printf 'v2\n' > "$src"
 BOOTSTRAP_FORCE=1 guarded_copy "$src" "$dest" "source.md"
 assert_equal "force-flag: dest reflects v2" "v2" "$(cat "$dest")"
+
+# --- Case 6: prune deletes removed managed file when unmodified -----------
+new_case "prune-unmodified-removed"
+src="$CASE_DIR/old-source.md"
+dest="$CASE_DIR/old.md"
+printf 'managed v1\n' > "$src"
+guarded_copy "$src" "$dest" "old.md"
+prune_log=$(manifest_prune_removed "$CASE_DIR" "active.md")
+assert_missing "prune-unmodified: removed managed file deleted" "$dest"
+assert_not_contains "prune-unmodified: manifest entry removed" "old.md" "$(cat "$MANIFEST_PATH")"
+assert_contains "prune-unmodified: clear prune log" "Pruned removed managed file: old.md" "$prune_log"
+
+# --- Case 7: prune preserves removed managed file after local edit ---------
+new_case "prune-local-edit"
+src="$CASE_DIR/old-source.md"
+dest="$CASE_DIR/old.md"
+printf 'managed v1\n' > "$src"
+guarded_copy "$src" "$dest" "old.md"
+printf 'locally edited removed file\n' > "$dest"
+prune_log=$(manifest_prune_removed "$CASE_DIR" "active.md")
+assert_equal "prune-local-edit: dest unchanged" "locally edited removed file" "$(cat "$dest")"
+assert_contains "prune-local-edit: manifest entry retained" "old.md" "$(cat "$MANIFEST_PATH")"
+assert_contains "prune-local-edit: clear preserve log" "Preserved locally edited removed managed file: old.md" "$prune_log"
+
+# --- Case 8: retired ownership seed prunes known unmodified files ----------
+new_case "prune-retired-seed"
+mkdir -p "$CASE_DIR/commands"
+retired="$CASE_DIR/commands/old-command.md"
+printf 'retired upstream command\n' > "$retired"
+retired_sha=$(_manifest_hash "$retired")
+printf 'retired upstream command\r\n' > "$retired"
+seed_log=$(manifest_seed_retired_managed "$CASE_DIR" "commands/old-command.md" "$retired_sha")
+prune_log=$(manifest_prune_removed "$CASE_DIR" "commands/_policy.md")
+assert_contains "prune-retired-seed: seed logged" "matched retired managed file: commands/old-command.md" "$seed_log"
+assert_missing "prune-retired-seed: retired file deleted" "$retired"
+assert_contains "prune-retired-seed: prune logged" "Pruned removed managed file: commands/old-command.md" "$prune_log"
+
+# --- Case 9: retired seed preserves edited files without manifest ownership -
+new_case "prune-retired-local-edit"
+mkdir -p "$CASE_DIR/commands"
+retired="$CASE_DIR/commands/old-command.md"
+printf 'retired upstream command\n' > "$retired"
+retired_sha=$(_manifest_hash "$retired")
+printf 'local rewrite of old command\n' > "$retired"
+seed_log=$(manifest_seed_retired_managed "$CASE_DIR" "commands/old-command.md" "$retired_sha")
+assert_equal "prune-retired-local-edit: file preserved" "local rewrite of old command" "$(cat "$retired")"
+assert_contains "prune-retired-local-edit: preserve logged" "preserved locally edited retired file: commands/old-command.md" "$seed_log"
+if [ -f "$MANIFEST_PATH" ]; then
+    assert_not_contains "prune-retired-local-edit: no ownership added" "old-command.md" "$(cat "$MANIFEST_PATH")"
+else
+    PASS=$((PASS + 1))
+fi
 
 # --- Summary --------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Closes #820. Links back to the parent audit in #819.

This PR adds manifest-backed pruning for removed managed install files across the Bash and PowerShell installer entry points:

- `bootstrap.sh`
- `bootstrap.ps1`
- `scripts/install.sh`
- `scripts/install.ps1`

## Changes

- Tracks managed file keys for global and project install roots before pruning.
- Copies managed directories through manifest-aware guarded copy paths so local edits are preserved.
- Prunes removed managed files only when the deployed file still matches the stored managed hash.
- Preserves and reports locally edited removed files instead of deleting them silently.
- Adds project install manifests at `<project>/.claude/.install-manifest.json`.
- Seeds known retired command-file ownership only when local bytes match historical upstream hashes, including CRLF-normalized legacy copies.
- Updates install documentation, README reinstall notes, and the changelog.

## Gap Analysis

I rechecked #819 and the split follow-up issues #821, #822, and #823 before opening this PR. No new child issue is needed for #820: the remaining audit gaps are already covered by those separate issues, while this PR covers the bounded installer prune scope.

## Validation

- `bash tests/scripts/test-install-preserves-customization.sh`
- `bash tests/scripts/test-install-manifest-helpers.sh`
- `bash tests/scripts/test-bootstrap-atomic-deploy.sh`
- `bash tests/scripts/test-install-atomic-deploy.sh`
- `bash tests/scripts/test-install-deploys-bash-lib.sh`
- `bash tests/scripts/test-installer-prompt-drift.sh`
- `bash tests/scripts/test-doc-prompt-lockstep.sh`
- `bash tests/scripts/test-diff-readme.sh`
- `bash tests/scripts/test-check-references.sh`
- `bash tests/scripts/test-global-files-referenced-exist.sh`
- `bash tests/scripts/test-installer-robustness.sh`
- `bash tests/scripts/test-language-policy-drift.sh`
- `bash tests/scripts/test-install-permissions-policy.sh`
- `bash tests/scripts/test-bootstrap-non-tty-smoke.sh`
- `bash -n scripts/install-manifest.sh bootstrap.sh scripts/install.sh`
- `git diff --check`

PowerShell helper tests were updated but not executed locally because this environment does not have `pwsh` or `powershell` installed.
