### PR TITLE
feat(issue-work): add pre-PR readiness gate and documentation-to-issue gap audit

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Run issue-work cleanup/resume tests (#840)
         run: bash tests/issue-work/test-cleanup.sh
 
+      - name: Run issue-work pre-PR readiness gate tests (#831)
+        run: bash tests/issue-work/test-pre-pr-gate.sh
+
       - name: Install pytest for fleet_orchestrator tests
         # pytest is already a transitive dep of jsonschema in some envs; pin
         # explicitly so the runner does not silently fall back to unittest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference implementations (`scripts/workspace.sh`, `scripts/agents.sh`,
   `scripts/cleanup-workspace.sh`) and fake-`gh` / bare-remote unit suites in
   `tests/issue-work/` (#838, #839, #840).
+- Added a mandatory pre-PR readiness gate for `issue-work` that runs after the
+  implementation and documentation are committed and before any push or PR. A
+  deterministic git-state helper
+  (`global/skills/_internal/issue-work/scripts/pre-pr-gate.sh`) refuses a dirty
+  worktree, fetches the base branch, fast-forwards the local base only when it
+  is strictly behind (an `ahead` or `diverged` base blocks and is never
+  rewound), integrates the refreshed base into the feature branch (rebase by
+  default, merge for shared branches), aborts and blocks on any conflict rather
+  than guessing intent, and re-integrates when the remote base moves — stopping
+  with `base_unstable` after a capped number of movements. It emits a single
+  `ready`/`blocked` JSON outcome that the skill routes on. The agent-side
+  documentation-to-issue gap audit reconciles each required behavior against
+  implementation, test, documentation, and issue evidence in a seven-field gap
+  ledger whose rows carry exactly one of four dispositions (`fix-in-pr`,
+  `followup-issue`, `already-satisfied`, `blocked`), never reports "no gap" when
+  retrieval was incomplete, and requires the resulting PR to target `develop`,
+  close the active issue, and use a Korean title and body. The contract is
+  documented in `reference/pre-pr-readiness.md` and covered by a bare-remote
+  unit suite in `tests/issue-work/test-pre-pr-gate.sh` (#831).
 
 ### Fixed
 

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -10,29 +10,29 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 21112
+    size: 22527
     tags: []
     sections:
       - {h: "Changelog", l: 1, e: 7}
       - {h: "[Unreleased]", l: 8, e: 9}
-      - {h: "Added", l: 10, e: 43}
-      - {h: "Fixed", l: 44, e: 67}
-      - {h: "1.11.0 - 2026-07-03", l: 68, e: 69}
-      - {h: "Fixed", l: 70, e: 83}
-      - {h: "Security", l: 84, e: 161}
-      - {h: "Added", l: 162, e: 190}
-      - {h: "Changed", l: 191, e: 237}
-      - {h: "1.10.0 - 2026-04-20", l: 238, e: 246}
-      - {h: "1.9.0 - 2026-04-13", l: 247, e: 256}
-      - {h: "1.8.0 - 2026-04-13", l: 257, e: 262}
-      - {h: "1.7.0 - 2026-04-06", l: 263, e: 277}
-      - {h: "1.6.0 - 2026-04-03", l: 278, e: 290}
-      - {h: "1.5.0 - 2026-03-21", l: 291, e: 309}
-      - {h: "1.4.0 - 2026-01-22", l: 310, e: 315}
-      - {h: "1.3.0 - 2026-01-15", l: 316, e: 324}
-      - {h: "1.2.0 - 2026-01-15", l: 325, e: 333}
-      - {h: "1.1.0 - 2025-01-15", l: 334, e: 344}
-      - {h: "1.0.0 - 2025-12-03", l: 345, e: 351}
+      - {h: "Added", l: 10, e: 62}
+      - {h: "Fixed", l: 63, e: 86}
+      - {h: "1.11.0 - 2026-07-03", l: 87, e: 88}
+      - {h: "Fixed", l: 89, e: 102}
+      - {h: "Security", l: 103, e: 180}
+      - {h: "Added", l: 181, e: 209}
+      - {h: "Changed", l: 210, e: 256}
+      - {h: "1.10.0 - 2026-04-20", l: 257, e: 265}
+      - {h: "1.9.0 - 2026-04-13", l: 266, e: 275}
+      - {h: "1.8.0 - 2026-04-13", l: 276, e: 281}
+      - {h: "1.7.0 - 2026-04-06", l: 282, e: 296}
+      - {h: "1.6.0 - 2026-04-03", l: 297, e: 309}
+      - {h: "1.5.0 - 2026-03-21", l: 310, e: 328}
+      - {h: "1.4.0 - 2026-01-22", l: 329, e: 334}
+      - {h: "1.3.0 - 2026-01-15", l: 335, e: 343}
+      - {h: "1.2.0 - 2026-01-15", l: 344, e: 352}
+      - {h: "1.1.0 - 2025-01-15", l: 353, e: 363}
+      - {h: "1.0.0 - 2025-12-03", l: 364, e: 370}
   - path: "COMPATIBILITY.md"
     title: "Compatibility Guide"
     description: ""
@@ -2808,7 +2808,7 @@ documents:
     description: ""
     category: skill
     scope: global
-    size: 28353
+    size: 31505
     tags: [global,skill]
     sections:
       - {h: "Usage", l: 36, e: 51}
@@ -2832,27 +2832,27 @@ documents:
       - {h: "Inline Strategy (short builds)", l: 374, e: 382}
       - {h: "Background + Log Polling Strategy (long builds)", l: 383, e: 391}
       - {h: "On Build/Test Failure", l: 392, e: 401}
-      - {h: "7. Documentation Update", l: 402, e: 414}
-      - {h: "8. Push and Create PR", l: 415, e: 423}
-      - {h: "Summary", l: 424, e: 426}
-      - {h: "Test Plan", l: 427, e: 437}
-      - {h: "9. Monitor CI", l: 438, e: 485}
-      - {h: "10. Squash Merge", l: 486, e: 515}
-      - {h: "11. Close Related Issues and Epics", l: 516, e: 531}
-      - {h: "12. Update Original Issue", l: 532, e: 542}
-      - {h: "Team Mode Instructions", l: 543, e: 546}
-      - {h: "Policies", l: 547, e: 550}
-      - {h: "Command-Specific Rules", l: 551, e: 558}
-      - {h: "Output", l: 559, e: 565}
-      - {h: "Work Summary", l: 566, e: 578}
-      - {h: "Changes Made", l: 579, e: 581}
-      - {h: "Files Modified", l: 582, e: 585}
-      - {h: "Next Steps", l: 586, e: 592}
-      - {h: "Work Summary (INCOMPLETE)", l: 593, e: 604}
-      - {h: "Action Required", l: 605, e: 610}
-      - {h: "Batch Mode Output", l: 611, e: 614}
-      - {h: "Error Handling", l: 615, e: 618}
-      - {h: "Side Effects and Loop-Safety", l: 619, e: 621}
+      - {h: "7. Documentation Update", l: 402, e: 464}
+      - {h: "8. Push and Create PR", l: 465, e: 473}
+      - {h: "Summary", l: 474, e: 476}
+      - {h: "Test Plan", l: 477, e: 487}
+      - {h: "9. Monitor CI", l: 488, e: 535}
+      - {h: "10. Squash Merge", l: 536, e: 565}
+      - {h: "11. Close Related Issues and Epics", l: 566, e: 581}
+      - {h: "12. Update Original Issue", l: 582, e: 592}
+      - {h: "Team Mode Instructions", l: 593, e: 596}
+      - {h: "Policies", l: 597, e: 600}
+      - {h: "Command-Specific Rules", l: 601, e: 608}
+      - {h: "Output", l: 609, e: 615}
+      - {h: "Work Summary", l: 616, e: 628}
+      - {h: "Changes Made", l: 629, e: 631}
+      - {h: "Files Modified", l: 632, e: 635}
+      - {h: "Next Steps", l: 636, e: 642}
+      - {h: "Work Summary (INCOMPLETE)", l: 643, e: 654}
+      - {h: "Action Required", l: 655, e: 660}
+      - {h: "Batch Mode Output", l: 661, e: 664}
+      - {h: "Error Handling", l: 665, e: 668}
+      - {h: "Side Effects and Loop-Safety", l: 669, e: 671}
   - path: "global/skills/_internal/issue-work/reference/batch-mode.md"
     title: "Batch Mode Instructions"
     description: ""

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -412,6 +412,56 @@ Commit separately:
 docs(scope): update documentation for <feature>
 ```
 
+### 7.5. Pre-PR Readiness Gate and Documentation-to-Issue Gap Audit
+
+**Mandatory.** This gate runs **after** the implementation and documentation are
+committed to the feature branch and **before** any push or PR. It has two
+halves — a deterministic git-state gate (`scripts/pre-pr-gate.sh`) and an
+agent-driven documentation-to-issue gap audit. The full contract (outcome table,
+develop-refresh rules, conflict rule, base-movement retry rule, gap-ledger
+schema, dispositions, Korean-PR requirement) lives in
+`reference/pre-pr-readiness.md`; do not duplicate it here.
+
+Run the git-state gate from the feature-branch checkout (the `$PROJECT` directory
+entered in Step 3), then branch on its structured outcome:
+
+```bash
+PREPR_JSON=$(bash ~/.claude/skills/_internal/issue-work/scripts/pre-pr-gate.sh \
+  --repo "$ORG/$PROJECT" --base develop --branch "$BRANCH_NAME")
+
+OUTCOME=$(printf '%s' "$PREPR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["outcome"])')
+REASON=$(printf '%s' "$PREPR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["reason"])')
+```
+
+**Outcome routing** (the JSON `outcome` field is authoritative):
+
+| `outcome` | Action |
+|-----------|--------|
+| `ready` | The base was refreshed (fast-forwarded or already current) and the feature was integrated cleanly onto a stable base. Run the gap audit below, then continue to Step 8. |
+| `blocked` | **STOP.** Report the `reason` (`dirty_worktree`, `base_ahead`, `base_diverged`, `conflict`, `base_unstable`, `fetch_failed`, ...). Do **NOT** push or open a PR. Resolve the cause per `reference/pre-pr-readiness.md` (e.g. commit impl+docs for `dirty_worktree`; hand-resolve only an unambiguous `conflict`, never guess), then rerun the gate. |
+
+The gate only ever **fast-forwards** the local `develop` when it is strictly
+behind the remote; an `ahead` or `diverged` base is left untouched and blocks —
+it is never reset. Integration defaults to rebase (private branch); pass
+`--integrate merge` for a shared branch. On any conflict the script aborts and
+blocks, leaving the feature branch exactly as it was — the agent may hand-resolve
+**only** verifiably-unambiguous conflicts and must rerun the affected
+verification and the gate before proceeding.
+
+On a `ready` outcome, perform the **documentation-to-issue gap audit** per
+`reference/pre-pr-readiness.md`: index the active issue plus its parent/child and
+linked issues, reconcile each required behavior against implementation, test, and
+documentation evidence, and record a gap ledger. Each row's `disposition` is
+exactly one of `fix-in-pr` (in scope — fix before pushing), `followup-issue`
+(out of scope — file a deduplicated follow-up), `already-satisfied`, or
+`blocked`. Never report "no gap" when issue or documentation retrieval was
+incomplete — treat those rows as `blocked`. Resolve every `fix-in-pr` row and
+rerun the gate before continuing to Step 8.
+
+The PR created in Step 8 must **target `develop`**, be written in **Korean** per
+`reference/pre-pr-readiness.md` (machine tokens — identifiers, paths, URLs, and
+the `Closes #N` keyword — stay ASCII), and **close the active issue**.
+
 ### 8. Push and Create PR
 
 ```bash

--- a/global/skills/_internal/issue-work/reference/pre-pr-readiness.md
+++ b/global/skills/_internal/issue-work/reference/pre-pr-readiness.md
@@ -1,0 +1,298 @@
+# Pre-PR Readiness Gate and Documentation-to-Issue Gap Audit
+
+Mandatory gate for `issue-work` that runs **after** the implementation and
+documentation have been committed to the feature branch and **before** the
+branch is pushed or a pull request is opened. It has two halves:
+
+1. A deterministic **git-state gate** — refresh the base branch (`develop`) and
+   integrate it into the feature branch with safe conflict handling. The
+   reference implementation is `scripts/pre-pr-gate.sh` (sibling directory); it
+   owns only the mechanical, non-judgemental decisions and emits a single JSON
+   object.
+2. An agent-driven **documentation-to-issue gap audit** — reconcile what the
+   issue and its surrounding documentation require against what the PR actually
+   delivers, producing a **gap ledger**. This half needs judgement (reading
+   issue bodies, matching requirements to evidence) and is therefore performed
+   by the agent following the procedure below, not by the script.
+
+This document is the contract for both halves. Code and doc must stay in sync —
+when one changes, change the other in the same PR (same rule as the sibling
+`reference/workspace-lifecycle.md` and `reference/triage-state-machine.md`).
+
+## Handoff
+
+The gate picks up after Step 7 (Documentation Update) of the Solo Mode workflow,
+with impl + docs already committed to the feature branch, and hands off to
+Step 8 (Push and Create PR) only on a `ready` outcome.
+
+```
+Step 7 (docs committed on feature branch)
+        |
+        v
+pre-pr-gate.sh --repo <owner/name> --base develop --branch <feature>
+        -> {"outcome":"ready", ...}       -> gap audit -> Step 8 (push + PR)
+        -> {"outcome":"blocked", "reason":...} -> STOP, report, no push/PR
+```
+
+## Git-state gate ordering
+
+`run_pre_pr_gate <repo> <base> <branch> [<remote>] [<max_base_moves>]
+[<integrate>]` runs these steps in order and stops at the first that blocks:
+
+1. **Clean-worktree precondition.** If the feature-branch worktree has tracked
+   staged/unstaged changes, block with `dirty_worktree`. Untracked files do not
+   block (they never impede a rebase). *Commit the implementation and docs
+   first — this gate integrates committed history, not a dirty tree.*
+2. **Checkout the feature branch** (defensive; the workflow is already on it).
+3. **Fetch the remote base** through the injected git (never GitHub network from
+   the script's own logic — the fetch is the only remote touch, and tests inject
+   a local bare remote via `GIT_BIN`).
+4. **Refresh the local base branch** per the develop-refresh rules below.
+5. **Integrate** the refreshed base into the feature branch (rebase by default,
+   merge for shared branches).
+6. **Re-fetch** and, if the remote base moved, **re-integrate** up to
+   `--max-base-moves` times (base-movement retry rule below).
+7. On a clean integration against a stable base, emit `ready`.
+
+### Outcome schema
+
+`run_pre_pr_gate` prints exactly one JSON object as its final stdout line. Keys
+are stable so a test can parse them:
+
+```json
+{
+  "outcome": "ready|blocked",
+  "reason": "<slug>",
+  "base": "develop",
+  "remote_base_sha": "<sha or empty>",
+  "local_base_sha_before": "<sha or empty>",
+  "local_base_sha_after": "<sha or empty>",
+  "attempts": 0
+}
+```
+
+`local_base_sha_before` and `local_base_sha_after` bracket the local base branch
+across the run, so a blocked `base_ahead` / `base_diverged` can prove the base
+was **not** rewound (`after == before`). `attempts` counts integration cycles.
+
+### Outcome table
+
+| `outcome` | `reason` | Meaning | Downstream action |
+|-----------|----------|---------|-------------------|
+| `ready` | `ready` | Clean worktree, base refreshed (fast-forwarded or already current), feature integrated cleanly onto a stable base. | Proceed to the gap audit, then Step 8 (push + PR). |
+| `blocked` | `dirty_worktree` | The feature worktree has uncommitted tracked changes. | Commit impl + docs, then rerun the gate. |
+| `blocked` | `base_ahead` | The local base has commits the remote lacks; the base was left untouched. | Investigate the unshared base commits; never rewind. Resolve upstream, then rerun. |
+| `blocked` | `base_diverged` | The local and remote base histories forked; the base was left untouched. | Reconcile the base manually; never reset. Then rerun. |
+| `blocked` | `conflict` | Integrating the base into the feature branch conflicted; the rebase/merge was aborted and the feature branch restored exactly. | Apply the conflict rule below (hand-resolve only unambiguous conflicts), then rerun. |
+| `blocked` | `base_unstable` | The remote base kept moving; re-integration hit the `--max-base-moves` cap. | Wait for the base to settle, then rerun. Do not loop indefinitely. |
+| `blocked` | `fetch_failed` | The base fetch failed. | Check connectivity/remote, then rerun. |
+| `blocked` | `checkout_failed` | The feature branch could not be checked out. | Verify the branch exists locally, then rerun. |
+| `blocked` | `missing_args` / `bad_integrate_mode` | Invalid invocation (missing `--repo`/`--base`/`--branch`, or an `--integrate` value other than `rebase`/`merge`). | Fix the invocation. |
+
+Only `ready` continues into the gap audit and PR creation. Every `blocked`
+outcome is terminal for the invocation: **stop, report the reason, and do not
+push or open a PR.**
+
+## Develop-refresh rules
+
+The gate classifies the local base against the freshly fetched remote base
+(`classify_base_relationship <local_sha> <remote_sha>` -> `equal` / `behind` /
+`ahead` / `diverged`) and acts:
+
+- **`equal`** — the local base is already current. No-op.
+- **`behind`** — the local base is strictly an ancestor of the remote base, so
+  advancing it is a **true fast-forward**. The gate moves the local base ref
+  forward to the remote sha (without a checkout, staying on the feature branch).
+- **`ahead`** — the remote base is an ancestor of the local base, i.e. the local
+  base carries commits the remote does not. **Block (`base_ahead`); never
+  rewind or reset the base.** A base branch that is ahead of its remote is a
+  signal something is wrong (a stray local commit, a wrong branch) that a script
+  must not paper over by discarding history.
+- **`diverged`** — neither sha is an ancestor of the other. **Block
+  (`base_diverged`); never reset.** Divergence requires human reconciliation.
+
+The refresh only ever **fast-forwards** the local base; it never rewinds it.
+This is why `local_base_sha_after == local_base_sha_before` on every `ahead` /
+`diverged` block.
+
+### Rebase private, merge shared
+
+Integration defaults to **rebase** (`--integrate rebase`): the feature branch is
+a private branch, so rebasing it onto the refreshed base keeps history linear
+and is the private-history policy from `workflow/git-conflict-resolution.md`
+("rebase private history, merge shared history"). Pass **`--integrate merge`**
+for a branch other people have already based work on — merging preserves the
+shared commits others depend on. The default is rebase; choose merge
+deliberately.
+
+## Conflict rule
+
+The script **cannot judge semantic ambiguity**, so on **any** integration
+conflict it aborts the operation (`git rebase --abort` / `git merge --abort`),
+leaving the feature branch exactly as it was before the integration attempt, and
+returns `blocked` / `conflict`. It never guesses a resolution.
+
+The agent then decides, per `workflow/git-conflict-resolution.md`:
+
+- The agent may hand-resolve a conflict **only** when the intent is
+  unambiguous — a lockfile it can regenerate, a changelog/append where both
+  sides clearly stack, a formatting-only clash. After resolving, it **reruns the
+  affected verification** (build/tests for the touched area) and then reruns the
+  gate.
+- For anything where both sides made substantial, overlapping semantic changes,
+  the agent **does not guess**. It surfaces the conflict to the user.
+- The agent **never creates the PR while an ambiguous conflict remains
+  unresolved.** A `conflict` block is not a "resolve however and proceed"
+  signal; it is a "stop unless the resolution is verifiably correct" signal.
+
+## Base-movement retry rule
+
+The remote base can move while the gate (and the gap audit) runs. After a clean
+integration the gate **re-fetches** the remote base; if its sha changed, it
+**re-integrates** the feature onto the new base. A `PRE_PR_ON_FETCH` command
+seam runs after every fetch so tests can push a new remote commit between
+fetches and simulate movement deterministically.
+
+Re-integration is **capped at `--max-base-moves` (default 3)**. If the base
+never stabilizes within that many cycles, the gate stops with `base_unstable`
+and reports `attempts`. This realizes the global 3-fail rule for the
+"base keeps moving" case: do not chase a moving target forever — stop, report,
+and let the base settle before rerunning.
+
+## Documentation-to-issue gap audit
+
+Performed by the agent on a `ready` outcome, before push/PR. It reconciles
+**what is required** against **what was delivered** and records the result in a
+gap ledger.
+
+### Audit scope
+
+Gather requirements and evidence from, in priority order:
+
+1. **The active issue** — its acceptance criteria, body, and comments.
+2. **Its parent and child issues** — the epic it is `Part of #N`, and any
+   sub-issues it decomposed into.
+3. **Directly linked issues and their closing PRs** — open or closed issues
+   referenced from the active issue (and the PRs that closed the closed ones),
+   for prior-art and contract context.
+4. **Same-milestone / component / label candidates** — issues sharing the
+   milestone, component, or labels that plausibly overlap this change.
+5. **Documentation tied to the changed paths** — README, design, architecture,
+   roadmap, spec, and changelog material that the changed files are governed by.
+
+**Index issue metadata first** (numbers, titles, states, labels, links); fetch
+full bodies and comments **only** for the candidates that survive that first
+pass as relevant. This keeps the audit bounded and avoids pulling every issue in
+the repository into context.
+
+### Gap ledger row schema
+
+Each requirement discovered in scope becomes one ledger row with **exactly**
+these fields:
+
+| Field | Meaning |
+|-------|---------|
+| `requirement` | The single obligation being checked (one acceptance criterion, one documented contract). |
+| `documentation evidence` | Where the requirement is documented (doc path + anchor), or "none". |
+| `implementation evidence` | The code that satisfies it (path + symbol), or "none". |
+| `test evidence` | The test that exercises it (path + case), or "none". |
+| `issue evidence` | The issue/PR that owns it (`#N`), or "none". |
+| `disposition` | One of the four dispositions below. |
+| `action` | The concrete next step implied by the disposition. |
+
+### Dispositions (exactly four)
+
+| Disposition | Definition |
+|-------------|------------|
+| `fix-in-pr` | The requirement is in scope for the **active** issue's acceptance criteria and is not yet fully satisfied. Fix it in the current PR before pushing. |
+| `followup-issue` | A genuine gap that is **out of scope** for the active issue. File a **deduplicated, non-duplicate** follow-up issue (search first; do not open a second issue for an already-tracked gap). |
+| `already-satisfied` | The requirement is met — implementation, test, and documentation evidence all line up. No action. |
+| `blocked` | The requirement cannot be dispositioned because retrieval was incomplete (see the incomplete-data rule) or an external dependency is unresolved. Report; do not proceed as if it were satisfied. |
+
+### Incomplete-data rule
+
+**Never report "no gap" when documentation or issue retrieval was incomplete.**
+If an issue body/comment fetch failed, a linked issue could not be read, or a
+governing document could not be located, the affected rows are `blocked`, not
+`already-satisfied`. Absence of evidence is not evidence of coverage.
+
+### Scope discipline
+
+Only gaps required by the **active** issue's acceptance criteria are fixed in
+the current PR (`fix-in-pr`). Independent, out-of-scope gaps become
+**deduplicated** follow-up issues (`followup-issue`) — never silently folded
+into this PR, and never opened twice. This mirrors the surgical-precision
+principle: the PR stays scoped to its issue.
+
+### Korean PR validation
+
+The PR's natural-language **title and body must be Korean** (the repo's active
+`CLAUDE_CONTENT_LANGUAGE` policy for this workflow). Machine tokens — code
+identifiers, file paths, URLs, and GitHub closing keywords such as
+`Closes #N` — remain ASCII and are allowed inside the Korean text. The PR body
+must contain these sections:
+
+- **Changes** — what changed.
+- **Rationale** — why.
+- **Scope** — what is in and out of scope (ties back to the gap ledger).
+- **Verification** — how it was verified (builds/tests run).
+- **Risks** — residual risks.
+- **Follow-up Work** — the `followup-issue` rows from the ledger.
+
+*(The gate and this document are English per repo policy for code and
+reference prose; the Korean requirement applies to the PR artifact the
+orchestrator writes, not to this file.)*
+
+### Post-creation checks
+
+After the PR is created, verify:
+
+- the PR **targets `develop`** (not `main`), per `workflow/branching-strategy.md`;
+- the PR **closes the active issue** (a `Closes #<active>` keyword is present).
+
+If either check fails, correct the PR before considering the workflow done.
+
+## Acceptance criteria
+
+Anchors the git-state test suite (`tests/issue-work/test-pre-pr-gate.sh`) maps
+to. AC1–AC6 are script-verifiable; AC7–AC12 are the agent-side gap-audit
+contract.
+
+> **AC1**: A dirty feature worktree (uncommitted tracked changes) blocks with
+> `dirty_worktree` before any fetch; the local base is untouched.
+> **AC2**: A local base strictly behind the remote is fast-forwarded to the
+> remote head and the feature is replayed onto it (`ready`); a base already
+> current reaches `ready` without being moved.
+> **AC3**: A local base that is ahead blocks with `base_ahead`, and a diverged
+> base blocks with `base_diverged`; in both cases `local_base_sha_after ==
+> local_base_sha_before` (never reset).
+> **AC4**: A clean integration replays the feature commits onto the refreshed
+> base (`ready`); `--integrate merge` integrates via a merge commit.
+> **AC5**: Any integration conflict aborts the rebase/merge and blocks with
+> `conflict`, leaving the feature branch HEAD unchanged and the worktree clean.
+> **AC6**: Repeated remote-base movement blocks with `base_unstable` after
+> `--max-base-moves` integration cycles, reporting `attempts`.
+> **AC7**: The gap ledger uses exactly the seven fields of the row schema.
+> **AC8**: Dispositions are exactly the four defined slugs.
+> **AC9**: Incomplete documentation/issue retrieval yields `blocked`, never a
+> "no gap" report.
+> **AC10**: Out-of-scope gaps become deduplicated follow-up issues; only
+> active-issue acceptance criteria are fixed in the current PR.
+> **AC11**: The PR title/body are Korean (machine tokens excepted) with the
+> Changes / Rationale / Scope / Verification / Risks / Follow-up Work sections.
+> **AC12**: After creation, the PR targets `develop` and closes the active issue.
+
+## Risks
+
+- **Automatic conflict resolution is limited to verifiable-intent cases.** The
+  script never resolves; the agent resolves only unambiguous conflicts and
+  reruns the affected verification. Anything ambiguous stops and surfaces to the
+  user — the PR is never created over an unresolved ambiguous conflict.
+- **Never reopen closed issues.** A closing PR referenced during the audit is
+  read for context only; the audit files new deduplicated follow-ups instead of
+  reopening.
+- **Never fabricate regulated evidence.** A missing test or document is a
+  `blocked` / `fix-in-pr` / `followup-issue` row, never an invented citation.
+- **Stop after three repeated base movements or identical failures.** The
+  base-movement cap and the global 3-fail rule both apply: do not chase a moving
+  base or retry an identical failure indefinitely — report and hand off.

--- a/global/skills/_internal/issue-work/scripts/pre-pr-gate.sh
+++ b/global/skills/_internal/issue-work/scripts/pre-pr-gate.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# issue-work: pre-PR readiness gate (git-state half)
+# ==================================================
+# Deterministic git-state gate for the issue-work skill. Runs AFTER the
+# implementation and documentation have been committed to the feature branch
+# and BEFORE the branch is pushed or a PR is opened. See
+# reference/pre-pr-readiness.md for the full contract (outcome table, the
+# develop-refresh rules, the conflict rule, the base-movement retry rule, and
+# the agent-side documentation-to-issue gap-audit procedure this script does
+# not itself perform).
+#
+# This script owns only the mechanical, non-judgemental half of the gate:
+#   1. Refuse to run against a dirty worktree (commit impl+docs first).
+#   2. Fetch the remote base and fast-forward the LOCAL base branch only when it
+#      is strictly behind the remote. If the local base is AHEAD or DIVERGED it
+#      is left untouched and the gate blocks -- it never rewinds a base branch.
+#   3. Integrate the refreshed base into the feature branch (rebase by default,
+#      merge for shared branches). On ANY integration conflict it aborts the
+#      rebase/merge -- leaving the feature branch exactly as it was -- and
+#      blocks, because a script cannot judge whether a conflict is semantically
+#      unambiguous. The agent-side procedure in the reference doc owns that call.
+#   4. Re-fetch after a clean integration; if the remote base moved, re-integrate
+#      against the new base, capped at --max-base-moves re-integrations.
+#
+# It emits a single JSON object on stdout and never touches the network beyond
+# the injected git (GIT_BIN), so tests drive it against a local bare remote.
+#
+# The script is both a sourceable library (unit-testable functions such as
+# classify_base_relationship) and a CLI (run_pre_pr_gate). Every git call goes
+# through _prepr_git so a fake git can shadow it via GIT_BIN; the git operations
+# target ${PREPR_REPO_DIR:-.} so the CLI runs against the current working
+# directory (the feature-branch checkout) while a sourced unit test can point a
+# single function at a throwaway repository.
+#
+# Usage:
+#   bash pre-pr-gate.sh --repo <owner/name> --base <develop> --branch <feature>
+#                       [--remote origin] [--max-base-moves 3]
+#                       [--integrate rebase|merge]
+
+set -uo pipefail
+
+# Injection seams (overridable by tests and callers).
+GIT_BIN="${GIT_BIN:-git}"
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it. Operations
+# run inside ${PREPR_REPO_DIR:-.}; the default targets the current working
+# directory (the feature-branch checkout in the real workflow), and a sourced
+# unit test may set PREPR_REPO_DIR to aim a single helper at a temp repo.
+_prepr_git() {
+    "$GIT_BIN" -C "${PREPR_REPO_DIR:-.}" "$@"
+}
+
+# ── Base-movement test seam ──────────────────────────────────────────
+# Command string run after every fetch, mirroring workspace.sh's env-var seam
+# style. It exists so a test can push a new commit to the bare remote between
+# fetches and deterministically simulate the base moving under the gate. It is
+# a no-op when unset and its failures are swallowed so a flaky hook never masks
+# a real gate result.
+_prepr_run_hook() {
+    [ -n "${PRE_PR_ON_FETCH:-}" ] || return 0
+    ( eval "$PRE_PR_ON_FETCH" ) >/dev/null 2>&1 || true
+}
+
+# ── Pure helper (unit-testable via GIT_BIN ancestry) ─────────────────
+# Classify how a local base sha relates to a remote base sha using commit
+# ancestry, funneled through _prepr_git so it is fakeable / testable against a
+# real throwaway repo. Prints exactly one of:
+#   equal     the two shas are identical (no refresh needed)
+#   behind    local is an ancestor of remote (safe fast-forward)
+#   ahead     remote is an ancestor of local (local has unshared commits)
+#   diverged  neither is an ancestor of the other (histories forked)
+# Returns 1 (printing "unknown") only when an argument is empty.
+classify_base_relationship() {
+    local local_sha="${1:-}" remote_sha="${2:-}"
+    if [ -z "$local_sha" ] || [ -z "$remote_sha" ]; then
+        printf 'unknown\n'
+        return 1
+    fi
+    if [ "$local_sha" = "$remote_sha" ]; then
+        printf 'equal\n'
+        return 0
+    fi
+    if _prepr_git merge-base --is-ancestor "$local_sha" "$remote_sha" 2>/dev/null; then
+        printf 'behind\n'
+        return 0
+    fi
+    if _prepr_git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null; then
+        printf 'ahead\n'
+        return 0
+    fi
+    printf 'diverged\n'
+    return 0
+}
+
+# ── Integration primitives ───────────────────────────────────────────
+# Integrate the (already refreshed) base branch into the currently checked-out
+# feature branch. Rebase is the private-branch default; merge is the shared-
+# branch escape hatch. Returns the underlying git exit code so the driver can
+# distinguish a clean integration from a conflict.
+_prepr_integrate() {
+    local mode="$1" base="$2"
+    case "$mode" in
+        rebase) _prepr_git rebase "$base" ;;
+        merge)  _prepr_git merge --no-edit "$base" ;;
+        *)      return 2 ;;
+    esac
+}
+
+# Abort an in-progress integration, restoring the feature branch to exactly the
+# state it had before the integration attempt. Best-effort: its own exit code is
+# ignored because the driver has already decided to block.
+_prepr_abort() {
+    local mode="$1"
+    case "$mode" in
+        rebase) _prepr_git rebase --abort >/dev/null 2>&1 || true ;;
+        merge)  _prepr_git merge --abort  >/dev/null 2>&1 || true ;;
+    esac
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+# Single stdout line. attempts is numeric (unquoted); every other field is a
+# string. Keys are stable so a test can parse them with jfield.
+_prepr_emit() {
+    local outcome="$1" reason="$2" base="$3" remote_sha="$4" before="$5" after="$6" attempts="$7"
+    printf '{"outcome":"%s","reason":"%s","base":"%s","remote_base_sha":"%s","local_base_sha_before":"%s","local_base_sha_after":"%s","attempts":%s}\n' \
+        "$outcome" "$reason" "$base" "$remote_sha" "$before" "$after" "$attempts"
+}
+
+# ── Driver ───────────────────────────────────────────────────────────
+# run_pre_pr_gate <repo> <base> <branch> [<remote>] [<max_base_moves>] [<integrate>]
+#
+# repo             expected "owner/name" identity (reported, not re-verified here
+#                  -- the workspace stage already verified origin identity).
+# base             the base branch to refresh and integrate from (e.g. develop).
+# branch           the feature branch to integrate the base into.
+# remote           remote to fetch the base from (default origin).
+# max_base_moves   cap on re-integrations when the remote base keeps moving
+#                  (default 3).
+# integrate        rebase (default, private branch) or merge (shared branch).
+run_pre_pr_gate() {
+    local repo="${1:-}" base="${2:-}" branch="${3:-}"
+    local remote="${4:-origin}" max_moves="${5:-3}" mode="${6:-rebase}"
+
+    if [ -z "$repo" ] || [ -z "$base" ] || [ -z "$branch" ]; then
+        _prepr_emit blocked missing_args "$base" "" "" "" 0
+        return 2
+    fi
+    case "$mode" in
+        rebase|merge) : ;;
+        *)
+            _prepr_emit blocked bad_integrate_mode "$base" "" "" "" 0
+            return 2
+            ;;
+    esac
+
+    # Best-effort snapshot of the local base before any refresh, so a blocked
+    # outcome can prove the base was not rewound.
+    local local_before
+    local_before="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+
+    # 1. Clean-worktree precondition. Tracked staged/unstaged changes block the
+    #    gate; untracked files (-uno) do not, since they never impede a rebase.
+    local dirty
+    dirty="$(_prepr_git status --porcelain --untracked-files=no 2>/dev/null)"
+    if [ -n "$dirty" ]; then
+        _prepr_emit blocked dirty_worktree "$base" "" "$local_before" "$local_before" 0
+        return 1
+    fi
+
+    # Ensure we operate from the feature branch (defensive: the real workflow is
+    # already on it). Everything after this integrates the base into HEAD.
+    if ! _prepr_git checkout "$branch" >/dev/null 2>&1; then
+        _prepr_emit blocked checkout_failed "$base" "" "$local_before" "$local_before" 0
+        return 1
+    fi
+
+    # Initial fetch of the remote base.
+    if ! _prepr_git fetch "$remote" "$base" >/dev/null 2>&1; then
+        _prepr_emit blocked fetch_failed "$base" "" "$local_before" "$local_before" 0
+        return 1
+    fi
+    local rb
+    rb="$(_prepr_git rev-parse FETCH_HEAD 2>/dev/null)"
+    _prepr_run_hook
+
+    local attempts=0
+    while : ; do
+        attempts=$((attempts + 1))
+
+        # Refresh the LOCAL base branch against the freshly fetched remote sha.
+        local lb rel
+        lb="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+        rel="$(classify_base_relationship "$lb" "$rb")"
+        case "$rel" in
+            equal)
+                : # local base already current; nothing to fast-forward.
+                ;;
+            behind)
+                # Strictly behind -> a true fast-forward. Move the ref without a
+                # checkout (we stay on the feature branch).
+                _prepr_git update-ref "refs/heads/${base}" "$rb" >/dev/null 2>&1
+                ;;
+            ahead)
+                # Local base has commits the remote lacks; never rewind it.
+                _prepr_emit blocked base_ahead "$base" "$rb" "$local_before" "$lb" "$attempts"
+                return 1
+                ;;
+            diverged|*)
+                _prepr_emit blocked base_diverged "$base" "$rb" "$local_before" "$lb" "$attempts"
+                return 1
+                ;;
+        esac
+
+        # Integrate the refreshed base into the feature branch.
+        _prepr_git checkout "$branch" >/dev/null 2>&1
+        if ! _prepr_integrate "$mode" "$base" >/dev/null 2>&1; then
+            # A script cannot judge conflict ambiguity: abort and block.
+            _prepr_abort "$mode"
+            local after_conf
+            after_conf="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+            _prepr_emit blocked conflict "$base" "$rb" "$local_before" "$after_conf" "$attempts"
+            return 1
+        fi
+
+        # Re-fetch to detect the remote base moving under us during the audit.
+        if ! _prepr_git fetch "$remote" "$base" >/dev/null 2>&1; then
+            local after_ff
+            after_ff="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+            _prepr_emit blocked fetch_failed "$base" "$rb" "$local_before" "$after_ff" "$attempts"
+            return 1
+        fi
+        local rb_new
+        rb_new="$(_prepr_git rev-parse FETCH_HEAD 2>/dev/null)"
+        _prepr_run_hook
+
+        if [ "$rb_new" = "$rb" ]; then
+            break # base stable across two consecutive fetches -> ready.
+        fi
+        rb="$rb_new"
+        if [ "$attempts" -ge "$max_moves" ]; then
+            local after_unstable
+            after_unstable="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+            _prepr_emit blocked base_unstable "$base" "$rb" "$local_before" "$after_unstable" "$attempts"
+            return 1
+        fi
+    done
+
+    local local_after
+    local_after="$(_prepr_git rev-parse "$base" 2>/dev/null)"
+    _prepr_emit ready ready "$base" "$rb" "$local_before" "$local_after" "$attempts"
+    return 0
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+_prepr_main() {
+    local repo="" base="" branch="" remote="origin" max_moves="3" mode="rebase"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --repo) repo="$2"; shift 2 ;;
+            --base) base="$2"; shift 2 ;;
+            --branch) branch="$2"; shift 2 ;;
+            --remote) remote="$2"; shift 2 ;;
+            --max-base-moves) max_moves="$2"; shift 2 ;;
+            --integrate) mode="$2"; shift 2 ;;
+            *) echo "unknown argument: $1" >&2; return 2 ;;
+        esac
+    done
+    if [ -z "$repo" ] || [ -z "$base" ] || [ -z "$branch" ]; then
+        echo "error: --repo <owner/name>, --base <branch>, and --branch <feature> are required" >&2
+        return 2
+    fi
+    run_pre_pr_gate "$repo" "$base" "$branch" "$remote" "$max_moves" "$mode"
+}
+
+# Run as CLI only when executed directly; stay quiet when sourced by tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    _prepr_main "$@"
+fi

--- a/tests/issue-work/README.md
+++ b/tests/issue-work/README.md
@@ -20,6 +20,8 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 | `fake-gh.sh` | Canned `gh` for the subset of commands triage.sh calls; records mutations to `mutations.log` and appends posted comments so idempotency reruns observe prior state. |
 | `test-workspace.sh` | Test runner for the workspace lifecycle stage (`scripts/workspace.sh`); see the dedicated section below. |
 | `test-agents.sh` | Test runner for the subagent spawn-contract + single-writer-lease stage (`scripts/agents.sh`); see the dedicated section below. |
+| `test-cleanup.sh` | Test runner for the resume-reconciliation + safe-cleanup stage (`scripts/cleanup-workspace.sh`); see the dedicated section below. |
+| `test-pre-pr-gate.sh` | Test runner for the pre-PR readiness gate (`scripts/pre-pr-gate.sh`); see the dedicated section below. |
 
 ## Acceptance-criteria coverage (issue #829)
 
@@ -168,3 +170,47 @@ PowerShell parity for the cleanup/resume stage is delivered as
 not wired into CI (it rejects junctions / reparse points where the `.sh` rejects
 symlinks). Cross-platform PS regression coverage is integrated in #832
 (consistent with the #829, #838, and #839 notes above).
+
+## Pre-PR readiness gate tests (issue #831)
+
+Unit and scenario tests for the pre-PR readiness gate (git-state half)
+(`global/skills/_internal/issue-work/scripts/pre-pr-gate.sh`), which runs after
+implementation + docs are committed and before push/PR: it refreshes the base
+branch (`develop`) and integrates it into the feature branch with safe conflict
+handling, emitting a single JSON outcome. The suite drives real local bare git
+repositories rather than a fake — this stage never calls `gh`, so no shim is
+needed to exercise the fetch / fast-forward / rebase / merge codepaths without
+network access. The classifier unit test points the sourced helper at a
+throwaway repo via the `PREPR_REPO_DIR` seam, and the base-movement case uses
+the `PRE_PR_ON_FETCH` seam to push a fresh remote commit between fetches. See
+`reference/pre-pr-readiness.md` for the full contract (including the agent-side
+documentation-to-issue gap-audit procedure the script does not itself perform).
+
+### Run
+
+```bash
+bash tests/issue-work/test-pre-pr-gate.sh
+```
+
+The suite is wired into CI by `.github/workflows/validate-skills.yml`.
+
+### Acceptance-criteria coverage (issue #831)
+
+| AC | Scenario | Assertion |
+|----|----------|-----------|
+| AC1 | Clean-worktree precondition | A dirty (uncommitted tracked) feature worktree blocks with `dirty_worktree` before any fetch; the local base is untouched. |
+| AC2 | Develop refresh (advance) | A local base strictly behind the remote is fast-forwarded to the remote head and the feature is replayed onto it (`ready`); a base already current reaches `ready` without being moved. |
+| AC3 | Develop refresh (guard) | A local base that is ahead blocks with `base_ahead`, and a diverged base blocks with `base_diverged`; both leave `local_base_sha_after == local_base_sha_before` (never reset). |
+| AC4 | Integration | A clean rebase replays the feature commits onto the refreshed base (`ready`); `--integrate merge` integrates via a merge commit. |
+| AC5 | Conflict | Any integration conflict aborts the rebase/merge and blocks with `conflict`, leaving the feature branch HEAD unchanged and the worktree clean. |
+| AC6 | Base-movement retry | Repeated remote-base movement (via `PRE_PR_ON_FETCH`) blocks with `base_unstable` after `--max-base-moves` cycles, reporting `attempts`. |
+| UNIT | Base-relationship classifier | `classify_base_relationship` returns `equal` / `behind` / `ahead` / `diverged` for the corresponding ancestry, and `unknown` on an empty argument. |
+
+### Scope note
+
+The script owns only the mechanical git-state half of the gate. The
+documentation-to-issue gap audit (gap ledger, four dispositions, Korean-PR
+validation, post-creation checks) is an agent-side procedure specified in
+`reference/pre-pr-readiness.md` (AC7–AC12) and is not script-tested. PowerShell
+parity for this stage is deferred to #832, consistent with the #829 / #838 /
+#839 / #840 notes above.

--- a/tests/issue-work/test-pre-pr-gate.sh
+++ b/tests/issue-work/test-pre-pr-gate.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Test suite for global/skills/_internal/issue-work/scripts/pre-pr-gate.sh
+# Run: bash tests/issue-work/test-pre-pr-gate.sh
+#
+# Drives the pre-PR readiness gate (git-state half) against REAL local bare git
+# repositories -- no fake git shim is needed for the mechanics, because the gate
+# never calls gh and driving real git exercises the actual fetch / fast-forward
+# / rebase / merge codepaths instead of a stand-in. The classifier unit test
+# points the sourced helper at a throwaway repo via the PREPR_REPO_DIR seam.
+#
+# AC -> test mapping (see reference/pre-pr-readiness.md):
+#   AC1  clean-worktree precondition -> dirty tree -> blocked/dirty_worktree
+#   AC2  develop refresh (advance)   -> behind -> local base ff'd -> ready;
+#                                       current -> ready with no reset
+#   AC3  develop refresh (guard)     -> ahead -> blocked/base_ahead (not reset);
+#                                       diverged -> blocked/base_diverged (not reset)
+#   AC4  integration                 -> clean rebase replays feature commits ->
+#                                       ready; merge mode also integrates -> ready
+#   AC5  conflict                    -> any conflict aborts -> blocked/conflict,
+#                                       feature HEAD unchanged, worktree clean
+#   AC6  base-movement retry         -> repeated movement -> blocked/base_unstable
+#                                       after --max-base-moves attempts, reported
+#   UNIT classify_base_relationship  -> equal/behind/ahead/diverged/unknown
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+ROOT_DIR="$PWD"
+GATE="$ROOT_DIR/global/skills/_internal/issue-work/scripts/pre-pr-gate.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# Explicit template (rather than a bare `mktemp -d`) so this suite is stable
+# under sandboxes that restrict the OS default temp directory but expose
+# $TMPDIR, as well as under plain CI runners where $TMPDIR is unset.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/iw-pre-pr-test.XXXXXX")"
+# Canonicalize (resolve symlinks + collapse //) so paths baked into the
+# PRE_PR_ON_FETCH hook match what git sees on macOS, whose default $TMPDIR
+# (/var/folders/...) is a symlink to /private/var/...
+WORK="$(cd "$WORK" && pwd -P)"
+trap 'rm -rf "$WORK"' EXIT
+
+ok()   { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL + 1)); ERRORS+=("FAIL: $1"); echo "  FAIL: $1"; }
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    if [ "$expected" = "$actual" ]; then ok "$label"; else
+        bad "$label -- expected '$expected', got '$actual'"; fi
+}
+
+assert_contains() {
+    local needle="$1" hay="$2" label="$3"
+    if printf '%s' "$hay" | grep -Fq -- "$needle"; then ok "$label"; else
+        bad "$label -- '$needle' not in output"; fi
+}
+
+assert_not_contains() {
+    local needle="$1" hay="$2" label="$3"
+    if printf '%s' "$hay" | grep -Fq -- "$needle"; then
+        bad "$label -- '$needle' unexpectedly present"
+    else
+        ok "$label"
+    fi
+}
+
+jfield() {  # jfield <json> <field>
+    printf '%s' "$1" | python3 -c 'import json,sys;print(json.load(sys.stdin).get(sys.argv[1],""))' "$2" 2>/dev/null
+}
+
+# Builds a bare "remote" under $WORK/remote seeded with one commit on a
+# "develop" branch, plus a "seed" working clone used to advance the remote
+# during a scenario. Prints "<remote-path>|<seed-path>".
+make_remote() {  # make_remote <name>
+    local name="$1" remote seed
+    remote="$WORK/remote/${name}.git"
+    seed="$WORK/seed-${name}"
+    mkdir -p "$(dirname "$remote")"
+    git init --bare -q "$remote"
+    git init -q -b develop "$seed"
+    git -C "$seed" config user.email "test@example.com"
+    git -C "$seed" config user.name "test"
+    echo "base" > "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" commit -q -m "seed commit" >/dev/null
+    git -C "$seed" remote add origin "$remote"
+    git -C "$seed" push -q origin develop
+    printf '%s|%s' "$remote" "$seed"
+}
+
+# Clones <remote>'s develop into <dest>, sets a test identity, and creates a
+# feature branch <branch> carrying one commit on <feat_file>. Prints <dest>.
+make_feature_clone() {  # make_feature_clone <remote> <dest> <branch> <feat_file>
+    local remote="$1" dest="$2" branch="$3" feat_file="$4"
+    git clone -q --branch develop --single-branch "$remote" "$dest"
+    git -C "$dest" config user.email "test@example.com"
+    git -C "$dest" config user.name "test"
+    git -C "$dest" checkout -q -b "$branch"
+    echo "feature work" > "$dest/$feat_file"
+    git -C "$dest" add "$feat_file"
+    git -C "$dest" commit -q -m "feature commit"
+    printf '%s' "$dest"
+}
+
+# Advance the remote develop by one non-conflicting commit via the seed clone.
+# Prints the new remote develop sha.
+advance_remote() {  # advance_remote <seed> <file> <content>
+    local seed="$1" file="$2" content="$3"
+    git -C "$seed" checkout -q develop
+    echo "$content" >> "$seed/$file"
+    git -C "$seed" add "$file"
+    git -C "$seed" commit -q -m "remote advance"
+    git -C "$seed" push -q origin develop
+    git -C "$seed" rev-parse develop
+}
+
+# Run the gate CLI from inside <repo> so PREPR_REPO_DIR defaults to that
+# checkout. Extra args are forwarded. Prints the JSON stdout line.
+run_gate() {  # run_gate <repo> [gate args...]
+    local repo="$1"; shift
+    ( cd "$repo" && bash "$GATE" "$@" )
+}
+
+echo "=== pre-pr-gate.sh UNIT: classify_base_relationship ==="
+# shellcheck disable=SC1090
+source "$GATE"
+cls_repo="$WORK/classify-repo"
+git init -q -b main "$cls_repo"
+git -C "$cls_repo" config user.email "test@example.com"
+git -C "$cls_repo" config user.name "test"
+echo a > "$cls_repo/f.txt"; git -C "$cls_repo" add f.txt; git -C "$cls_repo" commit -q -m A
+SHA_A="$(git -C "$cls_repo" rev-parse HEAD)"
+echo b >> "$cls_repo/f.txt"; git -C "$cls_repo" add f.txt; git -C "$cls_repo" commit -q -m B
+SHA_B="$(git -C "$cls_repo" rev-parse HEAD)"
+git -C "$cls_repo" checkout -q -b fork "$SHA_A"
+echo c > "$cls_repo/g.txt"; git -C "$cls_repo" add g.txt; git -C "$cls_repo" commit -q -m C
+SHA_C="$(git -C "$cls_repo" rev-parse HEAD)"
+
+assert_eq "equal"    "$(PREPR_REPO_DIR="$cls_repo" classify_base_relationship "$SHA_A" "$SHA_A")" "UNIT identical shas -> equal"
+assert_eq "behind"   "$(PREPR_REPO_DIR="$cls_repo" classify_base_relationship "$SHA_A" "$SHA_B")" "UNIT local ancestor of remote -> behind"
+assert_eq "ahead"    "$(PREPR_REPO_DIR="$cls_repo" classify_base_relationship "$SHA_B" "$SHA_A")" "UNIT remote ancestor of local -> ahead"
+assert_eq "diverged" "$(PREPR_REPO_DIR="$cls_repo" classify_base_relationship "$SHA_B" "$SHA_C")" "UNIT forked histories -> diverged"
+cls_unknown="$(PREPR_REPO_DIR="$cls_repo" classify_base_relationship "" "$SHA_A")"
+assert_eq "unknown"  "$cls_unknown" "UNIT empty argument -> unknown"
+
+echo ""
+echo "=== AC1: dirty worktree is refused before any fetch ==="
+IFS='|' read -r rem1 seed1 <<< "$(make_remote ac1)"
+repo1="$(make_feature_clone "$rem1" "$WORK/repo1" feat/x feature.txt)"
+dev1_before="$(git -C "$repo1" rev-parse develop)"
+echo "uncommitted" >> "$repo1/file.txt"   # tracked, uncommitted -> dirty
+out1="$(run_gate "$repo1" --repo o/ac1 --base develop --branch feat/x)"
+assert_eq "blocked" "$(jfield "$out1" outcome)" "AC1 outcome=blocked on a dirty worktree"
+assert_eq "dirty_worktree" "$(jfield "$out1" reason)" "AC1 reason=dirty_worktree"
+assert_eq "0" "$(jfield "$out1" attempts)" "AC1 no integration attempted (attempts=0)"
+assert_eq "$dev1_before" "$(git -C "$repo1" rev-parse develop)" "AC1 local base untouched by a refused run"
+
+echo ""
+echo "=== AC2: behind base -> local base fast-forwarded -> ready ==="
+IFS='|' read -r rem2 seed2 <<< "$(make_remote ac2)"
+repo2="$(make_feature_clone "$rem2" "$WORK/repo2" feat/x feature.txt)"
+dev2_before="$(git -C "$repo2" rev-parse develop)"
+remote2_sha="$(advance_remote "$seed2" churn.txt one)"   # remote develop moves ahead
+out2="$(run_gate "$repo2" --repo o/ac2 --base develop --branch feat/x)"
+assert_eq "ready" "$(jfield "$out2" outcome)" "AC2 outcome=ready when strictly behind"
+assert_eq "$remote2_sha" "$(jfield "$out2" remote_base_sha)" "AC2 remote_base_sha is the fetched remote head"
+assert_eq "$dev2_before" "$(jfield "$out2" local_base_sha_before)" "AC2 local_base_sha_before is the pre-refresh sha"
+assert_eq "$remote2_sha" "$(jfield "$out2" local_base_sha_after)" "AC2 local base fast-forwarded to the remote head"
+assert_eq "$remote2_sha" "$(git -C "$repo2" rev-parse develop)" "AC2 the on-disk local base branch was fast-forwarded"
+# The feature commits are replayed onto the refreshed base.
+assert_eq "1" "$(test -f "$repo2/feature.txt" && echo 1 || echo 0)" "AC2 feature file survives the rebase"
+assert_eq "1" "$(test -f "$repo2/churn.txt" && echo 1 || echo 0)" "AC2 refreshed base content is present after the rebase"
+
+echo ""
+echo "=== AC2: base already current -> ready with no reset ==="
+IFS='|' read -r rem2b seed2b <<< "$(make_remote ac2b)"
+repo2b="$(make_feature_clone "$rem2b" "$WORK/repo2b" feat/x feature.txt)"
+dev2b_before="$(git -C "$repo2b" rev-parse develop)"
+out2b="$(run_gate "$repo2b" --repo o/ac2b --base develop --branch feat/x)"
+assert_eq "ready" "$(jfield "$out2b" outcome)" "AC2 outcome=ready when base is already current"
+assert_eq "$dev2b_before" "$(jfield "$out2b" local_base_sha_before)" "AC2 current-base before sha recorded"
+assert_eq "$dev2b_before" "$(jfield "$out2b" local_base_sha_after)" "AC2 current base is not moved"
+
+echo ""
+echo "=== AC3: local base AHEAD -> blocked/base_ahead, base not reset ==="
+IFS='|' read -r rem3 seed3 <<< "$(make_remote ac3)"
+git clone -q --branch develop --single-branch "$rem3" "$WORK/repo3"
+repo3="$WORK/repo3"
+git -C "$repo3" config user.email "test@example.com"; git -C "$repo3" config user.name "test"
+# Put an unshared commit on the LOCAL develop, then branch the feature from it.
+git -C "$repo3" checkout -q develop
+echo "local-only" >> "$repo3/file.txt"; git -C "$repo3" add file.txt; git -C "$repo3" commit -q -m "local ahead"
+dev3_before="$(git -C "$repo3" rev-parse develop)"
+git -C "$repo3" checkout -q -b feat/x
+out3="$(run_gate "$repo3" --repo o/ac3 --base develop --branch feat/x)"
+assert_eq "blocked" "$(jfield "$out3" outcome)" "AC3 outcome=blocked when local base is ahead"
+assert_eq "base_ahead" "$(jfield "$out3" reason)" "AC3 reason=base_ahead"
+assert_eq "$dev3_before" "$(jfield "$out3" local_base_sha_after)" "AC3 local_base_sha_after unchanged (not reset)"
+assert_eq "$dev3_before" "$(git -C "$repo3" rev-parse develop)" "AC3 the on-disk local base was not rewound"
+
+echo ""
+echo "=== AC3: local base DIVERGED -> blocked/base_diverged, base not reset ==="
+IFS='|' read -r rem4 seed4 <<< "$(make_remote ac4)"
+git clone -q --branch develop --single-branch "$rem4" "$WORK/repo4"
+repo4="$WORK/repo4"
+git -C "$repo4" config user.email "test@example.com"; git -C "$repo4" config user.name "test"
+git -C "$repo4" checkout -q develop
+echo "local-side" >> "$repo4/local.txt"; git -C "$repo4" add local.txt; git -C "$repo4" commit -q -m "local diverge"
+dev4_before="$(git -C "$repo4" rev-parse develop)"
+git -C "$repo4" checkout -q -b feat/x
+advance_remote "$seed4" remote.txt other >/dev/null   # remote diverges independently
+out4="$(run_gate "$repo4" --repo o/ac4 --base develop --branch feat/x)"
+assert_eq "blocked" "$(jfield "$out4" outcome)" "AC3 outcome=blocked when histories diverge"
+assert_eq "base_diverged" "$(jfield "$out4" reason)" "AC3 reason=base_diverged"
+assert_eq "$dev4_before" "$(jfield "$out4" local_base_sha_after)" "AC3 diverged local base not reset"
+assert_eq "$dev4_before" "$(git -C "$repo4" rev-parse develop)" "AC3 the on-disk diverged base was not rewound"
+
+echo ""
+echo "=== AC4: clean rebase replays feature commits onto refreshed base ==="
+# Same mechanics as AC2 ready, asserted from the integration angle: the feature
+# commit sha changes (replayed) while its content and the new base coexist.
+IFS='|' read -r rem5 seed5 <<< "$(make_remote ac5)"
+repo5="$(make_feature_clone "$rem5" "$WORK/repo5" feat/x feature.txt)"
+feat5_before="$(git -C "$repo5" rev-parse HEAD)"
+advance_remote "$seed5" churn.txt two >/dev/null
+out5="$(run_gate "$repo5" --repo o/ac5 --base develop --branch feat/x)"
+assert_eq "ready" "$(jfield "$out5" outcome)" "AC4 clean integration -> ready"
+feat5_after="$(git -C "$repo5" rev-parse HEAD)"
+if [ "$feat5_before" != "$feat5_after" ]; then ok "AC4 feature commit was replayed (HEAD sha changed)"; else
+    bad "AC4 feature commit should have been replayed onto the refreshed base"; fi
+assert_eq "1" "$(git -C "$repo5" merge-base --is-ancestor develop HEAD && echo 1 || echo 0)" "AC4 refreshed base is an ancestor of the feature HEAD"
+
+echo ""
+echo "=== AC4: merge mode integrates the base -> ready ==="
+IFS='|' read -r rem6 seed6 <<< "$(make_remote ac6)"
+repo6="$(make_feature_clone "$rem6" "$WORK/repo6" feat/x feature.txt)"
+advance_remote "$seed6" churn.txt three >/dev/null
+out6="$(run_gate "$repo6" --repo o/ac6 --base develop --branch feat/x --integrate merge)"
+assert_eq "ready" "$(jfield "$out6" outcome)" "AC4 merge-mode integration -> ready"
+assert_eq "1" "$(git -C "$repo6" rev-list --merges -1 HEAD | wc -l | tr -d ' ')" "AC4 merge mode created a merge commit"
+
+echo ""
+echo "=== AC5: integration conflict -> abort -> blocked/conflict, feature untouched ==="
+IFS='|' read -r rem7 seed7 <<< "$(make_remote ac7)"
+git clone -q --branch develop --single-branch "$rem7" "$WORK/repo7"
+repo7="$WORK/repo7"
+git -C "$repo7" config user.email "test@example.com"; git -C "$repo7" config user.name "test"
+git -C "$repo7" checkout -q -b feat/x
+echo "OURS" > "$repo7/file.txt"; git -C "$repo7" add file.txt; git -C "$repo7" commit -q -m "feature edits shared file"
+feat7_before="$(git -C "$repo7" rev-parse HEAD)"
+# Remote edits the same line differently -> rebase will conflict.
+git -C "$seed7" checkout -q develop
+echo "THEIRS" > "$seed7/file.txt"; git -C "$seed7" add file.txt; git -C "$seed7" commit -q -m "remote edits shared file"
+git -C "$seed7" push -q origin develop
+out7="$(run_gate "$repo7" --repo o/ac7 --base develop --branch feat/x)"
+assert_eq "blocked" "$(jfield "$out7" outcome)" "AC5 outcome=blocked on an integration conflict"
+assert_eq "conflict" "$(jfield "$out7" reason)" "AC5 reason=conflict"
+assert_eq "$feat7_before" "$(git -C "$repo7" rev-parse HEAD)" "AC5 feature branch HEAD is unchanged (rebase aborted)"
+assert_eq "" "$(git -C "$repo7" status --porcelain)" "AC5 worktree is clean after the abort (no conflict markers left)"
+assert_eq "feat/x" "$(git -C "$repo7" rev-parse --abbrev-ref HEAD)" "AC5 still on the feature branch after the abort"
+
+echo ""
+echo "=== AC6: repeated base movement -> blocked/base_unstable after N attempts ==="
+IFS='|' read -r rem8 seed8 <<< "$(make_remote ac8)"
+repo8="$(make_feature_clone "$rem8" "$WORK/repo8" feat/x feature.txt)"
+counter="$WORK/ac8-counter"
+echo 0 > "$counter"
+# After every fetch, push a fresh non-conflicting commit so the base never
+# stabilizes. Absolute paths are baked in so the hook works from any cwd.
+hook="c=\$(cat '$counter'); c=\$((c+1)); echo \$c > '$counter'; echo churn\$c >> '$seed8/churn.txt'; git -C '$seed8' add -A; git -C '$seed8' commit -q -m churn\$c; git -C '$seed8' push -q origin develop"
+out8="$(cd "$repo8" && PRE_PR_ON_FETCH="$hook" bash "$GATE" --repo o/ac8 --base develop --branch feat/x)"
+assert_eq "blocked" "$(jfield "$out8" outcome)" "AC6 outcome=blocked when the base never stabilizes"
+assert_eq "base_unstable" "$(jfield "$out8" reason)" "AC6 reason=base_unstable"
+assert_eq "3" "$(jfield "$out8" attempts)" "AC6 attempts caps at the default --max-base-moves (3)"
+# A smaller cap is honored and reported.
+echo 0 > "$counter"
+out8b="$(cd "$repo8" && PRE_PR_ON_FETCH="$hook" bash "$GATE" --repo o/ac8 --base develop --branch feat/x --max-base-moves 2)"
+assert_eq "base_unstable" "$(jfield "$out8b" reason)" "AC6 reason=base_unstable with a smaller cap"
+assert_eq "2" "$(jfield "$out8b" attempts)" "AC6 attempts honors an explicit --max-base-moves 2"
+
+echo ""
+echo "=== Missing required args -> blocked/missing_args, returns 2 ==="
+# The JSON contract for a missing argument lives in the driver, exercised via
+# the function sourced above (the CLI wrapper prints a usage hint to stderr and
+# returns 2 without JSON, mirroring workspace.sh). The missing-arg check returns
+# before any git call, so PREPR_REPO_DIR is irrelevant here.
+out9="$(run_pre_pr_gate o/n develop "")"   # empty branch
+rc9=$?
+assert_eq "blocked" "$(jfield "$out9" outcome)" "missing branch -> blocked"
+assert_eq "missing_args" "$(jfield "$out9" reason)" "missing branch -> reason=missing_args"
+assert_eq "2" "$rc9" "missing required arg returns 2"
+
+echo ""
+echo "=== Summary ==="
+echo "  $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    for e in "${ERRORS[@]}"; do echo "  $e"; done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #831

Adds a mandatory pre-PR readiness gate and a documentation-to-issue gap audit to the `issue-work` skill. This is the third child of epic #828, following the already-merged siblings #829 (triage) and #830 (workspace lifecycle).

## Changes

- Added the deterministic git-state helper `global/skills/_internal/issue-work/scripts/pre-pr-gate.sh`. It refuses a dirty worktree, fetches the base branch, and fast-forwards the local base **only when it is strictly behind** — an `ahead` or `diverged` base is left untouched and blocks, never rewound. It integrates the refreshed base into the feature branch (rebase by default, merge for shared branches), aborts and blocks on any conflict rather than guessing intent, and re-integrates when the remote base moves — stopping with `base_unstable` after a capped number of movements. It emits a single `ready`/`blocked` JSON outcome on stdout.
- Added the contract `global/skills/_internal/issue-work/reference/pre-pr-readiness.md`: the gate ordering, outcome table, `develop`-refresh rules, conflict rule, base-movement retry rule, and the agent-side gap-audit procedure (audit scope, the seven-field gap ledger, exactly four dispositions, the incomplete-retrieval blocking rule, Korean-PR validation, and post-creation checks).
- Inserted a new **Step 7.5** into `global/skills/_internal/issue-work/SKILL.md` between Step 7 and Step 8. It invokes the gate and routes on the JSON `outcome`; existing step numbers are left unchanged.
- Wired the new test into `.github/workflows/validate-skills.yml` as a named step after the #840 step.
- Recorded the feature in `CHANGELOG.md` under Unreleased/Added, matching the convention set by siblings #837 and #843 (surfaced by the gap audit below).

## Rationale

The previous flow had no mandatory gate immediately before PR creation to refresh `develop`, reconcile conflicts, and compare development documentation against open and closed issues. This gate splits ownership: the script owns the mechanical, non-judgemental git-state half, while semantic judgement (whether a conflict is unambiguous, how a gap is dispositioned) stays with the agent-side procedure in the reference doc. This mirrors how `triage.sh` pairs with `triage-state-machine.md` and `workspace.sh` with `workspace-lifecycle.md`.

## Scope

- In scope: the solo-mode pre-PR gate script, its contract doc, the `SKILL.md` integration, the `bash` test suite, CI wiring, and the `CHANGELOG` entry.
- Out of scope: PowerShell parity (`pre-pr-gate.ps1`) and routing team/batch/orchestrator modes through the gate. These fall outside #831's acceptance criteria and are already tracked by the open issue #832 (cross-platform regression coverage), so no duplicate follow-up was filed.

## Verification

- All ten local CI-gate commands pass: `validate_skills.sh`, `spec_lint.sh --strict`, `check_references.sh`, `check_skill_drift.sh`, the four existing issue-work tests (triage, workspace, agents, cleanup), the new `test-pre-pr-gate.sh` (45 assertions), and `test-ci-wiring.sh`.
- The new test drives `pre-pr-gate.sh` against real temporary bare repositories covering: behind base, ahead base, diverged base, integration conflict, dirty worktree, repeated base movement, clean replay, and the base-relationship classifier as a pure function.
- This PR dogfooded the new gate: running `pre-pr-gate.sh` on this branch returned `outcome=ready` (remote and local `develop` identical), and the documentation-to-issue gap audit found one gap (the missing `CHANGELOG` entry) which was fixed here.

## Risks and Follow-up Work

- Automatic conflict resolution is limited to verifiable-intent cases; the script never guesses and blocks on any conflict, and no PR is created while an ambiguous conflict remains.
- Closed issues are never reopened and regulated evidence is never fabricated; the gate stops after three identical failures or repeated base movement.
- Follow-up: PowerShell parity and team/batch/orchestrator integration proceed under #832.
