### PR TITLE
refactor(issue-work): wire triage, workspace, and pre-PR gates through all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   close the active issue, and use a Korean title and body. The contract is
   documented in `reference/pre-pr-readiness.md` and covered by a bare-remote
   unit suite in `tests/issue-work/test-pre-pr-gate.sh` (#831).
+- `issue-work` now invokes the triage state machine, isolated-workspace
+  lifecycle, and pre-PR readiness gate from the actual solo, team, batch, and
+  external-orchestrator paths, so the standalone scripts added in #829, #830,
+  and #831 run in order instead of existing unused. Solo and team setup clone
+  through `scripts/workspace.sh` and tear down through
+  `scripts/cleanup-workspace.sh` instead of an in-place checkout; team
+  teammates are spawned only after the clone, with prompts built by the
+  `agents.sh` `agents_build_prompt` contract so each carries the absolute
+  repository path, active issue, baseline commit, and write scope; batch
+  results and resume state record the triage `requested`/`root`/`active`
+  triple, deduplicate by the resolved active issue, and pause on a decomposed
+  or blocked item instead of counting it as merged; and the Bash and
+  PowerShell batch orchestrators branch on a structured `ISSUE_WORK_RESULT:`
+  result marker rather than the process exit code alone. The triage,
+  workspace, and pre-PR gates are documented as mandatory in every
+  skill-loading tier, including `light` (#845).
 
 ### Fixed
 

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -10,29 +10,29 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 22527
+    size: 23659
     tags: []
     sections:
       - {h: "Changelog", l: 1, e: 7}
       - {h: "[Unreleased]", l: 8, e: 9}
-      - {h: "Added", l: 10, e: 62}
-      - {h: "Fixed", l: 63, e: 86}
-      - {h: "1.11.0 - 2026-07-03", l: 87, e: 88}
-      - {h: "Fixed", l: 89, e: 102}
-      - {h: "Security", l: 103, e: 180}
-      - {h: "Added", l: 181, e: 209}
-      - {h: "Changed", l: 210, e: 256}
-      - {h: "1.10.0 - 2026-04-20", l: 257, e: 265}
-      - {h: "1.9.0 - 2026-04-13", l: 266, e: 275}
-      - {h: "1.8.0 - 2026-04-13", l: 276, e: 281}
-      - {h: "1.7.0 - 2026-04-06", l: 282, e: 296}
-      - {h: "1.6.0 - 2026-04-03", l: 297, e: 309}
-      - {h: "1.5.0 - 2026-03-21", l: 310, e: 328}
-      - {h: "1.4.0 - 2026-01-22", l: 329, e: 334}
-      - {h: "1.3.0 - 2026-01-15", l: 335, e: 343}
-      - {h: "1.2.0 - 2026-01-15", l: 344, e: 352}
-      - {h: "1.1.0 - 2025-01-15", l: 353, e: 363}
-      - {h: "1.0.0 - 2025-12-03", l: 364, e: 370}
+      - {h: "Added", l: 10, e: 78}
+      - {h: "Fixed", l: 79, e: 102}
+      - {h: "1.11.0 - 2026-07-03", l: 103, e: 104}
+      - {h: "Fixed", l: 105, e: 118}
+      - {h: "Security", l: 119, e: 196}
+      - {h: "Added", l: 197, e: 225}
+      - {h: "Changed", l: 226, e: 272}
+      - {h: "1.10.0 - 2026-04-20", l: 273, e: 281}
+      - {h: "1.9.0 - 2026-04-13", l: 282, e: 291}
+      - {h: "1.8.0 - 2026-04-13", l: 292, e: 297}
+      - {h: "1.7.0 - 2026-04-06", l: 298, e: 312}
+      - {h: "1.6.0 - 2026-04-03", l: 313, e: 325}
+      - {h: "1.5.0 - 2026-03-21", l: 326, e: 344}
+      - {h: "1.4.0 - 2026-01-22", l: 345, e: 350}
+      - {h: "1.3.0 - 2026-01-15", l: 351, e: 359}
+      - {h: "1.2.0 - 2026-01-15", l: 360, e: 368}
+      - {h: "1.1.0 - 2025-01-15", l: 369, e: 379}
+      - {h: "1.0.0 - 2025-12-03", l: 380, e: 386}
   - path: "COMPATIBILITY.md"
     title: "Compatibility Guide"
     description: ""
@@ -2808,76 +2808,76 @@ documents:
     description: ""
     category: skill
     scope: global
-    size: 31505
+    size: 36385
     tags: [global,skill]
     sections:
       - {h: "Usage", l: 36, e: 51}
       - {h: "Arguments", l: 52, e: 93}
       - {h: "Argument Parsing", l: 94, e: 169}
-      - {h: "Instructions", l: 170, e: 171}
-      - {h: "Mode Routing", l: 172, e: 178}
-      - {h: "Batch Mode Instructions", l: 179, e: 190}
-      - {h: "Phase 0: Execution Mode Selection (Single-Item Mode)", l: 191, e: 194}
-      - {h: "0-1. If `--solo` or `--team` flag was provided", l: 195, e: 198}
-      - {h: "0-2. If no flag was provided (interactive selection)", l: 199, e: 231}
-      - {h: "0-3. Mode Routing", l: 232, e: 238}
-      - {h: "Solo Mode Instructions", l: 239, e: 242}
-      - {h: "1. Issue Triage Gate (state machine)", l: 243, e: 284}
-      - {h: "3. Git Environment Setup", l: 285, e: 314}
-      - {h: "4. Issue Assignment", l: 315, e: 320}
-      - {h: "5. Code Implementation", l: 321, e: 343}
-      - {h: "6. Build and Test Verification", l: 344, e: 348}
-      - {h: "Toolchain Availability Check", l: 349, e: 364}
-      - {h: "Strategy Selection", l: 365, e: 373}
-      - {h: "Inline Strategy (short builds)", l: 374, e: 382}
-      - {h: "Background + Log Polling Strategy (long builds)", l: 383, e: 391}
-      - {h: "On Build/Test Failure", l: 392, e: 401}
-      - {h: "7. Documentation Update", l: 402, e: 464}
-      - {h: "8. Push and Create PR", l: 465, e: 473}
-      - {h: "Summary", l: 474, e: 476}
-      - {h: "Test Plan", l: 477, e: 487}
-      - {h: "9. Monitor CI", l: 488, e: 535}
-      - {h: "10. Squash Merge", l: 536, e: 565}
-      - {h: "11. Close Related Issues and Epics", l: 566, e: 581}
-      - {h: "12. Update Original Issue", l: 582, e: 592}
-      - {h: "Team Mode Instructions", l: 593, e: 596}
-      - {h: "Policies", l: 597, e: 600}
-      - {h: "Command-Specific Rules", l: 601, e: 608}
-      - {h: "Output", l: 609, e: 615}
-      - {h: "Work Summary", l: 616, e: 628}
-      - {h: "Changes Made", l: 629, e: 631}
-      - {h: "Files Modified", l: 632, e: 635}
-      - {h: "Next Steps", l: 636, e: 642}
-      - {h: "Work Summary (INCOMPLETE)", l: 643, e: 654}
-      - {h: "Action Required", l: 655, e: 660}
-      - {h: "Batch Mode Output", l: 661, e: 664}
-      - {h: "Error Handling", l: 665, e: 668}
-      - {h: "Side Effects and Loop-Safety", l: 669, e: 671}
+      - {h: "Instructions", l: 170, e: 178}
+      - {h: "Mode Routing", l: 179, e: 185}
+      - {h: "Batch Mode Instructions", l: 186, e: 197}
+      - {h: "Phase 0: Execution Mode Selection (Single-Item Mode)", l: 198, e: 201}
+      - {h: "0-1. If `--solo` or `--team` flag was provided", l: 202, e: 205}
+      - {h: "0-2. If no flag was provided (interactive selection)", l: 206, e: 238}
+      - {h: "0-3. Mode Routing", l: 239, e: 245}
+      - {h: "Solo Mode Instructions", l: 246, e: 249}
+      - {h: "1. Issue Triage Gate (state machine)", l: 250, e: 298}
+      - {h: "3. Git Environment Setup", l: 299, e: 355}
+      - {h: "4. Issue Assignment", l: 356, e: 361}
+      - {h: "5. Code Implementation", l: 362, e: 384}
+      - {h: "6. Build and Test Verification", l: 385, e: 389}
+      - {h: "Toolchain Availability Check", l: 390, e: 405}
+      - {h: "Strategy Selection", l: 406, e: 414}
+      - {h: "Inline Strategy (short builds)", l: 415, e: 423}
+      - {h: "Background + Log Polling Strategy (long builds)", l: 424, e: 432}
+      - {h: "On Build/Test Failure", l: 433, e: 442}
+      - {h: "7. Documentation Update", l: 443, e: 505}
+      - {h: "8. Push and Create PR", l: 506, e: 514}
+      - {h: "Summary", l: 515, e: 517}
+      - {h: "Test Plan", l: 518, e: 528}
+      - {h: "9. Monitor CI", l: 529, e: 576}
+      - {h: "10. Squash Merge", l: 577, e: 606}
+      - {h: "11. Close Related Issues and Epics", l: 607, e: 622}
+      - {h: "12. Update Original Issue", l: 623, e: 656}
+      - {h: "Team Mode Instructions", l: 657, e: 660}
+      - {h: "Policies", l: 661, e: 664}
+      - {h: "Command-Specific Rules", l: 665, e: 672}
+      - {h: "Output", l: 673, e: 699}
+      - {h: "Work Summary", l: 700, e: 712}
+      - {h: "Changes Made", l: 713, e: 715}
+      - {h: "Files Modified", l: 716, e: 719}
+      - {h: "Next Steps", l: 720, e: 728}
+      - {h: "Work Summary (INCOMPLETE)", l: 729, e: 740}
+      - {h: "Action Required", l: 741, e: 748}
+      - {h: "Batch Mode Output", l: 749, e: 752}
+      - {h: "Error Handling", l: 753, e: 756}
+      - {h: "Side Effects and Loop-Safety", l: 757, e: 759}
   - path: "global/skills/_internal/issue-work/reference/batch-mode.md"
     title: "Batch Mode Instructions"
     description: ""
     category: reference
     scope: global
-    size: 18576
+    size: 21497
     tags: [global,reference,skill]
     sections:
       - {h: "B-0. Batch Discovery", l: 10, e: 41}
-      - {h: "B-1. Global Priority Sorting and Filtering", l: 42, e: 62}
-      - {h: "B-2. Auto Size/Mode Estimation per Item", l: 63, e: 79}
-      - {h: "B-3. Batch Plan Summary and Approval", l: 80, e: 84}
-      - {h: "Batch Plan: issue-work", l: 85, e: 105}
-      - {h: "B-4.0. Per-Item Rule Reminder", l: 106, e: 124}
-      - {h: "B-4. Sequential Execution Loop", l: 125, e: 128}
-      - {h: "B-4.a. Default — Subagent Delegation", l: 129, e: 188}
-      - {h: "B-4.b. Legacy — Inline Execution (`--inline` flag)", l: 189, e: 228}
-      - {h: "B-4.c. Delegation vs Inline Trade-offs", l: 229, e: 242}
-      - {h: "B-4.1. Chunked Confirmation Gate", l: 243, e: 301}
-      - {h: "Batch Context", l: 302, e: 310}
-      - {h: "Batch Progress", l: 311, e: 314}
-      - {h: "Next Action", l: 315, e: 339}
-      - {h: "B-5. Batch Summary Report", l: 340, e: 344}
-      - {h: "Batch Execution Summary", l: 345, e: 359}
-      - {h: "Failed Items", l: 360, e: 370}
+      - {h: "B-1. Global Priority Sorting and Filtering", l: 42, e: 84}
+      - {h: "B-2. Auto Size/Mode Estimation per Item", l: 85, e: 101}
+      - {h: "B-3. Batch Plan Summary and Approval", l: 102, e: 106}
+      - {h: "Batch Plan: issue-work", l: 107, e: 127}
+      - {h: "B-4.0. Per-Item Rule Reminder", l: 128, e: 146}
+      - {h: "B-4. Sequential Execution Loop", l: 147, e: 150}
+      - {h: "B-4.a. Default — Subagent Delegation", l: 151, e: 227}
+      - {h: "B-4.b. Legacy — Inline Execution (`--inline` flag)", l: 228, e: 267}
+      - {h: "B-4.c. Delegation vs Inline Trade-offs", l: 268, e: 281}
+      - {h: "B-4.1. Chunked Confirmation Gate", l: 282, e: 340}
+      - {h: "Batch Context", l: 341, e: 349}
+      - {h: "Batch Progress", l: 350, e: 353}
+      - {h: "Next Action", l: 354, e: 378}
+      - {h: "B-5. Batch Summary Report", l: 379, e: 383}
+      - {h: "Batch Execution Summary", l: 384, e: 398}
+      - {h: "Failed Items", l: 399, e: 412}
   - path: "global/skills/_internal/issue-work/reference/error-handling.md"
     title: "Error Handling"
     description: ""
@@ -2895,17 +2895,17 @@ documents:
     description: ""
     category: reference
     scope: global
-    size: 12142
+    size: 14240
     tags: [global,reference,skill]
     sections:
       - {h: "Team Architecture", l: 14, e: 37}
-      - {h: "T-1. Setup (Lead executes)", l: 38, e: 55}
-      - {h: "T-2. Create Team and Tasks", l: 56, e: 85}
-      - {h: "T-3. Spawn Teammates", l: 86, e: 202}
-      - {h: "T-4. Workflow Phases (Lead coordinates)", l: 203, e: 255}
-      - {h: "T-5. CI Failure Handling", l: 256, e: 265}
-      - {h: "T-6. Cleanup", l: 266, e: 277}
-      - {h: "T-Error. Team Mode Fallback", l: 278, e: 287}
+      - {h: "T-1. Setup (Lead executes)", l: 38, e: 62}
+      - {h: "T-2. Create Team and Tasks", l: 63, e: 92}
+      - {h: "T-3. Spawn Teammates", l: 93, e: 225}
+      - {h: "T-4. Workflow Phases (Lead coordinates)", l: 226, e: 279}
+      - {h: "T-5. CI Failure Handling", l: 280, e: 289}
+      - {h: "T-6. Cleanup", l: 290, e: 308}
+      - {h: "T-Error. Team Mode Fallback", l: 309, e: 318}
   - path: "global/skills/_internal/issue-work/reference/triage-state-machine.md"
     title: "Triage State Machine"
     description: ""

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -231,7 +231,7 @@ Store the result in `$EXEC_MODE` (solo | team).
 
 #### 0-3. Mode Routing
 
-- If `$EXEC_MODE == "solo"` → Execute **Solo Mode Instructions** (Steps 1-12 below)
+- If `$EXEC_MODE == "solo"` → Execute **Solo Mode Instructions** (Steps 1-13 below)
 - If `$EXEC_MODE == "team"` → Execute **Team Mode Instructions** (after Solo Mode section)
 
 ---
@@ -284,11 +284,38 @@ children and never posts a second summary (AC6).
 
 ### 3. Git Environment Setup
 
-```bash
-cd $PROJECT
-git fetch origin
-git checkout develop && git pull origin develop
+Git setup clones through the isolated-workspace stage (`scripts/workspace.sh`)
+instead of an in-place checkout of `$PROJECT` — every run gets a private,
+identity-verified clone rather than mutating a shared working copy. See
+`reference/workspace-lifecycle.md` for the full contract (run-root layout,
+manifest schema, identity-verification rule); this step only invokes it.
 
+```bash
+WORKSPACE_JSON=$(bash ~/.claude/skills/_internal/issue-work/scripts/workspace.sh \
+  --repo "$ORG/$PROJECT" --base "${TMPDIR:-/tmp}" --issue "$ISSUE_NUMBER")
+
+WS_STATE=$(printf '%s' "$WORKSPACE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["state"])')
+```
+
+**Outcome routing** (the JSON `state` field is authoritative):
+
+| `state` | Action |
+|---------|--------|
+| `READY` | Capture `repo_dir`, `baseline`, `manifest` below and continue. |
+| `REJECTED` | **Stop.** Report the `reason` (clone failure or origin identity mismatch). No branch, no code work. |
+
+```bash
+REPO_DIR=$(printf '%s' "$WORKSPACE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["repo_dir"])')
+BASELINE=$(printf '%s' "$WORKSPACE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["baseline"])')
+MANIFEST=$(printf '%s' "$WORKSPACE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["manifest"])')
+cd "$REPO_DIR"
+```
+
+Every step from here on (implementation, build, commit, push, PR) runs inside
+`$REPO_DIR`, not the shared `$PROJECT` checkout. Branch-name derivation is
+unchanged:
+
+```bash
 # Extract issue title for branch name
 ISSUE_TITLE=$(gh issue view $ISSUE_NUMBER --repo $ORG/$PROJECT --json title -q '.title')
 # Convert to kebab-case (lowercase, replace spaces with hyphens)
@@ -587,6 +614,29 @@ with a summary comment.
 gh issue comment <NUMBER> --repo $ORG/$PROJECT \
   --body "Implementation PR: #<PR_NUMBER>"
 ```
+
+### 13. Workspace Teardown
+
+**Mandatory, all tiers.** After the merge (Step 10) and issue/epic closure
+(Steps 11-12), tear down the isolated workspace claimed in Step 3. See
+`reference/workspace-lifecycle.md` (the #840 sections) for the full contract
+(resume-reconciliation rule, preservation predicate, remotely-recoverable
+rule, 3-fail preservation policy).
+
+```bash
+bash ~/.claude/skills/_internal/issue-work/scripts/cleanup-workspace.sh \
+  --phase reconcile --repo-dir "$REPO_DIR" --manifest "$MANIFEST" --pr "$PR_NUMBER"
+
+bash ~/.claude/skills/_internal/issue-work/scripts/cleanup-workspace.sh \
+  --phase cleanup --run-root "$(dirname "$REPO_DIR")" --repo-dir "$REPO_DIR" \
+  --manifest "$MANIFEST" --base "${TMPDIR:-/tmp}" --issue "$ISSUE_NUMBER" \
+  --pr "$PR_NUMBER" ${MERGE_COMMIT:+--merge-commit "$MERGE_COMMIT"}
+```
+
+`reconcile` re-reads the live branch/PR state before `cleanup` decides whether
+to remove the run root. A `PRESERVED` result (e.g. uncommitted work, an
+unmerged PR, or a still-held agent lease) is not a failure — report the
+`reason` and leave the run root on disk. Only a `CLEANED` result removes it.
 
 ---
 

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -169,6 +169,13 @@ fi
 
 ## Instructions
 
+**Gates are tier-independent.** The triage gate (Step 1 / T-1), the isolated
+workspace lifecycle (Step 3 clone and the Step 13 teardown), and the pre-PR
+readiness gate (Step 7.5) are MANDATORY and run in every tier, including
+`light`. The frontmatter `tiers.<name>.deep_checks` and `ref_docs` only
+control which OPTIONAL reference docs auto-load and whether the extra deep
+checks run — they never disable these three gates.
+
 ### Mode Routing
 
 - If `$BATCH_MODE == "single-repo"` or `$BATCH_MODE == "cross-repo"` → Execute **Batch Mode Instructions** below
@@ -270,6 +277,11 @@ ISSUE_NUMBER=$(printf '%s' "$TRIAGE_JSON" | python3 -c 'import json,sys;print(js
 | `blocked` | The issue has an unresolved blocker (comment posted only if the blocker state changed), or the issue fetch failed identically three times. **Stop** — no clone, no branch. |
 | `skipped` | The issue was closed, reassigned, or every child lost a claim race. **Stop.** |
 | `failed` | Cycle/depth guard tripped, or `needs_plan` (oversized issue, no children, no `--plan-file`). A `needs_plan` reason means "design a plan and re-invoke with `--plan-file`", not a hard error. **Stop and report.** |
+
+Every **Stop** row above still ends the invocation by printing the
+`ISSUE_WORK_RESULT:` marker (see Output) as its last line — `status` matches
+the `outcome` value, `requested`/`root` come from `$REQUESTED_ISSUE`/
+`$ROOT_ISSUE` above, and `pr_url` is `null`.
 
 Only `proceed` continues into code work. The other four outcomes are terminal
 for this invocation and perform no repository side effects — this is what lets a
@@ -662,6 +674,26 @@ See [_policy.md](../_policy.md) for common rules, including the **Atomic Multi-P
 
 **CRITICAL**: Do NOT produce a completion summary if CI has any failing, pending, or incomplete checks. A task is only complete when the PR is merged with all CI checks passing.
 
+### Result Marker
+
+Every exit path of this workflow — a terminal triage outcome (Step 1), a
+pre-PR gate block (Step 7.5), a CI failure (Step 9-10), or a full merge — ends
+by printing exactly one `ISSUE_WORK_RESULT:` line as the **last line** of its
+output:
+
+```
+ISSUE_WORK_RESULT: {"status":"merged|decomposed|blocked|skipped|failed","requested":"<n>","root":"<n>","active":"<n>","pr_url":"<url-or-null>","reason":"<short>"}
+```
+
+Fields mirror the batch subagent JSON contract (`reference/batch-mode.md`
+B-4.a): the same status vocabulary and the same `requested`/`root`/`active`
+triple from the triage outcome (`reference/triage-state-machine.md`). `status`
+is derived from the triage outcome when work did not proceed, else from the
+final merge/CI state. External orchestrators (`scripts/batch-issue-work.sh` /
+`.ps1`) parse this line to branch on the structured outcome instead of the
+process exit code alone. Both Work Summary formats below end with this
+marker, as the trailing line after the table and any following sections.
+
 After successful merge, provide summary:
 
 ```markdown
@@ -687,6 +719,8 @@ After successful merge, provide summary:
 
 ### Next Steps
 - Any follow-up items
+
+ISSUE_WORK_RESULT: {"status":"merged","requested":"$REQUESTED_ISSUE","root":"$ROOT_ISSUE","active":"$ISSUE_NUMBER","pr_url":"https://github.com/$ORG/$PROJECT/pull/$PR_NUMBER","reason":""}
 ```
 
 If CI failed or the PR was not merged, use this format instead:
@@ -706,6 +740,8 @@ If CI failed or the PR was not merged, use this format instead:
 
 ### Action Required
 - User must resolve CI failures before merge
+
+ISSUE_WORK_RESULT: {"status":"failed","requested":"$REQUESTED_ISSUE","root":"$ROOT_ISSUE","active":"$ISSUE_NUMBER","pr_url":"<url-or-null>","reason":"<short reason>"}
 ```
 
 **IMPORTANT**: Always include the full PR URL in the output (e.g., `https://github.com/org/repo/pull/123`).

--- a/global/skills/_internal/issue-work/SKILL.md
+++ b/global/skills/_internal/issue-work/SKILL.md
@@ -181,7 +181,7 @@ fi
 See `reference/batch-mode.md` for the complete batch mode workflow including discovery, priority sorting, plan approval, and sequential execution.
 
 **Batch-only behaviors** (do not apply in single-item mode):
-- **Subagent delegation by default** (B-4): each item is dispatched to a fresh `general-purpose` Agent so it starts with an unpolluted attention pool. The parent retains only `{item_id, status, pr_url, ci_conclusion}` per item. Pass `--inline` to fall back to the legacy single-context loop.
+- **Subagent delegation by default** (B-4): each item is dispatched to a fresh `general-purpose` Agent so it starts with an unpolluted attention pool. The parent retains only `{item_id, status, requested, root, active, pr_url, ci_conclusion}` per item. Pass `--inline` to fall back to the legacy single-context loop.
 - **Per-item rule reminder** (B-4.0): a 5-line invariant block is emitted as a fresh tool result before each item so language/CI/attribution rules stay in the recent attention window. In delegated mode this reminder is embedded in the subagent prompt; in `--inline` mode it is emitted directly in the parent context.
 - **No `@load: reference/...` inside the per-item loop**: keep the inline reminder as the most recent context anchor.
 - **Chunked confirmation gate** (B-4.1): user confirmation prompt every 5 items, bypassable with `--no-confirm`. When `--auto-restart` is set (and `--no-restart` is not), the gate is replaced by a forced session restart that writes `.claude/resume.md` and exits; a fresh `claude` session resumes from the next item.
@@ -256,6 +256,8 @@ TRIAGE_JSON=$(bash ~/.claude/skills/_internal/issue-work/scripts/triage.sh \
   --repo "$ORG/$PROJECT" ${ISSUE_NUMBER:+--issue "$ISSUE_NUMBER"} ${PLAN_FILE:+--plan-file "$PLAN_FILE"})
 
 OUTCOME=$(printf '%s' "$TRIAGE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["outcome"])')
+REQUESTED_ISSUE=$(printf '%s' "$TRIAGE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["requested"])')
+ROOT_ISSUE=$(printf '%s' "$TRIAGE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["root"])')
 ISSUE_NUMBER=$(printf '%s' "$TRIAGE_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["active"])')
 ```
 

--- a/global/skills/_internal/issue-work/reference/batch-mode.md
+++ b/global/skills/_internal/issue-work/reference/batch-mode.md
@@ -60,6 +60,28 @@ Apply filters:
 
 If no issues found after filtering, report "No open issues found matching criteria" and exit.
 
+### B-1.5. Active-Issue Deduplication
+
+Triage resolves a `requested` issue to an `active` issue (a parent can resolve
+to a child — see `reference/triage-state-machine.md`). Because the batch plan
+is built from `requested` issue numbers before any item runs triage, two
+different requested issues can resolve to the same `active` child. The batch
+maintains a seen-set of `active` issue numbers as items are dispatched:
+
+- Before (or at) dispatch, if a queued item's triage resolves to an `active`
+  issue number already in the seen-set, mark that item `skipped` with reason
+  `"deduplicated: active #N already handled"` and do **not** dispatch a
+  second subagent for it.
+- Add each dispatched item's `active` value to the seen-set as soon as its
+  triage outcome is known (`proceed`, `decomposed`, `blocked`, and `skipped`
+  all populate `active`/`root` — add whichever the outcome carries).
+- This is a batch-level optimization, not the sole safety mechanism: the
+  triage claim mechanism (issue assignment + re-verification,
+  `reference/triage-state-machine.md` "Claim race handling") is the backstop
+  that prevents two runs from actually working the same issue concurrently.
+  Deduplicating explicitly here avoids wasting a subagent dispatch on an item
+  that triage would reject anyway.
+
 ### B-2. Auto Size/Mode Estimation per Item
 
 For each issue in the batch, estimate size and decide solo vs team **without prompting the user**.
@@ -130,9 +152,15 @@ Process each item one at a time. The default dispatch strategy is **subagent del
 
 ```
 PROCESSED=0
-RESULTS=[]   # Parent-side queue: only {item_id, repo, title, mode, status, pr_url, ci_conclusion}
+RESULTS=[]   # Parent-side queue: {item_id, repo, title, mode, status, requested, root, active, pr_url, ci_conclusion}
+SEEN_ACTIVE=[]  # Active-issue dedup set (see B-1.5)
 
 for each item in approved batch plan:
+    0. Dedup check (B-1.5): if this item's triage would resolve to an `active`
+       already in SEEN_ACTIVE, mark it `skipped` ("deduplicated: active #N
+       already handled"), append to RESULTS, and continue to the next item
+       without dispatching a subagent.
+
     1. Log progress: "[N/TOTAL] Dispatching: $REPO #$ISSUE_NUMBER — $TITLE ($MODE)"
 
     2. Delegate the full single-item workflow to a fresh subagent:
@@ -150,32 +178,43 @@ for each item in approved batch plan:
                - Branch: feature off develop, squash merge back via PR
                - 3-fail rule: stop and propose alternatives after 3 identical failures
 
-               Run Solo Mode Steps 1-12 (or Team Mode T-1 through T-6 for team mode). If team
+               Run Solo Mode Steps 1-13 (or Team Mode T-1 through T-6 for team mode). If team
                mode, you MUST call TeamDelete() after completing the item.
 
                The single-item workflow begins with the Issue Triage Gate
-               (Solo Step 1 / Team T-1). Only a triage `proceed` outcome leads
-               to code work and a possible merge; `decomposed`, `blocked`,
-               `skipped`, and `failed` are terminal with no branch or PR.
+               (Solo Step 1 / Team T-1), whose outcome JSON already carries
+               `requested`/`root`/`active` (reference/triage-state-machine.md).
+               Only a triage `proceed` outcome leads to code work and a
+               possible merge; `decomposed`, `blocked`, `skipped`, and
+               `failed` are terminal with no branch or PR.
 
                Report under 100 words as a single JSON line. The status MUST
-               reflect the triage outcome when work did not proceed:
+               reflect the triage outcome when work did not proceed, and
+               requested/root/active MUST echo the triage outcome's values:
                {"item": "$REPO#$ISSUE_NUMBER", "status": "merged|decomposed|blocked|skipped|failed",
+                "requested": "<n>", "root": "<n>", "active": "<n>",
                 "pr_url": "https://github.com/...", "ci_conclusion": "success|failure|timeout",
                 "reason": "<short reason if not merged>"}
            """
        )
 
-    3. Parse the subagent's final JSON line and append it to RESULTS.
+    3. Parse the subagent's final JSON line, append it to RESULTS, and add
+       its `active` (or `root` if `active` is empty) to SEEN_ACTIVE.
        Do NOT retain the full subagent transcript — the 100-word summary IS the parent-side record.
 
-    4. Write batch progress to .claude/resume.md (for session recovery)
+    4. Pause condition: if `status` is `decomposed` or `blocked`, this is an
+       operator pause, not a per-item failure. Call `write_resume_md_for_batch`,
+       surface the item (repo, issue, status, reason) to the operator, and
+       STOP — do not dispatch any further items in this run. A decomposed or
+       blocked item is never tallied as merged (see B-5).
 
-    5. Log completion: "[N/TOTAL] Completed: $REPO #$ISSUE_NUMBER — $status"
+    5. Write batch progress to .claude/resume.md (for session recovery)
 
-    6. Pause 2 seconds between items (rate limiting)
+    6. Log completion: "[N/TOTAL] Completed: $REPO #$ISSUE_NUMBER — $status"
 
-    7. PROCESSED=$((PROCESSED + 1))
+    7. Pause 2 seconds between items (rate limiting)
+
+    8. PROCESSED=$((PROCESSED + 1))
        Chunked confirmation gate (see B-4.1) — fires every CONFIRM_INTERVAL
        items and only when more items remain.
 ```
@@ -204,7 +243,7 @@ for each item in approved batch plan:
        - $EXEC_MODE from estimated mode (solo or team)
 
     3. Execute the single-item workflow directly in the parent context:
-       - If solo: run Solo Mode Steps 1-12
+       - If solo: run Solo Mode Steps 1-13
        - If team: run Team Mode Steps T-1 through T-6
        Ensure TeamDelete() is called after each team-mode item.
 
@@ -286,7 +325,7 @@ fi
 
 **Why `--auto-restart` goes further**: An interactive gate still runs inside the same Claude process, so accumulated tool results (gh outputs, build logs, diffs) remain in the context window even after the user clicks "Continue". `--auto-restart` ends the process entirely: a fresh `claude` session starts with an empty tool-result history, the full CLAUDE.md and skill files reloaded at position zero, and resumes work from `resume.md`. This is the strongest context cleanup available short of spawning a separate OS process per item.
 
-**Resume state on pause or auto-restart**: Both `Pause` (interactive) and `--auto-restart` call `write_resume_md_for_batch`, which writes `.claude/resume.md` using the **Batch Workflow Resume Format** described in `workflow/reference/session-resume-templates.md`. The file must include the per-item progress table so a future session can distinguish `DONE`, `IN PROGRESS`, and `PENDING` items and pick up at `$((PROCESSED + 1))`.
+**Resume state on pause or auto-restart**: Both `Pause` (interactive), `--auto-restart`, and the B-4.a pause condition (step 4, a `decomposed`/`blocked` item) call `write_resume_md_for_batch`, which writes `.claude/resume.md` using the **Batch Workflow Resume Format** described in `workflow/reference/session-resume-templates.md`. The file must include the per-item progress table so a future session can distinguish `DONE`, `IN PROGRESS`, and `PENDING` items and pick up at `$((PROCESSED + 1))`. Each row of `${BATCH_PROGRESS_TABLE}` carries the item's `requested`/`root`/`active` triple (from RESULTS, step 3) alongside `#`/`Repo`/`Issue`/`Mode`/`Status`, so a resumed session can tell which issue was actually claimed versus requested without re-running triage.
 
 Minimal shape of `write_resume_md_for_batch`:
 
@@ -365,6 +404,9 @@ After all items are processed, present a summary:
 result means the batch produced child issues (the children may be picked up in a
 later run) — it is **not** a merge and must never be tallied as one. `Blocked`
 and `Skipped` are neither successes nor failures; surface them so the operator
-can act on the blocker or confirm the skip.
+can act on the blocker or confirm the skip. A `Decomposed` or `Blocked` item
+**pauses** the batch (B-4.a step 4): processing stops at that item, resume
+state is written, and no further items are dispatched in the same run —
+neither result is silently passed over.
 
 Delete `.claude/resume.md` after successful batch completion.

--- a/global/skills/_internal/issue-work/reference/team-mode.md
+++ b/global/skills/_internal/issue-work/reference/team-mode.md
@@ -37,20 +37,27 @@ loop — sending change requests back to the dev team until quality gates pass.
 
 ### T-1. Setup (Lead executes)
 
-Perform Solo Mode Steps 1-4 (Issue Triage Gate, Size Evaluation, Git Setup,
+Perform Solo Mode Steps 1-4 (Issue Triage Gate, isolated workspace clone,
 Assignment). These steps require sequential execution and must complete before
 parallelization.
 
-**Triage gate first**: Step 1 runs the shared triage state machine
-(`scripts/triage.sh`, see `reference/triage-state-machine.md`). Only a triage
-`proceed` outcome justifies creating a team. If the gate returns `decomposed`,
-`blocked`, `skipped`, or `failed`, do **not** create the team, spawn teammates,
-or create a branch — report the terminal outcome and stop. Team setup is a
-repository side effect and is gated behind `proceed` exactly like the clone and
-branch (issue #829 AC9).
+**Ordering: triage -> workspace.sh -> agents.** Step 1 runs the shared triage
+state machine (`scripts/triage.sh`, see `reference/triage-state-machine.md`).
+Only a triage `proceed` outcome justifies creating a team. If the gate returns
+`decomposed`, `blocked`, `skipped`, or `failed`, do **not** create the team,
+spawn teammates, or create a branch — report the terminal outcome and stop.
+
+On `proceed`, Step 3 clones the workspace via `scripts/workspace.sh` (see
+`reference/workspace-lifecycle.md`) **before any teammate is created**,
+capturing `repo_dir`, `baseline`, and `manifest` from its `READY` JSON. A
+`REJECTED` clone (origin identity mismatch or clone failure) is equally
+terminal — report the `reason` and stop. Team creation, teammate spawn, and
+branch creation are repository side effects gated behind **both** a triage
+`proceed` **and** a successful (`READY`) clone (issue #829 AC9).
 
 Prepare shared context for all teammates:
 - `$ORG`, `$PROJECT`, `$ISSUE_NUMBER`, `$BRANCH_NAME`, `$BRANCH_TYPE`
+- `$REPO_DIR`, `$BASELINE` (from `workspace.sh`), and the write scope each teammate is granted
 - Issue body and acceptance criteria (fetched via `gh issue view`)
 
 ### T-2. Create Team and Tasks
@@ -85,6 +92,19 @@ Create tasks with dependencies:
 
 ### T-3. Spawn Teammates
 
+Each teammate's prompt is built by `agents_build_prompt <repo_path> <issue>
+<branch> <baseline> <write_scope>` (`scripts/agents.sh`, see
+`reference/workspace-lifecycle.md`, the #839 sections) rather than hand-typed
+per role. This guarantees every teammate prompt carries the normalized
+absolute repository path (`$REPO_DIR` from `scripts/workspace.sh`), the active
+issue, the target branch, the baseline commit, and that teammate's write
+scope, plus the fixed ownership/prohibition clause (the coordinator owns all
+git/GitHub mutations). Each role's responsibility list below is appended to
+that generated base prompt as its `write_scope` / role framing — the base
+prompt is never hand-written per role. (The reviewer role remains the Lead's
+designated exception for push + PR creation in Task 11 below — an existing
+Team Mode responsibility that predates this prompt-generation change.)
+
 **Dev Team** (implementation + fixes):
 
 ```
@@ -92,8 +112,9 @@ Agent(
   name="dev",
   team_name="issue-$ISSUE_NUMBER",
   subagent_type="general-purpose",
-  prompt="You are the development team for issue #$ISSUE_NUMBER in $ORG/$PROJECT.
-    Branch: $BRANCH_NAME
+  prompt=agents_build_prompt("$REPO_DIR", "$ISSUE_NUMBER", "$BRANCH_NAME", "$BASELINE",
+    "source and test files required to implement issue #$ISSUE_NUMBER") + "
+
     Repository: https://github.com/$ORG/$PROJECT
 
     Your responsibilities:
@@ -131,8 +152,9 @@ Agent(
   name="reviewer",
   team_name="issue-$ISSUE_NUMBER",
   subagent_type="general-purpose",
-  prompt="You are the review team for issue #$ISSUE_NUMBER in $ORG/$PROJECT.
-    Branch: $BRANCH_NAME
+  prompt=agents_build_prompt("$REPO_DIR", "$ISSUE_NUMBER", "$BRANCH_NAME", "$BASELINE",
+    "PR title/body and review comment text (push and PR creation are this role's Task 11 exception, see above)") + "
+
     Repository: https://github.com/$ORG/$PROJECT
 
     Your responsibilities:
@@ -177,8 +199,9 @@ Agent(
   name="doc-writer",
   team_name="issue-$ISSUE_NUMBER",
   subagent_type="general-purpose",
-  prompt="You are the documentation team for issue #$ISSUE_NUMBER in $ORG/$PROJECT.
-    Branch: $BRANCH_NAME
+  prompt=agents_build_prompt("$REPO_DIR", "$ISSUE_NUMBER", "$BRANCH_NAME", "$BASELINE",
+    "README.md, CHANGELOG.md, API docs, and code comments in files touched by the implementation") + "
+
     Repository: https://github.com/$ORG/$PROJECT
 
     Your responsibilities:
@@ -251,7 +274,8 @@ Reviewer has findings?
 2. Lead monitors CI (Task 12): non-blocking polling, 30s intervals, 10min max
 3. On all checks pass: `gh pr merge $PR_NUMBER --repo $ORG/$PROJECT --squash --delete-branch`
 4. Close related issues and epics (Steps 11-12 from Solo Mode)
-5. Post implementation comment to issue
+5. Post implementation comment to issue (Step 12)
+6. Tear down the workspace (Step 13 / T-6)
 
 ### T-5. CI Failure Handling
 
@@ -274,6 +298,13 @@ SendMessage(to="doc-writer", message={type: "shutdown_request"})
 # Delete team
 TeamDelete()
 ```
+
+After merge and issue/epic closure (Solo Steps 11-12), tear down the isolated
+workspace claimed in T-1 the same way Solo Step 13 does: run
+`scripts/cleanup-workspace.sh --phase reconcile` then `--phase cleanup`
+against `$REPO_DIR` / `$MANIFEST` (see `reference/workspace-lifecycle.md`, the
+#840 sections). A `PRESERVED` result is not a failure — report the reason and
+leave the run root on disk.
 
 ### T-Error. Team Mode Fallback
 

--- a/scripts/batch-issue-work.ps1
+++ b/scripts/batch-issue-work.ps1
@@ -18,6 +18,13 @@
 #
 # On any item failure, the batch pauses and exits with a non-zero code so
 # the operator can inspect the log before deciding to continue.
+#
+# Each item's outcome is read from the trailing ISSUE_WORK_RESULT: marker
+# line the skill prints (see SKILL.md "Output" / reference/batch-mode.md
+# B-4.a) rather than the bare exit code: a decomposed/blocked status pauses
+# the batch as an operator hand-off, distinct from a failed status. When no
+# marker is found (older skill or a crash), the script falls back to the
+# previous exit-code-only behavior.
 
 param(
     [Parameter(Mandatory = $true, Position = 0)]
@@ -80,15 +87,59 @@ foreach ($Issue in $IssuesJson) {
     # discarded on exit. --print exits after the turn completes.
     $Prompt = "/issue-work $OrgProject $($Issue.number) --solo"
     & claude --print $Prompt *>$LogFile
+    $ExitCode = $LASTEXITCODE
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Err "#$($Issue.number) failed (exit $LASTEXITCODE). Pausing batch."
-        Write-Err "Inspect the log before continuing: $LogFile"
-        $FailedItem = "#$($Issue.number)"
-        break
+    # Prefer the structured result marker over the bare exit code -- it
+    # distinguishes a triage pause (decomposed/blocked) from a hard failure.
+    $MarkerMatch = Select-String -Path $LogFile -Pattern 'ISSUE_WORK_RESULT:\s*(.+)$' -ErrorAction SilentlyContinue |
+        Select-Object -Last 1
+    $Status = ''
+    if ($MarkerMatch) {
+        try {
+            $Status = ($MarkerMatch.Matches[0].Groups[1].Value | ConvertFrom-Json).status
+        } catch {
+            $Status = ''
+        }
     }
 
-    Write-Ok "#$($Issue.number) completed"
+    switch ($Status) {
+        'merged' {
+            Write-Ok "#$($Issue.number) merged"
+        }
+        'skipped' {
+            Write-Warn "#$($Issue.number) skipped (deduplicated or closed) -- continuing"
+        }
+        { $_ -in 'decomposed', 'blocked' } {
+            Write-Warn "#$($Issue.number) paused for operator ($Status) -- not a failure, but the batch stops here."
+            Write-Err "Inspect the log and resolve before resuming: $LogFile"
+            $FailedItem = "#$($Issue.number) ($Status)"
+        }
+        'failed' {
+            Write-Err "#$($Issue.number) failed (exit $ExitCode). Pausing batch."
+            Write-Err "Inspect the log before continuing: $LogFile"
+            $FailedItem = "#$($Issue.number)"
+        }
+        '' {
+            # No marker found -- fall back to the exit-code-only behavior
+            # this script used before the marker existed.
+            if ($ExitCode -eq 0) {
+                Write-Ok "#$($Issue.number) completed"
+            } else {
+                Write-Err "#$($Issue.number) failed (exit $ExitCode). Pausing batch."
+                Write-Err "Inspect the log before continuing: $LogFile"
+                $FailedItem = "#$($Issue.number)"
+            }
+        }
+        default {
+            Write-Err "#$($Issue.number) failed (unrecognized status=$Status, exit $ExitCode). Pausing batch."
+            Write-Err "Inspect the log before continuing: $LogFile"
+            $FailedItem = "#$($Issue.number)"
+        }
+    }
+
+    if ($FailedItem) {
+        break
+    }
 }
 
 Write-Host ''

--- a/scripts/batch-issue-work.sh
+++ b/scripts/batch-issue-work.sh
@@ -99,11 +99,12 @@ while IFS=$'\t' read -r ISSUE_NUMBER ISSUE_TITLE; do
 
     # Each item runs in a fresh claude process so its context state is
     # discarded on exit. --print exits after the turn completes.
+    # `|| EXIT_CODE=$?` captures claude's real exit status. An `if ! claude`
+    # guard would instead leave $? as the negation result (0), so a crash with
+    # no marker would be misread as success in the fallback branch below.
     EXIT_CODE=0
-    if ! claude --print "/issue-work ${ORG_PROJECT} ${ISSUE_NUMBER} --solo" \
-        >"$LOG_FILE" 2>&1; then
-        EXIT_CODE=$?
-    fi
+    claude --print "/issue-work ${ORG_PROJECT} ${ISSUE_NUMBER} --solo" \
+        >"$LOG_FILE" 2>&1 || EXIT_CODE=$?
 
     # Prefer the structured result marker over the bare exit code -- it
     # distinguishes a triage pause (decomposed/blocked) from a hard failure.

--- a/scripts/batch-issue-work.sh
+++ b/scripts/batch-issue-work.sh
@@ -19,6 +19,13 @@
 # On any item failure, the batch pauses and exits non-zero so the operator
 # can inspect the log before deciding to continue. Successful items are NOT
 # rolled back — reruns should skip already-merged issues by inspecting state.
+#
+# Each item's outcome is read from the trailing ISSUE_WORK_RESULT: marker
+# line the skill prints (see SKILL.md "Output" / reference/batch-mode.md
+# B-4.a) rather than the bare process exit code: a `decomposed`/`blocked`
+# status pauses the batch as an operator hand-off, distinct from a `failed`
+# status. When no marker is found (older skill or a crash), the script falls
+# back to the previous exit-code-only behavior.
 
 set -euo pipefail
 
@@ -92,16 +99,61 @@ while IFS=$'\t' read -r ISSUE_NUMBER ISSUE_TITLE; do
 
     # Each item runs in a fresh claude process so its context state is
     # discarded on exit. --print exits after the turn completes.
-    if claude --print "/issue-work ${ORG_PROJECT} ${ISSUE_NUMBER} --solo" \
+    EXIT_CODE=0
+    if ! claude --print "/issue-work ${ORG_PROJECT} ${ISSUE_NUMBER} --solo" \
         >"$LOG_FILE" 2>&1; then
-        success "#${ISSUE_NUMBER} completed"
-    else
         EXIT_CODE=$?
-        error "#${ISSUE_NUMBER} failed (exit ${EXIT_CODE}). Pausing batch."
-        error "Inspect the log before continuing: ${LOG_FILE}"
-        FAILED_ITEM="#${ISSUE_NUMBER}"
-        break
     fi
+
+    # Prefer the structured result marker over the bare exit code -- it
+    # distinguishes a triage pause (decomposed/blocked) from a hard failure.
+    # `|| true` so "no marker found" (older skill or a crash) does not abort
+    # the script under set -e/pipefail.
+    MARKER_LINE=$(grep -o 'ISSUE_WORK_RESULT:.*' "$LOG_FILE" 2>/dev/null | tail -n1 || true)
+    STATUS=""
+    if [[ -n "$MARKER_LINE" ]]; then
+        STATUS=$(printf '%s' "$MARKER_LINE" | sed -E 's/^ISSUE_WORK_RESULT:[[:space:]]*//' \
+            | python3 -c 'import json,sys;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+    fi
+
+    case "$STATUS" in
+        merged)
+            success "#${ISSUE_NUMBER} merged"
+            ;;
+        skipped)
+            warning "#${ISSUE_NUMBER} skipped (deduplicated or closed) — continuing"
+            ;;
+        decomposed|blocked)
+            warning "#${ISSUE_NUMBER} paused for operator (${STATUS}) — not a failure, but the batch stops here."
+            error "Inspect the log and resolve before resuming: ${LOG_FILE}"
+            FAILED_ITEM="#${ISSUE_NUMBER} (${STATUS})"
+            break
+            ;;
+        failed)
+            error "#${ISSUE_NUMBER} failed (exit ${EXIT_CODE}). Pausing batch."
+            error "Inspect the log before continuing: ${LOG_FILE}"
+            FAILED_ITEM="#${ISSUE_NUMBER}"
+            break
+            ;;
+        "")
+            # No marker found -- fall back to the exit-code-only behavior
+            # this script used before the marker existed.
+            if [[ "$EXIT_CODE" -eq 0 ]]; then
+                success "#${ISSUE_NUMBER} completed"
+            else
+                error "#${ISSUE_NUMBER} failed (exit ${EXIT_CODE}). Pausing batch."
+                error "Inspect the log before continuing: ${LOG_FILE}"
+                FAILED_ITEM="#${ISSUE_NUMBER}"
+                break
+            fi
+            ;;
+        *)
+            error "#${ISSUE_NUMBER} failed (unrecognized status=${STATUS}, exit ${EXIT_CODE}). Pausing batch."
+            error "Inspect the log before continuing: ${LOG_FILE}"
+            FAILED_ITEM="#${ISSUE_NUMBER}"
+            break
+            ;;
+    esac
 done <<< "$ISSUES"
 
 echo


### PR DESCRIPTION
Closes #845

## What

Wire the shared triage state machine, isolated-workspace lifecycle, and pre-PR
readiness gate into the actual solo, team, batch, and external-orchestrator
execution paths of `issue-work`. The reference scripts already existed (#829,
#830, #831) but the skill body and the team/batch references did not invoke them
in order.

## Why

Part of #832. Depends on #829, #830, #831 (all closed). Without this wiring the
gates were dead code: solo used an in-place `git checkout -b`, team hand-typed
teammate prompts, batch never recorded the triage triple or paused on
decomposition, and the external orchestrators branched on the process exit code
alone.

## Where

| File | Change |
|------|--------|
| `global/skills/_internal/issue-work/SKILL.md` | Solo Step 3 clones via `workspace.sh`; new Step 13 tears down via `cleanup-workspace.sh`; tier-independent gates note; `ISSUE_WORK_RESULT:` marker contract in Output |
| `.../reference/team-mode.md` | T-1 ordering triage -> `workspace.sh` -> agents; T-3 prompts via `agents_build_prompt`; T-6 teardown |
| `.../reference/batch-mode.md` | B-1.5 active-issue dedup; results/resume carry `requested`/`root`/`active`; pause on decomposed/blocked |
| `scripts/batch-issue-work.sh` / `.ps1` | Branch on the structured `ISSUE_WORK_RESULT:` marker, with exit-code fallback |
| `CHANGELOG.md`, `docs/.index/manifest.yaml` | Changelog entry and doc-index refresh (gap audit) |

## How

Acceptance criteria coverage:

- **AC1** Team invokes triage -> `workspace.sh` -> `agents.sh`, agents spawned only after the clone (team-mode.md T-1/T-3).
- **AC2** Teammate prompts are built by `agents_build_prompt <repo_path> <issue> <branch> <baseline> <write_scope>`, carrying the absolute repo path, active issue, baseline commit, and write scope (team-mode.md T-3).
- **AC3** Batch `RESULTS`, the delegated-subagent JSON report, and `write_resume_md_for_batch` all carry the `requested`/`root`/`active` triple (batch-mode.md, SKILL.md).
- **AC4** A `decomposed`/`blocked` item calls `write_resume_md_for_batch`, pauses the run, and is never tallied as merged (batch-mode.md B-4.a step 4, B-5).
- **AC5** B-1.5 deduplicates by the triage-resolved `active` issue so a parent and child cannot schedule the same active issue twice.
- **AC6** Both orchestrators parse the trailing `ISSUE_WORK_RESULT:` marker and branch on `merged`/`skipped`/`decomposed`/`blocked`/`failed`, falling back to the exit code only when no marker is present.
- **AC7** SKILL.md documents the triage, workspace, and pre-PR gates as mandatory in every tier, including `light`.

### Result marker contract

The single-item workflow prints one trailing line
`ISSUE_WORK_RESULT: {"status":...,"requested":...,"root":...,"active":...,"pr_url":...,"reason":...}`,
sharing the status vocabulary and triple of the batch subagent JSON contract so
in-session batch and the external orchestrators read the same shape.

### Review fix

A latent bug was found and fixed during review: the orchestrator captured the
per-item exit code with an `if ! claude ...; then EXIT_CODE=$?` guard, which
leaves `$?` as the negated result (`0`), so a crash with no marker would be
misread as success in the fallback branch. Replaced with `|| EXIT_CODE=$?`.

### Documentation-to-issue gap audit

Editing indexed skill docs invalidated `docs/.index/manifest.yaml` (size and
section line numbers). Since `validate-skills.yml` runs `validate-doc-index.sh`
on PRs to `develop`, this would have failed CI. Regenerated the four affected
entries (numbers only, `h:` strings untouched) and added the missing #845
`CHANGELOG.md` entry to match the #829/#830/#831 pattern.

## Test Plan

Run from the repo root — all green locally:

```
for t in triage workspace agents cleanup pre-pr-gate; do bash tests/issue-work/test-$t.sh; done
bash scripts/validate_skills.sh
bash scripts/spec_lint.sh --strict
bash scripts/check_references.sh
bash scripts/check_skill_drift.sh
bash scripts/check_agents.sh
bash scripts/check_versions.sh
bash scripts/validate-doc-index.sh
bash -n scripts/batch-issue-work.sh
```

`shellcheck`/`pwsh` are not installed in the dev environment; the Bash
orchestrator passes `bash -n` and the marker-parsing pipeline was smoke-tested
against synthetic logs. `scripts/batch-issue-work.sh` is outside the
`validate-hooks.yml` shellcheck path set, so no CI shellcheck step covers it.

## Out of Scope

- New PowerShell script ports (tracked by #846).
- The PowerShell regression harness and CI wiring (tracked by #847).
