### PR TITLE
fix(settings): remove dead Write() env deny rules

### DIFF
--- a/VERSION_MAP.yml
+++ b/VERSION_MAP.yml
@@ -23,5 +23,5 @@
 suite: 1.11.0
 plugin: 2.3.0
 plugin-lite: 1.1.0
-settings-schema: 1.17.0
+settings-schema: 1.17.1
 hooks: 1.1.1

--- a/global/settings.json
+++ b/global/settings.json
@@ -127,10 +127,6 @@
       "Read(**/*.key)",
       "Read(**/*.p12)",
       "Read(**/*password*)",
-      "Write(.env)",
-      "Write(.env.*)",
-      "Write(**/.env)",
-      "Write(**/.env.*)",
       "Edit(.env)",
       "Edit(.env.*)",
       "Edit(**/.env)",
@@ -542,7 +538,7 @@
   "skillListingBudgetFraction": 0.02,
   "disableSkillShellExecution": true,
   "description": "Claude Code Global Settings - Applied to all projects (permissions.deny for security)",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "showTurnDuration": true,
   "teammateMode": "in-process"
 }

--- a/global/settings.windows.json
+++ b/global/settings.windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Claude Code Global Settings (Windows) - Applied to all projects (permissions.deny for security). NOTE: the sandbox block below (sandbox.network.allowedDomains, sandbox.excludedCommands) is inert on Windows - the sandbox does not run on this platform (see core/environment.md), so permissions.allow/deny matching is the only active command gate; the env-secret leak channel is covered by hooks/shell-env-secret-guard.ps1.",
-  "version": "1.17.0",
+  "version": "1.17.1",
 
   "respectGitignore": true,
   "cleanupPeriodDays": 30,
@@ -585,10 +585,6 @@
       "Read(**/*.key)",
       "Read(**/*.p12)",
       "Read(**/*password*)",
-      "Write(.env)",
-      "Write(.env.*)",
-      "Write(**/.env)",
-      "Write(**/.env.*)",
       "Edit(.env)",
       "Edit(.env.*)",
       "Edit(**/.env)",

--- a/tests/scripts/test-windows-powershell-permissions.sh
+++ b/tests/scripts/test-windows-powershell-permissions.sh
@@ -106,7 +106,6 @@ required_deny = {
     "Read(**/credentials/**)",
     "Read(**/*.pem)",
     "Read(**/*.key)",
-    "Write(.env)",
     "Edit(.env)",
 }
 
@@ -122,6 +121,14 @@ if present_forbidden:
 missing_deny = sorted(required_deny - deny)
 if missing_deny:
     errors.append("sensitive-file deny entries missing: " + ", ".join(missing_deny))
+
+# Write(path) deny rules are never matched by file permission checks; the
+# harness warns about them at startup. Edit(path) rules cover all
+# file-editing tools (Edit, Write, NotebookEdit), so Write() entries are
+# dead weight and must not reappear.
+dead_write_deny = sorted(entry for entry in deny if entry.startswith("Write("))
+if dead_write_deny:
+    errors.append("ineffective Write() deny entries present: " + ", ".join(dead_write_deny))
 
 if perms.get("defaultMode") != "default":
     errors.append("permissions.defaultMode must remain default")


### PR DESCRIPTION
## What

### Summary

Removes the four `Write()` env deny entries (`Write(.env)`, `Write(.env.*)`, `Write(**/.env)`, `Write(**/.env.*)`) from both global settings profiles. They are never matched by file permission checks, and the harness warns about each of them at every session start. The equivalent `Edit()` entries -- which cover all file-editing tools (Edit, Write, NotebookEdit) -- already exist and are kept unchanged.

### Change Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactor

## Why

### Related Issues

- Closes #835

### Motivation

Dead deny rules produce four warnings at every session start and give a false sense of coverage. Per the harness guidance, `Edit(path)` is the rule form that file permission checks match.

## Where

| File | Change |
|------|--------|
| `global/settings.json` | Remove 4 `Write()` deny entries |
| `global/settings.windows.json` | Remove 4 `Write()` deny entries |
| `tests/scripts/test-windows-powershell-permissions.sh` | Drop `Write(.env)` from `required_deny`; add a check that fails on any `Write()` deny entry |
| `VERSION_MAP.yml` | `settings-schema` 1.17.0 -> 1.17.1 (propagated via `scripts/sync_versions.sh`) |

## How

### Implementation Highlights

- Security posture is unchanged: `Read()` and `Edit()` env deny entries are untouched, and `Edit()` rules already gate Write/NotebookEdit.
- The regression test now rejects any `Write()` deny entry so the dead-rule pattern cannot be reintroduced; the settings parity test transitively protects the Unix profile.

### Testing Done

- [x] `bash tests/scripts/test-windows-powershell-permissions.sh` -- PASS
- [x] `bash tests/scripts/test-windows-settings-parity.sh` -- PASS
- [x] `scripts/check_versions.ps1` -- OK (settings-schema=1.17.1)

### Breaking Changes

None.
