### PR TITLE
fix(hooks): deny bare *.env names in the file-channel guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `sensitive-file-guard.sh` and `sensitive-file-guard.ps1` no longer allow
+  env files written in the bare suffix form. Both matched the env class as
+  `.env`, `.env.*`, and `.envrc` against the basename, so `production.env`
+  and `staging.env` matched no arm and fell through to an allow — while
+  `.env.production`, the same artifact under the other common naming
+  convention, was denied by the same guard under the reason `(env file)`.
+  Both gain a `*.env` arm, keeping the file-channel pair in the lockstep
+  #856 established. The two Bash-channel guards (`bash-write-guard.sh`,
+  `bash-sensitive-read-guard.sh`) and the plugin's inline guard already
+  denied this form, so the `*.env` row in the retained-divergence table in
+  `docs/plugin-vs-global.md` is removed rather than rewritten: the
+  divergence no longer exists. `example.env` and `template.env` are denied
+  on purpose — the recognised template convention is the dotfile prefix
+  (`.env.example`), which the allow-list still admits because it is
+  evaluated first, and both Bash-channel guards already deny the mirrored
+  form (#863).
 - The plugin distribution's inline sensitive-file guard
   (`plugin/hooks/hooks.json`) no longer allows files the canonical
   `sensitive-file-guard.sh` denies. Its extension alternation was anchored
@@ -109,8 +125,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first, then `.env` / `.env.*` / `.envrc`, credential extensions, SSH
   private keys (`id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa` and their
   suffixed forms), and `credentials` / `config` under a `.aws/` path. The
-  plugin stays deliberately broader than the canonical guard for the bare
-  `*.env` suffix and the `private` directory pattern. Inline symlink
+  plugin stays deliberately broader than the canonical guard for the
+  `private` directory pattern. Inline symlink
   resolution is still out of scope and is now recorded as a retained
   divergence in `docs/plugin-vs-global.md`, which no longer claims full
   parity between the two surfaces (#860).

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -50,7 +50,7 @@ Hooks are user-defined commands that automatically execute during specific Claud
 **Purpose**: Block access to sensitive files like `.env`, `.pem`, `.key`
 
 **Blocked targets**:
-- Extensions and names: `.env` (incl. `.envrc` and `.env.*`), `.pem`, `.key`, `.p12`, `.pfx`
+- Extensions and names: `.env` (incl. `.envrc`, `.env.*`, and the bare `*.env` suffix form such as `production.env`), `.pem`, `.key`, `.p12`, `.pfx`
 - Directories: `secrets/`, `credentials/`, `passwords/`, `private/`
 
 **Behavior**:

--- a/docs/.index/manifest.yaml
+++ b/docs/.index/manifest.yaml
@@ -10,29 +10,29 @@ documents:
     description: ""
     category: root
     scope: root
-    size: 28799
+    size: 29878
     tags: []
     sections:
       - {h: "Changelog", l: 1, e: 7}
       - {h: "[Unreleased]", l: 8, e: 9}
       - {h: "Added", l: 10, e: 98}
-      - {h: "Fixed", l: 99, e: 174}
-      - {h: "1.11.0 - 2026-07-03", l: 175, e: 176}
-      - {h: "Fixed", l: 177, e: 190}
-      - {h: "Security", l: 191, e: 268}
-      - {h: "Added", l: 269, e: 297}
-      - {h: "Changed", l: 298, e: 344}
-      - {h: "1.10.0 - 2026-04-20", l: 345, e: 353}
-      - {h: "1.9.0 - 2026-04-13", l: 354, e: 363}
-      - {h: "1.8.0 - 2026-04-13", l: 364, e: 369}
-      - {h: "1.7.0 - 2026-04-06", l: 370, e: 384}
-      - {h: "1.6.0 - 2026-04-03", l: 385, e: 397}
-      - {h: "1.5.0 - 2026-03-21", l: 398, e: 416}
-      - {h: "1.4.0 - 2026-01-22", l: 417, e: 422}
-      - {h: "1.3.0 - 2026-01-15", l: 423, e: 431}
-      - {h: "1.2.0 - 2026-01-15", l: 432, e: 440}
-      - {h: "1.1.0 - 2025-01-15", l: 441, e: 451}
-      - {h: "1.0.0 - 2025-12-03", l: 452, e: 458}
+      - {h: "Fixed", l: 99, e: 190}
+      - {h: "1.11.0 - 2026-07-03", l: 191, e: 192}
+      - {h: "Fixed", l: 193, e: 206}
+      - {h: "Security", l: 207, e: 284}
+      - {h: "Added", l: 285, e: 313}
+      - {h: "Changed", l: 314, e: 360}
+      - {h: "1.10.0 - 2026-04-20", l: 361, e: 369}
+      - {h: "1.9.0 - 2026-04-13", l: 370, e: 379}
+      - {h: "1.8.0 - 2026-04-13", l: 380, e: 385}
+      - {h: "1.7.0 - 2026-04-06", l: 386, e: 400}
+      - {h: "1.6.0 - 2026-04-03", l: 401, e: 413}
+      - {h: "1.5.0 - 2026-03-21", l: 414, e: 432}
+      - {h: "1.4.0 - 2026-01-22", l: 433, e: 438}
+      - {h: "1.3.0 - 2026-01-15", l: 439, e: 447}
+      - {h: "1.2.0 - 2026-01-15", l: 448, e: 456}
+      - {h: "1.1.0 - 2025-01-15", l: 457, e: 467}
+      - {h: "1.0.0 - 2025-12-03", l: 468, e: 474}
   - path: "COMPATIBILITY.md"
     title: "Compatibility Guide"
     description: ""
@@ -78,7 +78,7 @@ documents:
     description: ""
     category: config
     scope: root
-    size: 73366
+    size: 73422
     tags: [config,hook,hooks]
     sections:
       - {h: "Overview", l: 7, e: 10}
@@ -1811,16 +1811,16 @@ documents:
     description: ""
     category: docs
     scope: docs
-    size: 9041
+    size: 8852
     tags: [docs,global,plugin]
     sections:
       - {h: "Decision Matrix", l: 16, e: 29}
       - {h: "Probe File Contract", l: 30, e: 67}
       - {h: "Behavior Matrix", l: 68, e: 88}
-      - {h: "Retained Divergences", l: 89, e: 109}
-      - {h: "Failure Modes", l: 110, e: 133}
-      - {h: "Spec Compliance", l: 134, e: 157}
-      - {h: "Related", l: 158, e: 164}
+      - {h: "Retained Divergences", l: 89, e: 108}
+      - {h: "Failure Modes", l: 109, e: 132}
+      - {h: "Spec Compliance", l: 133, e: 156}
+      - {h: "Related", l: 157, e: 163}
   - path: "docs/tier2-benchmark-results.md"
     title: "Tier 2 Benchmark Results"
     description: ""

--- a/docs/plugin-vs-global.md
+++ b/docs/plugin-vs-global.md
@@ -89,18 +89,17 @@ when the full suite is installed but one of its hook scripts is absent
 ## Retained Divergences
 
 The plugin's sensitive-file guard matches the same *filename* pattern set
-as `global/hooks/sensitive-file-guard.sh` — the `.env.*` family, `.envrc`,
-credential containers, SSH private keys, and AWS credential files, with
-`.env.example` / `.env.sample` / `.env.template` allowed through. The
-differences below remain by design. They are documented limitations, not
-oversights.
+as `global/hooks/sensitive-file-guard.sh` — the `.env.*` family, the bare
+`*.env` suffix, `.envrc`, credential containers, SSH private keys, and AWS
+credential files, with `.env.example` / `.env.sample` / `.env.template`
+allowed through. The differences below remain by design. They are
+documented limitations, not oversights.
 
 | Area | Global suite | Plugin | Disposition |
 |------|--------------|--------|-------------|
 | Path canonicalization | `resolve_path` (`global/hooks/lib/path-utils.sh`) expands `~`/`$HOME`, collapses symlinks through `realpath`, and canonicalizes macOS `/var` → `/private/var` before matching | Basename only — strips the directory prefix, trims surrounding whitespace, folds case | Limitation. A symlink pointing at a sensitive file is not caught. Resolving symlinks inside a single-line `bash -c` string would be a fragile approximation of the real check. |
 | Decision protocol | Reads hook JSON on stdin, replies with `permissionDecision` on stdout, always exits 0 | Reads `CLAUDE_FILE_PATH`, writes to stderr, exits 2 to deny | Intentional, not a gap. The plugin ships without the `jq` dependency and the `lib/` helpers the canonical hooks source. |
 | Sensitive-directory patterns | `secrets`, `credentials`, `passwords` | Same, plus `private` | Plugin is broader. Kept — narrowing it would remove shipped coverage. |
-| Bare `*.env` suffix | Not matched; only the `.env`, `.env.*`, `.envrc` basenames | Additionally matched, so `production.env` is denied | Plugin is broader. Kept — narrowing it would regress shipped behavior. |
 | `Bash` matcher scope | Three hooks: `dangerous-command-guard.sh`, `bash-write-guard.sh` (read-before-write, via shell tokenization), `bash-sensitive-read-guard.sh` (secret reads through the Bash channel) | One inline guard, three regexes: recursive delete of `/`, `chmod 777`/`a+rwx`, and `curl`/`wget` piped to a shell | Limitation. The plugin covers only part of the destructive-command class. Reading a secret via `cat`, and writing a file without reading it first, are unguarded on the plugin-only surface. |
 
 A machine running the plugin standalone therefore has meaningfully less

--- a/global/hooks/sensitive-file-guard.ps1
+++ b/global/hooks/sensitive-file-guard.ps1
@@ -54,11 +54,16 @@ if ($basenameLower -eq '.env.example' -or
     exit 0
 }
 
-# Env files. Mirrors the .env|.env.*|.envrc pattern set in the bash variant;
-# .envrc is direnv's config and carries the same class of secret.
+# Env files. Mirrors the .env|.env.*|.envrc|*.env pattern set in the bash
+# variant; .envrc is direnv's config and carries the same class of secret.
+# The *.env arm covers the suffix form (production.env, staging.env), which
+# denotes the same artifact as the .env.* dotfile form. example.env and
+# template.env are denied on purpose: the recognised template convention is
+# the dotfile prefix (.env.example).
 if ($basenameLower -eq '.env' -or
     $basenameLower -like '.env.*' -or
-    $basenameLower -eq '.envrc') {
+    $basenameLower -eq '.envrc' -or
+    $basenameLower -like '*.env') {
     New-HookDenyResponse -Reason "Access to sensitive file blocked: $FILE (env file)"
     exit 0
 }

--- a/global/hooks/sensitive-file-guard.sh
+++ b/global/hooks/sensitive-file-guard.sh
@@ -76,7 +76,13 @@ case "$BASENAME_LOWER" in
         # Template files — never contain real secrets, allow.
         # Listed BEFORE the broad .env.* block so they are not denied.
         ;;
-    .env|.env.*|.envrc)
+    .env|.env.*|.envrc|*.env)
+        # *.env covers the suffix form (production.env, staging.env), which
+        # denotes the same artifact as the .env.* dotfile form. Both Bash-channel
+        # guards already deny it; this arm closes the file-channel gap.
+        # example.env / template.env are denied on purpose: the recognised
+        # template convention is the dotfile prefix (.env.example), and the
+        # Bash-channel guards carry no template allow-list at all.
         deny_response "Access to sensitive file blocked: $FILE (env file)"
         ;;
     *.pem|*.key|*.p12|*.pfx)

--- a/tests/hooks/test-sensitive-file-guard.ps1
+++ b/tests/hooks/test-sensitive-file-guard.ps1
@@ -77,6 +77,19 @@ Assert-Allow -InputJson '{"tool_input":{"file_path":"~/.env.example"}}' -Label '
 Assert-Allow -InputJson '{"tool_input":{"file_path":"/app/.env.template "}}' -Label '.env.template with trailing space -> allow'
 
 Write-Host ''
+Write-Host '[Bare *.env suffix form (issue #863)]'
+# The suffix form denotes the same artifact as the .env.* dotfile form and is
+# already denied by both Bash-channel guards. The template allow-list asserted
+# in the issue #582 block above is load-bearing for this arm: it must keep
+# winning for .env.example / .env.sample / .env.template now that *.env matches.
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/app/production.env"}}' -Label 'production.env -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/srv/app/staging.env"}}' -Label 'path-qualified staging.env -> deny'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/app/example.env"}}' -Label 'example.env -> deny (not a recognised template form)'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/app/template.env"}}' -Label 'template.env -> deny (not a recognised template form)'
+Assert-Deny -InputJson '{"tool_input":{"file_path":"/app/PRODUCTION.ENV"}}' -Label 'PRODUCTION.ENV -> deny (case-folded)'
+Assert-Allow -InputJson '{"tool_input":{"file_path":"/app/foo.env.example"}}' -Label 'foo.env.example -> allow (ends in .example)'
+
+Write-Host ''
 Write-Host '[Certificate/key patterns]'
 Assert-Deny -InputJson '{"tool_input":{"file_path":"certs/server.pem"}}' -Label '.pem -> deny'
 Assert-Deny -InputJson '{"tool_input":{"file_path":"keys/private.key"}}' -Label '.key -> deny'

--- a/tests/hooks/test-sensitive-file-guard.sh
+++ b/tests/hooks/test-sensitive-file-guard.sh
@@ -77,6 +77,19 @@ assert_allow '{"tool_input":{"file_path":"~/.env.example"}}' "tilde ~/.env.examp
 assert_allow '{"tool_input":{"file_path":"/app/.env.template "}}' ".env.template with trailing space → allow"
 
 echo ""
+echo "[Bare *.env suffix form (issue #863)]"
+# The suffix form denotes the same artifact as the .env.* dotfile form and is
+# already denied by both Bash-channel guards. The template allow-list asserted
+# in the issue #582 block above is load-bearing for this arm: it must keep
+# winning for .env.example / .env.sample / .env.template now that *.env matches.
+assert_deny '{"tool_input":{"file_path":"/app/production.env"}}' "production.env → deny"
+assert_deny '{"tool_input":{"file_path":"/srv/app/staging.env"}}' "path-qualified staging.env → deny"
+assert_deny '{"tool_input":{"file_path":"/app/example.env"}}' "example.env → deny (not a recognised template form)"
+assert_deny '{"tool_input":{"file_path":"/app/template.env"}}' "template.env → deny (not a recognised template form)"
+assert_deny '{"tool_input":{"file_path":"/app/PRODUCTION.ENV"}}' "PRODUCTION.ENV → deny (case-folded)"
+assert_allow '{"tool_input":{"file_path":"/app/foo.env.example"}}' "foo.env.example → allow (ends in .example)"
+
+echo ""
 echo "[Certificate/key patterns]"
 assert_deny '{"tool_input":{"file_path":"certs/server.pem"}}' ".pem → deny"
 assert_deny '{"tool_input":{"file_path":"keys/private.key"}}' ".key → deny"


### PR DESCRIPTION
## Changes

Closes the last gap in the env-file pattern class. `global/hooks/sensitive-file-guard.sh` and `global/hooks/sensitive-file-guard.ps1` gain a bare `*.env` arm, so `production.env` is denied on the file channel as it already was everywhere else.

- `global/hooks/sensitive-file-guard.sh` - the env-file `case` becomes `.env|.env.*|.envrc|*.env`. The template allow-list keeps its position ahead of it.
- `global/hooks/sensitive-file-guard.ps1` - the mirrored condition gains `-like '*.env'`. Same pattern set, same deny reason, same ordering.
- `tests/hooks/test-sensitive-file-guard.sh`, `tests/hooks/test-sensitive-file-guard.ps1` - 6 fixtures each, added in lockstep. 38 to 44 assertions on the bash side, 47 to 53 on the PowerShell side.
- `docs/plugin-vs-global.md` - the `Bare *.env suffix` row is removed from `Retained Divergences`; the section preamble now names the suffix form as part of the shared set.
- `HOOKS.md`, `CHANGELOG.md`, `docs/.index/manifest.yaml` - documented pattern set, Unreleased/Fixed entry, index re-sync.

The decision protocol, path resolution, template allow-list membership, and every non-env arm are untouched.

## Rationale

The defect is one missing arm, and the guard contradicted itself because of it. `sensitive-file-guard.sh:79` matched the env class as `.env`, `.env.*`, `.envrc` against the normalized basename. `production.env` matches none of those, falls past every remaining arm, and is allowed - while `.env.production`, the same artifact under the other common naming convention, is denied by the same guard under the reason `(env file)`.

**This is not an open design question.** Four of the five implementations of this pattern class in the tree already deny the bare suffix:

| Implementation | Env-class pattern | `production.env` |
|---|---|---|
| `bash-sensitive-read-guard.sh:106` | `*/.env\|*.env\|*/.env.*\|*.env.*` | Denied |
| `bash-write-guard.sh:70` | `*/.env\|*.env\|*/.env.*\|*.env.*` | Denied |
| `plugin/hooks/hooks.json` inline guard | `.env\|.env.*\|.envrc\|*.env` | Denied |
| `sensitive-file-guard.sh:79` | `.env\|.env.*\|.envrc` | **Allowed** |
| `sensitive-file-guard.ps1` | same set, `-eq` / `-like` form | **Allowed** |

The two Bash-channel guards were written against the same threat model in the same tree and already carry the arm. #860 reached the same conclusion from the other direction: matching the canonical set exactly would have required deleting a passing assertion (`/tmp/some-secret.env`), which it read as a signal that the canonical set was the wrong one to match. It recorded the divergence and filed this issue rather than propagating the gap.

**`example.env` and `template.env` are denied. This is a decision, not a side effect.** The issue asks for it to be on the record either way. Three reasons for denying:

1. Both Bash-channel guards already deny them today - `example.env` matches their `*.env` arm. Allowing them here would open a fresh divergence in the opposite direction from the one this PR closes.
2. Neither Bash-channel guard carries a template allow-list at all. The allow-list is a file-channel affordance, and widening its reach by mirroring names into it is a scope increase this issue did not ask for.
3. The recognised template convention is the dotfile prefix. `.env.example` is a name people write on purpose; `example.env` is not a convention with the same standing.

`.env.example`, `.env.sample`, and `.env.template` remain allowed. They are matched by the allow-list, which is evaluated first, and `foo.env.example` ends in `.example` so it matches neither the allow-list nor `*.env` - that case is now pinned by a fixture in both suites.

**On amending the `#860` CHANGELOG entry.** That entry stated the plugin stays deliberately broader for the bare `*.env` suffix, which this change falsifies. The clause is struck rather than left standing. `[Unreleased]` has not shipped, so it is a staging area for the next release rather than a historical record; two entries in one release block, one saying the canonical guards gained `*.env` and the other saying the plugin is uniquely broader for it, would be a defect at publication. The `private` directory half of that sentence is still true and is kept.

## Scope

**`docs/deep-audit-2026-05-29.md` is untouched, deliberately.** The 2026-05-29 audit never observed this gap - it contains no finding about the env pattern set at all (`production.env`, `bare *.env`, `envrc`, `env.example`, and `env file` all return no match). Adding it would fabricate an observation that was not made. This is the same reasoning that kept #856 and #860 out of that file, and the reconciliation of its clusters belongs to #857.

**`HOOKS.md:53` is updated; `HOOKS.md:54` is not.** Line 53 enumerated the env class without the suffix form, so it under-described the guard this PR widens, and #863's `Where` section lists `HOOKS.md` conditionally on the pattern set being stated there - it is. Line 54 is the global/plugin directory-set conflation that #861 owns, and it is untouched.

This does overlap #861's stated scope, which covers the whole `52-54` block and notes the extension list is separately incomplete for SSH and AWS. Flagging it rather than burying it: #861 will restructure the block per surface and should pick up `*.env` in that rewrite. The line has already been edited once while #861 was open - the issue quotes line 53 as `- Extensions: .env, .pem, ...`, which no longer matches the file, since `.envrc` and `.env.*` were added in the #856/#862 work. A one-line textual conflict here is cheap; a shipped doc that under-describes the guard is not. A comment on #861 records this.

**`docs/hooks-ownership.md` is untouched and verified.** It carries no parity or pattern-set claim (`parity`, `same pattern set`, `identical`, `mirrors` all return no match), so nothing in it becomes false.

**`README.md` / `README.ko.md` are untouched.** Neither describes the guard pattern set, so `scripts/diff-readme.sh` is not engaged.

**`plugin/hooks/hooks.json` is untouched.** It already carries the arm as of #864. This PR moves the canonical guards to it, not the reverse.

**Overlap with other open issues.** #857 shares only `CHANGELOG.md` and its manifest section lines, the same expected-and-cheap conflict #864 recorded. #819 touches `sensitive-file-guard.ps1` but on the input-decoding path (`Read-HookInput`, UTF-8, fail-closed parse), not the pattern set - no semantic collision.

## Verification

All numbers are from the head of this branch, run locally on Git Bash and PowerShell 7.

- `bash tests/hooks/test-sensitive-file-guard.sh` - 44 passed, 0 failed.
- `pwsh -File tests/hooks/test-sensitive-file-guard.ps1` - 53 passed, 0 failed.
- `bash tests/scripts/test-plugin-standalone.sh` - 21 passed, 0 failed. The plugin surface is unchanged and stays green.
- `bash scripts/validate-doc-index.sh` - `OK (269 documents)`. The count is unchanged from #864, confirming entries were re-synced rather than added or dropped.
- `bash scripts/gen-hooks-md.sh --check` - exit 0, no drift. The generator reads the hook files' header comment blocks; the comments added here sit inside the `case` body, and the `HOOKS.md` edit is at line 53, outside the `BEGIN/END AUTO-GENERATED HOOKS` region at 1054-1766.

**Vacuity check.** With only the two guard files reverted to their `develop` state and the new fixtures left in place:

| Suite | Old guard | New guard |
|---|---|---|
| `test-sensitive-file-guard.sh` | 39 passed, 5 failed | 44 passed, 0 failed |
| `test-sensitive-file-guard.ps1` | 48 passed, 5 failed | 53 passed, 0 failed |

The five failures are exactly the five new deny fixtures, identically on both platforms, and every one reports `permissionDecision: allow` rather than an error - they reproduce the vulnerability rather than merely failing:

```
FAIL: production.env -> deny                - got: {"permissionDecision":"allow"}
FAIL: path-qualified staging.env -> deny    - got: {"permissionDecision":"allow"}
FAIL: example.env -> deny                   - got: {"permissionDecision":"allow"}
FAIL: template.env -> deny                  - got: {"permissionDecision":"allow"}
FAIL: PRODUCTION.ENV -> deny (case-folded)  - got: {"permissionDecision":"allow"}
```

The sixth new fixture, `foo.env.example -> allow`, passes under **both** the old and the new guard. That is the correct result, not a vacuous one: it is the regression guard for the widening. Under the old pattern nothing matched it; under the new one `*.env` comes close and must still not fire. The template-allow fixtures asserted in the existing `#582` block likewise pass under both, which is what proves the allow-list still wins now that a broad arm sits behind it.

**Manifest re-sync method.** Every value written to `docs/.index/manifest.yaml` was copied from the `actual=` field the validator prints on failure, never computed by hand. The reported shift was a uniform `+16` across all 15 downstream `CHANGELOG.md` section pointers, which independently confirms a pure insertion rather than an accidental edit elsewhere in the file. Section `e` values were updated alongside `l` even though the validator does not check them, since a stale end pointer is the drift this index exists to prevent.

## Risks

- **`*.env` is a broad suffix and will deny non-secret files that happen to use it.** A file named `schema.env` or `defaults.env` holding no credential is now blocked on the file channel. This is not new behavior on the machine as a whole - both Bash-channel guards have always denied it - so the change removes an inconsistency rather than adding a restriction, but a user who only ever hit the file channel may notice it for the first time.
- **`example.env` / `template.env` denial is a judgment call.** If a project genuinely uses the mirrored naming for committed templates, those files are now blocked and the user must rename or override. The reasoning is recorded above so the decision can be revisited on evidence rather than rediscovered.
- **Symlink resolution is unchanged.** `resolve_path` collapses symlinks on the canonical guards, so this arm inherits that behavior; the plugin's inline guard still matches basenames only. Unaffected by this change, still recorded in `docs/plugin-vs-global.md`.
- **`HOOKS.md:53` may conflict with #861.** Disclosed above rather than hidden. The conflict is one line and semantic resolution is obvious in either direction.

## Follow-up Work

- **#861** - `HOOKS.md:52-54`. Its rewrite should carry `*.env` forward and should also fold in the SSH-key and AWS-credential arms its body notes are missing. This PR leaves line 54 entirely to it.
- **#857** - deep-audit cluster reconciliation. Unblocked by this change and unaffected by it; the audit document is untouched here.
- **Observed, not acted on:** the two Bash-channel guards carry no template allow-list, so `.env.example` is denied on the Bash channel and allowed on the file channel. That is a real cross-channel divergence, it predates this change, and it is outside `#863`'s scope, which is the `*.env` arm alone. Worth its own issue rather than a drive-by here.

Closes #863
