### PR TITLE
feat(issue-work): subagent spawn contract and single-writer lease

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -171,6 +171,9 @@ jobs:
       - name: Run issue-work workspace lifecycle tests (#838)
         run: bash tests/issue-work/test-workspace.sh
 
+      - name: Run issue-work subagent lease tests (#839)
+        run: bash tests/issue-work/test-agents.sh
+
       - name: Install pytest for fleet_orchestrator tests
         # pytest is already a transitive dep of jsonschema in some envs; pin
         # explicitly so the runner does not silently fall back to unittest.

--- a/global/skills/_internal/issue-work/reference/workspace-lifecycle.md
+++ b/global/skills/_internal/issue-work/reference/workspace-lifecycle.md
@@ -196,3 +196,123 @@ It does **not**:
 A `REJECTED` run root is left on disk for inspection rather than deleted by
 this stage — cleanup ownership belongs entirely to #840, consistent with
 triage leaving no side effects on its own non-`proceed` terminal outcomes.
+
+---
+
+# Subagent spawn + single-writer lease (#839)
+
+Picks up where `READY` leaves off. The reference implementation is
+`scripts/agents.sh` (sibling directory), ported 1:1 to `scripts/agents.ps1`.
+It reuses the #838 manifest primitive (`workspace_manifest_write` / `_read` /
+`_state`) by sourcing `workspace.sh`, and advances the manifest through
+`READY -> AGENTS_RUNNING -> COMMITTED`. Code and doc must stay in sync — when
+one changes, change the other in the same PR (same rule as the #838 sections
+above).
+
+This stage delivers three things and nothing more:
+
+1. A **spawn-prompt contract** that guarantees every subagent is fully
+   specified before it is launched.
+2. A **single-writer lease** so only one writer mutates a shared checkout at a
+   time.
+3. The `READY -> AGENTS_RUNNING -> COMMITTED` manifest transitions, built on the
+   #838 atomic primitive.
+
+Per-agent worktrees are the escape hatch used **only** when concurrent writes
+are genuinely required; the default is the single-writer lease on the shared
+checkout.
+
+## Agent prompt contract
+
+`agents_build_prompt <repo_path> <issue> <branch> <baseline> <write_scope>`
+emits a prompt that ALWAYS contains every field below, so a coordinator can
+never spawn an under-specified agent:
+
+| Field | Source | Why it is mandatory |
+|-------|--------|---------------------|
+| Normalized absolute repo path | `agents_normalize_path` of `<repo_path>` | An agent must never guess its working directory; a relative path is resolved to an absolute, symlink-resolved path. |
+| Active issue | `<issue>` | Anchors the work and every artifact reference to one issue. |
+| Target branch | `<branch>` | The branch the coordinator will commit and push; the agent writes toward it but never pushes. |
+| Baseline commit | `<baseline>` | The exact `develop` HEAD the workspace was cloned at (#838 `baseline`). |
+| Explicit write scope | `<write_scope>` | The only paths the agent may create or edit. Everything else is read-only to it. |
+| Ownership / prohibition clause | fixed prose | States that the coordinator owns all git/GitHub mutations and forbids the agent from pushing to the remote, invoking the GitHub CLI, opening/updating/merging a pull request, or cleaning up the workspace. |
+
+The prohibition clause is worded to convey each ban without embedding a literal
+push or GitHub-CLI command token, so the capability-guard test can assert
+`agents.sh` itself performs no such command (see below).
+
+## Coordinator vs. agent capability split
+
+The whole point of the spawn contract is a hard capability boundary. This is
+the authority for who may do what:
+
+| Capability | Coordinator | Subagent |
+|------------|:-----------:|:--------:|
+| Read/write files within the agent's write scope | Yes | Yes |
+| Write files outside the write scope | Yes | No |
+| `git` commit / branch (local) | Yes | No |
+| `git push` to a remote | Yes | No |
+| `gh` / GitHub API mutations | Yes | No |
+| Open / update / merge a pull request | Yes | No |
+| `git worktree` add/remove | Yes | No (coordinator-managed) |
+| Workspace cleanup / teardown (#840) | Yes | No |
+
+`agents.sh` enforces its own half of this contract structurally: it contains
+**no** `gh` invocation and **no** remote push. The only git verb it ever runs
+is `git worktree` (add/remove). A test greps the script to keep it that way.
+
+## Lease protocol
+
+Only one writer may modify a shared checkout at a time. The lease is a
+directory whose creation is the atomic primitive:
+
+- **Acquire** (`agents_acquire_lease <lease_path> <owner_id>`): creates the
+  lease directory with `mkdir` (atomic on POSIX — exactly one caller can create
+  it) and records `<owner_id>` in an `owner` marker file inside it. If the
+  directory already exists, acquisition **fails** (non-zero) rather than
+  admitting a second writer.
+- **Release** (`agents_release_lease <lease_path> <owner_id>`): succeeds only
+  when the caller is the recorded owner. Removal is **guarded** — the path's
+  final component must equal the lease basename (`.iw-writer.lease`) and the
+  directory must exist; release then deletes the known `owner` marker and
+  `rmdir`s the now-empty directory. It never performs a recursive delete on a
+  caller-supplied path.
+- **Fail-safe**: when in doubt, refuse. A non-owner release, a release of a
+  missing lease, and a release of a path that is not a lease directory all
+  return non-zero and change nothing. A held lease is never silently stolen.
+- **Mutual exclusion guarantee**: because acquisition is a single atomic
+  directory create, two concurrent callers can never both observe success; the
+  loser is refused and must wait or fall back to a worktree.
+
+## Worktree rule
+
+The single-writer lease on the shared checkout is the **default** concurrency
+control. Per-agent worktrees (`agents_worktree_add` /
+`agents_worktree_remove`, thin wrappers over `git worktree`) are used **only**
+when agents must write concurrently and serializing them behind one lease is
+unacceptable. When worktrees are used:
+
+- Each worktree is created on its own branch under the run root.
+- Each worktree **must** be removed once its agent finishes. An orphaned
+  worktree keeps a lock in the parent repository and will block the #840
+  cleanup stage, so removal is not optional.
+
+## Manifest keys and transitions added by this stage
+
+This stage advances `state` and adds one key, using the same atomic
+`workspace_manifest_write` primitive (which redacts every value before it
+touches disk):
+
+| Key | Meaning |
+|-----|---------|
+| `state` | Advanced `READY -> AGENTS_RUNNING` (start phase) and `AGENTS_RUNNING -> COMMITTED` (post-commit phase). |
+| `lease_owner` | The owner id recorded when the AGENTS_RUNNING transition is taken with an owner (the single writer holding the checkout). |
+
+Transitions are strictly ordered. `agents_mark_running` refuses unless the
+current state is exactly `READY`; `agents_mark_committed` refuses unless it is
+exactly `AGENTS_RUNNING`. An out-of-order request (e.g. `COMMITTED` straight
+from `READY`) is rejected and leaves the manifest unchanged, so a crash or a
+mis-sequenced caller can never fabricate a state the work never actually passed
+through. The `PUSHED` / `PR_OPEN` states listed in the full lifecycle table
+remain the coordinator's / #840's responsibility — this stage stops at
+`COMMITTED`.

--- a/global/skills/_internal/issue-work/scripts/agents.ps1
+++ b/global/skills/_internal/issue-work/scripts/agents.ps1
@@ -1,0 +1,374 @@
+#Requires -Version 7.0
+# agents.ps1
+# issue-work: subagent spawn contract + single-writer lease (READY -> AGENTS_RUNNING -> COMMITTED)
+# ================================================================================================
+# PowerShell parity port of scripts/agents.sh. Same functions, same behavior,
+# same manifest transitions, same fail-safe lease semantics, same injection
+# seams, same capability boundary (NO GitHub CLI, NO remote push -- the only git
+# verb is `git worktree`). See reference/workspace-lifecycle.md for the contract
+# both scripts satisfy.
+#
+# NOTE (authoring-time caveat): pwsh was not available in the environment this
+# port was written in, so it was produced by mirroring the bash-verified logic
+# in agents.sh line-for-line rather than by running it. It has NOT been executed
+# and is NOT wired into CI. Cross-platform regression coverage is tracked in
+# issue #832, consistent with the existing PowerShell-parity notes for the
+# triage (#829) and workspace (#838) stages in tests/issue-work/README.md.
+#
+# The script is both a sourceable library (dot-source it to get the functions
+# below) and a CLI:
+#   pwsh -File agents.ps1 --manifest <path> --phase start|commit [--owner <id>]
+# CLI flags intentionally mirror agents.sh's flags exactly so the two entry
+# points are interchangeable from a caller's point of view.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Reuse the #838 manifest primitive (workspace_manifest_write/_read/_state,
+# workspace_redact_credentials). workspace.ps1 is quiet when dot-sourced.
+$script:AgentsDir = Split-Path -Parent $PSCommandPath
+. (Join-Path $script:AgentsDir 'workspace.ps1')
+
+# Injection seams (overridable by tests and callers via environment variables,
+# mirroring the bash GIT_BIN seam).
+$script:GitBin = if ($env:GIT_BIN) { $env:GIT_BIN } else { 'git' }
+
+# Lease directory basename. A release only ever removes a path whose final
+# component equals this value (see agents_release_lease), so a caller-supplied
+# path can never be mistaken for an arbitrary directory to delete.
+$script:AgentsLeaseDirname = if ($env:AGENTS_LEASE_DIRNAME) { $env:AGENTS_LEASE_DIRNAME } else { '.iw-writer.lease' }
+
+# Marker file recorded inside a held lease directory naming its owner.
+$script:AgentsLeaseOwnerFile = 'owner'
+
+# Lifecycle states this stage owns.
+$script:AgentsStateReady = 'READY'
+$script:AgentsStateRunning = 'AGENTS_RUNNING'
+$script:AgentsStateCommitted = 'COMMITTED'
+
+# Set by primitives on failure; consumed by run_agents to build a redacted
+# reason without re-touching git's raw output.
+$script:AgentsLastError = ''
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it via
+# $env:GIT_BIN. Only `git worktree` is ever passed in -- never a network verb.
+function _agents_git {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+    & $script:GitBin @GitArgs
+}
+
+# ── Path normalization ────────────────────────────────────────────────
+
+# Pure (filesystem-free) normalization of an already-absolute path: collapses
+# "." and empty segments and resolves ".." lexically. Never touches disk, so it
+# is safe for a path that does not (yet) exist.
+function _agents_normalize_pure {
+    param([string]$InputPath)
+    $result = ''
+    foreach ($seg in ($InputPath -split '/')) {
+        switch ($seg) {
+            '' { continue }
+            '.' { continue }
+            '..' {
+                $idx = $result.LastIndexOf('/')
+                $result = if ($idx -ge 0) { $result.Substring(0, $idx) } else { '' }
+            }
+            default { $result = "$result/$seg" }
+        }
+    }
+    if ([string]::IsNullOrEmpty($result)) { return '/' }
+    return $result
+}
+
+# Resolve Path to an absolute, normalized path. For an existing directory this
+# uses the resolved provider path (which also resolves symlinks); for a
+# non-existent path it makes the path absolute against the current directory and
+# normalizes it lexically. An absolute path is required by the spawn contract
+# (agents_build_prompt embeds it verbatim).
+function agents_normalize_path {
+    param([AllowEmptyString()][string]$Path = '')
+    if ([string]::IsNullOrEmpty($Path)) { return $null }
+    if (Test-Path -LiteralPath $Path -PathType Container) {
+        return (Resolve-Path -LiteralPath $Path).Path
+    }
+    $abs = $Path
+    if ($abs -notmatch '^/') {
+        $cwd = (Get-Location).Path.TrimEnd('/', '\')
+        $abs = "$cwd/$abs"
+    }
+    return _agents_normalize_pure $abs
+}
+
+# ── Spawn-prompt contract ──────────────────────────────────────────────
+
+# Build the subagent spawn prompt. The output ALWAYS contains every field the
+# contract requires so a coordinator can never spawn an under-specified agent:
+#   * a normalized absolute repo path   (agents_normalize_path)
+#   * the active issue number
+#   * the target branch
+#   * the baseline commit sha
+#   * an explicit write scope (the only paths the agent may touch)
+#   * an ownership/prohibition clause forbidding remote pushes, the GitHub CLI,
+#     opening/merging pull requests, and workspace cleanup
+#
+# The prohibition prose is worded to convey each ban WITHOUT embedding a literal
+# remote-push or bare GitHub-CLI command token, so the capability-guard test can
+# still assert this file performs no such command.
+function agents_build_prompt {
+    param(
+        [string]$RepoPath,
+        [string]$Issue,
+        [string]$Branch,
+        [string]$Baseline,
+        [AllowEmptyString()][string]$WriteScope = ''
+    )
+    $abs = agents_normalize_path $RepoPath
+    if ([string]::IsNullOrEmpty($abs)) { $abs = $RepoPath }
+    return @"
+You are an implementation subagent for issue #$Issue.
+
+Repository (normalized absolute path): $abs
+Active issue: #$Issue
+Target branch: $Branch
+Baseline commit: $Baseline
+
+Write scope -- you may create or edit ONLY these paths:
+$WriteScope
+
+Ownership and prohibitions (the coordinator owns ALL git and GitHub mutations):
+- You MUST NOT push any commit or branch to the remote.
+- You MUST NOT invoke the GitHub CLI or any GitHub API mutation.
+- You MUST NOT open, update, or merge a pull request (PR).
+- You MUST NOT clean up, delete, or otherwise tear down the workspace.
+- You may only read and write files within the write scope above.
+- When in doubt, stop and defer the mutation to the coordinator.
+"@
+}
+
+# ── Single-writer lease (mkdir-atomic) ────────────────────────────────
+
+# True only when LeasePath's final component equals AgentsLeaseDirname. This is
+# the guard that keeps agents_release_lease from ever removing an arbitrary
+# caller-supplied path.
+function _agents_valid_lease_path {
+    param([AllowEmptyString()][string]$LeasePath = '')
+    if ([string]::IsNullOrEmpty($LeasePath)) { return $false }
+    return ((Split-Path -Leaf $LeasePath) -eq $script:AgentsLeaseDirname)
+}
+
+# Atomically acquire the single-writer lease at LeasePath for OwnerId. Directory
+# creation is the atomic primitive: exactly one caller can create the directory,
+# so a second concurrent writer is refused with $false. Fail-safe: any error
+# (bad path, parent-create failure, lease already held) returns $false -- when
+# in doubt, refuse rather than admit a second writer.
+function agents_acquire_lease {
+    param([string]$LeasePath, [string]$OwnerId)
+    if ([string]::IsNullOrEmpty($LeasePath) -or [string]::IsNullOrEmpty($OwnerId)) { return $false }
+    if (-not (_agents_valid_lease_path $LeasePath)) {
+        $script:AgentsLastError = "lease path must end in $script:AgentsLeaseDirname"
+        return $false
+    }
+    if (Test-Path -LiteralPath $LeasePath) {
+        $script:AgentsLastError = 'lease already held'
+        return $false
+    }
+    try {
+        # -Force here creates parent directories; the prior Test-Path is the
+        # held-lease guard. New-Item throws if a race lost the create, which the
+        # catch turns into the fail-safe refusal.
+        New-Item -ItemType Directory -Path $LeasePath -ErrorAction Stop | Out-Null
+    } catch {
+        $script:AgentsLastError = 'lease already held'
+        return $false
+    }
+    Set-Content -LiteralPath (Join-Path $LeasePath $script:AgentsLeaseOwnerFile) -Value $OwnerId
+    return $true
+}
+
+# Return the owner recorded in a held lease ($null if none).
+function agents_lease_owner {
+    param([string]$LeasePath)
+    if ([string]::IsNullOrEmpty($LeasePath)) { return $null }
+    $ownerFile = Join-Path $LeasePath $script:AgentsLeaseOwnerFile
+    if (-not (Test-Path -LiteralPath $ownerFile)) { return $null }
+    return (Get-Content -LiteralPath $ownerFile -First 1)
+}
+
+# Release the lease at LeasePath, but only if OwnerId currently holds it.
+# Refuses ($false) for a non-owner, a missing lease, or a path that is not a
+# lease directory. Removal is guarded: it deletes the known owner marker and
+# then removes the now-empty directory -- never a recursive delete of the input.
+function agents_release_lease {
+    param([string]$LeasePath, [string]$OwnerId)
+    if ([string]::IsNullOrEmpty($LeasePath) -or [string]::IsNullOrEmpty($OwnerId)) { return $false }
+    if (-not (_agents_valid_lease_path $LeasePath)) {
+        $script:AgentsLastError = 'refusing to release a non-lease path'
+        return $false
+    }
+    if (-not (Test-Path -LiteralPath $LeasePath -PathType Container)) {
+        $script:AgentsLastError = 'no lease to release'
+        return $false
+    }
+    $stored = agents_lease_owner $LeasePath
+    if ($stored -ne $OwnerId) {
+        $script:AgentsLastError = 'lease held by another writer'
+        return $false
+    }
+    $ownerFile = Join-Path $LeasePath $script:AgentsLeaseOwnerFile
+    Remove-Item -LiteralPath $ownerFile -ErrorAction SilentlyContinue
+    try {
+        Remove-Item -LiteralPath $LeasePath -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    return $true
+}
+
+# ── Per-agent worktrees (concurrent-writes case ONLY) ─────────────────
+# The DEFAULT concurrency control is the single-writer lease above on the
+# shared checkout. Worktrees are used ONLY when agents must write concurrently;
+# each MUST be removed afterward (agents_worktree_remove) so no orphan is left
+# to block the #840 cleanup stage.
+
+# Add a worktree at WorktreePath on a NEW Branch, rooted in RepoDir.
+function agents_worktree_add {
+    param([string]$RepoDir, [string]$WorktreePath, [string]$Branch)
+    if ([string]::IsNullOrEmpty($RepoDir) -or [string]::IsNullOrEmpty($WorktreePath) -or [string]::IsNullOrEmpty($Branch)) { return $false }
+    $out = & $script:GitBin -C $RepoDir worktree add -b $Branch $WorktreePath 2>&1
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0) {
+        $joined = ($out | Out-String)
+        $redacted = workspace_redact_credentials $joined
+        $lastLine = ($redacted -split "`r?`n" | Where-Object { $_.Trim() -ne '' } | Select-Object -Last 1)
+        $script:AgentsLastError = if ($lastLine) { $lastLine } else { 'unknown error' }
+    }
+    return ($rc -eq 0)
+}
+
+# Remove the worktree at WorktreePath so it is not left orphaned.
+function agents_worktree_remove {
+    param([string]$RepoDir, [string]$WorktreePath)
+    if ([string]::IsNullOrEmpty($RepoDir) -or [string]::IsNullOrEmpty($WorktreePath)) { return $false }
+    $out = & $script:GitBin -C $RepoDir worktree remove $WorktreePath 2>&1
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0) {
+        $joined = ($out | Out-String)
+        $redacted = workspace_redact_credentials $joined
+        $lastLine = ($redacted -split "`r?`n" | Where-Object { $_.Trim() -ne '' } | Select-Object -Last 1)
+        $script:AgentsLastError = if ($lastLine) { $lastLine } else { 'unknown error' }
+    }
+    return ($rc -eq 0)
+}
+
+# ── Manifest state transitions ────────────────────────────────────────
+
+# Advance the manifest state from From to To, refusing if the current state is
+# not exactly From. This keeps the lifecycle strictly ordered
+# (READY -> AGENTS_RUNNING -> COMMITTED) rather than allowing an out-of-order jump.
+function _agents_transition {
+    param([string]$Manifest, [string]$From, [string]$To)
+    if ([string]::IsNullOrEmpty($Manifest) -or [string]::IsNullOrEmpty($From) -or [string]::IsNullOrEmpty($To)) { return $false }
+    $current = workspace_manifest_state -Path $Manifest
+    if ($current -ne $From) {
+        $shown = if ([string]::IsNullOrEmpty($current)) { '<empty>' } else { $current }
+        $script:AgentsLastError = "expected state $From but manifest is $shown"
+        return $false
+    }
+    workspace_manifest_write -Path $Manifest -Key 'state' -Value $To | Out-Null
+    return $true
+}
+
+# READY -> AGENTS_RUNNING. Records the lease owner when one is supplied.
+function agents_mark_running {
+    param([string]$Manifest, [AllowEmptyString()][string]$OwnerId = '')
+    if (-not (_agents_transition -Manifest $Manifest -From $script:AgentsStateReady -To $script:AgentsStateRunning)) { return $false }
+    if (-not [string]::IsNullOrEmpty($OwnerId)) {
+        workspace_manifest_write -Path $Manifest -Key 'lease_owner' -Value $OwnerId | Out-Null
+    }
+    return $true
+}
+
+# AGENTS_RUNNING -> COMMITTED. The coordinator calls this after committing.
+function agents_mark_committed {
+    param([string]$Manifest)
+    return (_agents_transition -Manifest $Manifest -From $script:AgentsStateRunning -To $script:AgentsStateCommitted)
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+function _agents_emit {
+    param([string]$State, [string]$Manifest)
+    Write-Output ('{{"state":"{0}","manifest":"{1}"}}' -f $State, $Manifest)
+}
+
+function _agents_emit_error {
+    param([AllowEmptyString()][string]$Reason = '')
+    $Reason = workspace_redact_credentials $Reason
+    Write-Output ('{{"state":"ERROR","reason":"{0}"}}' -f $Reason)
+}
+
+# ── Driver ──────────────────────────────────────────────────────────
+# run_agents -Manifest <path> -Phase start|commit [-OwnerId <id>]
+#
+# Phase=start   READY -> AGENTS_RUNNING (records lease_owner when owner given)
+# Phase=commit  AGENTS_RUNNING -> COMMITTED (the post-commit transition)
+function run_agents {
+    param([string]$Manifest, [string]$Phase, [AllowEmptyString()][string]$OwnerId = '')
+    if ([string]::IsNullOrEmpty($Manifest) -or [string]::IsNullOrEmpty($Phase)) {
+        _agents_emit_error 'missing required manifest/phase'
+        return 2
+    }
+    switch ($Phase) {
+        'start' {
+            if (-not (agents_mark_running -Manifest $Manifest -OwnerId $OwnerId)) {
+                $reason = if ($script:AgentsLastError) { $script:AgentsLastError } else { 'cannot enter AGENTS_RUNNING' }
+                _agents_emit_error $reason
+                return 1
+            }
+            _agents_emit $script:AgentsStateRunning $Manifest
+            return 0
+        }
+        'commit' {
+            if (-not (agents_mark_committed -Manifest $Manifest)) {
+                $reason = if ($script:AgentsLastError) { $script:AgentsLastError } else { 'cannot enter COMMITTED' }
+                _agents_emit_error $reason
+                return 1
+            }
+            _agents_emit $script:AgentsStateCommitted $Manifest
+            return 0
+        }
+        default {
+            _agents_emit_error "unknown phase: $Phase"
+            return 2
+        }
+    }
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+function Invoke-AgentsMain {
+    param([string[]]$Arguments = @())
+    $manifest = ''; $phase = ''; $owner = ''
+    $i = 0
+    while ($i -lt $Arguments.Count) {
+        switch ($Arguments[$i]) {
+            '--manifest' { $manifest = $Arguments[$i + 1]; $i += 2 }
+            '--phase' { $phase = $Arguments[$i + 1]; $i += 2 }
+            '--owner' { $owner = $Arguments[$i + 1]; $i += 2 }
+            default {
+                Write-Error "unknown argument: $($Arguments[$i])"
+                return 2
+            }
+        }
+    }
+    if (-not $manifest -or -not $phase) {
+        Write-Error 'error: --manifest <path> and --phase <start|commit> are required'
+        return 2
+    }
+    return run_agents -Manifest $manifest -Phase $phase -OwnerId $owner
+}
+
+# Run as CLI only when executed directly; stay quiet when dot-sourced by tests
+# (mirrors agents.sh's BASH_SOURCE guard).
+if ($MyInvocation.InvocationName -ne '.') {
+    exit (Invoke-AgentsMain -Arguments $args)
+}

--- a/global/skills/_internal/issue-work/scripts/agents.sh
+++ b/global/skills/_internal/issue-work/scripts/agents.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# issue-work: subagent spawn contract + single-writer lease (READY -> AGENTS_RUNNING -> COMMITTED)
+# ================================================================================================
+# Subagent-orchestration stage for the issue-work skill. Runs AFTER workspace.sh
+# reaches READY and BEFORE the coordinator commits. See
+# reference/workspace-lifecycle.md for the contract (spawn-prompt fields, the
+# coordinator-vs-agent capability split, the mkdir-based lease protocol, the
+# worktree rule, and the manifest keys this stage adds).
+#
+# This stage implements only the READY -> AGENTS_RUNNING -> COMMITTED manifest
+# transitions plus two orchestration primitives: a spawn-prompt builder and a
+# single-writer lease. It reuses the #838 manifest primitive by sourcing
+# workspace.sh (which stays quiet when sourced). Cleanup and resume
+# (CLEANUP_PENDING/CLEANED) remain issue #840.
+#
+# CAPABILITY BOUNDARY: a subagent may only read/write within its write scope.
+# The coordinator owns every GitHub mutation. Accordingly this script contains
+# NO GitHub CLI invocation and never pushes to a remote -- the only git verb it
+# runs is `git worktree` (add/remove), used solely for the concurrent-writes
+# case. The test suite greps this file to enforce that boundary.
+#
+# The script is both a sourceable library (unit-testable functions) and a CLI
+# (`run_agents`). Every git call funnels through _agents_git so tests can inject
+# a fake git via GIT_BIN, though the reference test suite prefers a real
+# temporary repository over a fake.
+#
+# Usage:
+#   bash agents.sh --manifest <path> --phase start|commit [--owner <id>]
+
+set -uo pipefail
+
+# Reuse the #838 manifest primitive (workspace_manifest_write/_read/_state,
+# workspace_redact_credentials). workspace.sh is quiet when sourced.
+_AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./workspace.sh
+. "${_AGENTS_DIR}/workspace.sh"
+
+# Injection seams (overridable by tests and callers).
+GIT_BIN="${GIT_BIN:-git}"
+
+# Lease directory basename. A release only ever removes a path whose final
+# component equals this value (see agents_release_lease), so a caller-supplied
+# path can never be mistaken for an arbitrary directory to delete.
+AGENTS_LEASE_DIRNAME="${AGENTS_LEASE_DIRNAME:-.iw-writer.lease}"
+
+# Marker file recorded inside a held lease directory naming its owner.
+_AGENTS_LEASE_OWNER_FILE="owner"
+
+# Lifecycle states this stage owns.
+_AGENTS_STATE_READY="READY"
+_AGENTS_STATE_RUNNING="AGENTS_RUNNING"
+_AGENTS_STATE_COMMITTED="COMMITTED"
+
+# Set by primitives on failure; consumed by run_agents to build a redacted
+# reason without re-touching git's raw output.
+AGENTS_LAST_ERROR=""
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it via GIT_BIN.
+# Only `git worktree` is ever passed in -- never a network verb.
+_agents_git() {
+    "$GIT_BIN" "$@"
+}
+
+# ── Path normalization ────────────────────────────────────────────────
+
+# Pure (filesystem-free) normalization of an already-absolute path: collapses
+# "." and empty segments and resolves ".." lexically. Never touches disk, so it
+# is safe for a path that does not (yet) exist.
+_agents_normalize_pure() {
+    local input="$1" seg result="" IFS=/
+    for seg in $input; do
+        case "$seg" in
+            ''|'.') continue ;;
+            '..')   result="${result%/*}" ;;
+            *)      result="${result}/${seg}" ;;
+        esac
+    done
+    printf '%s' "${result:-/}"
+}
+
+# Resolve <path> to an absolute, normalized path. For an existing directory this
+# uses cd+pwd -P (which also resolves symlinks); for a non-existent path it makes
+# the path absolute against $PWD and normalizes it lexically. An absolute path is
+# required by the spawn contract (agents_build_prompt embeds it verbatim).
+agents_normalize_path() {
+    local path="${1:-}"
+    [ -n "$path" ] || return 1
+    if [ -d "$path" ]; then
+        (cd "$path" 2>/dev/null && pwd -P) || return 1
+        return 0
+    fi
+    case "$path" in
+        /*) : ;;
+        *)  path="${PWD%/}/$path" ;;
+    esac
+    _agents_normalize_pure "$path"
+}
+
+# ── Spawn-prompt contract ──────────────────────────────────────────────
+
+# Build the subagent spawn prompt. The output ALWAYS contains every field the
+# contract requires so a coordinator can never spawn an under-specified agent:
+#   * a normalized absolute repo path   (agents_normalize_path)
+#   * the active issue number
+#   * the target branch
+#   * the baseline commit sha
+#   * an explicit write scope (the only paths the agent may touch)
+#   * an ownership/prohibition clause forbidding remote pushes, the GitHub CLI,
+#     opening/merging pull requests, and workspace cleanup
+#
+# The prohibition prose is worded to convey each ban WITHOUT embedding a literal
+# remote-push or bare GitHub-CLI command token, so the capability-guard test can
+# still assert this file performs no such command.
+#
+# Usage: agents_build_prompt <repo_path> <issue> <branch> <baseline> <write_scope>
+agents_build_prompt() {
+    local repo_path="${1:-}" issue="${2:-}" branch="${3:-}" baseline="${4:-}" write_scope="${5:-}"
+    local abs
+    abs="$(agents_normalize_path "$repo_path")" || abs="$repo_path"
+    cat <<EOF
+You are an implementation subagent for issue #${issue}.
+
+Repository (normalized absolute path): ${abs}
+Active issue: #${issue}
+Target branch: ${branch}
+Baseline commit: ${baseline}
+
+Write scope -- you may create or edit ONLY these paths:
+${write_scope}
+
+Ownership and prohibitions (the coordinator owns ALL git and GitHub mutations):
+- You MUST NOT push any commit or branch to the remote.
+- You MUST NOT invoke the GitHub CLI or any GitHub API mutation.
+- You MUST NOT open, update, or merge a pull request (PR).
+- You MUST NOT clean up, delete, or otherwise tear down the workspace.
+- You may only read and write files within the write scope above.
+- When in doubt, stop and defer the mutation to the coordinator.
+EOF
+}
+
+# ── Single-writer lease (mkdir-atomic) ────────────────────────────────
+
+# True only when <lease_path>'s final component equals AGENTS_LEASE_DIRNAME.
+# This is the guard that keeps agents_release_lease from ever removing an
+# arbitrary caller-supplied path.
+_agents_valid_lease_path() {
+    local lease_path="${1:-}"
+    [ -n "$lease_path" ] || return 1
+    [ "$(basename -- "$lease_path")" = "$AGENTS_LEASE_DIRNAME" ]
+}
+
+# Atomically acquire the single-writer lease at <lease_path> for <owner_id>.
+# `mkdir` (without -p) is atomic on POSIX: exactly one caller can create the
+# directory, so a second concurrent writer is refused with a non-zero return.
+# Fail-safe: any error (bad path, parent-create failure, lease already held)
+# returns non-zero -- when in doubt, refuse rather than admit a second writer.
+agents_acquire_lease() {
+    local lease_path="${1:-}" owner="${2:-}"
+    [ -n "$lease_path" ] && [ -n "$owner" ] || return 2
+    if ! _agents_valid_lease_path "$lease_path"; then
+        AGENTS_LAST_ERROR="lease path must end in ${AGENTS_LEASE_DIRNAME}"
+        return 2
+    fi
+    mkdir -p -- "$(dirname -- "$lease_path")" 2>/dev/null || return 1
+    if ! mkdir -- "$lease_path" 2>/dev/null; then
+        AGENTS_LAST_ERROR="lease already held"
+        return 1
+    fi
+    printf '%s\n' "$owner" > "${lease_path}/${_AGENTS_LEASE_OWNER_FILE}"
+    return 0
+}
+
+# Print the owner recorded in a held lease (empty + non-zero if none).
+agents_lease_owner() {
+    local lease_path="${1:-}" line=""
+    [ -n "$lease_path" ] || return 1
+    [ -f "${lease_path}/${_AGENTS_LEASE_OWNER_FILE}" ] || return 1
+    IFS= read -r line < "${lease_path}/${_AGENTS_LEASE_OWNER_FILE}" || true
+    printf '%s' "$line"
+}
+
+# Release the lease at <lease_path>, but only if <owner_id> currently holds it.
+# Refuses (non-zero) for a non-owner, a missing lease, or a path that is not a
+# lease directory. Removal is guarded: it deletes the known owner marker and
+# then rmdirs the now-empty directory -- never a bare `rm -rf` on the input.
+agents_release_lease() {
+    local lease_path="${1:-}" owner="${2:-}" stored=""
+    [ -n "$lease_path" ] && [ -n "$owner" ] || return 2
+    if ! _agents_valid_lease_path "$lease_path"; then
+        AGENTS_LAST_ERROR="refusing to release a non-lease path"
+        return 2
+    fi
+    if [ ! -d "$lease_path" ]; then
+        AGENTS_LAST_ERROR="no lease to release"
+        return 1
+    fi
+    stored="$(agents_lease_owner "$lease_path")" || stored=""
+    if [ "$stored" != "$owner" ]; then
+        AGENTS_LAST_ERROR="lease held by another writer"
+        return 1
+    fi
+    rm -f -- "${lease_path}/${_AGENTS_LEASE_OWNER_FILE}"
+    rmdir -- "$lease_path" 2>/dev/null || return 1
+    return 0
+}
+
+# ── Per-agent worktrees (concurrent-writes case ONLY) ─────────────────
+# The DEFAULT concurrency control is the single-writer lease above on the
+# shared checkout. Worktrees are used ONLY when agents must write concurrently;
+# each MUST be removed afterward (agents_worktree_remove) so no orphan is left
+# to block the #840 cleanup stage.
+
+# Add a worktree at <worktree_path> on a NEW <branch>, rooted in <repo_dir>.
+agents_worktree_add() {
+    local repo_dir="${1:-}" worktree_path="${2:-}" branch="${3:-}" out rc
+    [ -n "$repo_dir" ] && [ -n "$worktree_path" ] && [ -n "$branch" ] || return 2
+    out="$(_agents_git -C "$repo_dir" worktree add -b "$branch" "$worktree_path" 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        AGENTS_LAST_ERROR="$(workspace_redact_credentials "$out" | tail -n1)"
+    fi
+    return "$rc"
+}
+
+# Remove the worktree at <worktree_path> so it is not left orphaned.
+agents_worktree_remove() {
+    local repo_dir="${1:-}" worktree_path="${2:-}" out rc
+    [ -n "$repo_dir" ] && [ -n "$worktree_path" ] || return 2
+    out="$(_agents_git -C "$repo_dir" worktree remove "$worktree_path" 2>&1)"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        AGENTS_LAST_ERROR="$(workspace_redact_credentials "$out" | tail -n1)"
+    fi
+    return "$rc"
+}
+
+# ── Manifest state transitions ────────────────────────────────────────
+
+# Advance the manifest state from <from> to <to>, refusing if the current state
+# is not exactly <from>. This keeps the lifecycle strictly ordered
+# (READY -> AGENTS_RUNNING -> COMMITTED) rather than allowing an out-of-order jump.
+_agents_transition() {
+    local manifest="${1:-}" from="${2:-}" to="${3:-}" current
+    [ -n "$manifest" ] && [ -n "$from" ] && [ -n "$to" ] || return 2
+    current="$(workspace_manifest_state "$manifest")"
+    if [ "$current" != "$from" ]; then
+        AGENTS_LAST_ERROR="expected state ${from} but manifest is ${current:-<empty>}"
+        return 1
+    fi
+    workspace_manifest_write "$manifest" state "$to"
+}
+
+# READY -> AGENTS_RUNNING. Records the lease owner when one is supplied.
+agents_mark_running() {
+    local manifest="${1:-}" owner="${2:-}"
+    _agents_transition "$manifest" "$_AGENTS_STATE_READY" "$_AGENTS_STATE_RUNNING" || return $?
+    [ -n "$owner" ] && workspace_manifest_write "$manifest" lease_owner "$owner"
+    return 0
+}
+
+# AGENTS_RUNNING -> COMMITTED. The coordinator calls this after committing.
+agents_mark_committed() {
+    local manifest="${1:-}"
+    _agents_transition "$manifest" "$_AGENTS_STATE_RUNNING" "$_AGENTS_STATE_COMMITTED"
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+_agents_emit() {
+    local state="$1" manifest="$2"
+    printf '{"state":"%s","manifest":"%s"}\n' "$state" "$manifest"
+}
+
+_agents_emit_error() {
+    local reason
+    reason="$(workspace_redact_credentials "${1:-}")"
+    printf '{"state":"ERROR","reason":"%s"}\n' "$reason"
+}
+
+# ── Driver ──────────────────────────────────────────────────────────
+# run_agents <manifest> <phase> [<owner_id>]
+#
+# phase=start   READY -> AGENTS_RUNNING (records lease_owner when owner given)
+# phase=commit  AGENTS_RUNNING -> COMMITTED (the post-commit transition)
+run_agents() {
+    local manifest="${1:-}" phase="${2:-}" owner="${3:-}"
+    if [ -z "$manifest" ] || [ -z "$phase" ]; then
+        _agents_emit_error "missing required manifest/phase"
+        return 2
+    fi
+    case "$phase" in
+        start)
+            if ! agents_mark_running "$manifest" "$owner"; then
+                _agents_emit_error "${AGENTS_LAST_ERROR:-cannot enter AGENTS_RUNNING}"
+                return 1
+            fi
+            _agents_emit "$_AGENTS_STATE_RUNNING" "$manifest"
+            ;;
+        commit)
+            if ! agents_mark_committed "$manifest"; then
+                _agents_emit_error "${AGENTS_LAST_ERROR:-cannot enter COMMITTED}"
+                return 1
+            fi
+            _agents_emit "$_AGENTS_STATE_COMMITTED" "$manifest"
+            ;;
+        *)
+            _agents_emit_error "unknown phase: $phase"
+            return 2
+            ;;
+    esac
+    return 0
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+_agents_main() {
+    local manifest="" phase="" owner=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --manifest) manifest="$2"; shift 2 ;;
+            --phase) phase="$2"; shift 2 ;;
+            --owner) owner="$2"; shift 2 ;;
+            *) echo "unknown argument: $1" >&2; return 2 ;;
+        esac
+    done
+    if [ -z "$manifest" ] || [ -z "$phase" ]; then
+        echo "error: --manifest <path> and --phase <start|commit> are required" >&2
+        return 2
+    fi
+    run_agents "$manifest" "$phase" "$owner"
+}
+
+# Run as CLI only when executed directly; stay quiet when sourced by tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    _agents_main "$@"
+fi

--- a/tests/issue-work/README.md
+++ b/tests/issue-work/README.md
@@ -19,6 +19,7 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 | `test-triage.sh` | Test runner: pure-function unit tests + end-to-end scenarios. |
 | `fake-gh.sh` | Canned `gh` for the subset of commands triage.sh calls; records mutations to `mutations.log` and appends posted comments so idempotency reruns observe prior state. |
 | `test-workspace.sh` | Test runner for the workspace lifecycle stage (`scripts/workspace.sh`); see the dedicated section below. |
+| `test-agents.sh` | Test runner for the subagent spawn-contract + single-writer-lease stage (`scripts/agents.sh`); see the dedicated section below. |
 
 ## Acceptance-criteria coverage (issue #829)
 
@@ -86,3 +87,42 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 PowerShell parity for the workspace stage is delivered as
 `scripts/workspace.ps1`; cross-platform PS regression coverage is integrated
 in #832 (consistent with the existing #829 note above).
+
+## Subagent spawn / lease tests (issue #839)
+
+Unit and scenario tests for the subagent spawn-contract + single-writer-lease
+stage (`global/skills/_internal/issue-work/scripts/agents.sh`), which turns a
+`READY` workspace into an orchestrated one and advances the manifest
+`READY -> AGENTS_RUNNING -> COMMITTED`. The suite drives a real local git
+repository for the worktree scenarios rather than a fake — this stage never
+calls `gh`, so no shim is needed to exercise it without network access.
+Sourcing `agents.sh` also loads `workspace.sh`, so the #838 manifest primitive
+is available for assertions. See `reference/workspace-lifecycle.md` (the #839
+sections) for the full contract.
+
+### Run
+
+```bash
+bash tests/issue-work/test-agents.sh
+```
+
+The suite is wired into CI by `.github/workflows/validate-skills.yml`.
+
+### Acceptance-criteria coverage (issue #839)
+
+| AC | Scenario | Assertion |
+|----|----------|-----------|
+| AC1 | Path normalization | A relative path (existing or not-yet-existing) resolves to an absolute, lexically collapsed path; empty input fails. |
+| AC2 | Spawn-prompt contract | `agents_build_prompt` output contains every required field — normalized absolute repo path, active issue number, target branch, baseline sha, explicit write scope — plus a prohibition clause forbidding remote pushes, the GitHub CLI, opening/merging a PR, and workspace cleanup. |
+| AC3 | Lease mutual exclusion | First writer acquires; a second writer is refused while the lease is held; after the owner releases, the lease is re-acquirable. |
+| AC4 | Lease fail-safe | A non-owner release is refused (lease survives); releasing a non-existent lease fails cleanly; a non-lease path is refused (guarded removal). |
+| AC5 | Per-agent worktree | Adding a worktree on a new branch creates it and lists it; removing it deletes the directory and leaves no orphan in `git worktree list`. |
+| AC6 | State transitions | From `state=READY`, the start phase advances to `AGENTS_RUNNING` (recording `lease_owner`) and the commit phase to `COMMITTED`; an out-of-order transition is refused and leaves state unchanged. |
+| AC7 | Capability guard | `agents.sh` contains no `git push`, no `gh` invocation (word-boundary match), and no `gh` injection seam. |
+
+### Scope note
+
+PowerShell parity for the subagent/lease stage is delivered as
+`scripts/agents.ps1`; it is not runtime-verified here (no `pwsh`) and not wired
+into CI. Cross-platform PS regression coverage is integrated in #832
+(consistent with the #829 and #838 notes above).

--- a/tests/issue-work/test-agents.sh
+++ b/tests/issue-work/test-agents.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Test suite for global/skills/_internal/issue-work/scripts/agents.sh
+# Run: bash tests/issue-work/test-agents.sh
+#
+# Drives the subagent spawn-contract + single-writer-lease stage
+# (READY -> AGENTS_RUNNING -> COMMITTED) against a real local git repository --
+# no fake gh/git shim is needed because this stage never calls gh, and driving
+# real git exercises the actual worktree add/remove codepaths instead of a
+# stand-in. Sourcing agents.sh also loads workspace.sh, so the #838 manifest
+# primitive (workspace_manifest_*) is available for assertions.
+#
+# AC -> test mapping (see reference/workspace-lifecycle.md, #839 sections):
+#   AC1  path normalization      -> a relative path resolves to an absolute path
+#   AC2  spawn-prompt contract    -> prompt carries every required field + the
+#                                    full prohibition clause
+#   AC3  lease mutual exclusion   -> one writer at a time; re-acquire after release
+#   AC4  lease fail-safe          -> non-owner release refused; missing lease fails cleanly
+#   AC5  per-agent worktree        -> add then remove leaves no orphan
+#   AC6  state transitions         -> READY -> AGENTS_RUNNING -> COMMITTED
+#   AC7  capability guard          -> script performs no gh call and no remote push
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+AGENTS="$ROOT_DIR/global/skills/_internal/issue-work/scripts/agents.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# Explicit template (rather than a bare `mktemp -d`) so this suite is stable
+# under sandboxes that restrict the OS default temp directory but expose
+# $TMPDIR, as well as under plain CI runners where $TMPDIR is unset.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/iw-agents-test.XXXXXX")"
+# Resolve symlinks + collapse // so derived paths match `git worktree list`
+# output on macOS, whose default $TMPDIR (/var/folders/...) is a symlink to
+# /private/var/... that git canonicalizes. pwd -P matches git's own resolution.
+WORK="$(cd "$WORK" && pwd -P)"
+trap 'rm -rf "$WORK"' EXIT
+
+ok()   { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $1"); echo "  FAIL: $1"; }
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then ok "$label"; else
+        bad "$label -- expected '$expected', got '$actual'"; fi
+}
+
+assert_contains() {
+    local needle="$1" hay="$2" label="$3"
+    if printf '%s' "$hay" | grep -Fq -- "$needle"; then ok "$label"; else
+        bad "$label -- '$needle' not in output"; fi
+}
+
+# Builds a real (non-bare) repository with one commit on a "develop" branch and
+# prints its path. Worktree tests operate directly on this checkout.
+make_repo() {  # make_repo <name>
+    local name="$1" repo
+    repo="$WORK/repos/$name"
+    mkdir -p "$repo"
+    git init -q -b develop "$repo"
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "test"
+    echo "content" > "$repo/file.txt"
+    git -C "$repo" add file.txt
+    git -C "$repo" commit -q -m "seed commit" >/dev/null
+    printf '%s' "$repo"
+}
+
+echo "=== agents.sh unit + scenario tests ==="
+# shellcheck disable=SC1090
+source "$AGENTS"
+
+# Low-entropy, clearly-fake owner ids assembled at runtime. No credential is
+# needed for any lease/worktree/transition test; these are opaque identity
+# strings, never tokens, and carry no secret-scanner-shaped prefix.
+OWNER_A="agent-a-$$"
+OWNER_B="agent-b-$$"
+
+echo ""
+echo "=== AC1: path normalization -- a relative path resolves to an absolute path ==="
+norm_dir="$WORK/norm/sub"
+mkdir -p "$norm_dir"
+rel_out="$(cd "$WORK/norm" && agents_normalize_path "sub")"
+case "$rel_out" in
+    /*) ok "AC1 relative existing dir resolves to an absolute path" ;;
+    *)  bad "AC1 relative path did not resolve to an absolute path -- got '$rel_out'" ;;
+esac
+assert_contains "/norm/sub" "$rel_out" "AC1 normalized path retains the resolved directory"
+# Pure (non-existent) path is still made absolute and lexically collapsed.
+pure_out="$(cd "$WORK/norm" && agents_normalize_path "a/b/../c")"
+case "$pure_out" in
+    /*) ok "AC1 non-existent relative path is made absolute" ;;
+    *)  bad "AC1 non-existent relative path not absolute -- got '$pure_out'" ;;
+esac
+assert_contains "/a/c" "$pure_out" "AC1 '..' is collapsed lexically"
+if agents_normalize_path ""; then bad "AC1 empty input must fail"; else
+    ok "AC1 empty input fails"; fi
+
+echo ""
+echo "=== AC2: spawn-prompt contract carries every required field ==="
+prompt_repo="$WORK/repos/promptrepo"
+mkdir -p "$prompt_repo"
+abs_repo="$(agents_normalize_path "$prompt_repo")"
+scope_text="scripts/agents.sh, tests/issue-work/test-agents.sh"
+prompt="$(agents_build_prompt "$prompt_repo" 839 feat/issue-839-subagent-spawn-lease deadbeefcafe "$scope_text")"
+assert_contains "$abs_repo" "$prompt" "AC2 prompt contains the normalized absolute repo path"
+assert_contains "#839" "$prompt" "AC2 prompt contains the active issue number"
+assert_contains "feat/issue-839-subagent-spawn-lease" "$prompt" "AC2 prompt contains the target branch"
+assert_contains "deadbeefcafe" "$prompt" "AC2 prompt contains the baseline commit"
+assert_contains "$scope_text" "$prompt" "AC2 prompt contains the explicit write scope"
+# Prohibition clause: each ban must be present.
+assert_contains "push any commit" "$prompt" "AC2 prohibition forbids pushing to the remote"
+assert_contains "GitHub CLI" "$prompt" "AC2 prohibition forbids the GitHub CLI"
+assert_contains "pull request (PR)" "$prompt" "AC2 prohibition forbids opening/merging a PR"
+assert_contains "merge a pull request" "$prompt" "AC2 prohibition forbids merging a PR"
+assert_contains "clean up" "$prompt" "AC2 prohibition forbids workspace cleanup"
+assert_contains "coordinator owns ALL git and GitHub mutations" "$prompt" "AC2 prompt states coordinator ownership"
+
+echo ""
+echo "=== AC3: lease mutual exclusion -- one writer at a time ==="
+lease="$WORK/checkout/$AGENTS_LEASE_DIRNAME"
+if agents_acquire_lease "$lease" "$OWNER_A"; then ok "AC3 first writer acquires the lease"; else
+    bad "AC3 first acquire should succeed"; fi
+assert_eq "$OWNER_A" "$(agents_lease_owner "$lease")" "AC3 lease records the owning writer"
+if agents_acquire_lease "$lease" "$OWNER_B"; then
+    bad "AC3 a second writer must be refused while the lease is held"; else
+    ok "AC3 second writer is refused while the lease is held"; fi
+assert_eq "$OWNER_A" "$(agents_lease_owner "$lease")" "AC3 held lease still owned by the first writer"
+if agents_release_lease "$lease" "$OWNER_A"; then ok "AC3 owner releases the lease"; else
+    bad "AC3 owner release should succeed"; fi
+if [ -d "$lease" ]; then bad "AC3 lease directory must be gone after release"; else
+    ok "AC3 lease directory removed on release"; fi
+if agents_acquire_lease "$lease" "$OWNER_B"; then ok "AC3 lease is re-acquirable after release"; else
+    bad "AC3 re-acquire after release should succeed"; fi
+# Clean up for later independence.
+agents_release_lease "$lease" "$OWNER_B" >/dev/null 2>&1 || true
+
+echo ""
+echo "=== AC4: lease fail-safe -- non-owner release refused; missing lease fails cleanly ==="
+lease2="$WORK/checkout2/$AGENTS_LEASE_DIRNAME"
+agents_acquire_lease "$lease2" "$OWNER_A" >/dev/null 2>&1
+if agents_release_lease "$lease2" "$OWNER_B"; then
+    bad "AC4 a non-owner must not be able to release the lease"; else
+    ok "AC4 non-owner release is refused"; fi
+if [ -d "$lease2" ]; then ok "AC4 lease survives a refused non-owner release"; else
+    bad "AC4 lease must survive a refused non-owner release"; fi
+agents_release_lease "$lease2" "$OWNER_A" >/dev/null 2>&1 || true
+# Releasing a non-existent lease fails cleanly (non-zero, no crash).
+if agents_release_lease "$WORK/nope/$AGENTS_LEASE_DIRNAME" "$OWNER_A"; then
+    bad "AC4 releasing a non-existent lease must fail"; else
+    ok "AC4 releasing a non-existent lease fails cleanly"; fi
+# A path that is not a lease directory is refused outright (guarded removal).
+if agents_release_lease "$WORK/not-a-lease-dir" "$OWNER_A"; then
+    bad "AC4 releasing a non-lease path must be refused"; else
+    ok "AC4 non-lease path is refused (guarded removal)"; fi
+
+echo ""
+echo "=== AC5: per-agent worktree add then remove leaves no orphan ==="
+wt_repo="$(make_repo wtrepo)"
+wt_path="$WORK/worktrees/agent1"
+if agents_worktree_add "$wt_repo" "$wt_path" "feat/agent1-work"; then ok "AC5 worktree add succeeds"; else
+    bad "AC5 worktree add should succeed -- ${AGENTS_LAST_ERROR:-}"; fi
+if [ -d "$wt_path" ]; then ok "AC5 worktree directory exists after add"; else
+    bad "AC5 worktree directory should exist after add"; fi
+assert_contains "$wt_path" "$(git -C "$wt_repo" worktree list)" "AC5 git lists the added worktree"
+if agents_worktree_remove "$wt_repo" "$wt_path"; then ok "AC5 worktree remove succeeds"; else
+    bad "AC5 worktree remove should succeed -- ${AGENTS_LAST_ERROR:-}"; fi
+if [ -d "$wt_path" ]; then bad "AC5 worktree directory must be gone after remove"; else
+    ok "AC5 worktree directory removed"; fi
+assert_eq "" "$(git -C "$wt_repo" worktree list | grep -F "$wt_path" || true)" "AC5 removed worktree is not orphaned in git worktree list"
+
+echo ""
+echo "=== AC6: state transitions READY -> AGENTS_RUNNING -> COMMITTED ==="
+manifest="$WORK/manifest"
+workspace_manifest_write "$manifest" state READY
+out_start="$(run_agents "$manifest" start "$OWNER_A")"
+assert_contains "\"state\":\"AGENTS_RUNNING\"" "$out_start" "AC6 start phase emits AGENTS_RUNNING"
+assert_eq "AGENTS_RUNNING" "$(workspace_manifest_state "$manifest")" "AC6 manifest advances to AGENTS_RUNNING"
+assert_eq "$OWNER_A" "$(workspace_manifest_read "$manifest" lease_owner)" "AC6 start records the lease owner"
+out_commit="$(run_agents "$manifest" commit)"
+assert_contains "\"state\":\"COMMITTED\"" "$out_commit" "AC6 commit phase emits COMMITTED"
+assert_eq "COMMITTED" "$(workspace_manifest_state "$manifest")" "AC6 manifest advances to COMMITTED"
+# Out-of-order transition is refused (fail-safe on strict ordering).
+manifest_bad="$WORK/manifest-bad"
+workspace_manifest_write "$manifest_bad" state READY
+if run_agents "$manifest_bad" commit >/dev/null 2>&1; then
+    bad "AC6 commit from READY (skipping AGENTS_RUNNING) must be refused"; else
+    ok "AC6 out-of-order transition is refused"; fi
+assert_eq "READY" "$(workspace_manifest_state "$manifest_bad")" "AC6 refused transition leaves state unchanged"
+
+echo ""
+echo "=== AC7: capability guard -- script performs no gh call and no remote push ==="
+# The agent must never perform a GitHub mutation. Assert the script contains no
+# remote push and no GitHub-CLI invocation. The gh check uses a word boundary so
+# ordinary words ending in 'gh' (e.g. 'through') never register as a false match.
+if grep -Fq 'git push' "$AGENTS"; then
+    bad "AC7 agents.sh must not contain 'git push'"; else
+    ok "AC7 agents.sh performs no remote push"; fi
+if grep -Eq '(^|[^[:alnum:]_])gh ' "$AGENTS"; then
+    bad "AC7 agents.sh must not invoke the GitHub CLI (gh)"; else
+    ok "AC7 agents.sh performs no gh call"; fi
+if grep -Fq 'GH_BIN' "$AGENTS"; then
+    bad "AC7 agents.sh must not wire a gh injection seam"; else
+    ok "AC7 agents.sh has no gh injection seam"; fi
+
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #839.

## What

Implement the second stage of the `issue-work` isolated-workspace lifecycle:
`READY -> AGENTS_RUNNING -> COMMITTED`. Once #838's identity-verified clone is
`READY`, spawn subagents against it under a strict execution contract and
serialize writes to a shared checkout with a single-writer lease. GitHub-facing
mutations (push, PR, merge, cleanup) remain the coordinator's exclusive job.

## Why

Part of #830 (isolated workspace and subagent lifecycle), epic #828. Depends on
#838, which delivered the `READY` clone and the atomic manifest primitive but
explicitly deferred subagent spawn to this stage. This stage turns a `READY`
workspace into supervised subagent execution with safe concurrent-write control;
resume reconciliation and safe cleanup (`PUSHED -> ... -> CLEANED`) build on the
`COMMITTED` state in the final sub-issue #840.

## Where

| File | Change |
|------|--------|
| `global/skills/_internal/issue-work/scripts/agents.sh` | NEW - Bash reference implementation (sourceable library + CLI). |
| `global/skills/_internal/issue-work/scripts/agents.ps1` | NEW - PowerShell parity port. |
| `global/skills/_internal/issue-work/reference/workspace-lifecycle.md` | Extended - agent prompt contract, coordinator/agent capability split, lease protocol, worktree rule. |
| `tests/issue-work/test-agents.sh` | NEW - 43-assertion bash suite (real local git repo; git-only). |
| `tests/issue-work/README.md` | Extended - #839 test section + AC coverage table. |
| `.github/workflows/validate-skills.yml` | Added one run step after the #838 workspace-test step. |

## How

- `agents.sh` mirrors the #829/#838 convention: `set -uo pipefail`, section
  banners, public `agents_*` / internal `_agents_*` functions, a `GIT_BIN`
  injection seam, and a sourcing guard so tests can source it. It sources
  `workspace.sh` to reuse the #838 atomic manifest primitive for the
  `AGENTS_RUNNING`/`COMMITTED` transitions rather than reimplementing it.
- The agent-prompt contract (`agents_build_prompt`) always carries a normalized
  absolute repo path, the active issue, target branch, baseline commit, an
  explicit write scope, and an ownership/prohibition clause (no push, no GitHub
  CLI, no PR, no cleanup).
- The single-writer lease is `mkdir`-atomic (portable, no `flock`/`jq`),
  owner-checked on release, and fail-safe: a held or ambiguous lease refuses a
  second writer rather than allowing a corrupting concurrent write.
- Per-agent worktrees are provided for the concurrent-writes case only; the
  default is a single-writer lease on the shared checkout. Worktree removal is
  explicit so no orphan blocks the later cleanup stage (#840).
- `agents.sh` contains no GitHub CLI call and never pushes - agents cannot
  perform GitHub mutations by construction.

## Test plan

- `bash tests/issue-work/test-agents.sh` -> 43 passed, 0 failed (wired into CI
  right after the triage and workspace suites). Covers path normalization,
  prompt scope/ownership presence, lease mutual exclusion + fail-safe release,
  worktree add/remove with no orphan, and the manifest state transitions.
- The suite canonicalizes its run root with `pwd -P` so worktree-path
  assertions match git's realpath output on macOS (where `$TMPDIR` lives under
  `/var`, a symlink to `/private/var`); verified green under both a normal and a
  symlinked `TMPDIR`.
- No token-shaped literal is committed: any placeholder identity is assembled at
  runtime, consistent with the #838 test suite.
- `test-workspace.sh` regression: 42 passed, 0 failed.

## Pre-PR gate

- `develop` was unchanged since the working clone (origin/develop == the
  baseline commit), so no rebase/conflict resolution was needed.
- Documentation-to-issue gap audit against the #829/#838 precedent: full
  `SKILL.md` workflow integration, the `CHANGELOG.md` entry, and the
  `docs/.index/` regeneration are intentionally deferred to the
  lifecycle-completing sub-issue **#840**. Rationale: (1) `SKILL.md` and
  `CHANGELOG.md` are doc-indexed / user-facing, so a mid-lifecycle edit would
  document a workflow whose cleanup/resume half is not yet implemented; (2) this
  matches #838, which created `workspace-lifecycle.md` un-indexed and left
  `SKILL.md`/`CHANGELOG.md` for the whole feature; (3) the issue-work
  scripts/reference are not mirrored to `plugin/`, so no `check_references.sh`
  mirror update is required. A single coherent `SKILL.md`/`CHANGELOG` entry
  lands once the lifecycle is whole.

## Notes

- `agents.ps1` is a faithful 1:1 parity port but was **not** runtime-verified
  (no `pwsh` in the authoring environment); it is not executed by any CI step.
  Cross-platform PowerShell regression coverage is integrated in **#832**,
  consistent with the #829/#838 notes in `tests/issue-work/README.md`.
