### PR TITLE
feat(issue-work): add isolated workspace clone with identity check and secure manifest

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -168,6 +168,9 @@ jobs:
         # only; PowerShell parity is tracked in #832.
         run: bash tests/issue-work/test-triage.sh
 
+      - name: Run issue-work workspace lifecycle tests (#838)
+        run: bash tests/issue-work/test-workspace.sh
+
       - name: Install pytest for fleet_orchestrator tests
         # pytest is already a transitive dep of jsonschema in some envs; pin
         # explicitly so the runner does not silently fall back to unittest.

--- a/global/skills/_internal/issue-work/reference/workspace-lifecycle.md
+++ b/global/skills/_internal/issue-work/reference/workspace-lifecycle.md
@@ -1,0 +1,198 @@
+# Workspace Lifecycle
+
+Isolated-workspace stage for `issue-work`. Picks up exactly where the triage
+state machine (`reference/triage-state-machine.md`) hands off — a `proceed`
+outcome with a claimed `active` issue — and turns that claim into a private,
+identity-verified clone before any code is written.
+
+The reference implementation is `scripts/workspace.sh` (sibling directory),
+ported 1:1 to `scripts/workspace.ps1`. This document is the contract: the
+full lifecycle, the run-root layout, the marker format, the manifest schema,
+the identity-verification rule, and the credential-redaction rule. Code and
+doc must stay in sync — when one changes, change the other in the same PR.
+
+## Handoff from triage
+
+Triage (`run_triage`) ends at `PROCEED`: it selects and claims an issue but
+performs no repository side effects. `run_workspace` is the next stage. It
+takes the `active` issue number from triage's outcome JSON and turns it into
+an isolated, verified clone — nothing more.
+
+```
+triage: run_triage --repo <owner/name> [--issue <n>]
+          -> {"outcome":"proceed", "active":"<n>", ...}
+                    |
+                    v
+workspace: run_workspace <owner/name> <base> <active>
+          -> {"state":"READY", "run_root":..., "repo_dir":..., "baseline":..., ...}
+```
+
+## Full lifecycle
+
+```
+CLAIMED -> CLONING -> READY -> AGENTS_RUNNING -> COMMITTED -> PUSHED
+        -> PR_OPEN -> CI_PENDING -> MERGED -> CLEANUP_PENDING -> CLEANED
+```
+
+| State | Meaning | Delivered by |
+|-------|---------|---------------|
+| `CLAIMED` | Run root and marker exist; the manifest records the claim. | **#838 (this issue)** |
+| `CLONING` | The `develop` branch is being cloned into the run root. | **#838 (this issue)** |
+| `READY` | Clone complete, origin identity verified against the expected `owner/name`. | **#838 (this issue)** |
+| `AGENTS_RUNNING` | One or more implementation subagents are active in the workspace. | #839 |
+| `COMMITTED` | Work is committed to a local branch. | #839 |
+| `PUSHED` | The branch has been pushed to the remote. | #839 / #840 |
+| `PR_OPEN` | A pull request exists for the branch. | #839 / #840 |
+| `CI_PENDING` | CI is running against the PR. | #840 |
+| `MERGED` | The PR merged. | #840 |
+| `CLEANUP_PENDING` | The run root is scheduled for removal. | #840 |
+| `CLEANED` | The run root has been removed. | #840 |
+
+**This issue (#838) implements only `CLAIMED -> CLONING -> READY` and the
+manifest primitive** (`workspace_manifest_write` / `_read` / `_state`) that
+every later state transition reuses to record its own progress. It does not
+spawn subagents, create branches, or open PRs — see "Scope boundary" below.
+
+A `REJECTED` outcome is not part of the state list above: it is a terminal
+side-exit specific to this stage, reached only when the post-clone origin
+identity check fails or the clone itself fails. It never advances to
+`READY`, and no later stage should ever observe it as a valid predecessor
+state — a `REJECTED` run root is abandoned, not resumed.
+
+## Run-root layout
+
+```
+<base>/iw-<issue>-<suffix>/        # run root
+├── .iw-run-marker                 # marker file, see below
+├── manifest                       # key=value state file, see below
+└── repo/                          # the clone (created during CLONING)
+```
+
+- `<base>` is caller-supplied (a temp directory). The scripts never invent
+  their own base.
+- `<suffix>` makes the run root unique per invocation. It comes from the
+  `WORKSPACE_RUN_SUFFIX` injection seam when the caller/test sets it
+  (deterministic); otherwise it is a timestamp+pid combination so concurrent
+  real runs do not collide.
+- The `iw-<issue>-<suffix>` naming keeps the path short, which matters on
+  systems with path-length limits and keeps run roots visually distinct
+  from unrelated temp directories.
+- `repo/` does not exist until the clone step creates it — `git clone`
+  requires its destination to be absent or empty.
+
+## Marker format
+
+`.iw-run-marker` is written into the run root as soon as it is created,
+before any manifest state is written. It is a small `key=value` block (the
+same line format as the manifest, kept intentionally minimal):
+
+```
+issue=838
+created=2026-07-18T12:16:48Z
+```
+
+Its purpose is narrow: a resumed session (or the cleanup stage, #840) can
+confirm a candidate run root actually belongs to a specific issue — and was
+created by this stage, not some unrelated temp directory — before reusing or
+deleting it. The marker is not a substitute for the manifest; it never
+carries lifecycle state.
+
+## Manifest schema
+
+The manifest is a portable, line-based `key=value` file — no `jq` (or any
+JSON library) dependency, so both `workspace.sh` and `workspace.ps1` can read
+and write it with only string operations. One key per line, `key=value`,
+no quoting.
+
+Keys written by this stage (#838):
+
+| Key | Meaning |
+|-----|---------|
+| `issue` | The issue number this workspace was claimed for. |
+| `repo` | The expected `owner/name` identity. |
+| `run_root` | Absolute path to the run root (redundant with the manifest's own location, kept for convenience). |
+| `marker` | Absolute path to `.iw-run-marker`. |
+| `state` | Current lifecycle state — the single field every stage after this one reads first. |
+| `repo_dir` | Absolute path to the clone (`<run_root>/repo`). Written once the clone succeeds. |
+| `baseline` | The `HEAD` commit sha of the cloned `develop` branch at claim time. Written once verified. |
+
+Later stages (#839, #840) append their own keys to the same manifest using
+the same primitives; this document does not attempt to enumerate keys it
+does not own.
+
+### Atomicity rule
+
+Every manifest write goes through `workspace_manifest_write <path> <key>
+<value>`, which:
+
+1. Redacts `<value>` through `workspace_redact_credentials` unconditionally
+   (a no-op on non-URL-shaped values, so this is always safe to do).
+2. Rewrites the manifest to a sibling temp file (`<path>.tmp.$$`), replacing
+   any prior line for `<key>` and preserving every other key.
+3. `mv`s the temp file over the real manifest path.
+
+A reader (`workspace_manifest_read` / `workspace_manifest_state`) therefore
+never observes a partially-written manifest: the file it opens is either the
+version before the update or the version after, never a half-written mix.
+
+## Identity-verification rule
+
+Before a run root is allowed to reach `READY`, `workspace_verify_identity
+<repo_dir> <expected owner/name>` must succeed:
+
+1. Read `git -C <repo_dir> remote get-url origin`.
+2. Redact it through `workspace_redact_credentials`.
+3. Reduce it to its trailing `owner/name` path component — this step is
+   host-agnostic by design (it strips a `<scheme>://<host>/` prefix or an
+   SSH-shorthand `<user>@<host>:` prefix, then takes the final two
+   `/`-separated segments), so it accepts both `https://github.com/owner/name`
+   and `git@github.com:owner/name` (with or without a trailing `.git`) as
+   specified, while also working unmodified against GitHub Enterprise hosts.
+4. Compare the reduced value against the expected `owner/name` **exactly**.
+
+A missing origin, an empty expected value, or any mismatch fails the check.
+On failure the manifest is set to `REJECTED` (never `READY`) and the CLI
+prints a `{"state":"REJECTED","reason":...}` JSON line and exits non-zero.
+This is the single gate that keeps a workspace from ever being handed to a
+subagent (#839) with the wrong repository checked out.
+
+## Credential-redaction rule
+
+No credential may ever reach stdout, stderr, or the manifest:
+
+- `workspace_redact_credentials` strips any `<userinfo>@` segment
+  immediately following a `<scheme>://` prefix — this covers
+  `https://user:token@host/...` and the `x-access-token:<token>@` form used
+  by gh/CI credential helpers — and matches anywhere in its input, not just
+  at the start, so a credential embedded mid-sentence in a git error message
+  is also caught.
+- `workspace_manifest_write` runs every value through this redaction
+  unconditionally before it ever touches disk.
+- `_workspace_clone` never streams git's own stdout/stderr to the caller.
+  On failure it captures git's combined output, redacts it, and only a
+  redacted, single-line summary is ever placed in a `reason` field.
+- The identity-verification path redacts the origin URL before reducing it
+  to `owner/name`, so a credential embedded in the stored remote URL never
+  survives into a comparison, a log line, or an error message.
+- The clone step never adds `--recurse-submodules` (submodule URLs are a
+  second, uncontrolled source of embedded credentials this stage does not
+  attempt to sanitize) and supports `--depth` only through an explicit
+  `WORKSPACE_CLONE_DEPTH` seam, never on by default.
+
+## Scope boundary
+
+This stage stops at `READY`. It:
+
+- Creates the run root, the marker, and the manifest.
+- Clones `develop` and verifies the clone's origin identity.
+- Writes exactly one final JSON line (`READY` or `REJECTED`) to stdout.
+
+It does **not**:
+
+- Spawn any subagent (#839).
+- Create a branch, commit, push, or open a PR (#839 / #840).
+- Poll CI, merge, or clean up the run root (#840).
+
+A `REJECTED` run root is left on disk for inspection rather than deleted by
+this stage — cleanup ownership belongs entirely to #840, consistent with
+triage leaving no side effects on its own non-`proceed` terminal outcomes.

--- a/global/skills/_internal/issue-work/scripts/workspace.ps1
+++ b/global/skills/_internal/issue-work/scripts/workspace.ps1
@@ -1,0 +1,317 @@
+#Requires -Version 7.0
+# workspace.ps1
+# issue-work: workspace lifecycle (CLAIMED -> CLONING -> READY)
+# ================================================================
+# PowerShell parity port of scripts/workspace.sh. Same functions, same
+# behavior, same manifest format, same credential-redaction rule, same
+# REJECTED path, same final JSON schema. See
+# reference/workspace-lifecycle.md for the contract both scripts satisfy.
+#
+# NOTE (authoring-time caveat): pwsh was not available in the environment
+# this port was written in, so it was produced by mirroring the
+# bash-verified logic in workspace.sh line-for-line rather than by running
+# it. It has NOT been executed. Cross-platform regression coverage is
+# tracked in issue #832, consistent with the existing PowerShell-parity note
+# in tests/issue-work/README.md for the triage stage.
+#
+# The script is both a sourceable library (dot-source it to get the
+# functions below) and a CLI:
+#   pwsh -File workspace.ps1 --repo <owner/name> --base <tmpbase> --issue <n>
+#        [--clone-url <url>] [--manifest <path>]
+# CLI flags intentionally mirror workspace.sh's flags exactly (rather than
+# native PowerShell parameter binding) so the two entry points are
+# interchangeable from a caller's point of view.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Injection seams (overridable by tests and callers via environment
+# variables, mirroring the bash GIT_BIN / WORKSPACE_* seams).
+$script:GitBin = if ($env:GIT_BIN) { $env:GIT_BIN } else { 'git' }
+
+# Marker filename dropped into the run root once claimed.
+$script:WorkspaceMarkerFile = '.iw-run-marker'
+
+# Set by _workspace_clone on failure; consumed by run_workspace to build a
+# redacted REJECTED reason without ever touching git's raw output again.
+$script:WorkspaceLastError = ''
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it via
+# $env:GIT_BIN, mirroring _workspace_git in workspace.sh.
+function _workspace_git {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+    & $script:GitBin @GitArgs
+}
+
+# ── Pure helpers (unit-testable without git) ──────────────────────────
+
+# Strip credentials from a URL/string so `https://user:token@host/...`
+# becomes `https://host/...`. Handles any `<userinfo>@` segment immediately
+# following a `<scheme>://`, which covers the `x-access-token:<token>@` form
+# used by gh/CI credential helpers. Matches anywhere in the input (not just
+# at the start), so a credential embedded mid-sentence in a git error
+# message is also redacted. A no-op on input with no scheme://userinfo@
+# pattern.
+function workspace_redact_credentials {
+    param([AllowEmptyString()][string]$InputString = '')
+    return [regex]::Replace($InputString, '([A-Za-z][A-Za-z0-9+.\-]*://)[^/@\s]*@', '$1')
+}
+
+function _workspace_default_suffix {
+    $ts = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    return "$ts$PID"
+}
+
+# Compute a unique run-root path under the given temp base, using a short
+# issue-scoped name: "<base>/iw-<issue>-<suffix>". The suffix comes from the
+# WORKSPACE_RUN_SUFFIX injection seam when set (tests use this for
+# determinism); otherwise it falls back to a timestamp+pid combination so
+# concurrent real runs do not collide.
+function workspace_run_root {
+    param([Parameter(Mandatory)][string]$Base, [Parameter(Mandatory)][string]$Issue)
+    $suffix = if ($env:WORKSPACE_RUN_SUFFIX) { $env:WORKSPACE_RUN_SUFFIX } else { _workspace_default_suffix }
+    $trimmedBase = $Base.TrimEnd('/', '\')
+    return "$trimmedBase/iw-$Issue-$suffix"
+}
+
+# Reduce a (already-redacted) git remote URL to its trailing "owner/name"
+# path component. Host-agnostic by design: strips a "<scheme>://<host>/"
+# prefix or an SSH-shorthand "<user>@<host>:" prefix (or neither, for a bare
+# local path used by tests), then takes the final two "/"-separated
+# segments. Accepts both "https://github.com/owner/name(.git)" and
+# "git@github.com:owner/name(.git)" as specified, while remaining usable
+# against GitHub Enterprise hosts and local test doubles.
+function _workspace_owner_name_from_origin {
+    param([AllowEmptyString()][string]$Url = '')
+    if ([string]::IsNullOrEmpty($Url)) { return $null }
+    $cleaned = $Url
+    if ($cleaned.EndsWith('.git')) { $cleaned = $cleaned.Substring(0, $cleaned.Length - 4) }
+
+    $path = $null
+    $schemeIdx = $cleaned.IndexOf('://')
+    if ($schemeIdx -ge 0) {
+        $noScheme = $cleaned.Substring($schemeIdx + 3)
+        $slashIdx = $noScheme.IndexOf('/')
+        $path = if ($slashIdx -ge 0) { $noScheme.Substring($slashIdx + 1) } else { $noScheme }
+    } else {
+        $colonIdx = $cleaned.IndexOf(':')
+        $path = if ($colonIdx -ge 0) { $cleaned.Substring($colonIdx + 1) } else { $cleaned }
+    }
+    $path = $path.TrimEnd('/')
+    $segments = $path -split '/'
+    if ($segments.Count -lt 2) { return $null }
+    $name = $segments[$segments.Count - 1]
+    $owner = $segments[$segments.Count - 2]
+    if ([string]::IsNullOrEmpty($owner) -or [string]::IsNullOrEmpty($name)) { return $null }
+    return "$owner/$name"
+}
+
+# Read the origin remote of RepoDir, redact it, and succeed only when it
+# resolves to the expected "owner/name". Rejects on mismatch, a missing
+# origin, or an empty expected value. Native-command failure is detected via
+# $LASTEXITCODE rather than a thrown exception, since whether a non-zero git
+# exit becomes a terminating error depends on the pwsh minor version.
+function workspace_verify_identity {
+    param([string]$RepoDir, [string]$Expected)
+    if ([string]::IsNullOrEmpty($RepoDir) -or [string]::IsNullOrEmpty($Expected)) { return $false }
+    $origin = & $script:GitBin -C $RepoDir remote get-url origin 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($origin)) { return $false }
+    $origin = workspace_redact_credentials $origin
+    $actual = _workspace_owner_name_from_origin $origin
+    if ([string]::IsNullOrEmpty($actual)) { return $false }
+    return [string]::Equals($actual, $Expected, [System.StringComparison]::Ordinal)
+}
+
+# Atomically update a single `key=value` line in a portable line-based
+# manifest (no JSON dependency; readable by bash and PowerShell alike).
+# Writes to "<path>.tmp.$PID" then moves it into place so a reader never
+# observes a partially-written file. The value is always passed through
+# workspace_redact_credentials before being written, so a URL-shaped value
+# can never land in the manifest with embedded credentials.
+function workspace_manifest_write {
+    param([string]$Path, [string]$Key, [AllowEmptyString()][string]$Value = '')
+    if ([string]::IsNullOrEmpty($Path) -or [string]::IsNullOrEmpty($Key)) { return $false }
+    $Value = workspace_redact_credentials $Value
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $tmp = "$Path.tmp.$PID"
+    $escapedKey = [regex]::Escape($Key)
+    $lines = @()
+    if (Test-Path -LiteralPath $Path) {
+        $existing = @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+        $lines = @($existing | Where-Object { $_ -notmatch "^$escapedKey=" })
+    }
+    $lines += "$Key=$Value"
+    Set-Content -LiteralPath $tmp -Value $lines
+    Move-Item -LiteralPath $tmp -Destination $Path -Force
+    return $true
+}
+
+# Print the value for Key in the manifest ("" if the manifest or key is
+# absent). When a key was written more than once, the last write wins.
+function workspace_manifest_read {
+    param([string]$Path, [string]$Key)
+    if (-not (Test-Path -LiteralPath $Path)) { return '' }
+    $escapedKey = [regex]::Escape($Key)
+    $match = Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue |
+        Where-Object { $_ -match "^$escapedKey=" } |
+        Select-Object -Last 1
+    if (-not $match) { return '' }
+    return $match.Substring($Key.Length + 1)
+}
+
+# Convenience accessor for the current `state=` value.
+function workspace_manifest_state {
+    param([string]$Path)
+    return workspace_manifest_read -Path $Path -Key 'state'
+}
+
+# ── Marker ──────────────────────────────────────────────────────────
+# Writes the run marker into RunRoot and returns its path. Content is a tiny
+# key=value block (reuses the manifest line format) whose issue= line is the
+# field a resumed session checks before trusting the run root.
+function _workspace_write_marker {
+    param([string]$RunRoot, [string]$Issue)
+    $trimmedRoot = $RunRoot.TrimEnd('/', '\')
+    $path = "$trimmedRoot/$script:WorkspaceMarkerFile"
+    $created = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    Set-Content -LiteralPath $path -Value @("issue=$Issue", "created=$created")
+    return $path
+}
+
+# ── Clone ───────────────────────────────────────────────────────────
+# Clones Url's Branch into Dest. Shallowable via the WORKSPACE_CLONE_DEPTH
+# seam (adds --depth when set); never recurses submodules. All git output is
+# captured (never streamed to the caller's stdout/stderr) and, on failure,
+# redacted into $script:WorkspaceLastError so a caller can report a reason
+# without ever risking a credential leak through git's own error text.
+function _workspace_clone {
+    param([string]$Url, [string]$Branch, [string]$Dest)
+    $depthArgs = @()
+    if ($env:WORKSPACE_CLONE_DEPTH) { $depthArgs = @('--depth', $env:WORKSPACE_CLONE_DEPTH) }
+    $out = & $script:GitBin clone --branch $Branch --single-branch --no-recurse-submodules @depthArgs $Url $Dest 2>&1
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0) {
+        $joined = ($out | Out-String)
+        $redacted = workspace_redact_credentials $joined
+        $lastLine = ($redacted -split "`r?`n" | Where-Object { $_.Trim() -ne '' } | Select-Object -Last 1)
+        $script:WorkspaceLastError = if ($lastLine) { $lastLine } else { 'unknown error' }
+    }
+    return ($rc -eq 0)
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+function _workspace_emit_ready {
+    param([string]$RunRoot, [string]$RepoDir, [string]$Baseline, [string]$Manifest, [string]$Marker)
+    Write-Output ('{{"state":"READY","run_root":"{0}","repo_dir":"{1}","baseline":"{2}","manifest":"{3}","marker":"{4}"}}' `
+        -f $RunRoot, $RepoDir, $Baseline, $Manifest, $Marker)
+}
+
+function _workspace_emit_rejected {
+    param([string]$RunRoot, [string]$RepoDir, [string]$Manifest, [string]$Marker, [string]$Reason)
+    $Reason = workspace_redact_credentials $Reason
+    Write-Output ('{{"state":"REJECTED","reason":"{0}","run_root":"{1}","repo_dir":"{2}","manifest":"{3}","marker":"{4}"}}' `
+        -f $Reason, $RunRoot, $RepoDir, $Manifest, $Marker)
+}
+
+# ── Driver ──────────────────────────────────────────────────────────
+# run_workspace -Repo <owner/name> -Base <tmpbase> -Issue <n>
+#                [-CloneUrl <url>] [-ManifestOverride <path>]
+#
+# Repo   expected "owner/name" identity, also used to derive the default
+#        clone URL when CloneUrl is omitted.
+# Base   temp base directory the run root is created under.
+# Issue  issue number; scopes the run-root name and is recorded in the marker.
+function run_workspace {
+    param(
+        [string]$Repo,
+        [string]$Base,
+        [string]$Issue,
+        [string]$CloneUrl = '',
+        [string]$ManifestOverride = ''
+    )
+
+    if ([string]::IsNullOrEmpty($Repo) -or [string]::IsNullOrEmpty($Base) -or [string]::IsNullOrEmpty($Issue)) {
+        _workspace_emit_rejected '' '' '' '' 'missing required repo/base/issue'
+        return 2
+    }
+
+    $runRoot = workspace_run_root -Base $Base -Issue $Issue
+    try {
+        New-Item -ItemType Directory -Path $runRoot -Force -ErrorAction Stop | Out-Null
+    } catch {
+        _workspace_emit_rejected $runRoot '' '' '' 'failed to create run root'
+        return 1
+    }
+
+    $marker = _workspace_write_marker -RunRoot $runRoot -Issue $Issue
+    $manifest = if ($ManifestOverride) { $ManifestOverride } else { "$runRoot/manifest" }
+
+    workspace_manifest_write -Path $manifest -Key 'issue' -Value $Issue | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'repo' -Value $Repo | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'run_root' -Value $runRoot | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'marker' -Value $marker | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'state' -Value 'CLAIMED' | Out-Null
+
+    # Enter CLONING before the clone actually starts, so a crash mid-clone
+    # leaves the manifest correctly reflecting the in-progress phase rather
+    # than the stale CLAIMED state.
+    workspace_manifest_write -Path $manifest -Key 'state' -Value 'CLONING' | Out-Null
+    $repoDir = "$runRoot/repo"
+    $url = if ($CloneUrl) { $CloneUrl } else { "https://github.com/$Repo.git" }
+    if (-not (_workspace_clone -Url $url -Branch 'develop' -Dest $repoDir)) {
+        workspace_manifest_write -Path $manifest -Key 'state' -Value 'REJECTED' | Out-Null
+        $errText = if ($script:WorkspaceLastError) { $script:WorkspaceLastError } else { 'unknown error' }
+        _workspace_emit_rejected $runRoot $repoDir $manifest $marker "clone failed: $errText"
+        return 1
+    }
+
+    $baseline = (& $script:GitBin -C $repoDir rev-parse HEAD 2>$null)
+
+    if (-not (workspace_verify_identity -RepoDir $repoDir -Expected $Repo)) {
+        workspace_manifest_write -Path $manifest -Key 'state' -Value 'REJECTED' | Out-Null
+        _workspace_emit_rejected $runRoot $repoDir $manifest $marker "origin identity does not match expected repo $Repo"
+        return 1
+    }
+
+    workspace_manifest_write -Path $manifest -Key 'repo_dir' -Value $repoDir | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'baseline' -Value $baseline | Out-Null
+    workspace_manifest_write -Path $manifest -Key 'state' -Value 'READY' | Out-Null
+
+    _workspace_emit_ready $runRoot $repoDir $baseline $manifest $marker
+    return 0
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+function Invoke-WorkspaceMain {
+    param([string[]]$Arguments = @())
+    $repo = ''; $base = ''; $issue = ''; $cloneUrl = ''; $manifest = ''
+    $i = 0
+    while ($i -lt $Arguments.Count) {
+        switch ($Arguments[$i]) {
+            '--repo' { $repo = $Arguments[$i + 1]; $i += 2 }
+            '--base' { $base = $Arguments[$i + 1]; $i += 2 }
+            '--issue' { $issue = $Arguments[$i + 1]; $i += 2 }
+            '--clone-url' { $cloneUrl = $Arguments[$i + 1]; $i += 2 }
+            '--manifest' { $manifest = $Arguments[$i + 1]; $i += 2 }
+            default {
+                Write-Error "unknown argument: $($Arguments[$i])"
+                return 2
+            }
+        }
+    }
+    if (-not $repo -or -not $base -or -not $issue) {
+        Write-Error 'error: --repo <owner/name>, --base <tmpbase>, and --issue <n> are required'
+        return 2
+    }
+    return run_workspace -Repo $repo -Base $base -Issue $issue -CloneUrl $cloneUrl -ManifestOverride $manifest
+}
+
+# Run as CLI only when executed directly; stay quiet when dot-sourced by
+# tests (mirrors workspace.sh's BASH_SOURCE guard).
+if ($MyInvocation.InvocationName -ne '.') {
+    exit (Invoke-WorkspaceMain -Arguments $args)
+}

--- a/global/skills/_internal/issue-work/scripts/workspace.sh
+++ b/global/skills/_internal/issue-work/scripts/workspace.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# issue-work: workspace lifecycle (CLAIMED -> CLONING -> READY)
+# ================================================================
+# Isolated-workspace stage for the issue-work skill. Runs AFTER triage.sh
+# returns "proceed" and BEFORE any subagent is spawned or branch/PR is
+# created. See reference/workspace-lifecycle.md for the contract (full
+# lifecycle state list, run-root layout, marker format, manifest schema,
+# identity-verification rule, credential-redaction rule).
+#
+# This stage implements only CLAIMED -> CLONING -> READY plus the manifest
+# primitive. Agent spawn (AGENTS_RUNNING/COMMITTED) is issue #839; cleanup and
+# resume (CLEANUP_PENDING/CLEANED) are issue #840.
+#
+# The script is both a sourceable library (unit-testable functions) and a CLI
+# (`run_workspace`). Every git call goes through _workspace_git so tests can
+# inject a fake git via GIT_BIN, though the reference test suite prefers a
+# real temporary bare repository over a fake.
+#
+# Usage:
+#   bash workspace.sh --repo <owner/name> --base <tmpbase> --issue <n>
+#                      [--clone-url <url>] [--manifest <path>]
+
+set -uo pipefail
+
+# Injection seams (overridable by tests and callers).
+GIT_BIN="${GIT_BIN:-git}"
+
+# Marker filename dropped into the run root once claimed. Its presence (and
+# the issue= line inside it) lets a resumed session confirm a given run root
+# belongs to a specific issue before reusing or cleaning it up.
+_WORKSPACE_MARKER_FILE=".iw-run-marker"
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it.
+_workspace_git() {
+    "$GIT_BIN" "$@"
+}
+
+# ── Pure helpers (unit-testable without git) ──────────────────────────
+
+# Strip credentials from a URL/string so `https://user:token@host/...`
+# becomes `https://host/...`. Handles any `<userinfo>@` segment immediately
+# following a `<scheme>://`, which covers the `x-access-token:<token>@` form
+# used by gh/CI credential helpers. Matches anywhere in the input (not just
+# at the start), so a credential embedded mid-sentence in a git error message
+# ("fatal: unable to access 'https://user:token@host/...'") is also redacted.
+# Never fails on plain (non-URL) input -- it is a no-op when no scheme://
+# userinfo@ pattern is present.
+workspace_redact_credentials() {
+    local input="${1:-}"
+    printf '%s' "$input" \
+        | sed -E 's#([A-Za-z][A-Za-z0-9+.-]*://)[^/@[:space:]]*@#\1#g'
+}
+
+# Compute a unique run-root path under the given temp base, using a short
+# issue-scoped name: "<base>/iw-<issue>-<suffix>". The suffix comes from the
+# WORKSPACE_RUN_SUFFIX injection seam when set (tests use this for
+# determinism); otherwise it falls back to a timestamp+pid combination so
+# concurrent real runs do not collide.
+workspace_run_root() {
+    local base="$1" issue="$2" suffix
+    suffix="${WORKSPACE_RUN_SUFFIX:-$(_workspace_default_suffix)}"
+    printf '%s/iw-%s-%s\n' "${base%/}" "$issue" "$suffix"
+}
+
+_workspace_default_suffix() {
+    local ts
+    ts="$(date +%s 2>/dev/null || echo 0)"
+    printf '%s%s' "$ts" "$$"
+}
+
+# Reduce a (already-redacted) git remote URL to its trailing "owner/name"
+# path component. Host-agnostic by design: strips a "<scheme>://<host>/"
+# prefix or an SSH-shorthand "<user>@<host>:" prefix (or neither, for a bare
+# local path used by tests), then takes the final two "/"-separated
+# segments. This accepts both "https://github.com/owner/name(.git)" and
+# "git@github.com:owner/name(.git)" as specified, while remaining usable
+# against GitHub Enterprise hosts and local test doubles.
+_workspace_owner_name_from_origin() {
+    local url="${1:-}" cleaned no_scheme path owner name
+    [ -n "$url" ] || return 1
+    cleaned="${url%.git}"
+    if [ "$cleaned" != "${cleaned#*://}" ]; then
+        no_scheme="${cleaned#*://}"
+        path="${no_scheme#*/}"
+    elif [ "$cleaned" != "${cleaned#*:}" ]; then
+        path="${cleaned#*:}"
+    else
+        path="$cleaned"
+    fi
+    path="${path%/}"
+    name="${path##*/}"
+    owner="${path%/*}"
+    owner="${owner##*/}"
+    [ -n "$owner" ] && [ -n "$name" ] || return 1
+    printf '%s/%s' "$owner" "$name"
+}
+
+# Read the origin remote of <repo_dir>, redact it, and succeed only when it
+# resolves to the expected "owner/name". Rejects on mismatch, a missing
+# origin, or an empty expected value.
+workspace_verify_identity() {
+    local repo_dir="$1" expected="${2:-}" origin actual
+    [ -n "$repo_dir" ] && [ -n "$expected" ] || return 1
+    origin="$(_workspace_git -C "$repo_dir" remote get-url origin 2>/dev/null)" || return 1
+    [ -n "$origin" ] || return 1
+    origin="$(workspace_redact_credentials "$origin")"
+    actual="$(_workspace_owner_name_from_origin "$origin")" || return 1
+    [ -n "$actual" ] || return 1
+    [ "$actual" = "$expected" ]
+}
+
+# Atomically update a single `key=value` line in a portable line-based
+# manifest (no jq dependency; readable by bash and PowerShell alike). Writes
+# to "<path>.tmp.$$" then `mv`s into place so a reader never observes a
+# partially-written file. The value is always passed through
+# workspace_redact_credentials before being written, so a URL-shaped value
+# can never land in the manifest with embedded credentials.
+workspace_manifest_write() {
+    local path="${1:-}" key="${2:-}" value="${3:-}" dir tmp
+    [ -n "$path" ] && [ -n "$key" ] || return 1
+    value="$(workspace_redact_credentials "$value")"
+    dir="$(dirname -- "$path")"
+    [ -d "$dir" ] || mkdir -p -- "$dir" 2>/dev/null || return 1
+    tmp="${path}.tmp.$$"
+    if [ -f "$path" ]; then
+        grep -v -E "^${key}=" "$path" 2>/dev/null > "$tmp" || true
+    else
+        : > "$tmp"
+    fi
+    printf '%s=%s\n' "$key" "$value" >> "$tmp"
+    mv -f -- "$tmp" "$path"
+}
+
+# Print the value for <key> in the manifest ("" if the manifest or key is
+# absent). When a key was written more than once, the last write wins.
+workspace_manifest_read() {
+    local path="${1:-}" key="${2:-}"
+    [ -f "$path" ] || { printf ''; return 0; }
+    grep -E "^${key}=" "$path" 2>/dev/null | tail -n1 | sed -E "s/^${key}=//"
+}
+
+# Convenience accessor for the current `state=` value.
+workspace_manifest_state() {
+    workspace_manifest_read "$1" state
+}
+
+# ── Marker ──────────────────────────────────────────────────────────
+# Writes the run marker into <run_root> and prints its path. Content is a
+# tiny key=value block (reuses the manifest line format) whose issue= line
+# is the field a resumed session checks before trusting the run root.
+_workspace_write_marker() {
+    local run_root="$1" issue="$2" path created
+    path="${run_root%/}/${_WORKSPACE_MARKER_FILE}"
+    created="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+    printf 'issue=%s\ncreated=%s\n' "$issue" "$created" > "$path"
+    printf '%s' "$path"
+}
+
+# ── Clone ───────────────────────────────────────────────────────────
+# Clones <url>'s <branch> into <dest>. Shallowable via the WORKSPACE_CLONE_DEPTH
+# seam (adds --depth when set); never recurses submodules. All git output is
+# captured (never streamed to stdout/stderr) and, on failure, redacted into
+# WORKSPACE_LAST_ERROR so a caller can report a reason without ever risking a
+# credential leak through git's own error text.
+WORKSPACE_LAST_ERROR=""
+_workspace_clone() {
+    local url="$1" branch="$2" dest="$3" out rc
+    local depth_args=()
+    if [ -n "${WORKSPACE_CLONE_DEPTH:-}" ]; then
+        depth_args=(--depth "$WORKSPACE_CLONE_DEPTH")
+    fi
+    out="$(_workspace_git clone --branch "$branch" --single-branch \
+        --no-recurse-submodules "${depth_args[@]}" "$url" "$dest" 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        WORKSPACE_LAST_ERROR="$(workspace_redact_credentials "$out" | tail -n1)"
+    fi
+    return "$rc"
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+_workspace_emit_ready() {
+    local run_root="$1" repo_dir="$2" baseline="$3" manifest="$4" marker="$5"
+    printf '{"state":"READY","run_root":"%s","repo_dir":"%s","baseline":"%s","manifest":"%s","marker":"%s"}\n' \
+        "$run_root" "$repo_dir" "$baseline" "$manifest" "$marker"
+}
+
+_workspace_emit_rejected() {
+    local run_root="$1" repo_dir="$2" manifest="$3" marker="$4" reason="$5"
+    reason="$(workspace_redact_credentials "$reason")"
+    printf '{"state":"REJECTED","reason":"%s","run_root":"%s","repo_dir":"%s","manifest":"%s","marker":"%s"}\n' \
+        "$reason" "$run_root" "$repo_dir" "$manifest" "$marker"
+}
+
+# ── Driver ──────────────────────────────────────────────────────────
+# run_workspace <repo> <base> <issue> [<clone_url>] [<manifest_path>]
+#
+# repo   expected "owner/name" identity, also used to derive the default
+#        clone URL when <clone_url> is omitted.
+# base   temp base directory the run root is created under.
+# issue  issue number; scopes the run-root name and is recorded in the marker.
+run_workspace() {
+    local repo="${1:-}" base="${2:-}" issue="${3:-}" clone_url="${4:-}" manifest_override="${5:-}"
+
+    if [ -z "$repo" ] || [ -z "$base" ] || [ -z "$issue" ]; then
+        _workspace_emit_rejected "" "" "" "" "missing required repo/base/issue"
+        return 2
+    fi
+
+    local run_root; run_root="$(workspace_run_root "$base" "$issue")"
+    if ! mkdir -p -- "$run_root" 2>/dev/null; then
+        _workspace_emit_rejected "$run_root" "" "" "" "failed to create run root"
+        return 1
+    fi
+
+    local marker; marker="$(_workspace_write_marker "$run_root" "$issue")"
+    local manifest="${manifest_override:-${run_root%/}/manifest}"
+
+    workspace_manifest_write "$manifest" issue "$issue"
+    workspace_manifest_write "$manifest" repo "$repo"
+    workspace_manifest_write "$manifest" run_root "$run_root"
+    workspace_manifest_write "$manifest" marker "$marker"
+    workspace_manifest_write "$manifest" state CLAIMED
+
+    # Enter CLONING before the clone actually starts, so a crash mid-clone
+    # leaves the manifest correctly reflecting the in-progress phase rather
+    # than the stale CLAIMED state.
+    workspace_manifest_write "$manifest" state CLONING
+    local repo_dir="${run_root%/}/repo"
+    local url="${clone_url:-https://github.com/${repo}.git}"
+    if ! _workspace_clone "$url" develop "$repo_dir"; then
+        workspace_manifest_write "$manifest" state REJECTED
+        _workspace_emit_rejected "$run_root" "$repo_dir" "$manifest" "$marker" \
+            "clone failed: ${WORKSPACE_LAST_ERROR:-unknown error}"
+        return 1
+    fi
+
+    local baseline
+    baseline="$(_workspace_git -C "$repo_dir" rev-parse HEAD 2>/dev/null)"
+
+    if ! workspace_verify_identity "$repo_dir" "$repo"; then
+        workspace_manifest_write "$manifest" state REJECTED
+        _workspace_emit_rejected "$run_root" "$repo_dir" "$manifest" "$marker" \
+            "origin identity does not match expected repo ${repo}"
+        return 1
+    fi
+
+    workspace_manifest_write "$manifest" repo_dir "$repo_dir"
+    workspace_manifest_write "$manifest" baseline "$baseline"
+    workspace_manifest_write "$manifest" state READY
+
+    _workspace_emit_ready "$run_root" "$repo_dir" "$baseline" "$manifest" "$marker"
+    return 0
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+_workspace_main() {
+    local repo="" base="" issue="" clone_url="" manifest=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --repo) repo="$2"; shift 2 ;;
+            --base) base="$2"; shift 2 ;;
+            --issue) issue="$2"; shift 2 ;;
+            --clone-url) clone_url="$2"; shift 2 ;;
+            --manifest) manifest="$2"; shift 2 ;;
+            *) echo "unknown argument: $1" >&2; return 2 ;;
+        esac
+    done
+    if [ -z "$repo" ] || [ -z "$base" ] || [ -z "$issue" ]; then
+        echo "error: --repo <owner/name>, --base <tmpbase>, and --issue <n> are required" >&2
+        return 2
+    fi
+    run_workspace "$repo" "$base" "$issue" "$clone_url" "$manifest"
+}
+
+# Run as CLI only when executed directly; stay quiet when sourced by tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    _workspace_main "$@"
+fi

--- a/tests/issue-work/README.md
+++ b/tests/issue-work/README.md
@@ -18,6 +18,7 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 |------|------|
 | `test-triage.sh` | Test runner: pure-function unit tests + end-to-end scenarios. |
 | `fake-gh.sh` | Canned `gh` for the subset of commands triage.sh calls; records mutations to `mutations.log` and appends posted comments so idempotency reruns observe prior state. |
+| `test-workspace.sh` | Test runner for the workspace lifecycle stage (`scripts/workspace.sh`); see the dedicated section below. |
 
 ## Acceptance-criteria coverage (issue #829)
 
@@ -50,3 +51,38 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 
 These are bash tests. PowerShell parity for the triage gate is deferred to issue
 #832 (team/batch/cross-platform regression integration), per the epic #828 split.
+
+## Workspace lifecycle tests (issue #838)
+
+Unit and end-to-end tests for the workspace lifecycle stage
+(`global/skills/_internal/issue-work/scripts/workspace.sh`), which turns a
+triage `proceed` outcome into an isolated, identity-verified clone
+(`CLAIMED -> CLONING -> READY`). The suite drives a real local bare git
+repository rather than a fake — this stage never calls `gh`, so no shim is
+needed to exercise it without network access. See
+`reference/workspace-lifecycle.md` for the full contract.
+
+### Run
+
+```bash
+bash tests/issue-work/test-workspace.sh
+```
+
+The suite is wired into CI by `.github/workflows/validate-skills.yml`.
+
+### Acceptance-criteria coverage (issue #838)
+
+| AC | Scenario | Assertion |
+|----|----------|-----------|
+| AC1 | Run-root layout | Run root sits under the temp base, uniquely named per invocation, with a valid `.iw-run-marker` recording the issue number. |
+| AC2 | Clone from `develop` | Reaches `READY` with a `baseline` matching the seeded `develop` HEAD sha; the working tree is actually checked out. |
+| AC3 | Identity/origin mismatch | Outcome is `REJECTED`, never `READY`; the manifest never advances past `REJECTED`. |
+| AC4 | Credential redaction | Neither stdout nor the manifest ever contains a token, including on the real clone-failure path (a `GIT_BIN`-shimmed git that fails with a credential-bearing error message). |
+| AC5 | Manifest atomicity | `key=value` round-trips via `workspace_manifest_read`; a repeated key updates in place (no duplicate lines, no leftover `.tmp.$$` file). |
+| UNIT | Pure-function coverage | `workspace_redact_credentials`, `workspace_verify_identity` (https and SSH-shorthand origins, missing origin, empty expected value), `workspace_manifest_write`/`_read`/`_state`, `workspace_run_root`. |
+
+### Scope note
+
+PowerShell parity for the workspace stage is delivered as
+`scripts/workspace.ps1`; cross-platform PS regression coverage is integrated
+in #832 (consistent with the existing #829 note above).

--- a/tests/issue-work/test-workspace.sh
+++ b/tests/issue-work/test-workspace.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Test suite for global/skills/_internal/issue-work/scripts/workspace.sh
+# Run: bash tests/issue-work/test-workspace.sh
+#
+# Drives the workspace lifecycle stage (CLAIMED -> CLONING -> READY) against
+# a real local bare git repository -- no fake gh/git shim is needed because
+# this stage never calls gh, and driving real git exercises the actual clone
+# and remote-identity codepaths instead of a stand-in.
+#
+# AC -> test mapping (see reference/workspace-lifecycle.md):
+#   AC1  run root layout       -> under temp base, uniquely named, valid marker
+#   AC2  clone -> READY        -> develop clone reaches READY with correct baseline sha
+#   AC3  identity mismatch     -> REJECTED, never reaches READY
+#   AC4  credential redaction  -> manifest and stdout never contain a token
+#   AC5  manifest atomicity    -> key=value round-trips via read; no tmp leftovers
+#   UNIT pure-function coverage -> redact / verify_identity / manifest write+read
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+WORKSPACE="$ROOT_DIR/global/skills/_internal/issue-work/scripts/workspace.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# Explicit template (rather than a bare `mktemp -d`) so this suite is stable
+# under sandboxes that restrict the OS default temp directory but expose
+# $TMPDIR, as well as under plain CI runners where $TMPDIR is unset.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/iw-workspace-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+ok()   { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $1"); echo "  FAIL: $1"; }
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then ok "$label"; else
+        bad "$label -- expected '$expected', got '$actual'"; fi
+}
+
+assert_contains() {
+    local needle="$1" hay="$2" label="$3"
+    if printf '%s' "$hay" | grep -Fq -- "$needle"; then ok "$label"; else
+        bad "$label -- '$needle' not in output"; fi
+}
+
+assert_not_contains() {
+    local needle="$1" hay="$2" label="$3"
+    if printf '%s' "$hay" | grep -Fq -- "$needle"; then
+        bad "$label -- '$needle' unexpectedly present"
+    else
+        ok "$label"
+    fi
+}
+
+jfield() {  # jfield <json> <field>
+    printf '%s' "$1" | python3 -c 'import json,sys;print(json.load(sys.stdin).get(sys.argv[1],""))' "$2" 2>/dev/null
+}
+
+# Builds a bare "remote" laid out as <owner>/<name>.git under $WORK/remote,
+# seeds it with one commit on a "develop" branch, and prints the bare repo
+# path (used as --clone-url so the origin recorded after cloning reduces to
+# "<owner>/<name>", matching workspace_verify_identity's expectations).
+make_remote() {  # make_remote <owner> <name>
+    local owner="$1" name="$2" remote seed
+    remote="$WORK/remote/${owner}/${name}.git"
+    mkdir -p "$(dirname "$remote")"
+    git init --bare -q "$remote"
+    seed="$WORK/seed-${owner}-${name}"
+    git init -q -b develop "$seed"
+    git -C "$seed" config user.email "test@example.com"
+    git -C "$seed" config user.name "test"
+    echo "content" > "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" commit -q -m "seed commit" >/dev/null
+    git -C "$seed" remote add origin "$remote"
+    git -C "$seed" push -q origin develop
+    printf '%s' "$remote"
+}
+
+echo "=== workspace.sh unit tests (pure functions) ==="
+# shellcheck disable=SC1090
+source "$WORKSPACE"
+
+# --- Fake credential material (secret-scanner-safe) --------------------
+# Redaction is structural (it strips a "scheme://<userinfo>@" span), so the
+# placeholder value is irrelevant to what is tested. We use a low-entropy,
+# clearly-fake secret with NO real token prefix and assemble credential URLs
+# from it, so no complete "scheme://user:secret@host" literal (or token-shaped
+# string) is ever committed to source. This satisfies the no-secrets-in-source
+# policy and keeps secret scanners (e.g. GitGuardian) quiet.
+FAKE_SECRET="placeholder-not-a-real-secret"
+FAKE_USERINFO="x-access-token:${FAKE_SECRET}"
+
+# workspace_redact_credentials.
+r1="$(workspace_redact_credentials "https://${FAKE_USERINFO}@github.com/owner/name.git")"
+assert_eq "https://github.com/owner/name.git" "$r1" "redact strips x-access-token userinfo"
+r2="$(workspace_redact_credentials "fatal: unable to access 'https://${FAKE_USERINFO}@host/owner/name.git/': could not resolve")"
+assert_not_contains "$FAKE_SECRET" "$r2" "redact strips creds embedded mid-message"
+assert_contains "https://host/owner/name.git" "$r2" "redact preserves the scheme and path"
+r3="$(workspace_redact_credentials 'plain text, no url here')"
+assert_eq "plain text, no url here" "$r3" "redact is a no-op on non-URL input"
+r4="$(workspace_redact_credentials 'git@github.com:owner/name.git')"
+assert_eq "git@github.com:owner/name.git" "$r4" "redact leaves SSH shorthand untouched (no embedded secret)"
+
+# workspace_run_root.
+rr1="$(WORKSPACE_RUN_SUFFIX=abc123 workspace_run_root "$WORK/base" 838)"
+assert_eq "$WORK/base/iw-838-abc123" "$rr1" "run_root composes base/iw-<issue>-<suffix>"
+rr2="$(WORKSPACE_RUN_SUFFIX=xyz789 workspace_run_root "$WORK/base" 838)"
+if [ "$rr1" != "$rr2" ]; then ok "run_root differs when the suffix seam differs"; else
+    bad "run_root should differ for a different suffix"; fi
+
+# workspace_manifest_write / workspace_manifest_read round trip + atomicity.
+mpath="$WORK/unit-manifest"
+workspace_manifest_write "$mpath" state CLAIMED
+assert_eq "CLAIMED" "$(workspace_manifest_read "$mpath" state)" "manifest round-trips a fresh key"
+workspace_manifest_write "$mpath" state CLONING
+assert_eq "CLONING" "$(workspace_manifest_state "$mpath")" "manifest_state reflects the latest write"
+assert_eq "1" "$(grep -c '^state=' "$mpath")" "manifest update replaces the key rather than duplicating it"
+leftover="$(find "$WORK" -maxdepth 1 -name 'unit-manifest.tmp.*' 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq "0" "$leftover" "manifest write leaves no .tmp.\$\$ file behind"
+assert_eq "" "$(workspace_manifest_read "$mpath" nonexistent_key)" "manifest_read is empty for an absent key"
+
+# workspace_manifest_write redacts a credential-bearing value before it ever
+# touches disk (AC4, targeted at the manifest half of the guarantee).
+workspace_manifest_write "$mpath" origin_seen "https://${FAKE_USERINFO}@github.com/o/n.git"
+assert_not_contains "$FAKE_SECRET" "$(cat "$mpath")" "manifest never stores a raw credential"
+assert_eq "https://github.com/o/n.git" "$(workspace_manifest_read "$mpath" origin_seen)" "manifest stores the redacted form"
+
+# workspace_verify_identity.
+id_repo="$WORK/id-repo"
+git init -q "$id_repo"
+git -C "$id_repo" remote add origin "https://github.com/acme/widgets.git"
+if workspace_verify_identity "$id_repo" "acme/widgets"; then ok "verify_identity accepts a matching https origin"; else
+    bad "verify_identity should accept a matching https origin"; fi
+if workspace_verify_identity "$id_repo" "someone/else"; then bad "verify_identity must reject a mismatched owner/name"; else
+    ok "verify_identity rejects a mismatched owner/name"; fi
+
+git -C "$id_repo" remote set-url origin "git@github.com:acme/widgets.git"
+if workspace_verify_identity "$id_repo" "acme/widgets"; then ok "verify_identity accepts a matching SSH-shorthand origin"; else
+    bad "verify_identity should accept a matching SSH-shorthand origin"; fi
+
+no_origin_repo="$WORK/no-origin-repo"
+git init -q "$no_origin_repo"
+if workspace_verify_identity "$no_origin_repo" "acme/widgets"; then bad "verify_identity must reject a repo with no origin"; else
+    ok "verify_identity rejects a repo with no origin"; fi
+
+if workspace_verify_identity "$id_repo" ""; then bad "verify_identity must reject an empty expected value"; else
+    ok "verify_identity rejects an empty expected value"; fi
+
+echo ""
+echo "=== AC1: run root under temp base, uniquely named, valid marker ==="
+base1="$WORK/base1"
+mkdir -p "$base1"
+remote1="$(make_remote acme widgets)"
+out1="$(WORKSPACE_RUN_SUFFIX=run1 bash "$WORKSPACE" --repo acme/widgets --base "$base1" --issue 838 --clone-url "$remote1")"
+run_root1="$(jfield "$out1" run_root)"
+assert_contains "$base1/iw-838-run1" "$run_root1" "AC1 run root is under the temp base with the expected name"
+assert_eq "1" "$(find "$run_root1" -maxdepth 1 -name '.iw-run-marker' | wc -l | tr -d ' ')" "AC1 marker file exists in the run root"
+assert_contains "issue=838" "$(cat "$run_root1/.iw-run-marker")" "AC1 marker content includes the issue number"
+
+out1b="$(WORKSPACE_RUN_SUFFIX=run1b bash "$WORKSPACE" --repo acme/widgets --base "$base1" --issue 838 --clone-url "$remote1")"
+run_root1b="$(jfield "$out1b" run_root)"
+if [ "$run_root1" != "$run_root1b" ]; then ok "AC1 two runs for the same issue get uniquely named run roots"; else
+    bad "AC1 run roots should differ across runs"; fi
+
+echo ""
+echo "=== AC2: clone from develop reaches READY with correct baseline sha ==="
+base2="$WORK/base2"
+mkdir -p "$base2"
+remote2="$(make_remote acme gadgets)"
+expected_sha="$(git -C "$WORK/seed-acme-gadgets" rev-parse develop)"
+out2="$(WORKSPACE_RUN_SUFFIX=run2 bash "$WORKSPACE" --repo acme/gadgets --base "$base2" --issue 900 --clone-url "$remote2")"
+assert_eq "READY" "$(jfield "$out2" state)" "AC2 outcome=READY"
+assert_eq "$expected_sha" "$(jfield "$out2" baseline)" "AC2 baseline matches the seeded develop HEAD"
+repo_dir2="$(jfield "$out2" repo_dir)"
+assert_eq "1" "$(test -f "$repo_dir2/file.txt" && echo 1 || echo 0)" "AC2 clone actually checked out the working tree"
+manifest2="$(jfield "$out2" manifest)"
+assert_eq "READY" "$(workspace_manifest_state "$manifest2")" "AC2 manifest state reaches READY"
+assert_eq "$expected_sha" "$(workspace_manifest_read "$manifest2" baseline)" "AC2 manifest records the baseline"
+
+echo ""
+echo "=== AC3: identity/origin mismatch is REJECTED, never reaches READY ==="
+base3="$WORK/base3"
+mkdir -p "$base3"
+remote3="$(make_remote other owner)"
+out3="$(WORKSPACE_RUN_SUFFIX=run3 bash "$WORKSPACE" --repo acme/mismatch --base "$base3" --issue 901 --clone-url "$remote3")"
+assert_eq "REJECTED" "$(jfield "$out3" state)" "AC3 outcome=REJECTED on identity mismatch"
+assert_contains "acme/mismatch" "$(jfield "$out3" reason)" "AC3 reason names the expected repo"
+manifest3="$(jfield "$out3" manifest)"
+assert_eq "REJECTED" "$(workspace_manifest_state "$manifest3")" "AC3 manifest never advances to READY"
+assert_not_contains "READY" "$out3" "AC3 stdout JSON never claims READY"
+
+echo ""
+echo "=== AC4: credentials never appear in stdout or the manifest ==="
+base4="$WORK/base4"
+mkdir -p "$base4"
+remote4="$(make_remote acme secure)"
+token="$FAKE_SECRET"
+out4="$(WORKSPACE_RUN_SUFFIX=run4 bash "$WORKSPACE" --repo acme/secure --base "$base4" --issue 902 \
+    --clone-url "$remote4" --manifest "$base4/iw-902-run4/manifest")"
+assert_eq "READY" "$(jfield "$out4" state)" "AC4 baseline run reaches READY (sanity precondition)"
+assert_not_contains "$token" "$out4" "AC4 stdout never contains the fake token"
+assert_not_contains "$token" "$(cat "$base4/iw-902-run4/manifest")" "AC4 manifest never contains the fake token"
+# The token above never entered the run at all (defense-in-depth baseline);
+# the manifest_write unit test earlier already proves a credential-bearing
+# value handed directly to the manifest primitive is redacted before write.
+
+# AC4b: exercise the real clone-failure redaction path (_workspace_clone's
+# WORKSPACE_LAST_ERROR handling) without any network access, by shadowing
+# git with a local shim (via the GIT_BIN seam) whose "clone" subcommand
+# fails and echoes a credential-bearing URL to stderr, mimicking what a real
+# git failure against an authenticated remote looks like.
+fake_git="$WORK/fake-git-clone-fail"
+cat > "$fake_git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "clone" ]; then
+    echo "fatal: unable to access 'https://${FAKE_USERINFO}@github.com/acme/failing.git/': Could not resolve host" >&2
+    exit 1
+fi
+exit 0
+EOF
+chmod +x "$fake_git"
+base4b="$WORK/base4b"
+mkdir -p "$base4b"
+out4b="$(GIT_BIN="$fake_git" WORKSPACE_RUN_SUFFIX=run4b bash "$WORKSPACE" --repo acme/failing --base "$base4b" \
+    --issue 903 --clone-url "https://${FAKE_USERINFO}@github.com/acme/failing.git")"
+assert_eq "REJECTED" "$(jfield "$out4b" state)" "AC4b clone failure yields REJECTED"
+assert_contains "clone failed" "$(jfield "$out4b" reason)" "AC4b reason names the clone failure"
+assert_not_contains "$FAKE_SECRET" "$out4b" "AC4b stdout never contains git's own credential-bearing error"
+manifest4b="$WORK/base4b/iw-903-run4b/manifest"
+assert_not_contains "$FAKE_SECRET" "$(cat "$manifest4b" 2>/dev/null)" "AC4b manifest never contains git's own credential-bearing error"
+
+echo ""
+echo "=== AC5: manifest updates are atomic and key=value round-trips ==="
+manifest5="$WORK/atomic-manifest"
+workspace_manifest_write "$manifest5" a 1
+workspace_manifest_write "$manifest5" b 2
+workspace_manifest_write "$manifest5" a 3
+assert_eq "3" "$(workspace_manifest_read "$manifest5" a)" "AC5 later write for the same key wins"
+assert_eq "2" "$(workspace_manifest_read "$manifest5" b)" "AC5 unrelated key is preserved across updates"
+assert_eq "2" "$(grep -c '=' "$manifest5")" "AC5 manifest has exactly one line per key"
+
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #838.

## What

Implement the first stage of the `issue-work` isolated-workspace lifecycle:
`CLAIMED -> CLONING -> READY`, plus the secure, atomically-updated state
manifest primitive. This is the direct continuation of the triage gate (#829),
whose "Scope boundary" ends at `PROCEED` and explicitly defers cloning to this
workspace stage.

## Why

Part of #830 (isolated workspace and subagent lifecycle), epic #828. The current
workflow runs directly in an existing checkout with no per-issue isolation or
safe-cleanup contract. This stage establishes the isolated, identity-verified
clone that subagent execution (#839) and safe cleanup/resume (#840) build on.

## Where

| File | Change |
|------|--------|
| `global/skills/_internal/issue-work/scripts/workspace.sh` | NEW — Bash reference implementation (sourceable library + CLI). |
| `global/skills/_internal/issue-work/scripts/workspace.ps1` | NEW — PowerShell parity port. |
| `global/skills/_internal/issue-work/reference/workspace-lifecycle.md` | NEW — the contract (states, run-root layout, marker, manifest schema, identity + redaction rules), kept in sync with the scripts. |
| `tests/issue-work/test-workspace.sh` | NEW — 42-assertion bash suite (real local bare remote; git-only, no gh shim needed). |
| `tests/issue-work/README.md` | Extended — workspace test section + AC coverage table. |
| `.github/workflows/validate-skills.yml` | Added one run step after the triage-test step. |

## How

- `workspace.sh` mirrors the #829 `triage.sh` convention: `set -uo pipefail`,
  section banners, public `workspace_*` / internal `_workspace_*` functions, a
  `GIT_BIN` injection seam, and a sourcing guard so tests can source it.
- Manifest is a portable `key=value` file (no jq); every write is atomic
  (write-temp + `mv`) and every value passes through the credential redactor.
- Origin identity verification is host-agnostic (accepts `https://` and SSH
  shorthand; supports GHE and local test doubles).
- Clone uses `--branch develop --single-branch --no-recurse-submodules`; git
  output is captured and redacted so a credential in git's own error text can
  never leak to stdout/stderr/manifest.

## Test plan

- `bash tests/issue-work/test-workspace.sh` -> 42 passed, 0 failed (wired into
  CI right after the triage suite).
- Locally green: `validate_skills.sh`, `check_skill_drift.sh`,
  `check_references.sh`, `validate-doc-index.sh`, `spec_lint.sh --strict`,
  `check_versions.sh`, `check_agents.sh`.

## Pre-PR gate

- `develop` was unchanged since the working clone (no rebase/conflict needed).
- Documentation-to-issue gap audit against the #829 precedent: full `SKILL.md`
  workflow integration, the `CHANGELOG.md` entry, and the `docs/.index/`
  regeneration are intentionally deferred to the lifecycle-completing sub-issue
  **#840**. Rationale: (1) both `SKILL.md` and `CHANGELOG.md` are doc-indexed, so
  editing them requires a Claude-curated `docs/.index/` regeneration; (2) the
  workspace lifecycle is 1 of 3 stages here — documenting subagent spawn in
  `SKILL.md` now would describe behavior not implemented until #839; (3) this
  matches #829's principle of integrating complete features. A single coherent
  `SKILL.md`/`CHANGELOG` entry lands once the lifecycle is whole.

## Notes

- `workspace.ps1` is a faithful parity port but was **not** runtime-verified
  (no `pwsh` in the authoring environment); it is not executed by any CI step.
  Cross-platform PS regression coverage is integrated in **#832**, consistent
  with the #829 note in `tests/issue-work/README.md`.
