### PR TITLE
feat(issue-work): add triage and pre-PR PowerShell ports with parity

### DIFF
--- a/global/skills/_internal/issue-work/scripts/pre-pr-gate.ps1
+++ b/global/skills/_internal/issue-work/scripts/pre-pr-gate.ps1
@@ -1,0 +1,345 @@
+#Requires -Version 7.0
+# pre-pr-gate.ps1
+# issue-work: pre-PR readiness gate (git-state half)
+# ==================================================
+# PowerShell parity port of scripts/pre-pr-gate.sh. Same functions, same
+# behavior, same develop-refresh / conflict / base-movement rules, same
+# injection seams, and the same single-line JSON outcome schema (identical field
+# order, attempts as an unquoted number). See reference/pre-pr-readiness.md for
+# the full contract both scripts satisfy (outcome table, develop-refresh rules,
+# conflict rule, base-movement retry rule, and the agent-side gap audit this
+# script does not itself perform).
+#
+# NOTE (authoring-time caveat): pwsh was not available in the environment this
+# port was written in, so it was produced by mirroring the bash-verified logic
+# in pre-pr-gate.sh line-for-line rather than by running it. It has NOT been
+# executed and is NOT wired into CI. Cross-platform runtime regression coverage
+# is tracked in issue #847 under epic #832, consistent with the existing
+# PowerShell-parity notes for the triage (#829), workspace (#838), and agents
+# (#839) stages in tests/issue-work/README.md.
+#
+# This script owns only the mechanical, non-judgemental half of the gate:
+#   1. Refuse to run against a dirty worktree (commit impl+docs first).
+#   2. Fetch the remote base and fast-forward the LOCAL base branch only when it
+#      is strictly behind the remote. If the local base is AHEAD or DIVERGED it
+#      is left untouched and the gate blocks -- it never rewinds a base branch.
+#   3. Integrate the refreshed base into the feature branch (rebase by default,
+#      merge for shared branches). On ANY integration conflict it aborts the
+#      rebase/merge -- leaving the feature branch exactly as it was -- and blocks.
+#   4. Re-fetch after a clean integration; if the remote base moved, re-integrate
+#      against the new base, capped at --max-base-moves re-integrations.
+#
+# The script is both a sourceable library (dot-source it to get the functions
+# below, e.g. classify_base_relationship / run_pre_pr_gate) and a CLI:
+#   pwsh -File pre-pr-gate.ps1 --repo <owner/name> --base <develop> --branch <feature>
+#        [--remote origin] [--max-base-moves 3] [--integrate rebase|merge]
+# CLI flags intentionally mirror pre-pr-gate.sh's flags exactly (rather than
+# native PowerShell parameter binding) so the two entry points are
+# interchangeable from a caller's point of view.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Injection seams (overridable by tests and callers via environment variables,
+# mirroring the bash GIT_BIN seam). GIT_BIN is captured once at load time, as in
+# the bash script; PREPR_REPO_DIR is read fresh on every git call (see
+# _prepr_git) so a sourced unit test can aim a single helper at a temp repo.
+$script:GitBin = if ($env:GIT_BIN) { $env:GIT_BIN } else { 'git' }
+
+# ── Low-level git wrapper ────────────────────────────────────────────
+# All git access funnels through here so a fake git can shadow it via
+# $env:GIT_BIN. Operations run inside ${PREPR_REPO_DIR:-.}; the default targets
+# the current working directory (the feature-branch checkout in the real
+# workflow), and a sourced unit test may set PREPR_REPO_DIR to aim a single
+# helper at a temp repo.
+#
+# Native-command failure is surfaced via $LASTEXITCODE, never a thrown
+# exception: $ErrorActionPreference is locally lowered to 'Continue' so that a
+# benign non-zero git exit (e.g. `merge-base --is-ancestor` reporting "not an
+# ancestor") does NOT become a terminating error under the script-scope 'Stop'
+# preference -- whether it would depends on the pwsh minor version. git's stderr
+# is redirected to null so a caller only ever sees git's stdout on the success
+# stream.
+function _prepr_git {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+    $repoDir = if ($env:PREPR_REPO_DIR) { $env:PREPR_REPO_DIR } else { '.' }
+    $ErrorActionPreference = 'Continue'
+    & $script:GitBin -C $repoDir @GitArgs 2>$null
+}
+
+# Run a git command purely for its exit status, discarding stdout. Returns $true
+# when git exited 0. Mirrors the bash `if _prepr_git ... >/dev/null 2>&1` idiom.
+# $LASTEXITCODE is set by the native git inside _prepr_git and is not disturbed
+# by the Out-Null cmdlet or the function return, so it is safe to read here.
+function _prepr_git_ok {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+    _prepr_git @GitArgs | Out-Null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Run a git command and return its stdout as a single trimmed string ('' when
+# git produced nothing or failed). Mirrors the bash `x="$(_prepr_git ... )"`
+# command-substitution idiom, which likewise yields the empty string on failure.
+function _prepr_git_line {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+    $out = _prepr_git @GitArgs
+    if ($null -eq $out) { return '' }
+    return (($out | Out-String).Trim())
+}
+
+# ── Base-movement test seam ──────────────────────────────────────────
+# Command string run after every fetch, mirroring the bash env-var seam. It
+# exists so a test can push a new commit to the bare remote between fetches and
+# deterministically simulate the base moving under the gate. It is a no-op when
+# unset and its failures are swallowed so a flaky hook never masks a real gate
+# result. Mirrors the bash `eval` seam using Invoke-Expression.
+function _prepr_run_hook {
+    if ([string]::IsNullOrEmpty($env:PRE_PR_ON_FETCH)) { return }
+    try {
+        Invoke-Expression -Command $env:PRE_PR_ON_FETCH *> $null
+    } catch {
+        # A flaky hook must never mask a real gate result; swallow all failures.
+    }
+}
+
+# ── Pure helper (unit-testable via PREPR_REPO_DIR ancestry) ──────────
+# Classify how a local base sha relates to a remote base sha using commit
+# ancestry, funneled through _prepr_git so it is fakeable / testable against a
+# real throwaway repo. Returns exactly one of:
+#   equal     the two shas are identical (no refresh needed)
+#   behind    local is an ancestor of remote (safe fast-forward)
+#   ahead     remote is an ancestor of local (local has unshared commits)
+#   diverged  neither is an ancestor of the other (histories forked)
+# Returns "unknown" only when an argument is empty (the bash returns nonzero in
+# that case; the string is the contract the driver switches on, and "unknown"
+# falls through to the diverged branch there exactly as bash's `diverged|*`
+# does).
+function classify_base_relationship {
+    param(
+        [AllowEmptyString()][string]$LocalSha = '',
+        [AllowEmptyString()][string]$RemoteSha = ''
+    )
+    if ([string]::IsNullOrEmpty($LocalSha) -or [string]::IsNullOrEmpty($RemoteSha)) {
+        return 'unknown'
+    }
+    if ($LocalSha -eq $RemoteSha) {
+        return 'equal'
+    }
+    # `merge-base --is-ancestor` emits no stdout and signals via exit code only.
+    _prepr_git merge-base --is-ancestor $LocalSha $RemoteSha | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        return 'behind'
+    }
+    _prepr_git merge-base --is-ancestor $RemoteSha $LocalSha | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        return 'ahead'
+    }
+    return 'diverged'
+}
+
+# ── Integration primitives ───────────────────────────────────────────
+# Integrate the (already refreshed) base branch into the currently checked-out
+# feature branch. Rebase is the private-branch default; merge is the shared-
+# branch escape hatch. Returns $true on a clean integration and $false on a
+# conflict (or an unknown mode, which the driver validates away up front) so the
+# driver can distinguish a clean integration from a conflict.
+function _prepr_integrate {
+    param([string]$Mode, [string]$Base)
+    switch ($Mode) {
+        'rebase' { _prepr_git rebase $Base | Out-Null; return ($LASTEXITCODE -eq 0) }
+        'merge'  { _prepr_git merge --no-edit $Base | Out-Null; return ($LASTEXITCODE -eq 0) }
+        default  { return $false }
+    }
+}
+
+# Abort an in-progress integration, restoring the feature branch to exactly the
+# state it had before the integration attempt. Best-effort: its own exit code is
+# ignored because the driver has already decided to block.
+function _prepr_abort {
+    param([string]$Mode)
+    switch ($Mode) {
+        'rebase' { _prepr_git rebase --abort | Out-Null }
+        'merge'  { _prepr_git merge --abort | Out-Null }
+    }
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+# Single stdout line. attempts is numeric (unquoted); every other field is a
+# string. Field order is identical to pre-pr-gate.sh so a test can parse the two
+# scripts' output interchangeably. Doubled {{ }} are literal braces for the -f
+# operator, matching the workspace.ps1 emit idiom.
+function _prepr_emit {
+    param(
+        [string]$Outcome,
+        [string]$Reason,
+        [AllowEmptyString()][string]$Base = '',
+        [AllowEmptyString()][string]$RemoteSha = '',
+        [AllowEmptyString()][string]$Before = '',
+        [AllowEmptyString()][string]$After = '',
+        [int]$Attempts = 0
+    )
+    Write-Output ('{{"outcome":"{0}","reason":"{1}","base":"{2}","remote_base_sha":"{3}","local_base_sha_before":"{4}","local_base_sha_after":"{5}","attempts":{6}}}' `
+        -f $Outcome, $Reason, $Base, $RemoteSha, $Before, $After, $Attempts)
+}
+
+# ── Driver ───────────────────────────────────────────────────────────
+# run_pre_pr_gate <repo> <base> <branch> [<remote>] [<max_base_moves>] [<integrate>]
+#
+# Repo             expected "owner/name" identity (reported, not re-verified here
+#                  -- the workspace stage already verified origin identity).
+# Base             the base branch to refresh and integrate from (e.g. develop).
+# Branch           the feature branch to integrate the base into.
+# Remote           remote to fetch the base from (default origin).
+# MaxMoves         cap on re-integrations when the remote base keeps moving
+#                  (default 3).
+# Mode             rebase (default, private branch) or merge (shared branch).
+#
+# Parameters are declared positionally so the function can be called both by name
+# and positionally (`run_pre_pr_gate o/n develop feat/x`), mirroring the bash
+# positional contract the test suite exercises.
+function run_pre_pr_gate {
+    param(
+        [string]$Repo = '',
+        [string]$Base = '',
+        [string]$Branch = '',
+        [string]$Remote = 'origin',
+        [int]$MaxMoves = 3,
+        [string]$Mode = 'rebase'
+    )
+
+    if ([string]::IsNullOrEmpty($Repo) -or [string]::IsNullOrEmpty($Base) -or [string]::IsNullOrEmpty($Branch)) {
+        _prepr_emit 'blocked' 'missing_args' $Base '' '' '' 0
+        return 2
+    }
+    if ($Mode -ne 'rebase' -and $Mode -ne 'merge') {
+        _prepr_emit 'blocked' 'bad_integrate_mode' $Base '' '' '' 0
+        return 2
+    }
+
+    # Best-effort snapshot of the local base before any refresh, so a blocked
+    # outcome can prove the base was not rewound.
+    $localBefore = _prepr_git_line rev-parse $Base
+
+    # 1. Clean-worktree precondition. Tracked staged/unstaged changes block the
+    #    gate; untracked files (--untracked-files=no) do not, since they never
+    #    impede a rebase.
+    $dirty = _prepr_git_line status --porcelain --untracked-files=no
+    if (-not [string]::IsNullOrEmpty($dirty)) {
+        _prepr_emit 'blocked' 'dirty_worktree' $Base '' $localBefore $localBefore 0
+        return 1
+    }
+
+    # Ensure we operate from the feature branch (defensive: the real workflow is
+    # already on it). Everything after this integrates the base into HEAD.
+    if (-not (_prepr_git_ok checkout $Branch)) {
+        _prepr_emit 'blocked' 'checkout_failed' $Base '' $localBefore $localBefore 0
+        return 1
+    }
+
+    # Initial fetch of the remote base.
+    if (-not (_prepr_git_ok fetch $Remote $Base)) {
+        _prepr_emit 'blocked' 'fetch_failed' $Base '' $localBefore $localBefore 0
+        return 1
+    }
+    $rb = _prepr_git_line rev-parse FETCH_HEAD
+    _prepr_run_hook
+
+    $attempts = 0
+    while ($true) {
+        $attempts++
+
+        # Refresh the LOCAL base branch against the freshly fetched remote sha.
+        $lb = _prepr_git_line rev-parse $Base
+        $rel = classify_base_relationship $lb $rb
+        switch ($rel) {
+            'equal' {
+                # Local base already current; nothing to fast-forward.
+            }
+            'behind' {
+                # Strictly behind -> a true fast-forward. Move the ref without a
+                # checkout (we stay on the feature branch). Best-effort like the
+                # bash update-ref, whose exit is ignored.
+                _prepr_git update-ref "refs/heads/$Base" $rb | Out-Null
+            }
+            'ahead' {
+                # Local base has commits the remote lacks; never rewind it.
+                _prepr_emit 'blocked' 'base_ahead' $Base $rb $localBefore $lb $attempts
+                return 1
+            }
+            default {
+                # diverged (and the "unknown" fall-through) -> never reset.
+                _prepr_emit 'blocked' 'base_diverged' $Base $rb $localBefore $lb $attempts
+                return 1
+            }
+        }
+
+        # Integrate the refreshed base into the feature branch.
+        _prepr_git checkout $Branch | Out-Null
+        if (-not (_prepr_integrate $Mode $Base)) {
+            # A script cannot judge conflict ambiguity: abort and block.
+            _prepr_abort $Mode
+            $afterConf = _prepr_git_line rev-parse $Base
+            _prepr_emit 'blocked' 'conflict' $Base $rb $localBefore $afterConf $attempts
+            return 1
+        }
+
+        # Re-fetch to detect the remote base moving under us during the audit.
+        if (-not (_prepr_git_ok fetch $Remote $Base)) {
+            $afterFf = _prepr_git_line rev-parse $Base
+            _prepr_emit 'blocked' 'fetch_failed' $Base $rb $localBefore $afterFf $attempts
+            return 1
+        }
+        $rbNew = _prepr_git_line rev-parse FETCH_HEAD
+        _prepr_run_hook
+
+        if ($rbNew -eq $rb) {
+            break  # base stable across two consecutive fetches -> ready.
+        }
+        $rb = $rbNew
+        if ($attempts -ge $MaxMoves) {
+            $afterUnstable = _prepr_git_line rev-parse $Base
+            _prepr_emit 'blocked' 'base_unstable' $Base $rb $localBefore $afterUnstable $attempts
+            return 1
+        }
+    }
+
+    $localAfter = _prepr_git_line rev-parse $Base
+    _prepr_emit 'ready' 'ready' $Base $rb $localBefore $localAfter $attempts
+    return 0
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+# Mirrors pre-pr-gate.sh's _prepr_main: manual flag parsing over the argument
+# array (not native parameter binding) so the CLI surface matches the bash one
+# exactly. MaxMoves is left as a string here and coerced to [int] by
+# run_pre_pr_gate's parameter binding, matching the bash string-then-numeric use.
+function Invoke-PrePrGateMain {
+    param([string[]]$Arguments = @())
+    $repo = ''; $base = ''; $branch = ''; $remote = 'origin'; $maxMoves = '3'; $mode = 'rebase'
+    $i = 0
+    while ($i -lt $Arguments.Count) {
+        switch ($Arguments[$i]) {
+            '--repo' { $repo = $Arguments[$i + 1]; $i += 2 }
+            '--base' { $base = $Arguments[$i + 1]; $i += 2 }
+            '--branch' { $branch = $Arguments[$i + 1]; $i += 2 }
+            '--remote' { $remote = $Arguments[$i + 1]; $i += 2 }
+            '--max-base-moves' { $maxMoves = $Arguments[$i + 1]; $i += 2 }
+            '--integrate' { $mode = $Arguments[$i + 1]; $i += 2 }
+            default {
+                Write-Error "unknown argument: $($Arguments[$i])"
+                return 2
+            }
+        }
+    }
+    if (-not $repo -or -not $base -or -not $branch) {
+        Write-Error 'error: --repo <owner/name>, --base <branch>, and --branch <feature> are required'
+        return 2
+    }
+    return run_pre_pr_gate $repo $base $branch $remote $maxMoves $mode
+}
+
+# Run as CLI only when executed directly; stay quiet when dot-sourced by tests
+# (mirrors pre-pr-gate.sh's BASH_SOURCE guard).
+if ($MyInvocation.InvocationName -ne '.') {
+    exit (Invoke-PrePrGateMain -Arguments $args)
+}

--- a/global/skills/_internal/issue-work/scripts/triage.ps1
+++ b/global/skills/_internal/issue-work/scripts/triage.ps1
@@ -1,0 +1,654 @@
+#Requires -Version 7.0
+# triage.ps1
+# issue-work: triage state machine
+# ================================
+# PowerShell parity port of scripts/triage.sh. Same public functions, same
+# deterministic and idempotent behavior, same outcome JSON schema, same comment
+# fingerprint rule, same candidate eligibility predicate, same sort key, and the
+# same injection seams. See reference/triage-state-machine.md for the contract
+# both scripts satisfy.
+#
+# NOTE (authoring-time caveat): pwsh was not available in the environment this
+# port was written in, so it was produced by mirroring the bash-verified logic
+# in triage.sh line-for-line rather than by running it. It has NOT been executed.
+# Cross-platform runtime regression coverage (a PowerShell test suite plus CI
+# wiring) is tracked in issue #847 under epic #832, consistent with the existing
+# PowerShell-parity notes for the workspace/agents/cleanup stages.
+#
+# The script is both a sourceable library (dot-source it to get the functions
+# below) and a CLI:
+#   pwsh -File triage.ps1 --repo <owner/name> [--issue <n>] [--plan-file <path>]
+#        [--max-depth <n>] [--dry-run]
+# CLI flags intentionally mirror triage.sh's flags exactly (rather than native
+# PowerShell parameter binding) so the two entry points are interchangeable from
+# a caller's point of view.
+#
+# The embedded python3 JSON parsing in triage.sh is replaced here with native
+# ConvertFrom-Json, so this port carries no python3 dependency (matching the
+# other issue-work PowerShell ports).
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Injection seams (overridable by tests and callers via environment variables,
+# mirroring the bash GH_BIN / MAX_CHILD_DEPTH seams). TRIAGE_CURRENT_USER,
+# TRIAGE_DRY_RUN, and TRIAGE_MAX_FAILURES are read directly from $env at their
+# use sites, mirroring triage.sh's ${VAR:-default} at-use reads.
+$script:GhBin = if ($env:GH_BIN) { $env:GH_BIN } else { 'gh' }
+$script:MaxChildDepth = if ($env:MAX_CHILD_DEPTH) { [int]$env:MAX_CHILD_DEPTH } else { 5 }
+
+# Tracked issue identities consumed by _triage_emit. Initialized here so a
+# stray emit before run_triage can never trip StrictMode's uninitialized-var
+# rule; run_triage resets all three at the start of every run.
+$script:Requested = ''
+$script:Root = ''
+$script:Visited = ''
+
+# ── Low-level gh wrapper ─────────────────────────────────────────────
+# All GitHub access funnels through here so a fake gh can shadow it via
+# $env:GH_BIN, mirroring _triage_gh in triage.sh.
+#
+# Native-command failure is surfaced via $LASTEXITCODE / empty stdout, never a
+# thrown exception: $ErrorActionPreference is locally lowered to 'Continue' so a
+# benign non-zero gh exit (e.g. `issue view` on a missing issue, which the retry
+# and eligibility logic treats as empty output) does NOT become a terminating
+# error under the script-scope 'Stop' preference on pwsh 7.4+
+# ($PSNativeCommandUseErrorActionPreference). triage.sh relies on this tolerance
+# throughout (the `if gh ...; then` / `$?` idioms); without it the negative paths
+# (the three-failure fetch stop, closed/blocked reads) would throw instead of
+# returning empty. This mirrors the guard already used by _prepr_git in
+# pre-pr-gate.ps1.
+function _triage_gh {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GhArgs)
+    $ErrorActionPreference = 'Continue'
+    & $script:GhBin @GhArgs
+}
+
+# ── Pure helpers (unit-testable without gh) ──────────────────────────
+
+# Stable lowercase-hex SHA256 digest of the input. Matches `sha256sum` output
+# (lowercase hex, no separators). Accepts input via the pipeline or the first
+# positional parameter; the digest is computed over the UTF-8 bytes of the input
+# with no added trailing newline (mirroring `printf '%s' ... | sha256sum`).
+function triage_hash {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true, Position = 0)]
+        [AllowEmptyString()]
+        [string]$InputString = ''
+    )
+    begin { $builder = [System.Text.StringBuilder]::new() }
+    process { if ($null -ne $InputString) { [void]$builder.Append($InputString) } }
+    end {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($builder.ToString())
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $digest = $sha.ComputeHash($bytes)
+        } finally {
+            $sha.Dispose()
+        }
+        return (([System.BitConverter]::ToString($digest)) -replace '-', '').ToLowerInvariant()
+    }
+}
+
+# Extract blocker issue numbers from a body. Matches "Blocked by #N" and
+# "Depends on #N" (case-insensitive). Returns the numbers as integers, sorted
+# ascending and de-duplicated (the numeric-unique equivalent of `sort -un`).
+function triage_extract_blockers {
+    param([AllowEmptyString()][string]$Body = '')
+    if ([string]::IsNullOrEmpty($Body)) { return @() }
+    $seen = @{}
+    $nums = New-Object System.Collections.Generic.List[int]
+    foreach ($m in [regex]::Matches($Body, '(?i)(blocked by|depends on)\s+#([0-9]+)')) {
+        $n = [int]$m.Groups[2].Value
+        if (-not $seen.ContainsKey($n)) {
+            $seen[$n] = $true
+            [void]$nums.Add($n)
+        }
+    }
+    return ($nums | Sort-Object)
+}
+
+# Map a comma-separated label list to a numeric priority rank (lower = higher
+# priority). Unlabeled issues rank last.
+function triage_priority_rank {
+    param([AllowEmptyString()][string]$Labels = '')
+    $set = ",$Labels,"
+    if ($set -like '*,priority/critical,*') { return 0 }
+    if ($set -like '*,priority/high,*')     { return 1 }
+    if ($set -like '*,priority/medium,*')   { return 2 }
+    if ($set -like '*,priority/low,*')      { return 3 }
+    return 4
+}
+
+# Return $true if the raw comments blob already carries a marker of the given
+# kind whose hash equals the supplied fingerprint (state unchanged -> skip
+# posting). Return $false otherwise (no marker, or a different hash -> post).
+# When a kind appears more than once, the last marker wins (mirrors `tail -n1`).
+function triage_comment_marker_matches {
+    param([AllowEmptyString()][string]$Raw = '', [string]$Kind, [string]$Fingerprint)
+    $pattern = 'triage-fingerprint: ' + [regex]::Escape($Kind) + ':([0-9a-f]+)'
+    $hits = [regex]::Matches($Raw, $pattern)
+    if ($hits.Count -eq 0) { return $false }
+    $existing = $hits[$hits.Count - 1].Groups[1].Value
+    return ((-not [string]::IsNullOrEmpty($existing)) -and ($existing -eq $Fingerprint))
+}
+
+# Return $true if the raw comments blob carries any marker of the given kind.
+function triage_comment_marker_present {
+    param([AllowEmptyString()][string]$Raw = '', [string]$Kind)
+    $pattern = 'triage-fingerprint: ' + [regex]::Escape($Kind) + ':[0-9a-f]+'
+    return [regex]::IsMatch($Raw, $pattern)
+}
+
+# Eligibility predicate. Arguments are already-resolved scalar facts so the
+# predicate itself is pure and testable. Returns $true when eligible.
+#   State OPEN/CLOSED  Blocked true/false  OtherOnly true/false
+#   ActivePr true/false  Visited true/false
+function triage_is_eligible {
+    param([string]$State, [string]$Blocked, [string]$OtherOnly, [string]$ActivePr, [string]$Visited)
+    if ($State -ne 'OPEN')       { return $false }
+    if ($Blocked -ne 'false')    { return $false }
+    if ($OtherOnly -ne 'false')  { return $false }
+    if ($ActivePr -ne 'false')   { return $false }
+    if ($Visited -ne 'false')    { return $false }
+    return $true
+}
+
+# ── JSON field extraction (native, no python3) ───────────────────────
+
+# Safe property read: returns the property value coerced to a string, or '' when
+# the object or property is absent/null. This is the ConvertFrom-Json equivalent
+# of the python `x.get(<name>, "")` used by triage.sh, and it stays StrictMode
+# safe by inspecting PSObject.Properties rather than dereferencing directly.
+function _triage_prop {
+    param($Item, [string]$Name)
+    if ($null -eq $Item) { return '' }
+    $p = $Item.PSObject.Properties[$Name]
+    if ($null -eq $p -or $null -eq $p.Value) { return '' }
+    return [string]$p.Value
+}
+
+# Minimal field extraction from an issue JSON object. Replaces triage.sh's
+# embedded python3 with native ConvertFrom-Json. Prints the requested scalar as
+# a string; arrays are comma-joined with the same key rules as the bash version:
+#   labels    -> comma-joined `.name` values
+#   assignees -> comma-joined `.login` values
+#   other list-> comma-joined string values
+#   missing / null -> '' ; scalar -> value as-is
+function _triage_field {
+    param([AllowEmptyString()][string]$Json = '', [string]$Field)
+    if ([string]::IsNullOrWhiteSpace($Json)) { return '' }
+    $obj = $null
+    try {
+        $obj = $Json | ConvertFrom-Json
+    } catch {
+        return ''
+    }
+    if ($null -eq $obj) { return '' }
+    $prop = $obj.PSObject.Properties[$Field]
+    if ($null -eq $prop) { return '' }
+    $val = $prop.Value
+    if ($null -eq $val) { return '' }
+    if ($val -is [System.Array]) {
+        if ($Field -eq 'labels') {
+            return (@($val | ForEach-Object { _triage_prop $_ 'name' }) -join ',')
+        } elseif ($Field -eq 'assignees') {
+            return (@($val | ForEach-Object { _triage_prop $_ 'login' }) -join ',')
+        } else {
+            return (@($val | ForEach-Object { [string]$_ }) -join ',')
+        }
+    }
+    return [string]$val
+}
+
+# ── gh-backed accessors ──────────────────────────────────────────────
+
+function _triage_current_user {
+    if (-not [string]::IsNullOrEmpty($env:TRIAGE_CURRENT_USER)) {
+        return $env:TRIAGE_CURRENT_USER
+    }
+    return ((_triage_gh api user --jq '.login' 2>$null) | Out-String).Trim()
+}
+
+# Fetch a single issue as JSON. Returns the raw JSON object text ('' on failure).
+function _triage_issue_json {
+    param([string]$Repo, [string]$Num)
+    return ((_triage_gh issue view $Num --repo $Repo --json 'number,title,state,body,labels,assignees,createdAt' 2>$null) | Out-String).Trim()
+}
+
+# Fetch with up to TRIAGE_MAX_FAILURES identical attempts. Returns the JSON text
+# on success; returns $null only after the same fetch has failed that many times
+# in a row, implementing the "stop after three identical failures" rule
+# (#829 Risks) for the primary external dependency.
+function _triage_issue_json_retry {
+    param([string]$Repo, [string]$Num)
+    $max = if ($env:TRIAGE_MAX_FAILURES) { [int]$env:TRIAGE_MAX_FAILURES } else { 3 }
+    $attempt = 1
+    while ($attempt -le $max) {
+        $json = _triage_issue_json $Repo $Num
+        if (-not [string]::IsNullOrEmpty($json)) { return $json }
+        $attempt++
+    }
+    return $null
+}
+
+# Raw comments blob for marker scanning (matched as text, no JSON parse needed).
+function _triage_comments_raw {
+    param([string]$Repo, [string]$Num)
+    return ((_triage_gh issue view $Num --repo $Repo --json comments 2>$null) | Out-String).Trim()
+}
+
+# True when an open PR references the issue (proxy for "active work in
+# progress"). The "#<num> in:body" search narrows matches to PRs that mention
+# the issue in their body, reducing false positives from a bare numeric match.
+function _triage_has_active_pr {
+    param([string]$Repo, [string]$Num)
+    $out = ((_triage_gh pr list --repo $Repo --state open --search "#$Num in:body" --json number 2>$null) | Out-String).Trim()
+    if ([string]::IsNullOrEmpty($out) -or $out -eq '[]') { return $false }
+    return $true
+}
+
+# Resolve whether an issue is currently blocked. Returns a PSCustomObject with
+# OpenFound ('true'/'false') and Action (the normalized "#N:STATE" list, all
+# blockers, numerically sorted, trailing-space trimmed). Action is the
+# fingerprint input, so it MUST enumerate every blocker (not collapse to the
+# first): a later blocker's state change must still move the digest (AC4/AC4b).
+function _triage_block_state {
+    param([string]$Repo, [string]$Json)
+    $body = _triage_field $Json 'body'
+    $blockers = triage_extract_blockers $body
+    $openFound = 'false'
+    $pairs = ''
+    foreach ($b in $blockers) {
+        $bstate = ((_triage_gh issue view $b --repo $Repo --json state --jq '.state' 2>$null) | Out-String).Trim()
+        if ([string]::IsNullOrEmpty($bstate)) { $bstate = 'UNKNOWN' }
+        $pairs = "$pairs#${b}:$bstate "
+        if ($bstate -eq 'OPEN') { $openFound = 'true' }
+    }
+    return [PSCustomObject]@{ OpenFound = $openFound; Action = $pairs.TrimEnd() }
+}
+
+# ── Mutations ────────────────────────────────────────────────────────
+
+# Post a comment body unless the same-kind fingerprint marker already matches.
+# Returns $true if posted (or would post under a real run), $false if skipped as
+# unchanged. Honors the TRIAGE_DRY_RUN seam.
+function _triage_post_idempotent_comment {
+    param([string]$Repo, [string]$Num, [string]$Kind, [string]$Fingerprint, [string]$Body)
+    $raw = _triage_comments_raw $Repo $Num
+    if (triage_comment_marker_matches $raw $Kind $Fingerprint) {
+        return $false
+    }
+    if ($env:TRIAGE_DRY_RUN -eq 'true') {
+        return $true
+    }
+    $tmp = New-TemporaryFile
+    try {
+        $content = "$Body`n`n<!-- triage-fingerprint: ${Kind}:${Fingerprint} -->`n"
+        Set-Content -LiteralPath $tmp.FullName -Value $content -NoNewline
+        _triage_gh issue comment $Num --repo $Repo --body-file $tmp.FullName 2>$null | Out-Null
+    } finally {
+        Remove-Item -LiteralPath $tmp.FullName -ErrorAction SilentlyContinue
+    }
+    return $true
+}
+
+# ── Emit outcome JSON ─────────────────────────────────────────────────
+# Writes exactly one JSON object as the final stdout line. Field order is
+# identical to triage.sh: outcome, requested, root, active, visited, reason,
+# fingerprint. `visited` is a JSON array of issue-number strings and is inserted
+# raw (placeholder {4} is unquoted). Callers set the exit code themselves
+# (`failed` -> nonzero, everything else -> zero), mirroring triage.sh's
+# `_triage_emit ...; return $?` chaining.
+function _triage_emit {
+    param(
+        [string]$Outcome,
+        [string]$Reason,
+        [AllowEmptyString()][string]$Active = '',
+        [AllowEmptyString()][string]$Fingerprint = ''
+    )
+    $visitedJson = '[]'
+    if (-not [string]::IsNullOrWhiteSpace($script:Visited)) {
+        $nums = @($script:Visited -split '\s+' | Where-Object { $_ -ne '' })
+        if ($nums.Count -gt 0) {
+            $visitedJson = '[' + (($nums | ForEach-Object { '"' + $_ + '"' }) -join ',') + ']'
+        }
+    }
+    Write-Output ('{{"outcome":"{0}","requested":"{1}","root":"{2}","active":"{3}","visited":{4},"reason":"{5}","fingerprint":"{6}"}}' `
+        -f $Outcome, $script:Requested, $script:Root, $Active, $visitedJson, $Reason, $Fingerprint)
+}
+
+# ── State machine driver ─────────────────────────────────────────────
+# run_triage -Repo <owner/name> [-Issue <n>] [-PlanFile <path>]
+# Returns 0 for every terminal outcome except `failed`, which returns 1
+# (mirroring triage.sh's return-status chaining). The outcome JSON is emitted by
+# _triage_emit; the integer return is the process exit code.
+function run_triage {
+    param([string]$Repo, [AllowEmptyString()][string]$Issue = '', [AllowEmptyString()][string]$PlanFile = '')
+    $script:Requested = $Issue
+    $script:Root = ''
+    $script:Visited = ''
+    $depth = 0
+
+    # RESOLVE_REQUESTED: pick the root issue.
+    if ([string]::IsNullOrEmpty($Issue)) {
+        $Issue = ((_triage_gh issue list --repo $Repo --state open --limit 1 --json number --jq '.[0].number' 2>$null) | Out-String).Trim()
+        if ([string]::IsNullOrEmpty($Issue)) {
+            _triage_emit skipped 'no open issue to select'
+            return 0
+        }
+    }
+    $script:Root = $Issue
+    $active = $Issue
+    $user = _triage_current_user
+
+    while ($true) {
+        if ($depth -gt $script:MaxChildDepth) {
+            _triage_emit failed "child traversal exceeded MAX_CHILD_DEPTH=$($script:MaxChildDepth)"
+            return 1
+        }
+
+        # REFRESH: re-fetch the active issue, retrying up to TRIAGE_MAX_FAILURES
+        # times. Three identical failures in a row stop the run with a blocked
+        # outcome rather than a blind retry (#829 Risks).
+        $json = _triage_issue_json_retry $Repo $active
+        if ($null -eq $json) {
+            $max = if ($env:TRIAGE_MAX_FAILURES) { [int]$env:TRIAGE_MAX_FAILURES } else { 3 }
+            _triage_emit blocked "stopped after $max identical failures fetching #$active" '' ''
+            return 0
+        }
+        $state = _triage_field $json 'state'
+        if ($state -ne 'OPEN') {
+            $script:Visited = "$script:Visited $active"
+            _triage_emit skipped "issue #$active is $state"
+            return 0
+        }
+
+        # EVALUATE_BLOCKERS: recompute + idempotent blocked comment.
+        $blockOut = _triage_block_state $Repo $json
+        $openBlocker = $blockOut.OpenFound
+        $action = $blockOut.Action
+        if ($openBlocker -eq 'true') {
+            $fp = $action | triage_hash
+            _triage_post_idempotent_comment $Repo $active blocked $fp `
+                "Blocked: #$active has an unresolved dependency. Blocker states: $action" | Out-Null
+            $script:Visited = "$script:Visited $active"
+            _triage_emit blocked "unresolved blocker on #$active" '' $fp
+            return 0
+        }
+
+        # DECOMPOSE (explicit): a plan file means the caller is asking to
+        # decompose this invocation. Reconcile existing-vs-planned children,
+        # create only the missing ones, post one summary. This takes priority
+        # over child selection so a partial decomposition can be completed on a
+        # rerun (AC6) rather than immediately diving into an existing child.
+        if (-not [string]::IsNullOrEmpty($PlanFile) -and (Test-Path -LiteralPath $PlanFile -PathType Leaf)) {
+            if (_triage_create_children $Repo $active $PlanFile) {
+                $script:Visited = "$script:Visited $active"
+                _triage_emit decomposed "reconciled children for #$active" ''
+                return 0
+            }
+            _triage_emit failed "plan file supplied but contained no child titles for #$active"
+            return 1
+        }
+
+        # EVALUATE_SIZE (no plan): work directly, select a child, or audit.
+        if (-not (_triage_needs_decompose $json)) {
+            # CLAIM
+            if (_triage_claim $Repo $active $user) {
+                $script:Visited = "$script:Visited $active"
+                _triage_emit proceed "eligible issue #$active claimed" $active
+                return 0
+            }
+            # Claim lost: fall through to sibling selection below.
+            $script:Visited = "$script:Visited $active"
+        } else {
+            # Oversized with no plan: prefer an existing eligible open child.
+            $child = _triage_select_child $Repo $active $user
+            if (-not [string]::IsNullOrEmpty($child)) {
+                $script:Visited = "$script:Visited $active"
+                $active = $child
+                $depth++
+                continue
+            }
+            # No eligible open child. Distinguish "all children closed"
+            # (completion audit, AC8) from other terminal cases.
+            $stats = _triage_children_stats $Repo $active
+            $parts = @($stats -split '\s+' | Where-Object { $_ -ne '' })
+            $total = if ($parts.Count -ge 1) { [int]$parts[0] } else { 0 }
+            $openCount = if ($parts.Count -ge 2) { [int]$parts[1] } else { 0 }
+            if ($total -gt 0 -and $openCount -eq 0) {
+                $script:Visited = "$script:Visited $active"
+                _triage_emit skipped "all children of #$active are closed; run completion audit"
+                return 0
+            }
+            if ($total -gt 0) {
+                $script:Visited = "$script:Visited $active"
+                _triage_emit skipped "children of #$active exist but none are eligible"
+                return 0
+            }
+            # Oversized, no children, and no plan to create them with. Reason is
+            # prefixed "needs_plan" so callers/batch can distinguish this
+            # re-invoke signal from a genuine build/CI failure.
+            $script:Visited = "$script:Visited $active"
+            _triage_emit failed "needs_plan: issue #$active needs decomposition; re-invoke with --plan-file"
+            return 1
+        }
+
+        # Claim was lost: try the next eligible sibling of ROOT.
+        $next = _triage_select_child $Repo $script:Root $user
+        if (-not [string]::IsNullOrEmpty($next)) {
+            $active = $next
+            $depth++
+            continue
+        }
+        _triage_emit skipped 'claim race lost and no remaining eligible child'
+        return 0
+    }
+}
+
+# Decide whether an issue must be decomposed. Large by label, or large by body
+# with 4+ acceptance-criteria checkboxes.
+function _triage_needs_decompose {
+    param([string]$Json)
+    $labels = _triage_field $Json 'labels'
+    $set = ",$labels,"
+    if ($set -like '*,size/L,*' -or $set -like '*,size/XL,*') { return $true }
+    $body = _triage_field $Json 'body'
+    $acCount = 0
+    foreach ($line in ($body -split "`n")) {
+        if ($line -match '^\s*- \[[ xX]\]') { $acCount++ }
+    }
+    if ($body.Length -gt 1500 -and $acCount -ge 4) { return $true }
+    return $false
+}
+
+# Return "<total> <open>" counts of a parent's children (any state). Replaces
+# triage.sh's embedded python3 with native ConvertFrom-Json.
+function _triage_children_stats {
+    param([string]$Repo, [string]$Parent)
+    $list = ((_triage_gh issue list --repo $Repo --state all --search "Part of #$Parent in:body" --json 'number,state' 2>$null) | Out-String).Trim()
+    if ([string]::IsNullOrEmpty($list)) { return '0 0' }
+    $items = $null
+    try {
+        $items = $list | ConvertFrom-Json
+    } catch {
+        return '0 0'
+    }
+    if ($null -eq $items) { return '0 0' }
+    $arr = @($items)
+    $total = $arr.Count
+    $opened = @($arr | Where-Object { (_triage_prop $_ 'state') -eq 'OPEN' }).Count
+    return "$total $opened"
+}
+
+# List children of a parent (issues whose body references "Part of #<parent>"),
+# filter to eligible ones, sort by the deterministic key, and return the first.
+# Replaces triage.sh's embedded python3 with native ConvertFrom-Json and a
+# Sort-Object that replicates the python sort tuple EXACTLY:
+#   (mine=0-if-user-in-assignees-else-1, idx=original-list-index,
+#    prio=min(label ranks, else 4), createdAt string, int(number), number-string)
+function _triage_select_child {
+    param([string]$Repo, [string]$Parent, [string]$User)
+    $list = ((_triage_gh issue list --repo $Repo --state all --search "Part of #$Parent in:body" --json 'number,title,state,labels,assignees,createdAt' 2>$null) | Out-String).Trim()
+    if ([string]::IsNullOrEmpty($list)) { return '' }
+    $items = $null
+    try {
+        $items = $list | ConvertFrom-Json
+    } catch {
+        return ''
+    }
+    if ($null -eq $items) { return '' }
+    $items = @($items)
+
+    $visitedSet = @{}
+    foreach ($v in ($script:Visited -split '\s+')) {
+        if ($v -ne '') { $visitedSet[$v] = $true }
+    }
+
+    $rank = @{ 'priority/critical' = 0; 'priority/high' = 1; 'priority/medium' = 2; 'priority/low' = 3 }
+    $cands = @()
+    for ($idx = 0; $idx -lt $items.Count; $idx++) {
+        $it = $items[$idx]
+        $num = [string](_triage_prop $it 'number')
+        if ((_triage_prop $it 'state') -ne 'OPEN') { continue }
+        if ($visitedSet.ContainsKey($num)) { continue }
+
+        $assignees = @()
+        $aProp = $it.PSObject.Properties['assignees']
+        if ($aProp -and $null -ne $aProp.Value) {
+            foreach ($a in @($aProp.Value)) { $assignees += (_triage_prop $a 'login') }
+        }
+        # Assigned only to others (current user not among assignees) -> skip. The
+        # membership test is case-sensitive to match python's `user in assignees`.
+        if ($assignees.Count -gt 0 -and ($assignees -cnotcontains $User)) { continue }
+
+        $prio = 4
+        $lProp = $it.PSObject.Properties['labels']
+        if ($lProp -and $null -ne $lProp.Value) {
+            foreach ($l in @($lProp.Value)) {
+                $lname = _triage_prop $l 'name'
+                if ($rank.ContainsKey($lname) -and $rank[$lname] -lt $prio) { $prio = $rank[$lname] }
+            }
+        }
+        $mine = if ($assignees -ccontains $User) { 0 } else { 1 }
+        $numInt = 0
+        [void][int]::TryParse($num, [ref]$numInt)
+        $cands += [PSCustomObject]@{
+            Mine      = $mine
+            Idx       = $idx
+            Prio      = $prio
+            CreatedAt = [string](_triage_prop $it 'createdAt')
+            NumInt    = $numInt
+            NumStr    = $num
+        }
+    }
+    if ($cands.Count -eq 0) { return '' }
+    $sorted = @($cands | Sort-Object -Property Mine, Idx, Prio, CreatedAt, NumInt, NumStr)
+    return $sorted[0].NumStr
+}
+
+# Re-read the issue after a claim mutation and decide whether the claim holds.
+# Returns $false if we lost (closed, reassigned away, or a linked PR appeared).
+function _triage_claim_verify {
+    param([string]$Repo, [string]$Num, [string]$User)
+    $json = _triage_issue_json $Repo $Num
+    if ([string]::IsNullOrEmpty($json)) { return $false }
+    $state = _triage_field $json 'state'
+    if ($state -ne 'OPEN') { return $false }
+    $assignees = _triage_field $json 'assignees'
+    if (-not [string]::IsNullOrEmpty($assignees)) {
+        # We are (among) the assignees -> won; assigned only to others -> lost.
+        # Case-sensitive to match triage.sh's literal `case ",$assignees,"` test.
+        if (",$assignees," -cnotlike "*,$User,*") { return $false }
+    }
+    if (_triage_has_active_pr $Repo $Num) { return $false }
+    return $true
+}
+
+# Assign the issue to the current user, then re-verify no one else won the race.
+# On a lost race, roll back our speculative @me assignment so the abandoned issue
+# is not left showing us as an assignee.
+function _triage_claim {
+    param([string]$Repo, [string]$Num, [string]$User)
+    if ($env:TRIAGE_DRY_RUN -ne 'true') {
+        _triage_gh issue edit $Num --repo $Repo --add-assignee '@me' 2>$null | Out-Null
+    }
+    if (_triage_claim_verify $Repo $Num $User) {
+        return $true
+    }
+    if ($env:TRIAGE_DRY_RUN -ne 'true') {
+        _triage_gh issue edit $Num --repo $Repo --remove-assignee '@me' 2>$null | Out-Null
+    }
+    return $false
+}
+
+# Reconcile and create children from a plan file (one child title per line).
+# Idempotent: creates only titles that do not already exist; posts one parent
+# summary guarded by a decompose fingerprint. Returns $false if no usable plan.
+function _triage_create_children {
+    param([string]$Repo, [string]$Parent, [string]$PlanFile)
+    if ([string]::IsNullOrEmpty($PlanFile) -or -not (Test-Path -LiteralPath $PlanFile -PathType Leaf)) { return $false }
+
+    $existingRaw = (_triage_gh issue list --repo $Repo --state all --search "Part of #$Parent in:body" --json title --jq '.[].title' 2>$null) | Out-String
+    $existing = @($existingRaw -split "`r?`n" | ForEach-Object { $_.TrimEnd() } | Where-Object { $_ -ne '' })
+
+    $planned = 0
+    $created = 0
+    foreach ($title in (Get-Content -LiteralPath $PlanFile)) {
+        if ([string]::IsNullOrEmpty($title)) { continue }
+        $planned++
+        # Full-line, case-sensitive existence test (mirrors `grep -Fxq`).
+        if ($existing -ccontains $title) { continue }
+        if ($env:TRIAGE_DRY_RUN -ne 'true') {
+            $tmp = New-TemporaryFile
+            try {
+                Set-Content -LiteralPath $tmp.FullName -Value "Part of #$Parent"
+                _triage_gh issue create --repo $Repo --title $title --body-file $tmp.FullName 2>$null | Out-Null
+            } finally {
+                Remove-Item -LiteralPath $tmp.FullName -ErrorAction SilentlyContinue
+            }
+        }
+        $created++
+    }
+
+    if ($planned -le 0) { return $false }
+
+    # Post the parent summary once (idempotent via decompose fingerprint).
+    $fp = "decompose:${Parent}:${planned}" | triage_hash
+    _triage_post_idempotent_comment $Repo $Parent decompose $fp `
+        "Decomposed into $planned child issue(s); $created created this run." | Out-Null
+    return $true
+}
+
+# ── CLI entry ────────────────────────────────────────────────────────
+function Invoke-TriageMain {
+    param([string[]]$Arguments = @())
+    $repo = ''; $issue = ''; $planFile = ''
+    $i = 0
+    while ($i -lt $Arguments.Count) {
+        switch ($Arguments[$i]) {
+            '--repo' { $repo = $Arguments[$i + 1]; $i += 2 }
+            '--issue' { $issue = $Arguments[$i + 1]; $i += 2 }
+            '--plan-file' { $planFile = $Arguments[$i + 1]; $i += 2 }
+            '--max-depth' { $script:MaxChildDepth = [int]$Arguments[$i + 1]; $i += 2 }
+            '--dry-run' { $env:TRIAGE_DRY_RUN = 'true'; $i += 1 }
+            default {
+                Write-Error "unknown argument: $($Arguments[$i])"
+                return 2
+            }
+        }
+    }
+    if (-not $repo) {
+        Write-Error 'error: --repo <owner/name> is required'
+        return 2
+    }
+    return run_triage -Repo $repo -Issue $issue -PlanFile $planFile
+}
+
+# Run as CLI only when executed directly; stay quiet when dot-sourced by tests
+# (mirrors triage.sh's BASH_SOURCE guard).
+if ($MyInvocation.InvocationName -ne '.') {
+    exit (Invoke-TriageMain -Arguments $args)
+}

--- a/tests/issue-work/README.md
+++ b/tests/issue-work/README.md
@@ -52,8 +52,11 @@ The suite is wired into CI by `.github/workflows/validate-skills.yml`.
 
 ## Scope note
 
-These are bash tests. PowerShell parity for the triage gate is deferred to issue
-#832 (team/batch/cross-platform regression integration), per the epic #828 split.
+These are bash tests. PowerShell parity for the triage gate is delivered as
+`scripts/triage.ps1`; it is not runtime-verified here (no `pwsh`) and not wired
+into CI. Cross-platform PS regression coverage is integrated in #832 (the
+PowerShell regression suite plus CI wiring is tracked by #847), consistent with
+the workspace (#838), agents (#839), and cleanup (#840) notes below.
 
 ## Workspace lifecycle tests (issue #838)
 
@@ -212,5 +215,8 @@ The script owns only the mechanical git-state half of the gate. The
 documentation-to-issue gap audit (gap ledger, four dispositions, Korean-PR
 validation, post-creation checks) is an agent-side procedure specified in
 `reference/pre-pr-readiness.md` (AC7–AC12) and is not script-tested. PowerShell
-parity for this stage is deferred to #832, consistent with the #829 / #838 /
-#839 / #840 notes above.
+parity for this stage is delivered as `scripts/pre-pr-gate.ps1`; it is not
+runtime-verified here (no `pwsh`) and not wired into CI. Cross-platform PS
+regression coverage is integrated in #832 (the PowerShell regression suite plus
+CI wiring is tracked by #847), consistent with the #829 / #838 / #839 / #840
+notes above.


### PR DESCRIPTION
Closes #846

## Changes

- Add `scripts/triage.ps1` — behavioral PowerShell 7 parity port of `triage.sh` (deterministic/idempotent state machine, fingerprint + eligibility + sort-key rules, idempotent decomposition, claim/rollback). Embedded `python3` JSON parsing is replaced with native `ConvertFrom-Json`.
- Add `scripts/pre-pr-gate.ps1` — behavioral parity port of `pre-pr-gate.sh` (develop-refresh classification, rebase/merge integration, conflict abort, base-movement retry).
- Both new ports funnel every native `gh`/`git` call through a wrapper that locally lowers `$ErrorActionPreference` to `Continue` (the S1 guard below), so a benign non-zero exit is observed via `$LASTEXITCODE` / empty stdout rather than promoted to a terminating error under pwsh 7.4+.
- Update the triage and pre-PR PowerShell-parity scope notes in `tests/issue-work/README.md` from "deferred to #832" to the "delivered as ...; not runtime-verified (no pwsh) and not wired into CI" wording already used for the workspace/agents/cleanup stages, so all five parity notes are consistent.

## Rationale

`workspace.ps1`, `agents.ps1`, and `cleanup-workspace.ps1` already existed, but `triage.ps1` and `pre-pr-gate.ps1` did not, so cross-platform parity for the issue-work pipeline was only nominal. This delivers the two missing ports with the same public function names, injection seams, outcome JSON schema (identical field order; `attempts` an unquoted number), and CLI flags as their Bash counterparts, so the two entry points are interchangeable from a caller's point of view.

## Scope

In scope (this PR):
- Author the two missing ports (`triage.ps1`, `pre-pr-gate.ps1`).
- Reconcile the two now-stale README parity scope notes.

Out of scope (tracked elsewhere):
- PowerShell regression suite + CI wiring — #847.
- Skill-body / orchestrator wiring — the wiring child (#845, merged as #848).
- Fixing the systemic S1/S2 drifts in the pre-existing ports — see Risks / Follow-up Work.

## Verification

- **Static parity review** — each port was reviewed line-by-line against its `.sh` source and the reference contracts (`triage-state-machine.md`, `pre-pr-readiness.md`). The public function names the dot-sourcing test suites call are preserved verbatim, and the outcome JSON schemas match field-for-field.
- **Bash suites unaffected** — no `.sh` script or bash test was modified, so the five existing `tests/issue-work/test-*.sh` CI steps are untouched.
- **No runtime verification** — `pwsh` is not available in this environment, so the ports were authored by mirroring the bash-verified logic rather than by executing them, consistent with the existing authoring-time caveat on the other three ports. PSScriptAnalyzer was likewise not run. Runtime verification is carried by #847's PowerShell regression suite + CI.

## Gap ledger (documentation-to-issue audit)

| Requirement (AC) | Evidence | Disposition |
|---|---|---|
| `triage.ps1` + `pre-pr-gate.ps1` exist, same outcome JSON schema | new ports; schema reviewed vs `.sh` | already-satisfied |
| Both new ports use native `ConvertFrom-Json` (no python3 dep) | `_triage_field`, `_triage_select_child` | already-satisfied |
| Stale triage / pre-PR README parity scope notes | `tests/issue-work/README.md` update | fix-in-pr (done) |
| All five ports run under `pwsh` without error | — | blocked (no pwsh; #847) |
| Behavioral parity demonstrated per outcome (proceed/decomposed/blocked/skipped/failed; ready/blocked) | static review only | blocked (needs pwsh runtime; #847) |
| Runtime-verify pre-existing 3 ports and fix drift | static audit found S1/S2 | followup-issue (#847) |

Per the incomplete-data rule, requirements that need a `pwsh` runtime are recorded as `blocked`, not "no gap".

## Risks

A static audit of all five ports found two systemic drifts. Both manifest only at pwsh runtime, so they are routed to #847 (which owns the pwsh harness) rather than fixed blind in this environment. The two new ports in this PR are already immune to S1.

- **S1 — native non-zero exit throws (pwsh 7.4+).** Under `$ErrorActionPreference='Stop'` plus the default `$PSNativeCommandUseErrorActionPreference`, a benign non-zero `git`/`gh` exit is promoted to a terminating error before the `$LASTEXITCODE` check. This hits the pre-existing `workspace.ps1`, `agents.ps1`, and `cleanup-workspace.ps1` on negative paths the `.sh` handles cleanly (clone failure, no-origin, `merge-base --is-ancestor` "not ancestor", unpushed commit, PR-not-found, worktree failure). The two new ports guard the native wrapper against it.
- **S2 — CLI swallows the JSON.** Each driver `Write-Output`s the JSON then `return <int>`; in PowerShell the `return` int also lands on the success stream, so the CLI's `exit (Invoke-*Main ...)` consumes `@(<json>,<int>)` as the exit-code argument and the JSON never reaches stdout (`[int]@("...",0)` also fails to cast). This affects all five ports' CLI path; dot-sourced use is unaffected. It is deliberately left uniform across all five so #847 can fix + verify it in one place.

## Follow-up Work

- **#847** (PowerShell regression suite + CI wiring): runtime-verify all five ports against the shared fake-`gh` / temporary-Git fixtures; fix S1 in the three pre-existing ports and S2 across all five; then drop the "not wired into CI" qualifier from the five parity scope notes.
